### PR TITLE
Registered meta tag content attribute so it can translate virtual paths

### DIFF
--- a/src/DotVVM.Framework/Configuration/DotvvmMarkupConfiguration.cs
+++ b/src/DotVVM.Framework/Configuration/DotvvmMarkupConfiguration.cs
@@ -88,6 +88,10 @@ namespace DotVVM.Framework.Configuration
                     new HtmlTagAttributePair { TagName = "script", AttributeName = "src" },
                     new HtmlAttributeTransformConfiguration() { Type = typeof(TranslateVirtualPathHtmlAttributeTransformer) }
                 },
+                {
+                    new HtmlTagAttributePair { TagName = "meta", AttributeName = "content" },
+                    new HtmlAttributeTransformConfiguration() { Type = typeof(TranslateVirtualPathHtmlAttributeTransformer) }
+                },
             };
         }
 


### PR DESCRIPTION
MVC is able to translate virtual path within meta tag content attribute so I added this `HtmlTagAttributePair` to the `HtmlAttributeTransforms` dictionary in `DotvvmMarkupConfiguration`.

Issue https://github.com/riganti/dotvvm/issues/458