### PR TITLE
Onclick attribute rendering

### DIFF
--- a/src/DotVVM.Framework/Controls/Button.cs
+++ b/src/DotVVM.Framework/Controls/Button.cs
@@ -70,11 +70,6 @@ namespace DotVVM.Framework.Controls
             }
             writer.AddAttribute("type", IsSubmitButton ? "submit" : "button");
 
-            var clickBinding = GetCommandBinding(ClickProperty);
-            if (clickBinding != null)
-            {
-                writer.AddAttribute("onclick", KnockoutHelper.GenerateClientPostBackScript(nameof(Click), clickBinding, this));
-            }
 
             writer.AddKnockoutDataBind(ButtonTagName == ButtonTagName.input ? "value" : "text", this, TextProperty, () =>
             {
@@ -99,6 +94,12 @@ namespace DotVVM.Framework.Controls
             });
 
             base.AddAttributesToRender(writer, context);
+
+            var clickBinding = GetCommandBinding(ClickProperty);
+            if (clickBinding != null)
+            {
+                writer.AddAttribute("onclick", KnockoutHelper.GenerateClientPostBackScript(nameof(Click), clickBinding, this), true, ";");
+            }
         }
 
         protected override void RenderBeginTag(IHtmlWriter writer, IDotvvmRequestContext context)

--- a/src/DotVVM.Framework/Controls/LinkButton.cs
+++ b/src/DotVVM.Framework/Controls/LinkButton.cs
@@ -28,15 +28,16 @@ namespace DotVVM.Framework.Controls
 
             writer.AddAttribute("href", "#");
 
-            var clickBinding = GetCommandBinding(ClickProperty);
-            if (clickBinding != null)
-            {
-                writer.AddAttribute("onclick", KnockoutHelper.GenerateClientPostBackScript(nameof(Click), clickBinding, this));
-            }
 			var textbinding = GetValueBinding(TextProperty);
 			if (textbinding != null) writer.AddKnockoutDataBind("text", textbinding.GetKnockoutBindingExpression(this));
             
             base.AddAttributesToRender(writer, context);
+
+            var clickBinding = GetCommandBinding(ClickProperty);
+            if (clickBinding != null)
+            {
+                writer.AddAttribute("onclick", KnockoutHelper.GenerateClientPostBackScript(nameof(Click), clickBinding, this), true, ";");
+            }
         }
 
         /// <summary>

--- a/src/DotVVM.Framework/Controls/MultiSelectHtmlControlBase.cs
+++ b/src/DotVVM.Framework/Controls/MultiSelectHtmlControlBase.cs
@@ -24,10 +24,11 @@ namespace DotVVM.Framework.Controls
             RenderMultipleAttribute(writer);
             RenderEnabledProperty(writer);
             RenderOptionsProperties(writer);
-            RenderChangedEvent(writer);
             RenderSelectedValueProperty(writer);
 
             base.AddAttributesToRender(writer, context);
+
+            RenderChangedEvent(writer);
         }
 
         protected virtual void RenderMultipleAttribute(IHtmlWriter writer)

--- a/src/DotVVM.Framework/Controls/SelectHtmlControlBase.cs
+++ b/src/DotVVM.Framework/Controls/SelectHtmlControlBase.cs
@@ -31,10 +31,11 @@ namespace DotVVM.Framework.Controls
         {
             RenderEnabledProperty(writer);
             RenderOptionsProperties(writer);
-            RenderChangedEvent(writer);
             RenderSelectedValueProperty(writer);
 
             base.AddAttributesToRender(writer, context);
+
+            RenderChangedEvent(writer);
         }
 
         protected virtual void RenderEnabledProperty(IHtmlWriter writer)

--- a/src/DotVVM.Framework/Controls/SelectHtmlControlHelpers.cs
+++ b/src/DotVVM.Framework/Controls/SelectHtmlControlHelpers.cs
@@ -45,7 +45,7 @@ namespace DotVVM.Framework.Controls
             var selectionChangedBinding = selector.GetCommandBinding(SelectorBase.SelectionChangedProperty);
             if (selectionChangedBinding != null)
             {
-                writer.AddAttribute("onchange", KnockoutHelper.GenerateClientPostBackScript(nameof(SelectorBase.SelectionChanged), selectionChangedBinding, selector, isOnChange: true, useWindowSetTimeout: true));
+                writer.AddAttribute("onchange", KnockoutHelper.GenerateClientPostBackScript(nameof(SelectorBase.SelectionChanged), selectionChangedBinding, selector, isOnChange: true, useWindowSetTimeout: true), true, ";");
             }
         }
     }

--- a/src/DotVVM.Framework/Controls/TextBox.cs
+++ b/src/DotVVM.Framework/Controls/TextBox.cs
@@ -210,13 +210,14 @@ namespace DotVVM.Framework.Controls
         {
             // prepare changed event attribute
             var changedBinding = GetCommandBinding(ChangedProperty);
+
+            base.AddAttributesToRender(writer, context);
+
             if (changedBinding != null)
             {
                 writer.AddAttribute("onchange", KnockoutHelper.GenerateClientPostBackScript(nameof(Changed), 
-                    changedBinding, this, useWindowSetTimeout: true, isOnChange: true));
+                    changedBinding, this, useWindowSetTimeout: true, isOnChange: true), true, ";");
             }
-
-            base.AddAttributesToRender(writer, context);
         }
 
         private void AddSelectAllOnFocusPropertyToRender(IHtmlWriter writer, IDotvvmRequestContext context)

--- a/src/DotVVM.Samples.ApplicationInsingts.Owin/ApplicationInsights.config
+++ b/src/DotVVM.Samples.ApplicationInsingts.Owin/ApplicationInsights.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings">
-  <InstrumentationKey>a03d74c6-1d9e-4a8e-b77a-9da312846cf2</InstrumentationKey>
+  <!--<InstrumentationKey>a03d74c6-1d9e-4a8e-b77a-9da312846cf2</InstrumentationKey>-->
 	<TelemetryInitializers>
 	  <Add Type="ApplicationInsights.OwinExtensions.OperationIdTelemetryInitializer, ApplicationInsights.OwinExtensions"/>
 	  <Add Type="Microsoft.ApplicationInsights.DependencyCollector.HttpDependenciesParsingTelemetryInitializer, Microsoft.AI.DependencyCollector"/>

--- a/src/DotVVM.Samples.ApplicationInsingts.Owin/ApplicationInsights.config
+++ b/src/DotVVM.Samples.ApplicationInsingts.Owin/ApplicationInsights.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings">
-  <!--<InstrumentationKey>a03d74c6-1d9e-4a8e-b77a-9da312846cf2</InstrumentationKey>-->
+  <InstrumentationKey>a03d74c6-1d9e-4a8e-b77a-9da312846cf2</InstrumentationKey>
 	<TelemetryInitializers>
 	  <Add Type="ApplicationInsights.OwinExtensions.OperationIdTelemetryInitializer, ApplicationInsights.OwinExtensions"/>
 	  <Add Type="Microsoft.ApplicationInsights.DependencyCollector.HttpDependenciesParsingTelemetryInitializer, Microsoft.AI.DependencyCollector"/>

--- a/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
+++ b/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
@@ -17,9 +17,11 @@
   <ItemGroup>
     <None Remove="Views\ComplexSamples\CascadeSelectors\TripleComboBoxes.dothtml" />
     <None Remove="Views\ComplexSamples\GridViewDataSet\GridViewDataSetDelegate.dothtml" />
+    <None Remove="Views\ControlSamples\Button\ButtonOnclick.dothtml" />
     <None Remove="Views\ControlSamples\ComboBox\ComboBoxDelaySync.dothtml" />
     <None Remove="Views\ControlSamples\ComboBox\ComboBoxDelaySync2.dothtml" />
     <None Remove="Views\ControlSamples\IncludeInPageProperty\IncludeInPage.dothtml" />
+    <None Remove="Views\ControlSamples\LinkButton\LinkButtonOnclick.dothtml" />
     <None Remove="Views\ControlSamples\TextBox\SelectAllOnFocus.dothtml" />
     <None Remove="Views\FeatureSamples\ActionFilterErrorHandling\ActionFilterRedirect.dothtml" />
     <None Remove="Views\FeatureSamples\Api\GetCollection.dothtml" />
@@ -41,9 +43,11 @@
     <Content Include="Scripts\testResource2.js" />
     <Content Include="Views\ComplexSamples\CascadeSelectors\TripleComboBoxes.dothtml" />
     <Content Include="Views\ComplexSamples\GridViewDataSet\GridViewDataSetDelegate.dothtml" />
+    <Content Include="Views\ControlSamples\Button\ButtonOnclick.dothtml" />
     <Content Include="Views\ControlSamples\ComboBox\ComboBoxDelaySync.dothtml" />
     <Content Include="Views\ControlSamples\ComboBox\ComboBoxDelaySync2.dothtml" />
     <Content Include="Views\ControlSamples\IncludeInPageProperty\IncludeInPage.dothtml" />
+    <Content Include="Views\ControlSamples\LinkButton\LinkButtonOnclick.dothtml" />
     <Content Include="Views\ControlSamples\TextBox\SelectAllOnFocus.dothtml" />
     <Content Include="Views\FeatureSamples\ActionFilterErrorHandling\ActionFilterRedirect.dothtml" />
     <Content Include="Views\FeatureSamples\Api\GetCollection.dothtml" />

--- a/src/DotVVM.Samples.Common/ViewModels/ControlSamples/Button/ButtonOnclickViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/ControlSamples/Button/ButtonOnclickViewModel.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.ControlSamples.Button
+{
+	public class ButtonOnclickViewModel : DotvvmViewModelBase
+	{
+        public string Result { get; set; }
+
+	    public ButtonOnclickViewModel()
+	    {
+	        Result = "";
+	    }
+
+	    public void ChangeResult()
+	    {
+	        Result = "Changed from command binding";
+	    }
+	}
+}
+

--- a/src/DotVVM.Samples.Common/Views/ControlSamples/Button/ButtonOnclick.dothtml
+++ b/src/DotVVM.Samples.Common/Views/ControlSamples/Button/ButtonOnclick.dothtml
@@ -1,0 +1,20 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.ControlSamples.Button.ButtonOnclickViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+    <dot:Button id="Click1" Text="Click test" Click="{command: ChangeResult()}" onclick="getElementById('result').innerHTML+='Changed from onclick'" />
+
+    
+    <span id="result" class="result1">{{value: Result}}</span>
+    <span class="result2">{{value: Result}}</span>
+
+</body>
+</html>
+
+

--- a/src/DotVVM.Samples.Common/Views/ControlSamples/LinkButton/LinkButtonOnclick.dothtml
+++ b/src/DotVVM.Samples.Common/Views/ControlSamples/LinkButton/LinkButtonOnclick.dothtml
@@ -1,0 +1,21 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.ControlSamples.Button.ButtonOnclickViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+    <dot:LinkButton id="LinkButton" Text="Click test" Click="{command: ChangeResult()}" onclick="getElementById('result').innerHTML+='Changed from onclick'" />
+
+
+    <span id="result" class="result1">{{value: Result}}</span>
+    <span class="result2">{{value: Result}}</span>
+
+
+</body>
+</html>
+
+

--- a/src/DotVVM.Samples.Tests/Control/ButtonTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/ButtonTests.cs
@@ -76,5 +76,21 @@ namespace DotVVM.Samples.Tests.Control
             });
         }
 
+        [TestMethod]
+        public void Control_Button_ButtonOnClick()
+        {
+            RunInAllBrowsers(browser =>
+            {
+                browser.NavigateToUrl(SamplesRouteUrls.ControlSamples_Button_ButtonOnclick);
+                var onclickResult = browser.First("span.result1").Check();
+                var clickResult = browser.First("span.result2").Check();
+                clickResult.InnerText(s => s.Equals(""));
+                onclickResult.InnerText(s => s.Equals(""));
+
+                browser.First("input[type=button]").Click();
+                clickResult.InnerText(s => s.Equals("Changed from command binding"));
+                onclickResult.InnerText(s => s.Contains("Changed from onclick"));
+            });
+        }
     }
 }

--- a/src/DotVVM.Samples.Tests/Control/LinkButtonTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/LinkButtonTests.cs
@@ -42,5 +42,22 @@ namespace DotVVM.Samples.Tests.Control
                 browser.Last("span").CheckIfInnerTextEquals("1");
             });
         }
+
+        [TestMethod]
+        public void Control_LinkButton_LinkButtonOnClick()
+        {
+            RunInAllBrowsers(browser =>
+            {
+                browser.NavigateToUrl(SamplesRouteUrls.ControlSamples_LinkButton_LinkButtonOnclick);
+                var onclickResult = browser.First("span.result1").Check();
+                var clickResult = browser.First("span.result2").Check();
+                clickResult.InnerText(s => s.Equals(""));
+                onclickResult.InnerText(s => s.Equals(""));
+
+                browser.Click("#LinkButton");
+                clickResult.InnerText(s => s.Equals("Changed from command binding"));
+                onclickResult.InnerText(s => s.Contains("Changed from onclick"));
+            });
+        }
     }
 }

--- a/src/DotVVM.Samples.Tests/SamplesRouteUrls.cs
+++ b/src/DotVVM.Samples.Tests/SamplesRouteUrls.cs
@@ -59,6 +59,10 @@ namespace Dotvvm.Samples.Tests{
 
             public static string ControlSamples_Button_Button => "ControlSamples/Button/Button";
 
+            public static string ControlSamples_Button_ButtonOnclick => "ControlSamples/Button/ButtonOnclick";
+
+            public static string ControlSamples_LinkButton_LinkButtonOnclick => "ControlSamples/LinkButton/LinkButtonOnclick";
+
             public static string ControlSamples_Button_ButtonTagName => "ControlSamples/Button/ButtonTagName";
 
             public static string ControlSamples_Button_InputTypeButton_HtmlContentInside => "ControlSamples/Button/InputTypeButton_HtmlContentInside";


### PR DESCRIPTION
- Changed the order of rendering `onclick` attributes in `Button`, `LinkButton` and added tests cases for that. 
- Also changed the order with `onchanged` attributes in `TextBox`, `SelectHtmlControlBase` and `MultiSelectHtmlControlBase`. 
- There is also `onclick` attribute in `CheckableControlBase` but the order is correct in that control.
- Issue https://github.com/riganti/dotvvm/issues/357