### PR TITLE
Literal server rendering renders both value and binding

### DIFF
--- a/src/DotVVM.Framework/Controls/GridView.cs
+++ b/src/DotVVM.Framework/Controls/GridView.cs
@@ -161,13 +161,12 @@ namespace DotVVM.Framework.Controls
             var dataSourceBinding = GetDataSourceBinding();
             var dataSource = DataSource;
 
-            Action<string> sortCommand = null;
-
             if (dataSource is IRefreshableGridViewDataSet refreshableDataSet)
             {
                 CallGridViewDataSetRefreshRequest(refreshableDataSet);
             }
 
+            Action<string> sortCommand;
             if (dataSource is ISortableGridViewDataSet sortableGridViewDataSet)
             {
                 sortCommand = sortableGridViewDataSet.SetSortExpression;

--- a/src/DotVVM.Framework/Controls/Literal.cs
+++ b/src/DotVVM.Framework/Controls/Literal.cs
@@ -106,7 +106,7 @@ namespace DotVVM.Framework.Controls
             base.AddAttributesToRender(writer, context);
 
             // render Knockout data-bind
-            renderAsKnockoutBinding = HasBinding<IValueBinding>(TextProperty) && !RenderOnServer;
+            renderAsKnockoutBinding = HasBinding<IValueBinding>(TextProperty);
             if (renderAsKnockoutBinding)
             {
                 var expression = GetValueBinding(TextProperty).GetKnockoutBindingExpression();
@@ -137,9 +137,9 @@ namespace DotVVM.Framework.Controls
 
         protected override void RenderContents(IHtmlWriter writer, IDotvvmRequestContext context)
         {
-            if (!renderAsKnockoutBinding)
+            if (RenderOnServer)
             {
-                var textToDisplay = "";
+                string textToDisplay;
                 if (IsFormattingRequired)
                 {
                     var formatString = FormatString;

--- a/src/DotVVM.Framework/Controls/Repeater.cs
+++ b/src/DotVVM.Framework/Controls/Repeater.cs
@@ -109,6 +109,7 @@ namespace DotVVM.Framework.Controls
             var dataSource = DataSource;
             if (dataSource != null)
             {
+                (dataSource as IRefreshableGridViewDataSet)?.RequestRefresh();
                 var items = GetIEnumerableFromDataSource(dataSource).Cast<object>().ToArray();
                 var javascriptDataSourceExpression = dataSourceBinding.GetKnockoutBindingExpression();
                 foreach (var item in items)


### PR DESCRIPTION
I'm not sure, if it is always ok, but in a lot of cases it's better to render both, because the value can be updated after it was rendered.