### PR TITLE
Removed a check for empty binding group.

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Runtime/HtmlWriterTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/HtmlWriterTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using DotVVM.Framework.Configuration;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Testing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotVVM.Framework.Tests.Common.Runtime
+{
+    [TestClass]
+    public class HtmlWriterTests
+    {
+        string WriteHtml(Action<HtmlWriter> a)
+        {
+            var text = new StringWriter();
+            a(new HtmlWriter(text, new TestDotvvmRequestContext() {
+                Configuration = DotvvmConfiguration.CreateDefault()
+            }));
+            return text.ToString();
+        }
+
+        [TestMethod]
+        public void HtmlWriter_EmptyKnockoutGroup()
+        {
+            var text = WriteHtml(a => {
+                a.AddKnockoutDataBind("a", new KnockoutBindingGroup());
+                a.RenderSelfClosingTag("b");
+            });
+            Assert.AreEqual("<b data-bind=\"a: {}\"/>", text);
+        }
+    }
+}

--- a/src/DotVVM.Framework/Controls/HtmlWriter.cs
+++ b/src/DotVVM.Framework/Controls/HtmlWriter.cs
@@ -132,11 +132,6 @@ namespace DotVVM.Framework.Controls
                 throw new InvalidOperationException($"The value of binding handler '{name}' cannot be combined with a KnockoutBindingGroup!");
             }
 
-            if (bindingGroup.IsEmpty)
-            {
-                return;
-            }
-
             if (dataBindAttributes.Contains(name))
             {
                 var currentGroup = (KnockoutBindingGroup)dataBindAttributes[name];

--- a/src/DotVVM.Framework/Controls/KnockoutBindingGroup.cs
+++ b/src/DotVVM.Framework/Controls/KnockoutBindingGroup.cs
@@ -43,6 +43,7 @@ namespace DotVVM.Framework.Controls
 
         public override string ToString()
         {
+            if (entries.Count == 0) return "{}";
             return "{ " + string.Join(", ", entries) + " }";
         }
 


### PR DESCRIPTION
Should resolve #321, but I have basically removed one [check](https://github.com/riganti/dotvvm/compare/empty-binding-groups?expand=1#diff-74cad2da3bf59959ab8d2007e5e1d038L135), do you think it's OK? Why was there the check?