### PR TITLE
Updated .editorconfig with formatting settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,8 @@ root = true
 # Don't use tabs for indentation.
 [*]
 indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true
 # (Please don't specify an indent_size here; that has too many unintended consequences.)
 
 # Code files
@@ -50,9 +52,9 @@ csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_var_elsewhere = true:suggestion
 
 
-csharp_style_expression_bodied_methods = true:none
-csharp_style_expression_bodied_constructors = false:none
-csharp_style_expression_bodied_operators = true:none
+csharp_style_expression_bodied_methods = true:suggestion
+csharp_style_expression_bodied_constructors = false:suggestion
+csharp_style_expression_bodied_operators = true:suggestion
 csharp_style_expression_bodied_properties = true:suggestion
 csharp_style_expression_bodied_indexers = true:suggestion
 csharp_style_expression_bodied_accessors = true:suggestion
@@ -63,3 +65,22 @@ csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
 csharp_style_inlined_variable_declaration = true:suggestion
 csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
+
+csharp_new_line_before_open_brace = accessors, control_blocks, events, indexers, local_functions, methods, properties, types
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_within_query_expression_clauses = true
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = no_change
+csharp_space_after_cast	= false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true
+


### PR DESCRIPTION
Updated .editorconfig with formatting settings that are supported in the new version of Visual Studio. I think that these settings reflect the current style best, but there is no research behind it :) It's mostly a default, except:
* csharp_new_line_before_open_brace - the expressions don't have a new line before open brace
* csharp_indent_labels = no_change - I think this was the default when I have used it, but it does not matter as label is IMO used only once :P

I have also added options to trim trailing whitespace and an option to insert the final newline.