### PR TITLE
Query string parameters to RedirectToRoute, Query-* property group in RouteLink

### DIFF
--- a/src/DotVVM.Framework/Hosting/DotvvmRequestContextExtensions.cs
+++ b/src/DotVVM.Framework/Hosting/DotvvmRequestContextExtensions.cs
@@ -13,6 +13,7 @@ using DotVVM.Framework.Hosting.Middlewares;
 using DotVVM.Framework.ViewModel.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using System.Threading;
+using DotVVM.Framework.Routing;
 
 namespace DotVVM.Framework.Hosting
 {
@@ -88,39 +89,9 @@ namespace DotVVM.Framework.Hosting
         public static void RedirectToRoute(this IDotvvmRequestContext context, string routeName, object newRouteValues = null, bool replaceInHistory = false, bool allowSpaRedirect = true, string urlSuffix = null, object query = null)
         {
             var route = context.Configuration.RouteTable[routeName];
-            var url = route.BuildUrl(context.Parameters, newRouteValues) + BuildUrlSuffix(urlSuffix ?? "", query);
+            var url = route.BuildUrl(context.Parameters, newRouteValues) + UrlHelper.BuildUrlSuffix(urlSuffix, query);
 
             context.RedirectToUrl(url, replaceInHistory, allowSpaRedirect);
-        }
-
-        private static string BuildUrlSuffix(string urlSuffix, object query)
-        {
-            var hashIndex = urlSuffix.IndexOf('#');
-            var resultSuffix = hashIndex < 0 ? urlSuffix : urlSuffix.Substring(0, hashIndex);
-
-            switch (query)
-            {
-                case null:
-                    break;
-                case IEnumerable<KeyValuePair<string, string>> keyValueCollection:
-                    foreach (var item in keyValueCollection)
-                    {
-                        resultSuffix = resultSuffix + (urlSuffix.LastIndexOf('?') < 0 ? "?" : "&") +
-                                       Uri.EscapeDataString(item.Key) +
-                                       "=" + Uri.EscapeDataString(item.Value);
-                    }
-                    break;
-                default:
-                    foreach (var prop in query.GetType().GetProperties())
-                    {
-                        resultSuffix = resultSuffix + (urlSuffix.LastIndexOf('?') < 0 ? "?" : "&") +
-                                       Uri.EscapeDataString(prop.Name) +
-                                       "=" + Uri.EscapeDataString(prop.GetValue(query).ToString());
-                    }
-                    break;
-            }
-
-            return resultSuffix + (hashIndex < 0 ? "" : urlSuffix.Substring(hashIndex));
         }
 
         /// <summary>

--- a/src/DotVVM.Framework/Resources/Scripts/DotVVM.d.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/DotVVM.d.ts
@@ -241,6 +241,7 @@ declare class DotVVM {
     private restoreUpdatedControls(resultObject, updatedControls, applyBindingsOnEachControl);
     unwrapArrayExtension(array: any): any;
     buildRouteUrl(routePath: string, params: any): string;
+    buildUrlSuffix(urlSuffix: string, query: any): string;
     private isPostBackProhibited(element);
     private addKnockoutBindingHandlers();
 }

--- a/src/DotVVM.Framework/Resources/Scripts/DotVVM.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/DotVVM.ts
@@ -768,7 +768,7 @@ class DotVVM {
             if (query.hasOwnProperty(property)) {
                 if (!property) continue;
                 var queryParamValue = ko.unwrap(query[property]);
-                if (!queryParamValue) continue;
+                if (queryParamValue != null) continue;
                 resultSuffix = resultSuffix.concat(resultSuffix.indexOf("?") !== -1
                     ? `&${property}=${queryParamValue}`
                     : `?${property}=${queryParamValue}`);

--- a/src/DotVVM.Framework/Resources/Scripts/DotVVM.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/DotVVM.ts
@@ -755,6 +755,28 @@ class DotVVM {
         });
     }
 
+    public buildUrlSuffix(urlSuffix: string, query: any): string {
+        var resultSuffix, hashSuffix;
+        if (urlSuffix.indexOf("#") !== -1) {
+            resultSuffix = urlSuffix.substring(0, urlSuffix.indexOf("#"));
+            hashSuffix = urlSuffix.substring(urlSuffix.indexOf("#"));
+        } else {
+            resultSuffix = urlSuffix;
+            hashSuffix = "";
+        }
+        for (var property in query) {
+            if (query.hasOwnProperty(property)) {
+                if (!property) continue;
+                var queryParamValue = ko.unwrap(query[property]);
+                if (!queryParamValue) continue;
+                resultSuffix = resultSuffix.concat(resultSuffix.indexOf("?") !== -1
+                    ? `&${property}=${queryParamValue}`
+                    : `?${property}=${queryParamValue}`);
+            }
+        }
+        return resultSuffix.concat(hashSuffix);
+    }
+
     private isPostBackProhibited(element: HTMLElement) {
         if (element && element.tagName && element.tagName.toLowerCase() === "a" && element.getAttribute("disabled")) {
             return true;

--- a/src/DotVVM.Framework/Routing/UrlHelper.cs
+++ b/src/DotVVM.Framework/Routing/UrlHelper.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace DotVVM.Framework.Routing
+{
+    public static class UrlHelper
+    {
+        /// <summary>
+        /// Returns url suffix from a string value and query string parameters
+        /// </summary>
+        public static string BuildUrlSuffix(string urlSuffix, object query)
+        {
+            urlSuffix = urlSuffix ?? "";
+            var hashIndex = urlSuffix.IndexOf('#');
+            var resultSuffix = hashIndex < 0 ? urlSuffix : urlSuffix.Substring(0, hashIndex);
+
+            switch (query)
+            {
+                case null:
+                    break;
+                case IEnumerable<KeyValuePair<string, string>> keyValueCollection:
+                    foreach (var item in keyValueCollection)
+                    {
+                        resultSuffix = resultSuffix + (resultSuffix.LastIndexOf('?') < 0 ? "?" : "&") +
+                                       Uri.EscapeDataString(item.Key) +
+                                       "=" + Uri.EscapeDataString(item.Value);
+                    }
+                    break;
+                case IEnumerable<KeyValuePair<string, object>> keyValueCollection:
+                    foreach (var item in keyValueCollection)
+                    {
+                        resultSuffix = resultSuffix + (resultSuffix.LastIndexOf('?') < 0 ? "?" : "&") +
+                                       Uri.EscapeDataString(item.Key) +
+                                       "=" + Uri.EscapeDataString(item.Value.ToString());
+                    }
+                    break;
+                default:
+                    foreach (var prop in query.GetType().GetProperties())
+                    {
+                        resultSuffix = resultSuffix + (resultSuffix.LastIndexOf('?') < 0 ? "?" : "&") +
+                                       Uri.EscapeDataString(prop.Name) +
+                                       "=" + Uri.EscapeDataString(prop.GetValue(query).ToString());
+                    }
+                    break;
+            }
+
+            return resultSuffix + (hashIndex < 0 ? "" : urlSuffix.Substring(hashIndex));
+        }
+    }
+}

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/Redirect/RedirectViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/Redirect/RedirectViewModel.cs
@@ -27,13 +27,13 @@ namespace DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.Redirect
 
         public void RedirectObjectQueryString()
         {
-            Context.RedirectToRoute("FeatureSamples_Redirect_Redirect", urlSuffix: "?param=temp#test", queryStringParameters:new {time = DateTime.Now.Ticks});
+            Context.RedirectToRoute("FeatureSamples_Redirect_Redirect", urlSuffix: "?param=temp#test", query: new {time = DateTime.Now.Ticks});
 
             throw new Exception("This exception should not occur because Redirect interrupts the request execution!");
         }
         public void RedirectDictionaryQueryString()
         {
-            Context.RedirectToRoute("FeatureSamples_Redirect_Redirect", urlSuffix: "#test", queryStringParameters: new Dictionary<string,string>{{"time", DateTime.Now.Ticks.ToString()}});
+            Context.RedirectToRoute("FeatureSamples_Redirect_Redirect", urlSuffix: "#test", query: new Dictionary<string,string>{{"time", DateTime.Now.Ticks.ToString()}});
 
             throw new Exception("This exception should not occur because Redirect interrupts the request execution!");
         }

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/Redirect/RedirectViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/Redirect/RedirectViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using DotVVM.Framework.Hosting;
 using DotVVM.Framework.ViewModel;
@@ -20,6 +21,19 @@ namespace DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.Redirect
         public void RedirectTest()
         {
             Context.RedirectToUrl("~/FeatureSamples/Redirect/Redirect?time=" + DateTime.Now.Ticks);
+
+            throw new Exception("This exception should not occur because Redirect interrupts the request execution!");
+        }
+
+        public void RedirectObjectQueryString()
+        {
+            Context.RedirectToRoute("FeatureSamples_Redirect_Redirect", urlSuffix: "?param=temp#test", queryStringParameters:new {time = DateTime.Now.Ticks});
+
+            throw new Exception("This exception should not occur because Redirect interrupts the request execution!");
+        }
+        public void RedirectDictionaryQueryString()
+        {
+            Context.RedirectToRoute("FeatureSamples_Redirect_Redirect", urlSuffix: "#test", queryStringParameters: new Dictionary<string,string>{{"time", DateTime.Now.Ticks.ToString()}});
 
             throw new Exception("This exception should not occur because Redirect interrupts the request execution!");
         }

--- a/src/DotVVM.Samples.Common/Views/ControlSamples/Repeater/RouteLinkQuery.dothtml
+++ b/src/DotVVM.Samples.Common/Views/ControlSamples/Repeater/RouteLinkQuery.dothtml
@@ -1,0 +1,44 @@
+﻿@viewModel DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.Repeater.RouteLinkViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+    <h1>RouteLink in Repeater with query string parameters</h1>
+
+    <h3>Client rendered</h3>
+    <dot:Repeater DataSource="{value: Pages}" RenderSettings.Mode="Client">
+        <ItemTemplate>
+            <dot:RouteLink RouteName="ControlSamples_Repeater_RouteLinkQuery" Query-Static="query" Query-Id="{value: Id}" Param-Id="{value: Id}" Text="{value: Name}" />
+        </ItemTemplate>
+    </dot:Repeater>
+
+    <h3>Server rendered</h3>
+    <dot:Repeater DataSource="{value: Pages}" RenderSettings.Mode="Server">
+        <ItemTemplate>
+            <dot:RouteLink RouteName="ControlSamples_Repeater_RouteLinkQuery" Query-Static="query" Query-Id="{value: Id}" Param-Id="{value: Id}" Text="{value: Name}" />
+        </ItemTemplate>
+    </dot:Repeater>
+
+    <h3>Client rendered with UrlSuffix</h3>
+    <dot:Repeater DataSource="{value: Pages}" RenderSettings.Mode="Client">
+        <ItemTemplate>
+            <dot:RouteLink RouteName="ControlSamples_Repeater_RouteLinkQuery" Query-Static="query" Query-Id="{value: Id}" Param-Id="{value: Id}" Text="{value: Name}" UrlSuffix="?first=param#test" />
+        </ItemTemplate>
+    </dot:Repeater>
+
+    <h3>Server rendered with UrlSuffix</h3>
+    <dot:Repeater DataSource="{value: Pages}" RenderSettings.Mode="Server">
+        <ItemTemplate>
+            <dot:RouteLink RouteName="ControlSamples_Repeater_RouteLinkQuery" Query-Static="query" Query-Id="{value: Id}" Param-Id="{value: Id}" Text="{value: Name}" UrlSuffix="?first=param#test" />
+        </ItemTemplate>
+    </dot:Repeater>
+
+</body>
+</html>
+
+

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/Redirect/Redirect.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/Redirect/Redirect.dothtml
@@ -7,6 +7,8 @@
     <div class="container">
         <h1>Redirect test</h1>
         <p><dot:Button Text="Test redirect" Click="{command: RedirectTest()}" /></p>
+        <p><dot:Button Text="Test RedirectToRoute object queryString" Click="{command: RedirectObjectQueryString()}" /></p>
+        <p><dot:Button Text="Test RedirectToRoute dictionary queryString" Click="{command: RedirectDictionaryQueryString()}" /></p>
     </div>
 
 </body>

--- a/src/DotVVM.Samples.Tests/Control/RepeaterTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/RepeaterTests.cs
@@ -226,6 +226,35 @@ namespace DotVVM.Samples.Tests.Control
         }
 
         [TestMethod]
+        public void Control_Repeater_RouteLinkQuery()
+        {
+            RunInAllBrowsers(browser =>
+            {
+                browser.NavigateToUrl(SamplesRouteUrls.ControlSamples_Repeater_RouteLinkQuery);
+
+                // verify link urls
+                var url = browser.CurrentUrl;
+                browser.ElementAt("a", 0).CheckAttribute("href", url + "?Static=query&Id=1");
+                browser.ElementAt("a", 1).CheckAttribute("href", url + "?Static=query&Id=2");
+                browser.ElementAt("a", 2).CheckAttribute("href", url + "?Static=query&Id=3");
+                browser.ElementAt("a", 3).CheckAttribute("href", url + "?Static=query&Id=1");
+                browser.ElementAt("a", 4).CheckAttribute("href", url + "?Static=query&Id=2");
+                browser.ElementAt("a", 5).CheckAttribute("href", url + "?Static=query&Id=3");
+                browser.ElementAt("a", 6).CheckAttribute("href", url + "?first=param&Static=query&Id=1#test");
+                browser.ElementAt("a", 7).CheckAttribute("href", url + "?first=param&Static=query&Id=2#test");
+                browser.ElementAt("a", 8).CheckAttribute("href", url + "?first=param&Static=query&Id=3#test");
+                browser.ElementAt("a", 9).CheckAttribute("href", url + "?first=param&Static=query&Id=1#test");
+                browser.ElementAt("a", 10).CheckAttribute("href", url + "?first=param&Static=query&Id=2#test");
+                browser.ElementAt("a", 11).CheckAttribute("href", url + "?first=param&Static=query&Id=3#test");
+
+                for (int i = 0; i < 12; i++)
+                {
+                    browser.ElementAt("a", i).CheckIfInnerText(s => !string.IsNullOrWhiteSpace(s), "Not rendered Name");
+                }
+            });
+        }
+
+        [TestMethod]
         public void Control_Repeater_Separator()
         {
             RunInAllBrowsers(browser =>

--- a/src/DotVVM.Samples.Tests/Feature/RedirectTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/RedirectTests.cs
@@ -31,6 +31,48 @@ namespace DotVVM.Samples.Tests.Feature
         }
 
         [TestMethod]
+        public void Feature_Redirect_RedirectToRoute_ObjectQueryStringParameters()
+        {
+            RunInAllBrowsers(browser =>
+            {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_Redirect_Redirect);
+
+                var originalUrl = browser.CurrentUrl;
+
+                // click the button
+                browser.ElementAt("input[type=button]", 1).Click().Wait();
+                browser.CheckUrl(s => !s.Equals(originalUrl, StringComparison.OrdinalIgnoreCase),
+                    "Current url is same as origional url. Current url should be different.");
+
+                browser.CheckUrl(s => s.Contains("&time="));
+                browser.CheckUrl(s => s.Contains("?param=temp"));
+                browser.CheckUrl(s => s.EndsWith("#test"));
+            });
+        }
+
+        [TestMethod]
+        public void Feature_Redirect_RedirectToRoute_DictionaryQueryStringParameters()
+        {
+            RunInAllBrowsers(browser =>
+            {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_Redirect_Redirect);
+
+                var originalUrl = browser.CurrentUrl;
+
+                // click the button
+                browser.ElementAt("input[type=button]", 2).Click().Wait();
+
+                browser.CheckUrl(s => s.EndsWith("#test"));
+                browser.CheckUrl(s => !s.Equals(originalUrl + "#test", StringComparison.OrdinalIgnoreCase),
+                    "Current url is same as origional url. Current url should be different.");
+
+                browser.CheckUrl(s => s.Contains("?time="));
+                
+            });
+        }
+
+
+        [TestMethod]
         public void Feature_RedirectFromPresenter()
         {
             RunInAllBrowsers(browser =>

--- a/src/DotVVM.Samples.Tests/SamplesRouteUrls.cs
+++ b/src/DotVVM.Samples.Tests/SamplesRouteUrls.cs
@@ -149,6 +149,8 @@ namespace Dotvvm.Samples.Tests{
 
             public static string ControlSamples_Repeater_RouteLink => "ControlSamples/Repeater/RouteLink";
 
+            public static string ControlSamples_Repeater_RouteLinkQuery => "ControlSamples/Repeater/RouteLinkQuery";
+
             public static string ControlSamples_Repeater_RouteLinkUrlSuffix => "ControlSamples/Repeater/RouteLinkUrlSuffix";
 
             public static string ControlSamples_Repeater_Separator => "ControlSamples/Repeater/Separator";


### PR DESCRIPTION
Added option to specify query string parameters in `RedirectToRoute` method.

Added UI test for this feature.

Issue https://github.com/riganti/dotvvm/issues/405