### PR TITLE
Generate hash in url for resources derived from ResourceBase

### DIFF
--- a/src/DotVVM.Framework/DotVVM.Framework.csproj
+++ b/src/DotVVM.Framework/DotVVM.Framework.csproj
@@ -421,6 +421,7 @@
     <Compile Include="ResourceManagement\ResourceConfigurationCollectionNameAttribute.cs" />
     <Compile Include="ResourceManagement\ResourceRenderPosition.cs" />
     <Compile Include="ResourceManagement\ResourceRepositoryJsonConverter.cs" />
+    <Compile Include="ResourceManagement\ResourceUrlGenerator.cs" />
     <Compile Include="ResourceManagement\ScriptResource.cs" />
     <Compile Include="ResourceManagement\SingleResourceProcessorBase.cs" />
     <Compile Include="ResourceManagement\StylesheetResource.cs" />

--- a/src/DotVVM.Framework/ResourceManagement/ClientGlobalize/JQueryGlobalizeResourceRepository.cs
+++ b/src/DotVVM.Framework/ResourceManagement/ClientGlobalize/JQueryGlobalizeResourceRepository.cs
@@ -13,7 +13,8 @@ namespace DotVVM.Framework.ResourceManagement.ClientGlobalize
         {
             return new ScriptResource()
             {
-                Url = string.Format("~/{0}?{1}={2}", HostingConstants.GlobalizeCultureUrlPath, HostingConstants.GlobalizeCultureUrlIdParameter, name),
+                //Url = string.Format("~/{0}?{1}={2}", HostingConstants.GlobalizeCultureUrlPath, HostingConstants.GlobalizeCultureUrlIdParameter, name),
+                Url = ResourceUrlGenerator.GetGlobalizeCultureResourceUrl(name),
                 Dependencies = new[] { ResourceConstants.GlobalizeResourceName },
                 // TODO: cdn?
             };

--- a/src/DotVVM.Framework/ResourceManagement/ResourceBase.cs
+++ b/src/DotVVM.Framework/ResourceManagement/ResourceBase.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Net;
 using DotVVM.Framework.Compilation.Parser;
 using Newtonsoft.Json;
 using DotVVM.Framework.Controls;
@@ -61,13 +58,14 @@ namespace DotVVM.Framework.ResourceManagement
         /// <summary>
         /// Gets the URL.
         /// </summary>
-        protected string GetUrl()
+        protected string GetUrl(IDotvvmRequestContext context)
         {
             if (IsEmbeddedResource)
             {
-                return string.Format(HostingConstants.ResourceHandlerUrl, WebUtility.UrlEncode(Url), WebUtility.UrlEncode(EmbeddedResourceAssembly));
+                return ResourceUrlGenerator.GetEmbeddedResourceUrl(this.Url, this.EmbeddedResourceAssembly);
             }
-            return Url;
+
+            return ResourceUrlGenerator.GetResourceUrl(context, Url);
         }
     }
 }

--- a/src/DotVVM.Framework/ResourceManagement/ResourceUrlGenerator.cs
+++ b/src/DotVVM.Framework/ResourceManagement/ResourceUrlGenerator.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Security.Cryptography;
+using DotVVM.Framework.Hosting;
+using DotVVM.Framework.ResourceManagement.ClientGlobalize;
+
+namespace DotVVM.Framework.ResourceManagement
+{
+    internal static class ResourceUrlGenerator
+    {
+        private static readonly ConcurrentDictionary<string, string> ResourceHashDictionary = new ConcurrentDictionary<string, string>(); 
+
+        public static string GetEmbeddedResourceUrl(string resourceName, string assemblyName)
+        {
+            string key = resourceName;
+            if (ResourceHashDictionary.ContainsKey(key))
+                return ResourceHashDictionary[key];
+
+            string resourceUrl = String.Format(HostingConstants.ResourceHandlerUrl, WebUtility.UrlEncode(resourceName), WebUtility.UrlEncode(assemblyName));
+            ResourceHashDictionary[key] = resourceUrl;
+            var assembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name == assemblyName);
+            if (assembly != null)
+            {
+                using (Stream stream = assembly.GetManifestResourceStream(resourceName))
+                {
+                    if (stream != null)
+                    {
+                        string hash = GetHashString(stream);
+                        ResourceHashDictionary[key] = $"{resourceUrl}&hash={hash}";
+                    }
+                }
+            }
+            return ResourceHashDictionary[key];
+        }
+
+        public static string GetResourceUrl(IDotvvmRequestContext context, string resourceUrl)
+        {
+            string key = resourceUrl;
+            if (ResourceHashDictionary.ContainsKey(key))
+                return ResourceHashDictionary[key];
+
+            ResourceHashDictionary[key] = resourceUrl;
+
+            string applicationPhysicalPath = Path.GetFullPath(context.Configuration.ApplicationPhysicalPath);
+            string resourcePath = context.TranslateVirtualPath(resourceUrl).Replace("/", @"\");
+            if (Path.IsPathRooted(resourcePath))
+            {
+                resourcePath = resourcePath.TrimStart(Path.DirectorySeparatorChar);
+                resourcePath = resourcePath.TrimStart(Path.AltDirectorySeparatorChar);
+            }
+
+            resourcePath = System.IO.Path.Combine(applicationPhysicalPath, resourcePath);
+            if (File.Exists(resourcePath))
+            {
+                using (FileStream fs = new FileStream(resourcePath, FileMode.Open))
+                {
+                    string hash = GetHashString(fs);
+                    ResourceHashDictionary[key] = $"{resourceUrl}?hash={hash}";
+                }
+            }
+            return ResourceHashDictionary[key];
+        }
+
+        public static string GetGlobalizeCultureResourceUrl(string cultureName)
+        {
+            CultureInfo culture = CultureInfo.GetCultureInfo(cultureName);
+            string url = $"~/{HostingConstants.GlobalizeCultureUrlPath}?{HostingConstants.GlobalizeCultureUrlIdParameter}={cultureName}";
+            string key = url;
+            if (ResourceHashDictionary.ContainsKey(key))
+                return ResourceHashDictionary[key];
+
+            var js = JQueryGlobalizeScriptCreator.BuildCultureInfoScript(culture);
+            string hash = GetHashString(js);
+            ResourceHashDictionary[key] = $"{url}&hash={hash}";
+
+            return ResourceHashDictionary[key];
+        }
+
+        private static string GetHashString(Stream stream)
+        {
+            using (MD5CryptoServiceProvider provider = new MD5CryptoServiceProvider())
+            {
+                var hash = provider.ComputeHash(stream);
+                return ((uint)Convert.ToBase64String(hash).GetHashCode()).ToString();
+            }
+        }
+
+        private static string GetHashString(string str)
+        {
+            return ((uint)str.GetHashCode()).ToString();
+        }
+    }
+}

--- a/src/DotVVM.Framework/ResourceManagement/ScriptResource.cs
+++ b/src/DotVVM.Framework/ResourceManagement/ScriptResource.cs
@@ -60,14 +60,14 @@ namespace DotVVM.Framework.ResourceManagement
                 {
                     writer.RenderBeginTag("script");
 
-                    var url = context.TranslateVirtualPath(GetUrl());
+                    var url = context.TranslateVirtualPath(GetUrl(context));
                     writer.WriteUnencodedText(string.Format(CdnFallbackScript, GlobalObjectName, url));
                     writer.RenderEndTag();
                 }
             }
             else if (Url != null)
             {
-                writer.AddAttribute("src", GetUrl());
+                writer.AddAttribute("src", GetUrl(context));
                 writer.AddAttribute("type", "text/javascript");
                 writer.RenderBeginTag("script");
                 writer.RenderEndTag();

--- a/src/DotVVM.Framework/ResourceManagement/StylesheetResource.cs
+++ b/src/DotVVM.Framework/ResourceManagement/StylesheetResource.cs
@@ -23,7 +23,7 @@ namespace DotVVM.Framework.ResourceManagement
         /// </summary>
         public override void Render(IHtmlWriter writer, IDotvvmRequestContext context)
         {
-            writer.AddAttribute("href", GetUrl());
+            writer.AddAttribute("href", GetUrl(context));
             writer.AddAttribute("rel", "stylesheet");
             writer.AddAttribute("type", "text/css");
             writer.RenderSelfClosingTag("link");


### PR DESCRIPTION
Hello, this PR adds hash code into the each url for resources (embedded or static)

From now the resource is downloaded only when its content really changes

Examples:
- http://localhost/dotvvmEmbeddedResource?name=DotVVM.Framework.Resources.Scripts.Globalize.globalize.js&assembly=DotVVM.Framework&hash=1548875813
- http://localhost/dotvvmGlobalizeCulture?id=en-US&hash=3887097858
