### PR TITLE
Gather timestamps during the execution of the request

### DIFF
--- a/src/DotVVM.Framework/DependencyInjection/DotVVMServiceCollectionExtensions.cs
+++ b/src/DotVVM.Framework/DependencyInjection/DotVVMServiceCollectionExtensions.cs
@@ -46,7 +46,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton<IControlUsageValidator, DefaultControlUsageValidator>();
             services.TryAddSingleton<ILocalResourceUrlManager, LocalResourceUrlManager>();
             services.TryAddSingleton<IResourceHashService, DefaultResourceHashService>();
-            
+            services.TryAddSingleton<IStopwatch, DefaultStopwatch>();
+
             services.AddSingleton(s => configuration ?? (configuration = DotvvmConfiguration.CreateDefault(s)));
 
             services.Configure<BindingCompilationOptions>(o => {

--- a/src/DotVVM.Framework/Hosting/DefaultStopwatch.cs
+++ b/src/DotVVM.Framework/Hosting/DefaultStopwatch.cs
@@ -1,0 +1,25 @@
+﻿using System.Diagnostics;
+
+namespace DotVVM.Framework.Hosting
+{
+    public class DefaultStopwatch : IStopwatch
+    {
+        private Stopwatch stopwatch;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultStopwatch" /> class.
+        /// </summary>
+        public DefaultStopwatch()
+        {
+            stopwatch = Stopwatch.StartNew();
+        }
+
+        /// <summary>
+        /// Returns elapsed miliseconds in the stopwatch.
+        /// </summary>
+        public long GetElapsedMiliseconds()
+        {
+            return stopwatch.ElapsedMilliseconds;
+        }
+    }
+}

--- a/src/DotVVM.Framework/Hosting/DotvvmPresenter.cs
+++ b/src/DotVVM.Framework/Hosting/DotvvmPresenter.cs
@@ -240,9 +240,9 @@ namespace DotVVM.Framework.Hosting
                 {
                     ViewModelLoader.DisposeViewModel(context.ViewModel);
                 }
-                System.Threading.Thread.Sleep(1000);
                 foreach (var f in requestFilters) await f.OnPageLoadedAsync(context);
                 lastStopwatchState = addTraceData(lastStopwatchState, "EndRequest", context);
+
             }
             catch (DotvvmInterruptRequestExecutionException) { throw; }
             catch (DotvvmHttpException) { throw; }

--- a/src/DotVVM.Framework/Hosting/DotvvmPresenter.cs
+++ b/src/DotVVM.Framework/Hosting/DotvvmPresenter.cs
@@ -80,7 +80,9 @@ namespace DotVVM.Framework.Hosting
         /// <returns></returns>
         public async Task ProcessRequestCore(IDotvvmRequestContext context)
         {
-            long lastStopwatchState = addTraceData(context.Configuration.ServiceLocator.GetService<IStopwatch>().GetElapsedMiliseconds(), "BeginRequest", context);
+            var stopwatch = context.Configuration.ServiceLocator.GetService<IStopwatch>();
+
+            long lastStopwatchState = AddTraceData(stopwatch.GetElapsedMiliseconds(), "BeginRequest", context, stopwatch);
             if (context.HttpContext.Request.Method != "GET" && context.HttpContext.Request.Method != "POST")
             {
                 // unknown HTTP method
@@ -98,7 +100,7 @@ namespace DotVVM.Framework.Hosting
             var page = DotvvmViewBuilder.BuildView(context);
             page.SetValue(Internal.RequestContextProperty, context);
             context.View = page;
-            lastStopwatchState = addTraceData(lastStopwatchState, "ViewInitialized", context);
+            lastStopwatchState = AddTraceData(lastStopwatchState, "ViewInitialized", context, stopwatch);
 
             // locate and create the view model
             context.ViewModel = ViewModelLoader.InitializeViewModel(context, page);
@@ -111,7 +113,7 @@ namespace DotVVM.Framework.Hosting
             {
                 await f.OnPageLoadingAsync(context);
             }
-            lastStopwatchState = addTraceData(lastStopwatchState, "ViewModelInitialized", context);
+            lastStopwatchState = AddTraceData(lastStopwatchState, "ViewModelInitialized", context, stopwatch);
 
             try
             {
@@ -124,7 +126,7 @@ namespace DotVVM.Framework.Hosting
                 {
                     await filter.OnViewModelCreatedAsync(context);
                 }
-                lastStopwatchState = addTraceData(lastStopwatchState, "ViewModelCreated", context);
+                lastStopwatchState = AddTraceData(lastStopwatchState, "ViewModelCreated", context, stopwatch);
 
                 // init the view model lifecycle
                 if (context.ViewModel is IDotvvmViewModel viewModel)
@@ -136,7 +138,7 @@ namespace DotVVM.Framework.Hosting
 
                 // run the init phase in the page
                 DotvvmControlCollection.InvokePageLifeCycleEventRecursive(page, LifeCycleEventType.Init);
-                lastStopwatchState = addTraceData(lastStopwatchState, "InitCompleted", context);
+                lastStopwatchState = AddTraceData(lastStopwatchState, "InitCompleted", context, stopwatch);
 
                 if (!isPostBack)
                 {
@@ -148,7 +150,7 @@ namespace DotVVM.Framework.Hosting
 
                     // run the load phase in the page
                     DotvvmControlCollection.InvokePageLifeCycleEventRecursive(page, LifeCycleEventType.Load);
-                    lastStopwatchState = addTraceData(lastStopwatchState, "LoadCompleted", context);
+                    lastStopwatchState = AddTraceData(lastStopwatchState, "LoadCompleted", context, stopwatch);
                 }
                 else
                 {
@@ -165,7 +167,7 @@ namespace DotVVM.Framework.Hosting
                     {
                         await filter.OnViewModelDeserializedAsync(context);
                     }
-                    lastStopwatchState = addTraceData(lastStopwatchState, "ViewModelDeserialized", context);
+                    lastStopwatchState = AddTraceData(lastStopwatchState, "ViewModelDeserialized", context, stopwatch);
 
                     // validate CSRF token 
                     CsrfProtector.VerifyToken(context, context.CsrfToken);
@@ -177,7 +179,7 @@ namespace DotVVM.Framework.Hosting
 
                     // run the load phase in the page
                     DotvvmControlCollection.InvokePageLifeCycleEventRecursive(page, LifeCycleEventType.Load);
-                    lastStopwatchState = addTraceData(lastStopwatchState, "LoadCompleted", context);
+                    lastStopwatchState = AddTraceData(lastStopwatchState, "LoadCompleted", context, stopwatch);
 
                     // invoke the postback command
                     var actionInfo = ViewModelSerializer.ResolveCommand(context, page);
@@ -192,7 +194,7 @@ namespace DotVVM.Framework.Hosting
 
                         await ExecuteCommand(actionInfo, context, methodFilters);
                     }
-                    lastStopwatchState = addTraceData(lastStopwatchState, "CommandExecuted", context);
+                    lastStopwatchState = AddTraceData(lastStopwatchState, "CommandExecuted", context, stopwatch);
                 }
 
                 if (context.ViewModel is IDotvvmViewModel)
@@ -205,7 +207,7 @@ namespace DotVVM.Framework.Hosting
 
                 // run the prerender complete phase in the page
                 DotvvmControlCollection.InvokePageLifeCycleEventRecursive(page, LifeCycleEventType.PreRenderComplete);
-                lastStopwatchState = addTraceData(lastStopwatchState, "PreRenderCompleted", context);
+                lastStopwatchState = AddTraceData(lastStopwatchState, "PreRenderCompleted", context, stopwatch);
 
                 // generate CSRF token if required
                 if (string.IsNullOrEmpty(context.CsrfToken))
@@ -218,7 +220,7 @@ namespace DotVVM.Framework.Hosting
                 {
                     await filter.OnViewModelSerializingAsync(context);
                 }
-                lastStopwatchState = addTraceData(lastStopwatchState, "ViewModelSerialized", context);
+                lastStopwatchState = AddTraceData(lastStopwatchState, "ViewModelSerialized", context, stopwatch);
 
                 // render the output
                 ViewModelSerializer.BuildViewModel(context);
@@ -234,14 +236,14 @@ namespace DotVVM.Framework.Hosting
                     ViewModelSerializer.AddPostBackUpdatedControls(context);
                     await OutputRenderer.WriteViewModelResponse(context, page);
                 }
-                lastStopwatchState = addTraceData(lastStopwatchState, "OutputRendered", context);
+                lastStopwatchState = AddTraceData(lastStopwatchState, "OutputRendered", context, stopwatch);
 
                 if (context.ViewModel != null)
                 {
                     ViewModelLoader.DisposeViewModel(context.ViewModel);
                 }
                 foreach (var f in requestFilters) await f.OnPageLoadedAsync(context);
-                lastStopwatchState = addTraceData(lastStopwatchState, "EndRequest", context);
+                lastStopwatchState = AddTraceData(lastStopwatchState, "EndRequest", context, stopwatch);
 
             }
             catch (DotvvmInterruptRequestExecutionException) { throw; }
@@ -262,11 +264,10 @@ namespace DotVVM.Framework.Hosting
             }
         }
 
-        private long addTraceData(long lastStopwatchState, string processName, IDotvvmRequestContext context)
+        private long AddTraceData(long lastStopwatchState, string eventName, IDotvvmRequestContext context, IStopwatch stopwatch)
         {
-            var stopwatch = context.Configuration.ServiceLocator.GetService<IStopwatch>();
             long nextStopwatchState = stopwatch.GetElapsedMiliseconds();
-            context.TraceData.Add(processName, nextStopwatchState - lastStopwatchState);
+            context.TraceData.Add(eventName, nextStopwatchState - lastStopwatchState);
             return nextStopwatchState;
         }
 

--- a/src/DotVVM.Framework/Hosting/DotvvmPresenter.cs
+++ b/src/DotVVM.Framework/Hosting/DotvvmPresenter.cs
@@ -80,6 +80,7 @@ namespace DotVVM.Framework.Hosting
         /// <returns></returns>
         public async Task ProcessRequestCore(IDotvvmRequestContext context)
         {
+            long lastStopwatchState = addTraceData(context.Configuration.ServiceLocator.GetService<IStopwatch>().GetElapsedMiliseconds(), "BeginRequest", context);
             if (context.HttpContext.Request.Method != "GET" && context.HttpContext.Request.Method != "POST")
             {
                 // unknown HTTP method
@@ -97,6 +98,7 @@ namespace DotVVM.Framework.Hosting
             var page = DotvvmViewBuilder.BuildView(context);
             page.SetValue(Internal.RequestContextProperty, context);
             context.View = page;
+            lastStopwatchState = addTraceData(lastStopwatchState, "ViewInitialized", context);
 
             // locate and create the view model
             context.ViewModel = ViewModelLoader.InitializeViewModel(context, page);
@@ -109,6 +111,7 @@ namespace DotVVM.Framework.Hosting
             {
                 await f.OnPageLoadingAsync(context);
             }
+            lastStopwatchState = addTraceData(lastStopwatchState, "ViewModelInitialized", context);
 
             try
             {
@@ -121,6 +124,7 @@ namespace DotVVM.Framework.Hosting
                 {
                     await filter.OnViewModelCreatedAsync(context);
                 }
+                lastStopwatchState = addTraceData(lastStopwatchState, "ViewModelCreated", context);
 
                 // init the view model lifecycle
                 if (context.ViewModel is IDotvvmViewModel viewModel)
@@ -132,6 +136,7 @@ namespace DotVVM.Framework.Hosting
 
                 // run the init phase in the page
                 DotvvmControlCollection.InvokePageLifeCycleEventRecursive(page, LifeCycleEventType.Init);
+                lastStopwatchState = addTraceData(lastStopwatchState, "InitCompleted", context);
 
                 if (!isPostBack)
                 {
@@ -143,6 +148,7 @@ namespace DotVVM.Framework.Hosting
 
                     // run the load phase in the page
                     DotvvmControlCollection.InvokePageLifeCycleEventRecursive(page, LifeCycleEventType.Load);
+                    lastStopwatchState = addTraceData(lastStopwatchState, "LoadCompleted", context);
                 }
                 else
                 {
@@ -159,6 +165,7 @@ namespace DotVVM.Framework.Hosting
                     {
                         await filter.OnViewModelDeserializedAsync(context);
                     }
+                    lastStopwatchState = addTraceData(lastStopwatchState, "ViewModelDeserialized", context);
 
                     // validate CSRF token 
                     CsrfProtector.VerifyToken(context, context.CsrfToken);
@@ -167,9 +174,10 @@ namespace DotVVM.Framework.Hosting
                     {
                         await ((IDotvvmViewModel)context.ViewModel).Load();
                     }
-                    
+
                     // run the load phase in the page
                     DotvvmControlCollection.InvokePageLifeCycleEventRecursive(page, LifeCycleEventType.Load);
+                    lastStopwatchState = addTraceData(lastStopwatchState, "LoadCompleted", context);
 
                     // invoke the postback command
                     var actionInfo = ViewModelSerializer.ResolveCommand(context, page);
@@ -184,6 +192,7 @@ namespace DotVVM.Framework.Hosting
 
                         await ExecuteCommand(actionInfo, context, methodFilters);
                     }
+                    lastStopwatchState = addTraceData(lastStopwatchState, "CommandExecuted", context);
                 }
 
                 if (context.ViewModel is IDotvvmViewModel)
@@ -196,6 +205,7 @@ namespace DotVVM.Framework.Hosting
 
                 // run the prerender complete phase in the page
                 DotvvmControlCollection.InvokePageLifeCycleEventRecursive(page, LifeCycleEventType.PreRenderComplete);
+                lastStopwatchState = addTraceData(lastStopwatchState, "PreRenderCompleted", context);
 
                 // generate CSRF token if required
                 if (string.IsNullOrEmpty(context.CsrfToken))
@@ -208,6 +218,7 @@ namespace DotVVM.Framework.Hosting
                 {
                     await filter.OnViewModelSerializingAsync(context);
                 }
+                lastStopwatchState = addTraceData(lastStopwatchState, "ViewModelSerialized", context);
 
                 // render the output
                 ViewModelSerializer.BuildViewModel(context);
@@ -223,13 +234,15 @@ namespace DotVVM.Framework.Hosting
                     ViewModelSerializer.AddPostBackUpdatedControls(context);
                     await OutputRenderer.WriteViewModelResponse(context, page);
                 }
+                lastStopwatchState = addTraceData(lastStopwatchState, "OutputRendered", context);
 
                 if (context.ViewModel != null)
                 {
                     ViewModelLoader.DisposeViewModel(context.ViewModel);
                 }
-
+                System.Threading.Thread.Sleep(1000);
                 foreach (var f in requestFilters) await f.OnPageLoadedAsync(context);
+                lastStopwatchState = addTraceData(lastStopwatchState, "EndRequest", context);
             }
             catch (DotvvmInterruptRequestExecutionException) { throw; }
             catch (DotvvmHttpException) { throw; }
@@ -247,6 +260,14 @@ namespace DotVVM.Framework.Hosting
                 }
                 throw;
             }
+        }
+
+        private long addTraceData(long lastStopwatchState, string processName, IDotvvmRequestContext context)
+        {
+            var stopwatch = context.Configuration.ServiceLocator.GetService<IStopwatch>();
+            long nextStopwatchState = stopwatch.GetElapsedMiliseconds();
+            context.TraceData.Add(processName, nextStopwatchState - lastStopwatchState);
+            return nextStopwatchState;
         }
 
         public async Task ProcessStaticCommandRequest(IDotvvmRequestContext context)

--- a/src/DotVVM.Framework/Hosting/DotvvmRequestContext.cs
+++ b/src/DotVVM.Framework/Hosting/DotvvmRequestContext.cs
@@ -80,7 +80,7 @@ namespace DotVVM.Framework.Hosting
         /// <summary>
         /// Gets the data gathered during execution of the request.
         /// </summary>
-        public Dictionary<string, object> TraceData { get; set; }
+        public Dictionary<string, object> TraceData { get; private set; }
 
         public Dictionary<string, string> PostBackUpdatedControls { get; private set; }
 

--- a/src/DotVVM.Framework/Hosting/DotvvmRequestContext.cs
+++ b/src/DotVVM.Framework/Hosting/DotvvmRequestContext.cs
@@ -77,6 +77,11 @@ namespace DotVVM.Framework.Hosting
         /// </summary>
         public ModelState ModelState { get; private set; }
 
+        /// <summary>
+        /// Gets the data gathered during execution of the request.
+        /// </summary>
+        public Dictionary<string, object> TraceData { get; set; }
+
         public Dictionary<string, string> PostBackUpdatedControls { get; private set; }
 
         public JObject ViewModelJson { get; set; }
@@ -157,6 +162,7 @@ namespace DotVVM.Framework.Hosting
         {
             ModelState = new ModelState();
             PostBackUpdatedControls = new Dictionary<string, string>();
+            TraceData = new Dictionary<string, object>();
         }
 
         /// <summary>

--- a/src/DotVVM.Framework/Hosting/IDotvvmRequestContext.cs
+++ b/src/DotVVM.Framework/Hosting/IDotvvmRequestContext.cs
@@ -25,6 +25,10 @@ namespace DotVVM.Framework.Hosting
 
         JObject ReceivedViewModelJson { get; set; }
 
+        /// <summary>
+        /// Gets the data gathered during execution of the request.
+        /// </summary>
+        Dictionary<string, object> TraceData { get; set; }
 
         /// <summary>
         /// Gets the unique id of the SpaContentPlaceHolder that should be loaded.

--- a/src/DotVVM.Framework/Hosting/IDotvvmRequestContext.cs
+++ b/src/DotVVM.Framework/Hosting/IDotvvmRequestContext.cs
@@ -28,7 +28,7 @@ namespace DotVVM.Framework.Hosting
         /// <summary>
         /// Gets the data gathered during execution of the request.
         /// </summary>
-        Dictionary<string, object> TraceData { get; set; }
+        Dictionary<string, object> TraceData { get; }
 
         /// <summary>
         /// Gets the unique id of the SpaContentPlaceHolder that should be loaded.

--- a/src/DotVVM.Framework/Hosting/IStopwatch.cs
+++ b/src/DotVVM.Framework/Hosting/IStopwatch.cs
@@ -1,0 +1,10 @@
+﻿namespace DotVVM.Framework.Hosting
+{
+    public interface IStopwatch
+    {
+        /// <summary>
+        /// Returns elapsed miliseconds in the stopwatch.
+        /// </summary>
+        long GetElapsedMiliseconds();
+    }
+}

--- a/src/DotVVM.Framework/Hosting/RequestTracingConstants.cs
+++ b/src/DotVVM.Framework/Hosting/RequestTracingConstants.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DotVVM.Framework.Hosting
+{
+    /// <summary>
+    /// Constants containing names of events for tracing a request.
+    /// </summary>
+    public class RequestTracingConstants
+    {
+        public static readonly string InitCompleted = "InitCompleted";
+        public static readonly string BeginRequest = "BeginRequest";
+        public static readonly string ViewInitialized = "ViewInitialized";
+        public static readonly string ViewModelCreated = "ViewModelCreated";
+        public static readonly string LoadCompleted = "LoadCompleted";
+        public static readonly string ViewModelDeserialized = "ViewModelDeserialized";
+        public static readonly string CommandExecuted = "CommandExecuted";
+        public static readonly string PreRenderCompleted = "PreRenderCompleted";
+        public static readonly string ViewModelSerialized = "ViewModelSerialized";
+        public static readonly string OutputRendered = "OutputRendered";
+        public static readonly string EndRequest = "EndRequest";
+    }
+}

--- a/src/DotVVM.Framework/Testing/TestDotvvmRequestContext.cs
+++ b/src/DotVVM.Framework/Testing/TestDotvvmRequestContext.cs
@@ -41,6 +41,7 @@ namespace DotVVM.Framework.Testing
         public string ApplicationHostPath { get; set; }
         public string ResultIdFragment { get; set; }
         public Dictionary<string, string> PostBackUpdatedControls { get; }
+        public Dictionary<string, object> TraceData { get; set; }
         public DotvvmView View { get; set; }
 
         private IServiceProvider _services;

--- a/src/DotVVM.Framework/Testing/TestDotvvmRequestContext.cs
+++ b/src/DotVVM.Framework/Testing/TestDotvvmRequestContext.cs
@@ -41,7 +41,7 @@ namespace DotVVM.Framework.Testing
         public string ApplicationHostPath { get; set; }
         public string ResultIdFragment { get; set; }
         public Dictionary<string, string> PostBackUpdatedControls { get; }
-        public Dictionary<string, object> TraceData { get; set; }
+        public Dictionary<string, object> TraceData { get; private set; }
         public DotvvmView View { get; set; }
 
         private IServiceProvider _services;


### PR DESCRIPTION
Added gathering of timestamps during the exectuion of the request described in https://github.com/riganti/dotvvm/issues/369. It uses the IStopwatch interface to register a System.Diagnostics.Stopwatch singleton object. 