### PR TITLE
Added API to configure serializer from code.

### DIFF
--- a/src/DotVVM.Framework/ViewModel/Serialization/ViewModelMapperHelper.cs
+++ b/src/DotVVM.Framework/ViewModel/Serialization/ViewModelMapperHelper.cs
@@ -1,0 +1,64 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DotVVM.Framework.ViewModel.Serialization
+{
+    public static class ViewModelMapperHelper
+    {
+        public static IViewModelSerializationMapper GetSerializationMapper(this Configuration.DotvvmConfiguration configuration) => configuration.ServiceLocator.GetService<IViewModelSerializationMapper>();
+
+        public static IViewModelSerializationMapper Map(this IViewModelSerializationMapper mapper, Type type, Action<ViewModelSerializationMap> action)
+        {
+            var map = mapper.GetMap(type);
+            action(map);
+            map.ResetFunctions();
+            return mapper;
+        }
+
+        public static ViewModelPropertyMap Property(this ViewModelSerializationMap map, string name)
+        {
+            var r = map.Properties.SingleOrDefault(p => p.Name == name);
+            if (r == null) throw new InvalidOperationException($"Property '{name}' was not found on '{map.Type}'.");
+            return r;
+        }
+
+        public static ViewModelPropertyMap Bind(this ViewModelPropertyMap property, Direction direction)
+        {
+            property.TransferAfterPostback = direction.HasFlag(Direction.ServerToClientPostback);
+            property.TransferFirstRequest = direction.HasFlag(Direction.ServerToClientFirstRequest);
+            property.TransferToServer = direction.HasFlag(Direction.ClientToServerNotInPostbackPath) || direction.HasFlag(Direction.ClientToServerInPostbackPath);
+            property.TransferToServerOnlyInPath = !direction.HasFlag(Direction.ClientToServerNotInPostbackPath) && property.TransferToServer;
+
+            return property;
+        }
+
+        public static ViewModelPropertyMap Protect(this ViewModelPropertyMap property, ProtectMode protectMode)
+        {
+            property.ViewModelProtection = protectMode;
+            return property;
+        }
+
+        public static void Ignore(this ViewModelPropertyMap property)
+        {
+            property.Bind(Direction.None);
+            property.ValidationRules.Clear();
+            property.ClientExtenders.Clear();
+        }
+
+        public static ViewModelPropertyMap AddClientExtender(this ViewModelPropertyMap property, ClientExtenderInfo clientExtender)
+        {
+            property.ClientExtenders.Add(clientExtender);
+            return property;
+        }
+
+        public static ViewModelPropertyMap SetJsonConverter(this ViewModelPropertyMap property, JsonConverter converter)
+        {
+            property.JsonConverter = converter;
+            return property;
+        }
+    }
+}

--- a/src/DotVVM.Framework/ViewModel/Serialization/ViewModelPropertyMap.cs
+++ b/src/DotVVM.Framework/ViewModel/Serialization/ViewModelPropertyMap.cs
@@ -10,16 +10,11 @@ namespace DotVVM.Framework.ViewModel.Serialization
 {
     public class ViewModelPropertyMap
     {
-        public ViewModelPropertyMap()
-        {
-            this.ClientExtenders = new List<ClientExtenderInfo>();
-        }
-
         public PropertyInfo PropertyInfo { get; set; }
 
         public string Name { get; set; } 
 
-        public List<ClientExtenderInfo> ClientExtenders { get; private set; }
+        public List<ClientExtenderInfo> ClientExtenders { get; set; }
 
         public ProtectMode ViewModelProtection { get; set; }
 

--- a/src/DotVVM.Framework/ViewModel/Serialization/ViewModelSerializationMap.cs
+++ b/src/DotVVM.Framework/ViewModel/Serialization/ViewModelSerializationMap.cs
@@ -33,6 +33,11 @@ namespace DotVVM.Framework.ViewModel.Serialization
             Properties = properties.ToList();
         }
 
+        public void ResetFunctions()
+        {
+            readerFactory = null;
+            writerFactory = null;
+        }
 
         private Action<JObject, JsonSerializer, object, EncryptedValuesReader> readerFactory;
         /// <summary>

--- a/src/DotVVM.Samples.Common/DotvvmStartup.cs
+++ b/src/DotVVM.Samples.Common/DotvvmStartup.cs
@@ -3,7 +3,10 @@ using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.ResourceManagement;
 using DotVVM.Framework.Routing;
+using DotVVM.Framework.ViewModel;
+using DotVVM.Framework.ViewModel.Serialization;
 using DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.Redirect;
+using DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.Serialization;
 
 namespace DotVVM.Samples.BasicSamples
 {
@@ -55,6 +58,15 @@ namespace DotVVM.Samples.BasicSamples
             // import namespaces
             config.Markup.ImportedNamespaces.Add(new Framework.Compilation.NamespaceImport("DotVVM.Samples.BasicSamples.TestNamespace1", "TestNamespaceAlias"));
             config.Markup.ImportedNamespaces.Add(new Framework.Compilation.NamespaceImport("DotVVM.Samples.BasicSamples.TestNamespace2"));
+
+            // configure serializer
+            config.GetSerializationMapper()
+                .Map(typeof(SerializationViewModel), map =>
+                {
+                    map.Property(nameof(SerializationViewModel.Value)).Bind(Direction.ServerToClient);
+                    map.Property(nameof(SerializationViewModel.Value2)).Bind(Direction.ClientToServer);
+                    map.Property(nameof(SerializationViewModel.IgnoredProperty)).Ignore();
+                });
         }
     }
 }

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/Serialization/Serialization.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/Serialization/Serialization.cs
@@ -21,6 +21,8 @@ namespace DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.Serialization
 
         public string Results { get; set; }
 
+        public string IgnoredProperty { get; set; } = "";
+
 
         public void Test()
         {


### PR DESCRIPTION
Bind, Protect, Ignore, client extenders and JsonConverter are supported

Short sample:
```C#
config.GetSerializationMapper()
.Map(typeof(ViewModel1), map =>
{
    map.Property(nameof(ViewModel1.Property)).Bind(Direction.ServerToClient);
    map.Property(nameof(ViewModel1.Property2)).Protect(ProtectMode.EncryptData);
    map.Property(nameof(ViewModel1.Property2)).AddClientExtender(new ClientExtenderInfo { Name = "nnn", Parameter = ""});
    map.Property(nameof(ViewModel1.IgnoredProperty)).Ignore();
})
.Map(typeof(AnotherViewModel), map =>
{
    map.Property(nameof(AnotherViewModel.Prop)).Ignore();
});
```