### PR TITLE
Added SqlDataSource control

### DIFF
--- a/src/DotVVM.Framework/Compilation/ControlTree/BindingExtensionParameter.cs
+++ b/src/DotVVM.Framework/Compilation/ControlTree/BindingExtensionParameter.cs
@@ -85,4 +85,19 @@ namespace DotVVM.Framework.Compilation.ControlTree
             );
         }
     }
+
+    public class DataSourceExtensionParameter: BindingExtensionParameter
+    {
+        public DataSourceExtensionParameter(): base("_dataSource", new ResolvedTypeDescriptor(typeof(DataSource.IndexableDS)), true) { }
+
+        public override Expression GetServerEquivalent(Expression controlParameter)
+        {
+            return ExpressionUtils.Replace((DotvvmBindableObject c) => new DataSource.IndexableDS(c), controlParameter);
+        }
+
+        public override JsExpression GetJsTranslation(JsExpression dataContext)
+        {
+            return new JsIdentifierExpression("dotvvm").Member("dataSources");
+        }
+    }
 }

--- a/src/DotVVM.Framework/Compilation/ControlTree/ControlTreeResolverBase.cs
+++ b/src/DotVVM.Framework/Compilation/ControlTree/ControlTreeResolverBase.cs
@@ -69,7 +69,8 @@ namespace DotVVM.Framework.Compilation.ControlTree
 
             var dataContextTypeStack = CreateDataContextTypeStack(viewModelType, null, namespaceImports, new BindingExtensionParameter[] {
                 new CurrentMarkupControlExtensionParameter(wrapperType),
-                new BindingPageInfoExtensionParameter()
+                new BindingPageInfoExtensionParameter(),
+                new DataSourceExtensionParameter()
             });
 
             var view = treeBuilder.BuildTreeRoot(this, viewMetadata, root, dataContextTypeStack, directives);

--- a/src/DotVVM.Framework/Controls/SqlDataSource.cs
+++ b/src/DotVVM.Framework/Controls/SqlDataSource.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Text;
+using Dapper;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Hosting;
+using DotVVM.Framework.Utils;
+using Newtonsoft.Json;
+
+namespace DotVVM.Framework.Controls
+{
+    public abstract class DataSource : DotvvmControl
+    {
+        public static readonly DotvvmProperty DataSourcesProperty =
+            DotvvmProperty.Register<ImmutableDictionary<string, Func<IList<IDictionary<string, object>>>>, DataSource>("DataSources",
+                ImmutableDictionary<string, Func<IList<IDictionary<string, object>>>>.Empty);
+
+        public class IndexableDS
+        {
+            private ImmutableDictionary<string, Func<IList<IDictionary<string, object>>>> dict;
+
+            public IndexableDS(DotvvmBindableObject control)
+            {
+                this.dict = control.GetRoot().GetValue(DataSourcesProperty).CastTo<ImmutableDictionary<string, Func<IList<IDictionary<string, object>>>>>();
+            }
+
+            public IList<IDictionary<string, object>> this[string name] => dict[name]();
+        }
+    }
+
+    [ControlMarkupOptions(AllowContent = false)]
+    public class SqlDataSource : DataSource
+    {
+        [MarkupOptions]
+        public string SelectCommand
+        {
+            get { return (string)GetValue(SelectCommandProperty); }
+            set { SetValue(SelectCommandProperty, value); }
+        }
+
+        public static readonly DotvvmProperty SelectCommandProperty =
+            DotvvmProperty.Register<string, SqlDataSource>(c => c.SelectCommand);
+
+        [MarkupOptions]
+        public string ConnectionString
+        {
+            get { return (string)GetValue(ConnectionStringProperty); }
+            set { SetValue(ConnectionStringProperty, value); }
+        }
+
+        public static readonly DotvvmProperty ConnectionStringProperty =
+            DotvvmProperty.Register<string, SqlDataSource>(c => c.ConnectionString);
+
+        protected internal override void OnInit(IDotvvmRequestContext context)
+        {
+            base.OnLoad(context);
+            this.GetRoot().SetValue(DataSourcesProperty, this.GetRoot().GetValue(DataSourcesProperty).CastTo<ImmutableDictionary<string, Func<IList<IDictionary<string, object>>>>>().Add(ID, () => ((IEnumerable<IDictionary<string, object>>)new SqlConnection(ConnectionString).Query(SelectCommand)).ToList()));
+        }
+
+        protected internal override void OnPreRender(IDotvvmRequestContext context)
+        {
+            var json = JsonConvert.SerializeObject(this.GetRoot().GetValue(DataSourcesProperty).CastTo<ImmutableDictionary<string, Func<IList<IDictionary<string, object>>>>>()[ID](), typeof(IList<IDictionary<string, object>>), new JsonSerializerSettings());
+            var js = "+function () { dotvvm.dataSources = dotvvm.dataSources || {}; dotvvm.dataSources[" + JsonConvert.ToString(ID) + "] = dotvvm.dataSources[" + JsonConvert.ToString(ID) + "] || ko.observable(); dotvvm.serialization.deserialize("+json+", dotvvm.dataSources[" + JsonConvert.ToString(ID) + "]); }();";
+            context.ResourceManager.AddStartupScript(Guid.NewGuid().ToString(), js, "dotvvm");
+            base.OnPreRender(context);
+        }
+
+        protected override void RenderControl(IHtmlWriter writer, IDotvvmRequestContext context)
+        {
+        }
+    }
+}

--- a/src/DotVVM.Framework/DotVVM.Framework.csproj
+++ b/src/DotVVM.Framework/DotVVM.Framework.csproj
@@ -77,6 +77,7 @@
     <ProjectReference Include="..\DotVVM.Core\DotVVM.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Dapper" Version="1.50.2" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>

--- a/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
+++ b/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
@@ -19,6 +19,7 @@
     <None Remove="Views\ComplexSamples\GridViewDataSet\GridViewDataSetDelegate.dothtml" />
     <None Remove="Views\ControlSamples\ComboBox\ComboBoxDelaySync.dothtml" />
     <None Remove="Views\FeatureSamples\ActionFilterErrorHandling\ActionFilterRedirect.dothtml" />
+    <None Remove="Views\FeatureSamples\DataSource\SimpleSqlDataSource.dothtml" />
     <None Remove="Views\FeatureSamples\MarkupControl\CommandBindingInDataContextWithControlProperty.dothtml" />
     <None Remove="Views\FeatureSamples\MarkupControl\ControlCommandBinding.dotcontrol" />
     <None Remove="Views\FeatureSamples\MarkupControl\ControlValueBindingWithCommand.dotcontrol" />
@@ -35,6 +36,7 @@
     <Content Include="Views\ComplexSamples\GridViewDataSet\GridViewDataSetDelegate.dothtml" />
     <Content Include="Views\ControlSamples\ComboBox\ComboBoxDelaySync.dothtml" />
     <Content Include="Views\FeatureSamples\ActionFilterErrorHandling\ActionFilterRedirect.dothtml" />
+    <Content Include="Views\FeatureSamples\DataSource\SimpleSqlDataSource.dothtml" />
     <Content Include="Views\FeatureSamples\DependencyInjection\ViewModelScopedService.dothtml" />
     <Content Include="Views\FeatureSamples\MarkupControl\ControlValueBindingWithCommand.dotcontrol" />
     <Content Include="Views\FeatureSamples\MarkupControl\ControlCommandBinding.dotcontrol" />

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/DataSource/SimpleSqlDataSourceViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/DataSource/SimpleSqlDataSourceViewModel.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.DataSource
+{
+	public class SimpleSqlDataSourceViewModel : DotvvmViewModelBase
+	{
+        public string SelectedAuthor { get; set; }
+
+        public void SelectAuthor(object name)
+        {
+            SelectedAuthor = (string)name;
+        }
+    }
+}
+

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/DataSource/SimpleSqlDataSource.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/DataSource/SimpleSqlDataSource.dothtml
@@ -1,0 +1,38 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.DataSource.SimpleSqlDataSourceViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+    <style>
+        .highlight {
+            background-color: yellow;
+        }
+    </style>
+</head>
+<body>
+
+    <dot:SqlDataSource ConnectionString="Data Source=(localdb)\ProjectsV13;Initial Catalog=test;" 
+                       SelectCommand="select Table1.[Activity] as [Activity], 
+                                             Table2.[FromEmail] as [From],
+                                             Table2.[ToEmail] as [To],
+                                             Table2.[Subject] as [Subject] from Table1, Table2 
+                                      where Table1.[Email] = Table2.[FromEmail] 
+                                      and Table2.[ToEmail] is not null" ID="Source1" />
+    <p>Messages:</p>
+    <dot:GridView DataSource="{value: _dataSource["Source1"]}">
+        <dot:GridViewTextColumn ValueBinding="{value: _this["From"]}" CssClass="{value: _parent.SelectedAuthor == _this["From"] ? "highlight" : ""}" HeaderText="Author" />
+        <dot:GridViewTextColumn ValueBinding="{value: _this["Activity"]}" HeaderText="Author's Activity" />
+        <dot:GridViewTextColumn ValueBinding="{value: _this["To"]}" CssClass="{value: _parent.SelectedAuthor == _this["To"] ? "highlight" : ""}" HeaderText="Recipient" />
+        <dot:GridViewTextColumn ValueBinding="{value: _this["Subject"]}" HeaderText="Subject" />
+
+        <dot:GridViewTemplateColumn HeaderText="Even supports commands">
+            <dot:Button Click="{command: _parent.SelectAuthor(_this["From"])}" Text="Select author" />
+        </dot:GridViewTemplateColumn>
+    </dot:GridView>
+</body>
+</html>
+
+


### PR DESCRIPTION
Added SqlDataSource control, that loads data from SQL database right into GridView or Repeater. DataSource can be bound from any binding using `_dataSource[... data source ID ...]` special property.

``` html
    <dot:SqlDataSource ConnectionString="Data Source=(localdb)\ProjectsV13;Initial Catalog=test;" 
                       SelectCommand="select Table2.[FromEmail] as [From],
                                             Table2.[ToEmail] as [To],
                                             Table2.[Subject] as [Subject] from Table2 
                                      where Table2.[ToEmail] is not null" ID="Source1" />
    <p>Messages:</p>
    <dot:GridView DataSource="{value: _dataSource["Source1"]}">
        <dot:GridViewTextColumn ValueBinding="{value: _this["From"]}" HeaderText="Author" />
        <dot:GridViewTextColumn ValueBinding="{value: _this["Activity"]}" HeaderText="Author's Activity" />
        <dot:GridViewTextColumn ValueBinding="{value: _this["To"]}" HeaderText="Recipient" />
        <dot:GridViewTextColumn ValueBinding="{value: _this["Subject"]}" HeaderText="Subject" />
    </dot:GridView>
```