### PR TITLE
If DataProtectionProvider comes as null from owin create a new one

### DIFF
--- a/src/DotVVM.Framework/Configuration/DefaultDataProtectionProvider.cs
+++ b/src/DotVVM.Framework/Configuration/DefaultDataProtectionProvider.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.Owin.Security.DataProtection;
+using Owin;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DotVVM.Framework.Configuration
+{
+    internal class DefaultDataProtectionProvider : IDataProtectionProvider
+    {
+        private IAppBuilder appBuilder;
+
+        public DefaultDataProtectionProvider(IAppBuilder appBuilder)
+        {
+            this.appBuilder = appBuilder;
+        }
+
+        public IDataProtector Create(params string[] purposes)
+        {
+            return this.appBuilder.CreateDataProtector(new string[] { });
+        }
+    }
+}

--- a/src/DotVVM.Framework/DotVVM.Framework.csproj
+++ b/src/DotVVM.Framework/DotVVM.Framework.csproj
@@ -300,6 +300,7 @@
     <Compile Include="Compilation\Validation\IControlUsageValidator.cs" />
     <Compile Include="Compilation\ViewCompilingVisitor.cs" />
     <Compile Include="Configuration\ConfigurationHelper.cs" />
+    <Compile Include="Configuration\DefaultDataProtectionProvider.cs" />
     <Compile Include="Configuration\DefaultControlRegistrationStrategy.cs" />
     <Compile Include="Configuration\HtmlAttributeTransformConfiguration.cs" />
     <Compile Include="Configuration\HtmlTagAttributePair.cs" />

--- a/src/DotVVM.Framework/Hosting/OwinExtensions.cs
+++ b/src/DotVVM.Framework/Hosting/OwinExtensions.cs
@@ -22,7 +22,14 @@ namespace DotVVM.Framework.Hosting
         internal static DotvvmConfiguration UseDotVVM(this IAppBuilder app, string applicationRootDirectory, bool errorPages = true)
         {
             var configuration = CreateConfiguration(applicationRootDirectory);
-            configuration.ServiceLocator.RegisterSingleton<IDataProtectionProvider>(app.GetDataProtectionProvider);
+
+            var protectionProvider = app.GetDataProtectionProvider();
+            if (protectionProvider == null)
+            {
+                protectionProvider = new DefaultDataProtectionProvider(app);
+            }
+
+            configuration.ServiceLocator.RegisterSingleton<IDataProtectionProvider>(() => protectionProvider);
 
             // add middlewares
             if (errorPages)


### PR DESCRIPTION
I'm creating a self-host web application with Owin but without ASP MVC nor .Net Core.
For some reason unknown to me app.GetDataProtectionProvider() returns NULL and I'm getting a NullReferenceException in DotVVM.Framework.Security.DefaultCsrfProtector.GetOrCreateSessionId when there is a request.

I propose a new class DefaultDataProtectionProvider that returns the appBuilder.CreateDataProtector which returns something usable when the request arrives to DefaultCsrfProtector.