### PR TITLE
Added route groups

### DIFF
--- a/src/DotVVM.Framework/Routing/RouteTableGroup.cs
+++ b/src/DotVVM.Framework/Routing/RouteTableGroup.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DotVVM.Framework.Routing
+{
+    public class RouteTableGroup
+    {
+        public Action<string, RouteBase> AddToParentRouteTable { get; private set; }
+
+        public string GroupName { get; private set; }
+        public string RouteNamePrefix { get; private set; }
+        public string UrlPrefix { get; private set; }
+        public string VirtualPathPrefix { get; private set; }
+
+        public RouteTableGroup(string groupName, string routeNamePrefix, string urlPrefix, string virtualPathPrefix, Action<string, RouteBase> addToParentRouteTable)
+        {
+            GroupName = groupName;
+            RouteNamePrefix = routeNamePrefix;
+            UrlPrefix = urlPrefix;
+            VirtualPathPrefix = virtualPathPrefix;
+            AddToParentRouteTable = addToParentRouteTable;
+        }
+    }
+}


### PR DESCRIPTION
Route groups can be added to a RouteTable, described in https://github.com/riganti/dotvvm/issues/224. Group has its prefixes for route name, url and virtual path. The group can be retrieved and works as a RouteTable.