### PR TITLE
Better exception information on invalid command invocation

### DIFF
--- a/src/DotVVM.Framework/Hosting/ErrorPages/ErrorFormatter.cs
+++ b/src/DotVVM.Framework/Hosting/ErrorPages/ErrorFormatter.cs
@@ -346,11 +346,8 @@ namespace DotVVM.Framework.Hosting.ErrorPages
                     infos.Add(new ExceptionAdditionalInfo()
                     {
                         Title = data.Key,
-                        Objects = new object[]
-                        {
-                            data.Value
-                        },
-                        Display = ExceptionAdditionalInfo.DisplayMode.ToString
+                        Objects = data.Value,
+                        Display = ExceptionAdditionalInfo.DisplayMode.ToHtmlList
                     });
                 }
                 return infos;

--- a/src/DotVVM.Framework/Hosting/ErrorPages/ErrorFormatter.cs
+++ b/src/DotVVM.Framework/Hosting/ErrorPages/ErrorFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -8,6 +9,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using DotVVM.Framework.Compilation;
+using DotVVM.Framework.Runtime.Commands;
 
 namespace DotVVM.Framework.Hosting.ErrorPages
 {
@@ -35,7 +37,14 @@ namespace DotVVM.Framework.Hosting.ErrorPages
                         errorColumn: f.GetFileColumnNumber())
                 }));
 
-                m.AdditionalInfo = InfoLoaders.Select(info => info(exception)).Where(info => info != null && info.Objects != null).ToArray();
+                //Adding additional information to ExceptionModel from InfoLoaders and InfoCollectionLoader
+                m.AdditionalInfo = InfoLoaders.Select(info => info(exception))
+                    .Where(info => info != null && info.Objects != null).ToArray()
+                    .Union(InfoCollectionLoader.Select(infoCollection => infoCollection(exception))
+                        .Where(infoCollection => infoCollection != null)
+                        .SelectMany(infoCollection => infoCollection)
+                        .Where(info => info != null && info.Objects != null).ToArray())
+                    .ToArray();
             }
             stack.Reverse();
             m.Stack = stack.ToArray();
@@ -49,17 +58,20 @@ namespace DotVVM.Framework.Hosting.ErrorPages
             {
                 frame.MoreInfo = FrameInfoLoaders.Select(f => f(frame)).Where(f => f != null).ToArray();
             }
-            catch { }
+            catch
+            {
+            }
 
             return frame;
         }
 
-        public List<Func<StackFrameModel, IFrameMoreInfo>> FrameInfoLoaders = new List<Func<StackFrameModel, IFrameMoreInfo>>()
-        {
-            CreateDotvvmDocsLink,
-            CreateReferenceSourceLink,
-            CreateGithubLink
-        };
+        public List<Func<StackFrameModel, IFrameMoreInfo>> FrameInfoLoaders =
+            new List<Func<StackFrameModel, IFrameMoreInfo>>()
+            {
+                CreateDotvvmDocsLink,
+                CreateReferenceSourceLink,
+                CreateGithubLink
+            };
 
         protected static IFrameMoreInfo CreateDotvvmDocsLink(StackFrameModel frame)
         {
@@ -85,15 +97,19 @@ namespace DotVVM.Framework.Hosting.ErrorPages
                 // dotvvm github
                 if (frame.At?.FileName != null)
                 {
-                    var fileName = frame.At.FileName.Substring(frame.At.FileName.LastIndexOf("DotVVM.Framework", StringComparison.Ordinal));
+                    var fileName =
+                        frame.At.FileName.Substring(
+                            frame.At.FileName.LastIndexOf("DotVVM.Framework", StringComparison.Ordinal));
                     var url = GithubUrl + fileName.Replace('\\', '/').TrimStart('/') + "#L" + frame.At.LineNumber;
                     return FrameMoreInfo.CreateThumbLink(url, Octocat);
                 }
                 else
                 {
                     // guess by method name
-                    var fileName = frame.Method.DeclaringType.FullName.Replace("DotVVM.Framework", "").Replace('.', '/');
-                    if (fileName.Contains("+")) fileName = fileName.Remove(fileName.IndexOf('+')); // remove nested class
+                    var fileName = frame.Method.DeclaringType.FullName.Replace("DotVVM.Framework", "")
+                        .Replace('.', '/');
+                    if (fileName.Contains("+"))
+                        fileName = fileName.Remove(fileName.IndexOf('+')); // remove nested class
                     var url = GithubUrl + "DotVVM.Framework" + fileName + ".cs";
                     return FrameMoreInfo.CreateThumbLink(url, Octocat);
                 }
@@ -101,12 +117,62 @@ namespace DotVVM.Framework.Hosting.ErrorPages
             return null;
         }
 
-        static HashSet<string> ReferenceSourceAssemblies = new HashSet<string> { "mscorlib", "PresentationFramework", "System.Web", "System", "System.Windows.Forms", "PresentationCore", "System.ServiceModel", "System.Data", "System.Data.Entity", "System.Core", "System.Xml", "System.Activities", "WindowsBase", "System.Activities.Presentation", "System.Drawing", "Microsoft.VisualBasic", "System.IdentityModel", "System.Web.Extensions", "System.Runtime.Serialization", "System.Workflow.ComponentModel", "System.Data.SqlXml", "System.Data.Linq", "UIAutomationClientsideProviders", "PresentationBuildTasks", "System.Configuration", "System.Management", "System.Data.Services", "System.Workflow.Activities", "System.Management.Automation", "Microsoft.CSharp", "System.Web.Mobile", "System.Web.Services", "System.Security", "System.Data.Services.Client", "System.ServiceModel.Web", "System.ServiceModel.Activities", "System.Workflow.Runtime", "System.ComponentModel.DataAnnotations", "System.Activities.Core.Presentation", "System.Net.Http", "System.Design", "Microsoft.Build.Tasks.v4.0", "UIAutomationClient", "System.Runtime.Remoting", "Microsoft.JSc", "System.Private.CoreLib" };
+        static HashSet<string> ReferenceSourceAssemblies = new HashSet<string>
+        {
+            "mscorlib",
+            "PresentationFramework",
+            "System.Web",
+            "System",
+            "System.Windows.Forms",
+            "PresentationCore",
+            "System.ServiceModel",
+            "System.Data",
+            "System.Data.Entity",
+            "System.Core",
+            "System.Xml",
+            "System.Activities",
+            "WindowsBase",
+            "System.Activities.Presentation",
+            "System.Drawing",
+            "Microsoft.VisualBasic",
+            "System.IdentityModel",
+            "System.Web.Extensions",
+            "System.Runtime.Serialization",
+            "System.Workflow.ComponentModel",
+            "System.Data.SqlXml",
+            "System.Data.Linq",
+            "UIAutomationClientsideProviders",
+            "PresentationBuildTasks",
+            "System.Configuration",
+            "System.Management",
+            "System.Data.Services",
+            "System.Workflow.Activities",
+            "System.Management.Automation",
+            "Microsoft.CSharp",
+            "System.Web.Mobile",
+            "System.Web.Services",
+            "System.Security",
+            "System.Data.Services.Client",
+            "System.ServiceModel.Web",
+            "System.ServiceModel.Activities",
+            "System.Workflow.Runtime",
+            "System.ComponentModel.DataAnnotations",
+            "System.Activities.Core.Presentation",
+            "System.Net.Http",
+            "System.Design",
+            "Microsoft.Build.Tasks.v4.0",
+            "UIAutomationClient",
+            "System.Runtime.Remoting",
+            "Microsoft.JSc",
+            "System.Private.CoreLib"
+        };
+
         protected static IFrameMoreInfo CreateReferenceSourceLink(StackFrameModel frame)
         {
             const string DotNetIcon = "http://referencesource.microsoft.com/favicon.ico";
             const string SourceUrl = "http://referencesource.microsoft.com/";
-            if (frame.Method?.DeclaringType?.GetTypeInfo()?.Assembly != null && ReferenceSourceAssemblies.Contains(frame.Method.DeclaringType.GetTypeInfo().Assembly.GetName().Name))
+            if (frame.Method?.DeclaringType?.GetTypeInfo()?.Assembly != null &&
+                ReferenceSourceAssemblies.Contains(frame.Method.DeclaringType.GetTypeInfo().Assembly.GetName().Name))
             {
                 if (frame.At?.FileName != null)
                 {
@@ -114,19 +180,20 @@ namespace DotVVM.Framework.Hosting.ErrorPages
                 }
                 else
                 {
-                   
                     if (frame.Method.DeclaringType.GetTypeInfo().IsGenericType)
                     {
-                        var url = SourceUrl + "#q=" + WebUtility.HtmlEncode(GetGenericFullName(frame.Method.DeclaringType).Replace('+', '.'));
+                        var url = SourceUrl + "#q=" +
+                                  WebUtility.HtmlEncode(
+                                      GetGenericFullName(frame.Method.DeclaringType).Replace('+', '.'));
                         return FrameMoreInfo.CreateThumbLink(url, DotNetIcon);
                     }
                     else
                     {
-                        var url = SourceUrl + "#q=" + WebUtility.HtmlEncode(frame.Method.DeclaringType.FullName.Replace('+', '.') + "." + frame.Method.Name);
+                        var url = SourceUrl + "#q=" +
+                                  WebUtility.HtmlEncode(frame.Method.DeclaringType.FullName.Replace('+', '.') + "." +
+                                                        frame.Method.Name);
                         return FrameMoreInfo.CreateThumbLink(url, DotNetIcon);
                     }
-
-
                 }
             }
             return null;
@@ -153,17 +220,35 @@ namespace DotVVM.Framework.Hosting.ErrorPages
             sb.Append(">");
 
             return sb.ToString();
-
         }
 
-        public List<Func<Exception, ExceptionAdditionalInfo>> InfoLoaders = new List<Func<Exception, ExceptionAdditionalInfo>>();
+        public List<Func<Exception, IEnumerable<ExceptionAdditionalInfo>>> InfoCollectionLoader =
+            new List<Func<Exception, IEnumerable<ExceptionAdditionalInfo>>>();
+
+        public List<Func<Exception, ExceptionAdditionalInfo>> InfoLoaders =
+            new List<Func<Exception, ExceptionAdditionalInfo>>();
 
         public void AddInfoLoader<T>(Func<T, ExceptionAdditionalInfo> func)
             where T : Exception
         {
             InfoLoaders.Add(e =>
             {
-                if (e is T) return func((T)e);
+                if (e is T) return func((T) e);
+                else return null;
+            });
+        }
+
+        /// <summary>
+        /// Adds a function to InfoCollectionLoader that returns a collection of ExceptionAdditionalInfo
+        /// </summary>
+        /// <typeparam name="T">type of the exception</typeparam>
+        /// <param name="func">function that returns a collection of ExceptionAdditionalInfo</param>
+        public void AddInfoCollectionLoader<T>(Func<T, IEnumerable<ExceptionAdditionalInfo>> func)
+            where T : Exception
+        {
+            InfoCollectionLoader.Add(e =>
+            {
+                if (e is T) return func((T) e);
                 else return null;
             });
         }
@@ -186,7 +271,8 @@ namespace DotVVM.Framework.Hosting.ErrorPages
                     if (lineNumber >= 0)
                     {
                         result.CurrentLine = lines[Math.Max(0, lineNumber - 1)];
-                        result.PreLines = lines.Skip(lineNumber - additionalLineCount).TakeWhile(l => l != result.CurrentLine).ToArray();
+                        result.PreLines = lines.Skip(lineNumber - additionalLineCount)
+                            .TakeWhile(l => l != result.CurrentLine).ToArray();
                     }
                     else additionalLineCount = 30;
                     result.PostLines = lines.Skip(lineNumber).Take(additionalLineCount).ToArray();
@@ -200,13 +286,15 @@ namespace DotVVM.Framework.Hosting.ErrorPages
             return result;
         }
 
-        public List<Func<Exception, IHttpContext, IErrorSectionFormatter>> Formatters = new List<Func<Exception, IHttpContext, IErrorSectionFormatter>>();
+        public List<Func<Exception, IHttpContext, IErrorSectionFormatter>> Formatters =
+            new List<Func<Exception, IHttpContext, IErrorSectionFormatter>>();
 
         public string ErrorHtml(Exception exception, IHttpContext context)
         {
             var template = new ErrorPageTemplate();
             template.Formatters = Formatters.Select(f => f(exception, context))
-                .Concat(context.GetEnvironmentTabs().Select(o => DictionarySection.Create(o.Item1, "env_" + o.Item1.GetHashCode(), o.Item2)))
+                .Concat(context.GetEnvironmentTabs()
+                    .Select(o => DictionarySection.Create(o.Item1, "env_" + o.Item1.GetHashCode(), o.Item2)))
                 .Where(t => t != null).ToArray();
             template.ErrorCode = context.Response.StatusCode;
             template.ErrorDescription = "Unhandled exception occured";
@@ -219,7 +307,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
         {
             var f = new ErrorFormatter();
             f.Formatters.Add((e, o) => DotvvmMarkupErrorSection.Create(e));
-            f.Formatters.Add((e, o) => new ExceptionSectionFormatter { Exception = f.LoadException(e) });
+            f.Formatters.Add((e, o) => new ExceptionSectionFormatter {Exception = f.LoadException(e)});
             f.Formatters.Add((e, o) => DictionarySection.Create("Cookies", "cookies", o.Request.Cookies));
             f.Formatters.Add((e, o) => DictionarySection.Create("Request Headers", "reqHeaders", o.Request.Headers));
             f.AddInfoLoader<ReflectionTypeLoadException>(e => new ExceptionAdditionalInfo
@@ -244,6 +332,28 @@ namespace DotVVM.Framework.Hosting.ErrorPages
                     };
                 }
                 return info;
+            });
+
+            f.AddInfoCollectionLoader<InvalidCommandInvocationException>(e =>
+            {
+                if (e.AdditionData == null || !e.AdditionData.Any())
+                {
+                    return null;
+                }
+                var infos = new List<ExceptionAdditionalInfo>();
+                foreach (var data in e.AdditionData)
+                {
+                    infos.Add(new ExceptionAdditionalInfo()
+                    {
+                        Title = data.Key,
+                        Objects = new object[]
+                        {
+                            data.Value
+                        },
+                        Display = ExceptionAdditionalInfo.DisplayMode.ToString
+                    });
+                }
+                return infos;
             });
 
             return f;

--- a/src/DotVVM.Framework/Hosting/ErrorPages/ExceptionAdditionalInfo.cs
+++ b/src/DotVVM.Framework/Hosting/ErrorPages/ExceptionAdditionalInfo.cs
@@ -14,6 +14,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
 
         public enum DisplayMode
         {
+            ToHtmlList,
             ToString,
             ObjectBrowser,
             KVTable

--- a/src/DotVVM.Framework/Hosting/ErrorPages/ExceptionSectionFormatter.cs
+++ b/src/DotVVM.Framework/Hosting/ErrorPages/ExceptionSectionFormatter.cs
@@ -41,6 +41,11 @@ namespace DotVVM.Framework.Hosting.ErrorPages
                     w.WriteText(info.Title);
                     w.WriteUnencoded("</h3>");
                     if (info.Objects != null)
+                    {
+                        if (info.Display == ExceptionAdditionalInfo.DisplayMode.ToHtmlList)
+                        {
+                            w.WriteUnencoded("<ul>");
+                        }
                         foreach (var obj in info.Objects)
                         {
                             if (info.Display == ExceptionAdditionalInfo.DisplayMode.ToString)
@@ -51,7 +56,16 @@ namespace DotVVM.Framework.Hosting.ErrorPages
                             {
                                 w.ObjectBrowser(obj);
                             }
+                            else if (info.Display == ExceptionAdditionalInfo.DisplayMode.ToHtmlList)
+                            {
+                                w.WriteUnencoded("<li>" + WebUtility.HtmlEncode(obj.ToString()) + "</li>");
+                            }
                         }
+                        if (info.Display == ExceptionAdditionalInfo.DisplayMode.ToHtmlList)
+                        {
+                            w.WriteUnencoded("</ul>");
+                        }
+                    }
                     w.WriteUnencoded("</div><hr />");
                 }
                 w.WriteUnencoded("</div>");

--- a/src/DotVVM.Framework/Runtime/Commands/CandidateBindings.cs
+++ b/src/DotVVM.Framework/Runtime/Commands/CandidateBindings.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using DotVVM.Framework.Binding.Expressions;
+
+namespace DotVVM.Framework.Runtime.Commands
+{
+    public class CandidateBindings
+    {
+        public List<KeyValuePair<string, IBinding>> Bindings { get; set; }
+
+        public CandidateBindings()
+        {
+            Bindings = new List<KeyValuePair<string, IBinding>>();
+        }
+
+        public void AddBinding(KeyValuePair<string, IBinding> binding)
+        {
+            Bindings.Add(binding);
+        }
+
+        public override string ToString()
+        {
+            string result = null;
+            foreach (var binding in Bindings)
+            {
+                result = result == null
+                    ? $"[{(string.IsNullOrWhiteSpace(binding.Key) ? "" : $"{binding.Key}, ")}{binding.Value}]"
+                    : string.Join(";", result, $"[{binding.Key}, {binding.Value}]");
+            }
+            return result;
+        }
+    }
+}

--- a/src/DotVVM.Framework/Runtime/Commands/CandidateBindings.cs
+++ b/src/DotVVM.Framework/Runtime/Commands/CandidateBindings.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using DotVVM.Framework.Binding.Expressions;
 
 namespace DotVVM.Framework.Runtime.Commands
@@ -17,16 +18,7 @@ namespace DotVVM.Framework.Runtime.Commands
             Bindings.Add(binding);
         }
 
-        public override string ToString()
-        {
-            string result = null;
-            foreach (var binding in Bindings)
-            {
-                result = result == null
-                    ? $"[{(string.IsNullOrWhiteSpace(binding.Key) ? "" : $"{binding.Key}, ")}{binding.Value}]"
-                    : string.Join(";", result, $"[{binding.Key}, {binding.Value}]");
-            }
-            return result;
-        }
+        public override string ToString() =>
+            string.Join("; ", Bindings.Select(b => $"[{(string.IsNullOrWhiteSpace(b.Key) ? "" : $"{b.Key}, ")}{b.Value}]"));
     }
 }

--- a/src/DotVVM.Framework/Runtime/Commands/CandidateBindings.cs
+++ b/src/DotVVM.Framework/Runtime/Commands/CandidateBindings.cs
@@ -18,6 +18,9 @@ namespace DotVVM.Framework.Runtime.Commands
             Bindings.Add(binding);
         }
 
+        public string[] BindingsToString() =>
+            Bindings.Select(b => $"[{(string.IsNullOrWhiteSpace(b.Key) ? "" : $"{b.Key}, ")}{b.Value}]").ToArray();
+
         public override string ToString() =>
             string.Join("; ", Bindings.Select(b => $"[{(string.IsNullOrWhiteSpace(b.Key) ? "" : $"{b.Key}, ")}{b.Value}]"));
     }

--- a/src/DotVVM.Framework/Runtime/Commands/EventValidator.cs
+++ b/src/DotVVM.Framework/Runtime/Commands/EventValidator.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using DotVVM.Framework.Binding;
 using DotVVM.Framework.Binding.Expressions;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.ViewModel;
+using DotVVM.Framework.Runtime.Commands;
 
 namespace DotVVM.Framework.Runtime.Commands
 {
@@ -22,7 +25,7 @@ namespace DotVVM.Framework.Runtime.Commands
             var result = FindCommandBinding(path, commandId, viewRootControl, validationTargetPath);
             if (result == null || result.Binding == null)
             {
-                throw EventValidationException();
+                throw EventValidationException(result?.ErrorMessage, result?.CandidateBindings);
             }
 
             // validate the command against the control
@@ -30,7 +33,7 @@ namespace DotVVM.Framework.Runtime.Commands
             {
                 if (!((IEventValidationHandler)result.Control).ValidateCommand(result.Property))
                 {
-                    throw EventValidationException();
+                    throw EventValidationException(result?.ErrorMessage, result?.CandidateBindings);
                 }
             }
             return result;
@@ -46,25 +49,67 @@ namespace DotVVM.Framework.Runtime.Commands
             DotvvmBindableObject resultControl = null;
             DotvvmProperty resultProperty = null;
 
+            bool bindingInPath = false;
+            var candidateBindings = new Dictionary<string, CandidateBindings>();
+
             var walker = new ControlTreeWalker(viewRootControl);
             walker.ProcessControlTree((control) =>
             {
-                // compare path
-                if (resultBinding == null && ViewModelPathComparer.AreEqual(path, walker.CurrentPathArray))
+                if (resultBinding == null)
                 {
                     // find bindings of current control
-                    var binding = control.GetAllBindings()
-                        .FirstOrDefault(b => b.Value is CommandBindingExpression commandBinding && commandBinding.BindingId == commandId);
-                    if (binding.Key != null)
+                    var bindings = control.GetAllBindings()
+                        .Where(b => b.Value is CommandBindingExpression);
+                    string exceptionPropertyKey = null;
+                    foreach (var binding in bindings)
                     {
-                        // we have found the binding, now get the validation path
-                        var currentValidationTargetPath = KnockoutHelper.GetValidationTargetExpression(control);
-                        if (currentValidationTargetPath == validationTargetPath)
+                        StringBuilder infoMessage = new StringBuilder();
+
+                        // checking path
+                        if (!ViewModelPathComparer.AreEqual(path, walker.CurrentPathArray))
                         {
-                            // the validation path is equal, we have found the binding
+                            exceptionPropertyKey = "DataContext path";
+                            infoMessage.Append(
+                                $"Expected DataContext path: '{string.Join("/", path)}' Command binding DataContext path: '{string.Join("/", walker.CurrentPathArray)}'");
+                        }
+                        else
+                        {
+                            //Found a binding in DataContext
+                            bindingInPath = true;
+                        }
+
+                        //checking binding id
+                        if (((CommandBindingExpression)binding.Value).BindingId != commandId)
+                        {
+                            exceptionPropertyKey = exceptionPropertyKey == null
+                                ? "binding id"
+                                : string.Join(", ", exceptionPropertyKey, "binding id");
+                        }
+
+                        //checking validation path
+                        var currentValidationTargetPath = KnockoutHelper.GetValidationTargetExpression(control);
+                        if (currentValidationTargetPath != validationTargetPath)
+                        {
+                            exceptionPropertyKey = exceptionPropertyKey == null
+                                ? "binding id"
+                                : string.Join(", ", exceptionPropertyKey, "validation path");
+                            infoMessage.Append($"Expected validation path: '{string.Join("/", validationTargetPath)}' Command binding validation path: '{string.Join("/", currentValidationTargetPath)}'");
+                        }
+                        if(exceptionPropertyKey == null)
+                        {
+                            //correct binding found
                             resultBinding = (CommandBindingExpression)binding.Value;
                             resultControl = control;
                             resultProperty = binding.Key;
+                        }
+                        else
+                        {
+                            exceptionPropertyKey = "Command bindings with wrong " + exceptionPropertyKey;
+                            if (!candidateBindings.ContainsKey(exceptionPropertyKey))
+                            {
+                                candidateBindings.Add(exceptionPropertyKey, new CandidateBindings());
+                            }
+                            candidateBindings[exceptionPropertyKey].AddBinding(new KeyValuePair<string, IBinding>(infoMessage.ToString(), binding.Value));
                         }
                     }
                 }
@@ -72,6 +117,8 @@ namespace DotVVM.Framework.Runtime.Commands
 
             return new FindBindingResult
             {
+                ErrorMessage = bindingInPath ? null : "Nothing was found in found inside specified DataContext, check if ViewModel is populated",
+                CandidateBindings = candidateBindings,
                 Binding = resultBinding,
                 Control = resultControl,
                 Property = resultProperty
@@ -87,7 +134,7 @@ namespace DotVVM.Framework.Runtime.Commands
             var result = FindControlCommandBinding(path, commandId, viewRootControl, targetControl, validationTargetPath);
             if (result.Binding == null)
             {
-                throw EventValidationException();
+                throw EventValidationException(result.ErrorMessage, result.CandidateBindings);
             }
             return result;
         }
@@ -99,32 +146,82 @@ namespace DotVVM.Framework.Runtime.Commands
         {
             // walk the control tree and find the path
             CommandBindingExpression resultBinding = null;
-            DotvvmProperty resultProperty = null;
             DotvvmBindableObject resultControl = null;
+            DotvvmProperty resultProperty = null;
+
+            bool bindingInPath = false;
+            bool isControl;
+            string errorMessage = null;
+            var candidateBindings = new Dictionary<string, CandidateBindings>();
 
             var walker = new ControlTreeWalker(viewRootControl);
             walker.ProcessControlTree((control) =>
             {
-                // compare path
-                if (ViewModelPathComparer.AreEqual(path, walker.CurrentPathArray))
+                if (resultBinding == null)
                 {
                     // find bindings of current control
-                    var binding = control.GetAllBindings()
-                        .FirstOrDefault(b => b.Value is CommandBindingExpression commandBinding && commandBinding.BindingId == commandId);
-                    if (binding.Key != null)
+                    var bindings = control.GetAllBindings()
+                        .Where(b => b.Value is CommandBindingExpression);
+                    string exceptionPropertyKey = null;
+                    foreach (var binding in bindings)
                     {
-                        // verify that the target control is the control command target
-                        if (control.GetClosestControlBindingTarget() == targetControl)
+                        StringBuilder infoMessage = new StringBuilder();
+
+                        // checking path
+                        if (!ViewModelPathComparer.AreEqual(path, walker.CurrentPathArray))
                         {
-                            // we have found the binding, now get the validation path
-                            var currentValidationTargetPath = KnockoutHelper.GetValidationTargetExpression(control);
-                            if (currentValidationTargetPath == validationTargetPath)
+                            exceptionPropertyKey = "DataContext path";
+                            infoMessage.Append(
+                                $"Expected DataContext path: '{string.Join("/", path)}' Command binding DataContext path: '{string.Join("/", walker.CurrentPathArray)}'");
+                        }
+                        else
+                        {
+                            //Found a binding in DataContext
+                            bindingInPath = true;
+                        }
+
+                        //checking binding id
+                        if (((CommandBindingExpression)binding.Value).BindingId != commandId)
+                        {
+                            exceptionPropertyKey = exceptionPropertyKey == null
+                                ? "binding id"
+                                : string.Join(", ", exceptionPropertyKey, "binding id");
+                        }
+
+                        //checking validation path
+                        var currentValidationTargetPath = KnockoutHelper.GetValidationTargetExpression(control);
+                        if (currentValidationTargetPath != validationTargetPath)
+                        {
+                            exceptionPropertyKey = exceptionPropertyKey == null
+                                ? "binding id"
+                                : string.Join(", ", exceptionPropertyKey, "validation path");
+                            infoMessage.Append(
+                                $"Expected validation path: '{string.Join("/", validationTargetPath)}' Command binding validation path: '{string.Join("/", currentValidationTargetPath)}'");
+                        }
+
+                        //checking if binding is control binding
+                        isControl = control.GetClosestControlBindingTarget() == targetControl;
+
+                        if (exceptionPropertyKey == null && isControl)
+                        {
+                            //correct binding found
+                            resultBinding = (CommandBindingExpression)binding.Value;
+                            resultControl = control;
+                            resultProperty = binding.Key;
+                        }
+                        else if (exceptionPropertyKey != null)
+                        {
+                            exceptionPropertyKey = (isControl ? "Control command bindings with wrong " : "Command bindings with wrong ") + exceptionPropertyKey;
+                            if (!candidateBindings.ContainsKey(exceptionPropertyKey))
                             {
-                                // the validation path is equal, we have found the binding
-                                resultBinding = (CommandBindingExpression)binding.Value;
-                                resultProperty = binding.Key;
-                                resultControl = control;
+                                candidateBindings.Add(exceptionPropertyKey, new CandidateBindings());
                             }
+                            candidateBindings[exceptionPropertyKey]
+                                .AddBinding(new KeyValuePair<string, IBinding>(infoMessage.ToString(), binding.Value));
+                        }
+                        else
+                        {
+                            errorMessage = "Invalid command invocation (the binding is not control command binding)";
                         }
                     }
                 }
@@ -132,21 +229,38 @@ namespace DotVVM.Framework.Runtime.Commands
 
             return new FindBindingResult
             {
-                Property = resultProperty,
+                ErrorMessage = bindingInPath ? errorMessage : "Nothing was found in found inside specified DataContext, check if ViewModel is populated",
+                CandidateBindings = candidateBindings,
                 Binding = resultBinding,
-                Control = resultControl
+                Control = resultControl,
+                Property = resultProperty
             };
         }
+
+
 
         /// <summary>
         /// Throws the event validation exception.
         /// </summary>
-        private Exception EventValidationException()
-            => new Exception("Illegal command invocation!");
+        private Exception EventValidationException(string errorMessage = null, Dictionary<string, CandidateBindings> data = null)
+        {
+            var e = new Exception(errorMessage == null ? "Invalid command invocation!" : errorMessage);
+            if (data != null)
+            {
+                foreach (var bindings in data)
+                {
+                    e.Data.Add(bindings.Key, bindings.Value.ToString());
+                }
+            }
+            return e;
+        }
     }
 
     public class FindBindingResult
     {
+        public string ErrorMessage { get; set; }
+        public Dictionary<string, CandidateBindings> CandidateBindings { get; set; }
+
         public CommandBindingExpression Binding { get; set; }
         public DotvvmBindableObject Control { get; set; }
         public DotvvmProperty Property { get; set; }

--- a/src/DotVVM.Framework/Runtime/Commands/InvalidCommandInvocationException.cs
+++ b/src/DotVVM.Framework/Runtime/Commands/InvalidCommandInvocationException.cs
@@ -5,7 +5,7 @@ namespace DotVVM.Framework.Runtime.Commands
 {
     public class InvalidCommandInvocationException : Exception
     {
-        public Dictionary<string, string> AdditionData { get; set; }
+        public Dictionary<string, string[]> AdditionData { get; set; }
 
         public InvalidCommandInvocationException(string message)
             : base(message)
@@ -30,10 +30,10 @@ namespace DotVVM.Framework.Runtime.Commands
         {
             if(data != null)
             {
-                AdditionData = new Dictionary<string, string>();
+                AdditionData = new Dictionary<string, string[]>();
                 foreach (var bindings in data)
                 {
-                    AdditionData.Add(bindings.Key, bindings.Value.ToString());
+                    AdditionData.Add(bindings.Key, bindings.Value.BindingsToString());
                 }
             }
 

--- a/src/DotVVM.Framework/Runtime/Commands/InvalidCommandInvocationException.cs
+++ b/src/DotVVM.Framework/Runtime/Commands/InvalidCommandInvocationException.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+
+namespace DotVVM.Framework.Runtime.Commands
+{
+    public class InvalidCommandInvocationException : Exception
+    {
+        public Dictionary<string, string> AdditionData { get; set; }
+
+        public InvalidCommandInvocationException(string message)
+            : base(message)
+        {
+            
+        }
+
+        public InvalidCommandInvocationException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+            
+        }
+
+        public InvalidCommandInvocationException(string message, Dictionary<string, CandidateBindings> data)
+            : this(message, (Exception) null, data)
+        {
+
+        }
+
+        public InvalidCommandInvocationException(string message, Exception innerException, Dictionary<string, CandidateBindings> data)
+            : base(message, innerException)
+        {
+            if(data != null)
+            {
+                AdditionData = new Dictionary<string, string>();
+                foreach (var bindings in data)
+                {
+                    AdditionData.Add(bindings.Key, bindings.Value.ToString());
+                }
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
Added properties with information about commands on the page to exception thrown when invoking invalid command. Properties contain key which describes the group of bindings and command bindings that did not match path, binding id or validation path with information why the validation failed.

Problem is described in https://github.com/riganti/dotvvm/issues/315.

![invalid-command](https://user-images.githubusercontent.com/23234718/28429797-47245be6-6d7e-11e7-9816-2e28e82987a1.png)
