### PR TITLE
Feature: FormControls.Enabled

### DIFF
--- a/src/DotVVM.Framework/Binding/CustomDefaultProperty.cs
+++ b/src/DotVVM.Framework/Binding/CustomDefaultProperty.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using DotVVM.Framework.Controls;
+
+namespace DotVVM.Framework.Binding
+{
+    public class CustomDefaultProperty : DotvvmProperty
+    {
+        /// <summary>
+        /// Gets the property whose value this property will default to if it is not set
+        /// </summary>
+        public DotvvmProperty DefaultProperty { get; protected set; }
+
+        /// <summary>
+        /// Gets whether the value of the default property when can be inherited from the parent controls.
+        /// </summary>
+        public bool DefaultPropertyInherit { get; protected set; }
+
+        /// <summary>
+        /// Gets the value of the property.
+        /// </summary>
+        public override object GetValue(DotvvmBindableObject control, bool inherit = true)
+        {
+            object value;
+            if (control.properties != null)
+            {
+                if (control.properties.TryGetValue(this, out value))
+                {
+                    return value;
+                }
+            }
+            if (IsValueInherited && inherit && control.Parent != null)
+            {
+                return GetValue(control.Parent);
+            }
+
+            return DefaultProperty.GetValue(control, DefaultPropertyInherit);
+        }
+
+        /// <summary>
+        /// Gets whether the value of the property is set
+        /// </summary>
+        public override bool IsSet(DotvvmBindableObject control, bool inherit = true)
+        {
+            if (control.properties != null && control.properties.ContainsKey(this))
+            {
+                return true;
+            }
+
+            if (IsValueInherited && inherit && control.Parent != null)
+            {
+                return IsSet(control.Parent);
+            }
+
+            return DefaultProperty.IsSet(control, DefaultPropertyInherit);
+        }
+
+        /// <summary>
+        /// Registers the specified DotVVM property.
+        /// </summary>
+        public static CustomDefaultProperty Register<TPropertyType, TDeclaringType>(string propertyName, DotvvmProperty defaultProperty, bool defaultPropertyInherit, bool isValueInherited = false)
+        {
+            var property = new CustomDefaultProperty() { DefaultProperty = defaultProperty, DefaultPropertyInherit = defaultPropertyInherit };
+            return DotvvmProperty.Register<TPropertyType, TDeclaringType>(propertyName, isValueInherited: isValueInherited, property: property) as CustomDefaultProperty;
+        }
+    }
+}

--- a/src/DotVVM.Framework/Binding/CustomDefaultProperty.cs
+++ b/src/DotVVM.Framework/Binding/CustomDefaultProperty.cs
@@ -5,6 +5,9 @@ using DotVVM.Framework.Controls;
 
 namespace DotVVM.Framework.Binding
 {
+    /// <summary>
+    /// A DotvvmProperty that defaults to another DotvvmProperty's value
+    /// </summary>
     public class CustomDefaultProperty : DotvvmProperty
     {
         /// <summary>

--- a/src/DotVVM.Framework/Binding/DotvvmPropertyWithFallback.cs
+++ b/src/DotVVM.Framework/Binding/DotvvmPropertyWithFallback.cs
@@ -8,7 +8,7 @@ namespace DotVVM.Framework.Binding
     /// <summary>
     /// A DotvvmProperty that defaults to another DotvvmProperty's value
     /// </summary>
-    public class CustomDefaultProperty : DotvvmProperty
+    public class DotvvmPropertyWithFallback : DotvvmProperty
     {
         /// <summary>
         /// Gets the property whose value this property will default to if it is not set
@@ -62,10 +62,10 @@ namespace DotVVM.Framework.Binding
         /// <summary>
         /// Registers the specified DotVVM property.
         /// </summary>
-        public static CustomDefaultProperty Register<TPropertyType, TDeclaringType>(string propertyName, DotvvmProperty defaultProperty, bool defaultPropertyInherit, bool isValueInherited = false)
+        public static DotvvmPropertyWithFallback Register<TPropertyType, TDeclaringType>(string propertyName, DotvvmProperty defaultProperty, bool defaultPropertyInherit, bool isValueInherited = false)
         {
-            var property = new CustomDefaultProperty() { DefaultProperty = defaultProperty, DefaultPropertyInherit = defaultPropertyInherit };
-            return DotvvmProperty.Register<TPropertyType, TDeclaringType>(propertyName, isValueInherited: isValueInherited, property: property) as CustomDefaultProperty;
+            var property = new DotvvmPropertyWithFallback() { DefaultProperty = defaultProperty, DefaultPropertyInherit = defaultPropertyInherit };
+            return DotvvmProperty.Register<TPropertyType, TDeclaringType>(propertyName, isValueInherited: isValueInherited, property: property) as DotvvmPropertyWithFallback;
         }
     }
 }

--- a/src/DotVVM.Framework/Controls/ButtonBase.cs
+++ b/src/DotVVM.Framework/Controls/ButtonBase.cs
@@ -47,7 +47,7 @@ namespace DotVVM.Framework.Controls
             set {  SetValue(EnabledProperty, value); }
         }
         public static readonly DotvvmProperty EnabledProperty =
-            CustomDefaultProperty.Register<bool, ButtonBase>(nameof(Enabled),
+            DotvvmPropertyWithFallback.Register<bool, ButtonBase>(nameof(Enabled),
                 FormControls.EnabledProperty, defaultPropertyInherit: true);
 
 

--- a/src/DotVVM.Framework/Controls/ButtonBase.cs
+++ b/src/DotVVM.Framework/Controls/ButtonBase.cs
@@ -46,9 +46,9 @@ namespace DotVVM.Framework.Controls
             get { return (bool)GetValue(EnabledProperty); }
             set {  SetValue(EnabledProperty, value); }
         }
-        public static readonly DotvvmProperty EnabledProperty =
-            DotvvmProperty.Register<bool, ButtonBase>(t => t.Enabled, true);
-
+        public static readonly DotvvmProperty EnabledProperty = 
+            CustomDefaultProperty.Register<bool, ButtonBase>("Enabled", 
+                FormControls.EnabledProperty, defaultPropertyInherit: true);
 
 
         /// <summary>

--- a/src/DotVVM.Framework/Controls/ButtonBase.cs
+++ b/src/DotVVM.Framework/Controls/ButtonBase.cs
@@ -46,8 +46,8 @@ namespace DotVVM.Framework.Controls
             get { return (bool)GetValue(EnabledProperty); }
             set {  SetValue(EnabledProperty, value); }
         }
-        public static readonly DotvvmProperty EnabledProperty = 
-            CustomDefaultProperty.Register<bool, ButtonBase>("Enabled", 
+        public static readonly DotvvmProperty EnabledProperty =
+            CustomDefaultProperty.Register<bool, ButtonBase>(nameof(Enabled),
                 FormControls.EnabledProperty, defaultPropertyInherit: true);
 
 

--- a/src/DotVVM.Framework/Controls/CheckableControlBase.cs
+++ b/src/DotVVM.Framework/Controls/CheckableControlBase.cs
@@ -59,7 +59,7 @@ namespace DotVVM.Framework.Controls
         }
 
         public static readonly DotvvmProperty EnabledProperty =
-            CustomDefaultProperty.Register<bool, CheckableControlBase>(nameof(Enabled),
+            DotvvmPropertyWithFallback.Register<bool, CheckableControlBase>(nameof(Enabled),
                 FormControls.EnabledProperty, defaultPropertyInherit: true);
 
         /// <summary>

--- a/src/DotVVM.Framework/Controls/CheckableControlBase.cs
+++ b/src/DotVVM.Framework/Controls/CheckableControlBase.cs
@@ -58,8 +58,9 @@ namespace DotVVM.Framework.Controls
             set { SetValue(EnabledProperty, value); }
         }
 
-        public static readonly DotvvmProperty EnabledProperty =
-            DotvvmProperty.Register<bool, CheckableControlBase>(t => t.Enabled, true);
+        public static readonly DotvvmProperty EnabledProperty = 
+            CustomDefaultProperty.Register<bool, CheckableControlBase>("Enabled", 
+                FormControls.EnabledProperty, defaultPropertyInherit: true);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CheckableControlBase"/> class.

--- a/src/DotVVM.Framework/Controls/CheckableControlBase.cs
+++ b/src/DotVVM.Framework/Controls/CheckableControlBase.cs
@@ -58,8 +58,8 @@ namespace DotVVM.Framework.Controls
             set { SetValue(EnabledProperty, value); }
         }
 
-        public static readonly DotvvmProperty EnabledProperty = 
-            CustomDefaultProperty.Register<bool, CheckableControlBase>("Enabled", 
+        public static readonly DotvvmProperty EnabledProperty =
+            CustomDefaultProperty.Register<bool, CheckableControlBase>(nameof(Enabled),
                 FormControls.EnabledProperty, defaultPropertyInherit: true);
 
         /// <summary>

--- a/src/DotVVM.Framework/Controls/DataPager.cs
+++ b/src/DotVVM.Framework/Controls/DataPager.cs
@@ -134,7 +134,7 @@ namespace DotVVM.Framework.Controls
             set { SetValue(EnabledProperty, value); }
         }
         public static readonly DotvvmProperty EnabledProperty =
-            CustomDefaultProperty.Register<bool, DataPager>(nameof(Enabled),
+            DotvvmPropertyWithFallback.Register<bool, DataPager>(nameof(Enabled),
                 FormControls.EnabledProperty, defaultPropertyInherit: true);
 
 

--- a/src/DotVVM.Framework/Controls/DataPager.cs
+++ b/src/DotVVM.Framework/Controls/DataPager.cs
@@ -133,9 +133,9 @@ namespace DotVVM.Framework.Controls
             get { return (bool)GetValue(EnabledProperty); }
             set { SetValue(EnabledProperty, value); }
         }
-        public static readonly DotvvmProperty EnabledProperty
-            = DotvvmProperty.Register<bool, DataPager>(c => c.Enabled, true);
-
+        public static readonly DotvvmProperty EnabledProperty =
+            CustomDefaultProperty.Register<bool, DataPager>(nameof(Enabled),
+                FormControls.EnabledProperty, defaultPropertyInherit: true);
 
 
         private HtmlGenericControl content;

--- a/src/DotVVM.Framework/Controls/FormControls.cs
+++ b/src/DotVVM.Framework/Controls/FormControls.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using DotVVM.Framework.Binding;
+
+namespace DotVVM.Framework.Controls
+{
+    [ContainsDotvvmProperties]
+    public class FormControls
+    {
+        [AttachedProperty(typeof(bool))]
+        public static DotvvmProperty EnabledProperty = DotvvmProperty.Register<bool, FormControls>(() => EnabledProperty, true, true);
+    }
+}

--- a/src/DotVVM.Framework/Controls/SelectorBase.cs
+++ b/src/DotVVM.Framework/Controls/SelectorBase.cs
@@ -24,9 +24,9 @@ namespace DotVVM.Framework.Controls
             get { return (bool)GetValue(EnabledProperty); }
             set { SetValue(EnabledProperty, value); }
         }
-        public static readonly DotvvmProperty EnabledProperty =
-            DotvvmProperty.Register<bool, SelectorBase>(t => t.Enabled, true);
-
+        public static readonly DotvvmProperty EnabledProperty = 
+            CustomDefaultProperty.Register<bool, SelectorBase>("Enabled", 
+                FormControls.EnabledProperty, defaultPropertyInherit: true);
         
 
         /// <summary>

--- a/src/DotVVM.Framework/Controls/SelectorBase.cs
+++ b/src/DotVVM.Framework/Controls/SelectorBase.cs
@@ -24,8 +24,8 @@ namespace DotVVM.Framework.Controls
             get { return (bool)GetValue(EnabledProperty); }
             set { SetValue(EnabledProperty, value); }
         }
-        public static readonly DotvvmProperty EnabledProperty = 
-            CustomDefaultProperty.Register<bool, SelectorBase>("Enabled", 
+        public static readonly DotvvmProperty EnabledProperty =
+            CustomDefaultProperty.Register<bool, SelectorBase>(nameof(Enabled),
                 FormControls.EnabledProperty, defaultPropertyInherit: true);
         
 

--- a/src/DotVVM.Framework/Controls/SelectorBase.cs
+++ b/src/DotVVM.Framework/Controls/SelectorBase.cs
@@ -25,7 +25,7 @@ namespace DotVVM.Framework.Controls
             set { SetValue(EnabledProperty, value); }
         }
         public static readonly DotvvmProperty EnabledProperty =
-            CustomDefaultProperty.Register<bool, SelectorBase>(nameof(Enabled),
+            DotvvmPropertyWithFallback.Register<bool, SelectorBase>(nameof(Enabled),
                 FormControls.EnabledProperty, defaultPropertyInherit: true);
         
 

--- a/src/DotVVM.Framework/Controls/TextBox.cs
+++ b/src/DotVVM.Framework/Controls/TextBox.cs
@@ -23,8 +23,10 @@ namespace DotVVM.Framework.Controls
             set { SetValue(EnabledProperty, value); }
         }
 
-        public static readonly DotvvmProperty EnabledProperty =
-            DotvvmProperty.Register<bool, TextBox>(t => t.Enabled, true);
+        public static readonly DotvvmProperty EnabledProperty = 
+            CustomDefaultProperty.Register<bool, TextBox>("Enabled", 
+                FormControls.EnabledProperty, defaultPropertyInherit: true);
+
 
         /// <summary>
         /// Gets or sets a format of presentation of value to client.

--- a/src/DotVVM.Framework/Controls/TextBox.cs
+++ b/src/DotVVM.Framework/Controls/TextBox.cs
@@ -24,7 +24,7 @@ namespace DotVVM.Framework.Controls
         }
 
         public static readonly DotvvmProperty EnabledProperty =
-            CustomDefaultProperty.Register<bool, TextBox>(nameof(Enabled),
+            DotvvmPropertyWithFallback.Register<bool, TextBox>(nameof(Enabled),
                 FormControls.EnabledProperty, defaultPropertyInherit: true);
 
 

--- a/src/DotVVM.Framework/Controls/TextBox.cs
+++ b/src/DotVVM.Framework/Controls/TextBox.cs
@@ -23,8 +23,8 @@ namespace DotVVM.Framework.Controls
             set { SetValue(EnabledProperty, value); }
         }
 
-        public static readonly DotvvmProperty EnabledProperty = 
-            CustomDefaultProperty.Register<bool, TextBox>("Enabled", 
+        public static readonly DotvvmProperty EnabledProperty =
+            CustomDefaultProperty.Register<bool, TextBox>(nameof(Enabled),
                 FormControls.EnabledProperty, defaultPropertyInherit: true);
 
 

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/FormControlsEnabled/FormControlsEnabled.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/FormControlsEnabled/FormControlsEnabled.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using DotVVM.Framework.ViewModel;
+
+
+namespace DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.FormControlsEnabled
+{
+    public class FormControlsEnabled : DotvvmViewModelBase
+    {
+        public ChildForm Child { get; set; } = new ChildForm();
+
+        public string[] Items { get; set; } = { "one", "two", "three" };
+        public string SelectedItem { get; set; } = "one";
+        public bool[] FormsEnabled { get; set; } = { false, true};
+        public int LinkButtonsPressed { get; set; } = 0;
+        public bool Enabled { get; set; } = false;
+
+        public void Switch() => Enabled = !Enabled;
+
+        public void LinkButtonPressed() => LinkButtonsPressed++;
+    }
+
+    public class ChildForm
+    {
+        public string Text1 { get; set; }
+        public string Text2 { get; set; }
+    }
+}

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/FormControlsEnabled/FormControlsEnabled.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/FormControlsEnabled/FormControlsEnabled.dothtml
@@ -1,0 +1,115 @@
+﻿@viewModel DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.FormControlsEnabled.FormControlsEnabled, DotVVM.Samples.Common
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />    
+    <title>Hello from DotVVM!</title>
+</head>
+<body ClientIDMode="Static">
+    <h1>FormControls.Enabled</h1>
+
+    <dot:Button ID="toggle" Text="Toggle FormControls.Enabled" Click="{command: Switch()}"/>
+    Currently {{value: Enabled}}.
+    LinkButtons pressed: <span id="linkbuttons-pressed">{{value: LinkButtonsPressed}}</span>
+
+    <fieldset FormControls.Enabled="{value: Enabled}">
+        <dot:Button ID="b1-default" Text="Button" />
+        <dot:Button ID="b1-enabled" Text="Button Enabled" Enabled="{value: true}" />
+        <dot:Button ID="b1-disabled" Text="Button Disabled" Enabled="{value: false}"  />
+        <br />
+        <dot:CheckBox ID="c1-default" Checked="{value: false}" />
+        <dot:CheckBox ID="c1-enabled" Checked="{value: false}" Enabled="{value: true}" />
+        <dot:CheckBox ID="c1-disabled" Checked="{value: false}" Enabled="{value: false}" />
+        <br />
+        <dot:ComboBox ID="cb1-default" DataSource="{value: Items}" SelectedValue="{value: SelectedItem}" />
+        <dot:ComboBox ID="cb1-enabled" Enabled="{value: true}" DataSource="{value: Items}" SelectedValue="{value: SelectedItem}" />
+        <dot:ComboBox ID="cb1-disabled" Enabled="{value: false}" DataSource="{value: Items}" SelectedValue="{value: SelectedItem}" />
+        <br />
+        <dot:LinkButton ID="linkb1-default" Click="{command: LinkButtonPressed()}" Text="LinkButton"/>
+        <dot:LinkButton ID="linkb1-enabled" Click="{command: LinkButtonPressed()}" Enabled="{value: true}" Text="LinkButton Enabled"/>
+        <dot:LinkButton ID="linkb1-disabled" Click="{command: LinkButtonPressed()}" Enabled="{value: false}" Text="LinkButton Disabled"/>
+        <br />
+        <dot:ListBox ID="lb1-default" DataSource="{value: Items}" SelectedValue="{value: SelectedItem}" />
+        <dot:ListBox ID="lb1-enabled" Enabled="{value: true}" DataSource="{value: Items}" SelectedValue="{value: SelectedItem}" />
+        <dot:ListBox ID="lb1-disabled" Enabled="{value: false}" DataSource="{value: Items}" SelectedValue="{value: SelectedItem}" />
+        <br />
+        <dot:RadioButton ID="rb1-default" CheckedValue="{value: false}" />
+        <dot:RadioButton ID="rb1-enabled" CheckedValue="{value: false}" Enabled="{value: true}" />
+        <dot:RadioButton ID="rb1-disabled" CheckedValue="{value: false}" Enabled="{value: false}" />
+        <br />
+        <dot:TextBox ID="tb1-default" Text="Test" />
+        <dot:TextBox ID="tb1-enabled" Enabled="{value: true}" Text="Test" />
+        <dot:TextBox ID="tb1-disabled" Enabled="{value: false}" Text="Test" />
+
+        <h2>DataContext</h2>
+        <fieldset DataContext="{value: Child}">
+            <dot:Button ID="b2-default" Text="Button" />
+            <dot:Button ID="b2-enabled" Text="Button Enabled" Enabled="{value: true}" />
+            <dot:Button ID="b2-disabled" Text="Button Disabled" Enabled="{value: false}"/>
+            <br />
+            <dot:CheckBox ID="c2-default" Checked="{value: false}" />
+            <dot:CheckBox ID="c2-enabled" Checked="{value: false}" Enabled="{value: true}" />
+            <dot:CheckBox ID="c2-disabled" Checked="{value: false}" Enabled="{value: false}" />
+            <br />
+            <dot:ComboBox ID="cb2-default" DataSource="{value: _root.Items}" SelectedValue="{value: _root.SelectedItem}" />
+            <dot:ComboBox ID="cb2-enabled" Enabled="{value: true}" DataSource="{value: _root.Items}" SelectedValue="{value: _root.SelectedItem}" />
+            <dot:ComboBox ID="cb2-disabled" Enabled="{value: false}" DataSource="{value: _root.Items}" SelectedValue="{value: _root.SelectedItem}" />
+            <br />
+            <dot:LinkButton ID="linkb2-default" Click="{command: _root.LinkButtonPressed()}" Text="LinkButton"/>
+            <dot:LinkButton ID="linkb2-enabled" Click="{command: _root.LinkButtonPressed()}" Enabled="{value: true}" Text="LinkButton Enabled"/>
+            <dot:LinkButton ID="linkb2-disabled" Click="{command: _root.LinkButtonPressed()}" Enabled="{value: false}" Text="LinkButton Disabled"/>
+            <br />
+            <dot:ListBox ID="lb2-default" DataSource="{value: _root.Items}" SelectedValue="{value: _root.SelectedItem}" />
+            <dot:ListBox ID="lb2-enabled" Enabled="{value: true}" DataSource="{value: _root.Items}" SelectedValue="{value: _root.SelectedItem}" />
+            <dot:ListBox ID="lb2-disabled" Enabled="{value: false}" DataSource="{value: _root.Items}" SelectedValue="{value: _root.SelectedItem}" />
+            <br />
+            <dot:RadioButton ID="rb2-default" CheckedValue="{value: false}" />
+            <dot:RadioButton ID="rb2-enabled" CheckedValue="{value: false}" Enabled="{value: true}" />
+            <dot:RadioButton ID="rb2-disabled" CheckedValue="{value: false}" Enabled="{value: false}" />
+            <br />
+            <dot:TextBox ID="tb2-default" Text="Test" />
+            <dot:TextBox ID="tb2-enabled" Enabled="{value: true}" Text="Test" />
+            <dot:TextBox ID="tb2-disabled" Enabled="{value: false}" Text="Test" />
+        </fieldset>
+
+        <h2>Repeater</h2>
+        <dot:Repeater ID="repeater" DataSource="{value: FormsEnabled}">
+            <ItemTemplate>
+                <fieldset FormControls.Enabled="{value: _this}">
+                    Enabled: {{value: _this}}
+                    <br />
+                    <dot:Button ID="b-default" Text="Button" />
+                    <dot:Button ID="b-enabled" Text="Button Enabled" Enabled="{value: true}" />
+                    <dot:Button ID="b-disabled" Text="Button Disabled" Enabled="{value: false}"/>
+                    <br />
+                    <dot:CheckBox ID="c-default" Checked="{value: false}" />
+                    <dot:CheckBox ID="c-enabled" Checked="{value: false}" Enabled="true" />
+                    <dot:CheckBox ID="c-disabled" Checked="{value: false}" Enabled="false" />
+                    <br />
+                    <dot:ComboBox ID="cb-default" DataSource="{value: _root.Items}" SelectedValue="{value: _root.SelectedItem}" />
+                    <dot:ComboBox ID="cb-enabled" Enabled="{value: true}" DataSource="{value: _root.Items}" SelectedValue="{value: _root.SelectedItem}" />
+                    <dot:ComboBox ID="cb-disabled" Enabled="{value: false}" DataSource="{value: _root.Items}" SelectedValue="{value: _root.SelectedItem}" />
+                    <br />
+                    <dot:LinkButton ID="linkb-default" Click="{command: _root.LinkButtonPressed()}" Text="LinkButton"/>
+                    <dot:LinkButton ID="linkb-enabled" Click="{command: _root.LinkButtonPressed()}" Enabled="{value: true}" Text="LinkButton Enabled"/>
+                    <dot:LinkButton ID="linkb-disabled" Click="{command: _root.LinkButtonPressed()}" Enabled="{value: false}" Text="LinkButton Disabled"/>
+                    <br />
+                    <dot:ListBox ID="lb-default" DataSource="{value: _root.Items}" SelectedValue="{value: _root.SelectedItem}" />
+                    <dot:ListBox ID="lb-enabled" Enabled="{value: true}" DataSource="{value: _root.Items}" SelectedValue="{value: _root.SelectedItem}" />
+                    <dot:ListBox ID="lb-disabled" Enabled="{value: false}" DataSource="{value: _root.Items}" SelectedValue="{value: _root.SelectedItem}" />
+                    <br />
+                    <dot:RadioButton ID="rb-default" CheckedValue="{value: false}" />
+                    <dot:RadioButton ID="rb-enabled" CheckedValue="{value: false}" Enabled="{value: true}" />
+                    <dot:RadioButton ID="rb-disabled" CheckedValue="{value: false}" Enabled="{value: false}" />
+                    <br />
+                    <dot:TextBox ID="tb-default" Text="Test" />
+                    <dot:TextBox ID="tb-enabled" Enabled="{value: true}" Text="Test" />
+                    <dot:TextBox ID="tb-disabled" Enabled="{value: false}" Text="Test" />
+                </fieldset>
+            </ItemTemplate>
+        </dot:Repeater>
+    </fieldset>
+
+</body>
+</html>

--- a/src/DotVVM.Samples.Tests/Feature/FormControlsEnabledTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/FormControlsEnabledTests.cs
@@ -18,9 +18,6 @@ namespace DotVVM.Samples.Tests.Feature
             // Button, CheckBox, ComboBox, ListBox, RadioButton, TextBox
             string[] prefixes = { "b", "c", "cb", "lb", "rb", "tb" };
 
-            // TODO: test LinkButton (Selenium's CheckIfIsEnabled/NotEnabled doesn't work with them)
-            // and command bindings are broken - the link buttons get the same hash
-
             RunInAllBrowsers(browser =>
             {
                 browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_FormControlsEnabled_FormControlsEnabled);
@@ -62,8 +59,45 @@ namespace DotVVM.Samples.Tests.Feature
                     browser.First("#toggle").Click().Wait();
                     enabled = !enabled;
                 }
-            });
 
+                // LinkButton tests. Selenium does not recognize them as disabled as that is handled by DotVVM.
+                int linkButtonPresses = 0;
+
+                // These controls should always be enabled because they are explicitly set to Enabled
+                TestLinkButton(browser, "linkb1-enabled", true, ref linkButtonPresses);
+                TestLinkButton(browser, "linkb2-enabled", true, ref linkButtonPresses);
+                TestLinkButton(browser, "repeater_0_linkb-enabled", true, ref linkButtonPresses);
+                TestLinkButton(browser, "repeater_1_linkb-enabled", true, ref linkButtonPresses);
+
+                // These controls should always be disabled
+                TestLinkButton(browser, "linkb1-disabled", false, ref linkButtonPresses);
+                TestLinkButton(browser, "linkb2-disabled", false, ref linkButtonPresses);
+                TestLinkButton(browser, "repeater_0_linkb-disabled", false, ref linkButtonPresses);
+                TestLinkButton(browser, "repeater_1_linkb-disabled", false, ref linkButtonPresses);
+
+                // These should be changed by the Toggle button
+                TestLinkButton(browser, "linkb1-default", enabled, ref linkButtonPresses);
+                TestLinkButton(browser, "linkb2-default", enabled, ref linkButtonPresses);
+
+                // These are overriden by the repeater
+                TestLinkButton(browser, "repeater_0_linkb-default", false, ref linkButtonPresses);
+                TestLinkButton(browser, "repeater_1_linkb-default", true, ref linkButtonPresses);
+
+                browser.First("#toggle").Click().Wait();
+                enabled = !enabled;
+            });
         }
+
+        private void TestLinkButton(BrowserWrapper browser, string id, bool shouldBeEnabled, ref int currentPresses)
+        {
+            browser.First($"#{id}").Click();
+            if (shouldBeEnabled)
+            {
+                currentPresses++;
+            }
+
+            browser.First("#linkbuttons-pressed").CheckIfInnerTextEquals(currentPresses.ToString());
+        }
+
     }
 }

--- a/src/DotVVM.Samples.Tests/Feature/FormControlsEnabledTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/FormControlsEnabledTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Dotvvm.Samples.Tests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Riganti.Utils.Testing.Selenium.Core;
+
+namespace DotVVM.Samples.Tests.Feature
+{
+    [TestClass]
+    public class FormControlsEnabledTests : SeleniumTest
+    {
+        [TestMethod]
+        public void Feature_FormControlsEnabled_FormControlsEnabled()
+        {
+            // Button, CheckBox, ComboBox, ListBox, RadioButton, TextBox
+            string[] prefixes = { "b", "c", "cb", "lb", "rb", "tb" };
+
+            // TODO: test LinkButton (Selenium's CheckIfIsEnabled/NotEnabled doesn't work with them)
+            // and command bindings are broken - the link buttons get the same hash
+
+            RunInAllBrowsers(browser =>
+            {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_FormControlsEnabled_FormControlsEnabled);
+
+                bool enabled = false;
+
+                for (int i = 0; i < 2; i++)
+                {
+                    foreach (var prefix in prefixes)
+                    {
+                        // These controls should always be enabled because they are explicitly set to Enabled
+                        browser.First($"#{prefix}1-enabled").CheckIfIsEnabled();
+                        browser.First($"#{prefix}2-enabled").CheckIfIsEnabled();
+                        browser.First($"#repeater_0_{prefix}-enabled").CheckIfIsEnabled();
+                        browser.First($"#repeater_1_{prefix}-enabled").CheckIfIsEnabled();
+
+                        // These controls should always be disabled
+                        browser.First($"#{prefix}1-disabled").CheckIfIsNotEnabled();
+                        browser.First($"#{prefix}2-disabled").CheckIfIsNotEnabled();
+                        browser.First($"#repeater_0_{prefix}-disabled").CheckIfIsNotEnabled();
+                        browser.First($"#repeater_1_{prefix}-disabled").CheckIfIsNotEnabled();
+
+                        // These should be changed by the Toggle button
+                        if (enabled)
+                        {
+                            browser.First($"#{prefix}1-default").CheckIfIsEnabled();
+                            browser.First($"#{prefix}2-default").CheckIfIsEnabled();
+                        }
+                        else
+                        {
+                            browser.First($"#{prefix}1-default").CheckIfIsNotEnabled();
+                            browser.First($"#{prefix}2-default").CheckIfIsNotEnabled();
+                        }
+
+                        // These are overriden by the repeater
+                        browser.First($"#repeater_0_{prefix}-default").CheckIfIsNotEnabled();
+                        browser.First($"#repeater_1_{prefix}-default").CheckIfIsEnabled();
+                    }
+                    browser.First("#toggle").Click().Wait();
+                    enabled = !enabled;
+                }
+            });
+
+        }
+    }
+}

--- a/src/DotVVM.Samples.Tests/SamplesRouteUrls.cs
+++ b/src/DotVVM.Samples.Tests/SamplesRouteUrls.cs
@@ -275,6 +275,8 @@ namespace Dotvvm.Samples.Tests{
 
             public static string FeatureSamples_Formatting_Formatting => "FeatureSamples/Formatting/Formatting";
 
+            public static string FeatureSamples_FormControlsEnabled_FormControlsEnabled => "FeatureSamples/FormControlsEnabled/FormControlsEnabled";
+
             public static string FeatureSamples_GenericTypes_InCommandBinding => "FeatureSamples/GenericTypes/InCommandBinding";
 
             public static string FeatureSamples_GenericTypes_InResourceBinding => "FeatureSamples/GenericTypes/InResourceBinding";


### PR DESCRIPTION
# FormControls.Enabled
_proposed in #296_


Adds a FormControls.Enabled property to all HTML elements which disables controls inside that are not explicitly enabled.

## Controls affected
### DotVVM

- Button (ButtonBase)
- CheckBox (CheckableControlBase)
- ComboBox (SelectorBase)
- DataPager
- LinkButton (ButtonBase)
- ListBox (SelectorBase)
- RadioButton (CheckableControlBase)
- TextBox

### Bootstrap (not yet implemented)

- Button
- CheckBox
- DataPager
- RadioButton
- TextBoxGroup


### Business pack (not yet implemented)

- Button
- Calendar
- CheckBox
- CheckBoxList
- ColorPicker
- ComboBox
- DataPager
- DateTimePicker
- DateTimeRangerPicker
- DropDownList
- MultiSelect
- NumericUpDown
- RadioButton
- RadioButtonList
- RangeCalendar
- RangeSlider
- Rating
- Slider
- TextBox

ListView (Business pack) does not have an Enabled property
DateTimePicker (Bootstrap) does not have an Enabled property
DropDownButton (Bootstrap) does not have an Enabled property

Example
---
```html
<div FormControls.Enabled="{value: false}">
    <dot:Button Text="I am disabled" />
    <dot:Button Text="I am enabled" Enabled="{value: true}" />
</div>
```