### PR TITLE
Allow manual integrity hash and add tests

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Binding/IntegrityCheckTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/IntegrityCheckTests.cs
@@ -12,6 +12,7 @@ namespace DotVVM.Framework.Tests.Binding
     public class IntegrityCheckTests
     {
         private const string _integrityHash = "sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=";
+        private const string _jqueryUri = "https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js";
 
         private string RenderResource(DotvvmConfiguration configuration, ScriptResource jquery)
         {
@@ -37,7 +38,7 @@ namespace DotVVM.Framework.Tests.Binding
             //Arrange
             var configuration = DotvvmTestHelper.CreateConfiguration();
 
-            configuration.Resources.Register(ResourceConstants.JQueryResourceName, new ScriptResource { Location = new UrlResourceLocation("https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"), RenderPosition = ResourceRenderPosition.Head, VerifyResourceIntegrity = false });
+            configuration.Resources.Register(ResourceConstants.JQueryResourceName, new ScriptResource { Location = new UrlResourceLocation(_jqueryUri), VerifyResourceIntegrity = false });
 
             var jquery = configuration.Resources.FindResource(ResourceConstants.JQueryResourceName) as ScriptResource;
 
@@ -56,7 +57,7 @@ namespace DotVVM.Framework.Tests.Binding
             //Arrange
             var configuration = DotvvmTestHelper.CreateConfiguration();
 
-            configuration.Resources.Register(ResourceConstants.JQueryResourceName, new ScriptResource { Location = new UrlResourceLocation("https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"), RenderPosition = ResourceRenderPosition.Head, VerifyResourceIntegrity = false, IntegrityHash = _integrityHash });
+            configuration.Resources.Register(ResourceConstants.JQueryResourceName, new ScriptResource { Location = new UrlResourceLocation(_jqueryUri), VerifyResourceIntegrity = false, IntegrityHash = _integrityHash });
 
             var jquery = configuration.Resources.FindResource(ResourceConstants.JQueryResourceName) as ScriptResource;
 
@@ -74,7 +75,7 @@ namespace DotVVM.Framework.Tests.Binding
             //Arrange
             var configuration = DotvvmTestHelper.CreateConfiguration();
 
-            configuration.Resources.Register(ResourceConstants.JQueryResourceName, new ScriptResource { Location = new UrlResourceLocation("https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"), RenderPosition = ResourceRenderPosition.Head, VerifyResourceIntegrity = true, IntegrityHash = "123" });
+            configuration.Resources.Register(ResourceConstants.JQueryResourceName, new ScriptResource { Location = new UrlResourceLocation(_jqueryUri), VerifyResourceIntegrity = true, IntegrityHash = "123" });
 
             var jquery = configuration.Resources.FindResource(ResourceConstants.JQueryResourceName) as ScriptResource;
 
@@ -92,7 +93,7 @@ namespace DotVVM.Framework.Tests.Binding
             //Arrange
             var configuration = DotvvmTestHelper.CreateConfiguration();
 
-            configuration.Resources.Register(ResourceConstants.JQueryResourceName, new ScriptResource { Location = new UrlResourceLocation("https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"), RenderPosition = ResourceRenderPosition.Head, VerifyResourceIntegrity = true, IntegrityHash = _integrityHash });
+            configuration.Resources.Register(ResourceConstants.JQueryResourceName, new ScriptResource { Location = new UrlResourceLocation(_jqueryUri), VerifyResourceIntegrity = true, IntegrityHash = _integrityHash });
 
             var jquery = configuration.Resources.FindResource(ResourceConstants.JQueryResourceName) as ScriptResource;
 

--- a/src/DotVVM.Framework.Tests.Common/Binding/IntegrityCheckTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/IntegrityCheckTests.cs
@@ -1,0 +1,107 @@
+using DotVVM.Framework.Configuration;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.ResourceManagement;
+using DotVVM.Framework.Testing;
+using DotVVM.Framework.ViewModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+
+namespace DotVVM.Framework.Tests.Binding
+{
+    [TestClass]
+    public class IntegrityCheckTests
+    {
+        private const string _integrityHash = "sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=";
+
+        private string RenderResource(DotvvmConfiguration configuration, ScriptResource jquery)
+        {
+            var context = new TestDotvvmRequestContext()
+            {
+                Configuration = configuration,
+                ResourceManager = new ResourceManager(configuration),
+                ViewModel = new DotvvmViewModelBase()
+            };
+
+            using (var text = new StringWriter())
+            {
+                var html = new HtmlWriter(text, context);
+                jquery.RenderLink(jquery.Location, html, context, ResourceConstants.JQueryResourceName);
+
+                return text.GetStringBuilder().ToString();
+            }
+        }
+
+        [TestMethod]
+        public void IntegrityCheck_NoCheck()
+        {
+            //Arrange
+            var configuration = DotvvmTestHelper.CreateConfiguration();
+
+            configuration.Resources.Register(ResourceConstants.JQueryResourceName, new ScriptResource { Location = new UrlResourceLocation("https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"), RenderPosition = ResourceRenderPosition.Head, VerifyResourceIntegrity = false });
+
+            var jquery = configuration.Resources.FindResource(ResourceConstants.JQueryResourceName) as ScriptResource;
+
+            //Act
+            string scriptTag = RenderResource(configuration, jquery);
+
+            //Assert
+            Assert.IsFalse(scriptTag.Contains("integrity"));
+            Assert.IsFalse(scriptTag.Contains(_integrityHash));
+
+        }
+
+        [TestMethod]
+        public void IntegrityCheck_NoCheck_WithIntegrityHash()
+        {
+            //Arrange
+            var configuration = DotvvmTestHelper.CreateConfiguration();
+
+            configuration.Resources.Register(ResourceConstants.JQueryResourceName, new ScriptResource { Location = new UrlResourceLocation("https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"), RenderPosition = ResourceRenderPosition.Head, VerifyResourceIntegrity = false, IntegrityHash = _integrityHash });
+
+            var jquery = configuration.Resources.FindResource(ResourceConstants.JQueryResourceName) as ScriptResource;
+
+            //Act
+            string scriptTag = RenderResource(configuration, jquery);
+
+            //Assert
+            Assert.IsFalse(scriptTag.Contains("integrity"));
+            Assert.IsFalse(scriptTag.Contains(_integrityHash));
+        }
+
+        [TestMethod]
+        public void IntegrityCheck_ShouldFail()
+        {
+            //Arrange
+            var configuration = DotvvmTestHelper.CreateConfiguration();
+
+            configuration.Resources.Register(ResourceConstants.JQueryResourceName, new ScriptResource { Location = new UrlResourceLocation("https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"), RenderPosition = ResourceRenderPosition.Head, VerifyResourceIntegrity = true, IntegrityHash = "123" });
+
+            var jquery = configuration.Resources.FindResource(ResourceConstants.JQueryResourceName) as ScriptResource;
+
+            //Act
+            string scriptTag = RenderResource(configuration, jquery);
+
+            //Assert
+            Assert.IsTrue(scriptTag.Contains("integrity"));
+            Assert.IsFalse(scriptTag.Contains(_integrityHash));
+        }
+
+        [TestMethod]
+        public void IntegrityCheck_ShouldSucceed()
+        {
+            //Arrange
+            var configuration = DotvvmTestHelper.CreateConfiguration();
+
+            configuration.Resources.Register(ResourceConstants.JQueryResourceName, new ScriptResource { Location = new UrlResourceLocation("https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"), RenderPosition = ResourceRenderPosition.Head, VerifyResourceIntegrity = true, IntegrityHash = _integrityHash });
+
+            var jquery = configuration.Resources.FindResource(ResourceConstants.JQueryResourceName) as ScriptResource;
+
+            //Act
+            string scriptTag = RenderResource(configuration, jquery);
+
+            //Assert
+            Assert.IsTrue(scriptTag.Contains("integrity"));
+            Assert.IsTrue(scriptTag.Contains(_integrityHash));
+        }
+    }
+}

--- a/src/DotVVM.Framework/ResourceManagement/LinkResourceBase.cs
+++ b/src/DotVVM.Framework/ResourceManagement/LinkResourceBase.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
-using System.Threading.Tasks;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.Hosting;
-using System.Text;
 using System.IO;
 using Newtonsoft.Json;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,6 +19,7 @@ namespace DotVVM.Framework.ResourceManagement
         public ResourceLocationFallback LocationFallback { get; set; }
         public string MimeType { get; private set; }
         public bool VerifyResourceIntegrity { get; set; }
+        public string IntegrityHash { get; set; }
 
         public LinkResourceBase(ResourceRenderPosition renderPosition, string mimeType, IResourceLocation location) : base(renderPosition)
         {
@@ -84,7 +82,7 @@ namespace DotVVM.Framework.ResourceManagement
 
         protected void AddIntegrityAttribute(IHtmlWriter writer, IDotvvmRequestContext context)
         {
-            var hash = ComputeIntegrityHash(context);
+            var hash = IntegrityHash ?? ComputeIntegrityHash(context);
             if (hash != null)
             {
                 writer.AddAttribute("integrity", hash);


### PR DESCRIPTION
Seems that auto-computing the integrity hash, as is done now, wouldn't necessarily be the right thing, given that it would only ensure that the resource hasn't changed while the instance of Dotvvm is running.

If you restart your instance, and the resource has become malicious, then it will just hash the malicious resource and write that as the integrity SRI.

Most good CDNs provide the SRI, and it should never change. So if you have it, you should be able to use it.

This patch, as is, doesn't remove the auto-computing, it only adds the ability to add a manual hash, just to be conservative for now, if there was another use case I hadn't considered (development?).

But you may wish to remove the auto-compute entirely. Then you could remove the boolean VerifyResourceIntegrity property, as well.