### PR TITLE
Tests for server-side styles

### DIFF
--- a/src/DotVVM.Samples.Common/Controls/DerivedControl.cs
+++ b/src/DotVVM.Samples.Common/Controls/DerivedControl.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Controls;
+
+namespace DotVVM.Samples.BasicSamples.Controls
+{
+    public class DerivedControl : ServerSideStylesControl
+    {
+    }
+}

--- a/src/DotVVM.Samples.Common/Controls/ServerSideStylesControl.cs
+++ b/src/DotVVM.Samples.Common/Controls/ServerSideStylesControl.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Hosting;
+
+namespace DotVVM.Samples.BasicSamples.Controls
+{
+    public class ServerSideStylesControl : HtmlGenericControl
+    {
+        public string Added
+        {
+            get { return Convert.ToString(GetValue(CustomProperty)); }
+            set { SetValue(CustomProperty, value); }
+        }
+
+        public static readonly DotvvmProperty AddedProperty =
+            DotvvmProperty.Register<string, ServerSideStylesControl>(t => t.Added, "");
+
+        public string Custom
+        {
+            get { return Convert.ToString(GetValue(CustomProperty)); }
+            set { SetValue(CustomProperty, value); }
+        }
+
+        [MarkupOptions(AllowBinding = true)]
+        public static readonly DotvvmProperty CustomProperty =
+            DotvvmProperty.Register<string, ServerSideStylesControl>(t => t.Custom, "");
+
+        public ServerSideStylesControl() : base("input")
+        {
+        }
+
+        protected override void AddAttributesToRender(IHtmlWriter writer, IDotvvmRequestContext context)
+        {
+            writer.AddAttribute("type", "button");
+
+            AddCustomAttributes(writer);
+            base.AddAttributesToRender(writer, context);
+        }
+
+        private void AddCustomAttributes(IHtmlWriter writer)
+        {
+            var customBinding = GetValueBinding(CustomProperty);
+            if (customBinding != null)
+            {
+                writer.AddKnockoutDataBind("customAttr", this, CustomProperty);
+            }
+            else
+            {
+                // render the value in the HTML
+                writer.AddAttribute("customAttr", Custom);
+            }
+        }
+    }
+}

--- a/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
+++ b/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
@@ -40,6 +40,8 @@
     <None Remove="Views\FeatureSamples\MarkupControl\HierarchyControlPage.dothtml" />
     <None Remove="Views\FeatureSamples\MarkupControl\MultiControlHierarchy.dothtml" />
     <None Remove="Views\FeatureSamples\ParameterBinding\ParameterBinding.dothtml" />
+    <None Remove="Views\FeatureSamples\ServerSideStyles\ServerSideStyles.dothtml" />
+    <None Remove="Views\FeatureSamples\ServerSideStyles\ServerSideStyles_DotvvmProperties.dothtml" />
     <None Remove="Views\FeatureSamples\StaticCommand\StaticCommand_ComboBoxSelectionChanged.dothtml" />
     <None Remove="Views\FeatureSamples\StaticCommand\StaticCommand_ComboBoxSelectionChanged_Objects.dothtml" />
     <None Remove="Views\FeatureSamples\ViewModelProtection\ComplexViewModelProtection.dothtml" />
@@ -78,6 +80,8 @@
     <Content Include="Views\FeatureSamples\MarkupControl\HierarchyControlPage.dothtml" />
     <Content Include="Views\FeatureSamples\MarkupControl\MultiControlHierarchy.dothtml" />
     <Content Include="Views\FeatureSamples\ParameterBinding\ParameterBinding.dothtml" />
+    <Content Include="Views\FeatureSamples\ServerSideStyles\ServerSideStyles.dothtml" />
+    <Content Include="Views\FeatureSamples\ServerSideStyles\ServerSideStyles_DotvvmProperties.dothtml" />
     <Content Include="Views\FeatureSamples\StaticCommand\StaticCommand_ComboBoxSelectionChanged.dothtml" />
     <Content Include="Views\FeatureSamples\StaticCommand\StaticCommand_ComboBoxSelectionChanged_Objects.dothtml" />
     <Content Include="Views\FeatureSamples\ViewModelProtection\ComplexViewModelProtection.dothtml" />

--- a/src/DotVVM.Samples.Common/DotvvmStartup.cs
+++ b/src/DotVVM.Samples.Common/DotvvmStartup.cs
@@ -1,10 +1,14 @@
+using System.Linq;
 using System.Reflection;
+using DotVVM.Framework.Binding;
 using DotVVM.Framework.Compilation.Parser;
 using DotVVM.Framework.Configuration;
+using DotVVM.Framework.Controls;
 using DotVVM.Framework.ResourceManagement;
 using DotVVM.Framework.Routing;
 using DotVVM.Framework.ViewModel;
 using DotVVM.Framework.ViewModel.Serialization;
+using DotVVM.Samples.BasicSamples.Controls;
 using DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.Redirect;
 using DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.Serialization;
 
@@ -17,6 +21,7 @@ namespace DotVVM.Samples.BasicSamples
             config.DefaultCulture = "en-US";
 
             AddControls(config);
+            AddStyles(config);
 
             AddRoutes(config);
 
@@ -71,6 +76,21 @@ namespace DotVVM.Samples.BasicSamples
 
         }
 
+        public static void AddStyles(DotvvmConfiguration config)
+        {
+            config.Styles.Register<Controls.ServerSideStylesControl>()
+                .SetAttribute("value", "Text changed")
+                .SetDotvvmProperty(Controls.ServerSideStylesControl.CustomProperty, "Custom property changed", false)
+                .SetAttribute("class", "Class changed", true);
+            config.Styles.Register("customTagName")
+                .SetAttribute("noAppend", "Attribute changed")
+                .SetAttribute("append", "Attribute changed", true);
+            config.Styles.Register<Controls.ServerSideStylesControl>(c => c.HasProperty(Controls.ServerSideStylesControl.CustomProperty), false)
+                .SetAttribute("derivedAttr", "Derived attribute");
+            config.Styles.Register<Controls.ServerSideStylesControl>(c => c.HasProperty(Controls.ServerSideStylesControl.AddedProperty))
+                .SetAttribute("addedAttr", "Added attribute");
+        }
+
         private static void AddRoutes(DotvvmConfiguration config)
         {
             config.RouteTable.Add("Default", "", "Views/Default.dothtml");
@@ -87,6 +107,8 @@ namespace DotVVM.Samples.BasicSamples
 
         private static void AddControls(DotvvmConfiguration config)
         {
+            config.Markup.AddCodeControls("cc", typeof(Controls.ServerSideStylesControl));
+            config.Markup.AddCodeControls("cc", typeof(Controls.DerivedControl));
             config.Markup.AddCodeControls("PropertyUpdate", typeof(Controls.ServerRenderedLabel));
             config.Markup.AddCodeControls("cc", typeof(Controls.PromptButton));
             config.Markup.AddMarkupControl("IdGeneration", "Control", "Views/FeatureSamples/IdGeneration/IdGeneration_control.dotcontrol");

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/ServerSideStyles/ServerSideStylesViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/ServerSideStyles/ServerSideStylesViewModel.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.ServerSideStyles
+{
+	public class ServerSideStylesViewModel : DotvvmViewModelBase
+	{
+	    public string CustomPropertyText { get; set; } = "Default value";
+	}
+}
+

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/ServerSideStyles/ServerSideStyles.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/ServerSideStyles/ServerSideStyles.dothtml
@@ -1,0 +1,33 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.ServerSideStyles.ServerSideStylesViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+    <div>
+        <cc:ServerSideStylesControl id="dotvvmControlNoAttr" />
+        <br />
+        <cc:ServerSideStylesControl id="dotvvmControlWithAttr"
+                                    value="Default text"
+                                    class="Default class" />
+    </div>
+    <div>
+        <customTagName id="htmlControlNoAttr">
+            Custom html control with no default attributes
+        </customTagName>
+        <br />
+
+        <customTagName id="htmlControlWithAttr"
+                       append="Default attribute"
+                       noAppend="Default attribute">
+            Custom html control with default attributes
+        </customTagName>
+    </div>
+
+</body>
+</html>
+

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/ServerSideStyles/ServerSideStyles_DotvvmProperties.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/ServerSideStyles/ServerSideStyles_DotvvmProperties.dothtml
@@ -1,0 +1,23 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.ServerSideStyles.ServerSideStylesViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+    <div>
+        <cc:ServerSideStylesControl id="dotvvmControlNoAttr" />
+        <br />
+        <cc:ServerSideStylesControl id="dotvvmControlWithAttr"
+                                    Custom="Default value"
+                                    Added=""/>
+        <cc:DerivedControl id="derivedControl"
+                           Added="" />
+    </div>
+</body>
+</html>
+
+

--- a/src/DotVVM.Samples.Tests/Feature/ServerSideStylesTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/ServerSideStylesTests.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Dotvvm.Samples.Tests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Riganti.Utils.Testing.Selenium.Core;
+
+namespace DotVVM.Samples.Tests.Feature
+{
+    [TestClass]
+    public class ServerSideStylesTests : SeleniumTest
+    {
+        [TestMethod]
+        public void Feature_ServerSideStyles_DotvvmContolNoAttributes()
+        {
+            RunInAllBrowsers(browser =>
+            {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_ServerSideStyles_ServerSideStyles);
+                browser.First("input[id=dotvvmControlNoAttr]").CheckClassAttribute("Class changed");
+                browser.First("input[id=dotvvmControlNoAttr]").CheckIfTextEquals("Text changed");
+            });
+        }
+
+        [TestMethod]
+        public void Feature_ServerSideStyles_DotvvmContolWithAttributes()
+        {
+            RunInAllBrowsers(browser =>
+            {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_ServerSideStyles_ServerSideStyles);
+                browser.First("input[id=dotvvmControlWithAttr]").CheckClassAttribute("Class changed");
+                browser.First("input[id=dotvvmControlWithAttr]").CheckIfTextEquals("Default text");
+            });
+        }
+
+        [TestMethod]
+        public void Feature_ServerSideStyles_HtmlContolNoAttributes()
+        {
+            RunInAllBrowsers(browser =>
+            {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_ServerSideStyles_ServerSideStyles);
+                browser.First("customTagName[id=htmlControlNoAttr]").CheckAttribute("append", "Attribute changed");
+                browser.First("customTagName[id=htmlControlNoAttr]").CheckAttribute("noAppend", "Attribute changed");
+            });
+        }
+
+        [TestMethod]
+        public void Feature_ServerSideStyles_HtmlControlWithAttributes()
+        {
+            RunInAllBrowsers(browser =>
+            {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_ServerSideStyles_ServerSideStyles);
+                browser.First("customTagName[id=htmlControlWithAttr]").CheckAttribute("append", "Attribute changed");
+                browser.First("customTagName[id=htmlControlWithAttr]").CheckAttribute("noAppend", "Default attribute");
+            });
+        }
+
+
+        [TestMethod]
+        public void Feature_ServerSideStyles_DotvvmControlProperties()
+        {
+            RunInAllBrowsers(browser =>
+            {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_ServerSideStyles_ServerSideStyles_DotvvmProperties);
+                browser.First("input[id=dotvvmControlWithAttr]").CheckAttribute("customAttr", "Default value");
+                browser.First("input[id=dotvvmControlNoAttr]").CheckAttribute("customAttr", "Custom property changed");
+            });
+        }
+
+        [TestMethod]
+        public void Feature_ServerSideStyles_DerivedMatcher()
+        {
+            RunInAllBrowsers(browser =>
+            {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_ServerSideStyles_ServerSideStyles_DotvvmProperties);
+                browser.First("input[id=dotvvmControlWithAttr]").CheckIfHasAttribute("derivedAttr");
+                browser.First("input[id=dotvvmControlNoAttr]").CheckIfHasAttribute("derivedAttr");
+                browser.First("input[id=derivedControl]").CheckIfHasNotAttribute("derivedAttr");
+            });
+        }
+
+        [TestMethod]
+        public void Feature_ServerSideStyles_Matcher()
+        {
+            RunInAllBrowsers(browser =>
+            {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_ServerSideStyles_ServerSideStyles_DotvvmProperties);
+                browser.First("input[id=dotvvmControlWithAttr]").CheckIfHasAttribute("addedAttr");
+                browser.First("input[id=dotvvmControlNoAttr]").CheckIfHasNotAttribute("addedAttr");
+                browser.First("input[id=derivedControl]").CheckIfHasAttribute("addedAttr");
+            });
+        }
+    }
+}

--- a/src/DotVVM.Samples.Tests/SamplesRouteUrls.cs
+++ b/src/DotVVM.Samples.Tests/SamplesRouteUrls.cs
@@ -2,8 +2,8 @@
 
 namespace Dotvvm.Samples.Tests{
     public class SamplesRouteUrls{
-        
-            public static string Default => "Default";
+
+        public static string Default => "Default";
 
             public static string ComplexSamples_Auth_Login => "ComplexSamples/Auth/Login";
 
@@ -330,6 +330,10 @@ namespace Dotvvm.Samples.Tests{
             public static string FeatureSamples_Serialization_Serialization => "FeatureSamples/Serialization/Serialization";
 
             public static string FeatureSamples_ServerComments_ServerComments => "FeatureSamples/ServerComments/ServerComments";
+
+            public static string FeatureSamples_ServerSideStyles_ServerSideStyles => "FeatureSamples/ServerSideStyles/ServerSideStyles";
+
+            public static string FeatureSamples_ServerSideStyles_ServerSideStyles_DotvvmProperties => "FeatureSamples/ServerSideStyles/ServerSideStyles_DotvvmProperties";
 
             public static string FeatureSamples_StaticCommand_StaticCommand => "FeatureSamples/StaticCommand/StaticCommand";
 


### PR DESCRIPTION
Added tests for server-side styles:

- I used `ServerSideStylesControl` and `DerivedControl` which are Code-only controls so the styles do not disrupt other controls
- I used `customTagName` for testing HTML elemets
- Issue https://github.com/riganti/dotvvm/issues/399