### PR TITLE
Removing some IHttpRequest properties

### DIFF
--- a/src/DotVVM.Framework.Hosting.Owin/Hosting/Middlewares/DotvvmMiddleware.cs
+++ b/src/DotVVM.Framework.Hosting.Owin/Hosting/Middlewares/DotvvmMiddleware.cs
@@ -127,7 +127,7 @@ namespace DotVVM.Framework.Hosting
         /// <returns></returns>
         public static string GetCleanRequestUrl(IHttpContext context)
         {
-            return context.Request.Path.Value.TrimStart('/').TrimEnd('/');
+            return context.Request.Url.AbsolutePath.TrimStart('/').TrimEnd('/');
         }
     }
 }

--- a/src/DotVVM.Framework.Tests.Owin/DefaultViewModelSerializerTests.cs
+++ b/src/DotVVM.Framework.Tests.Owin/DefaultViewModelSerializerTests.cs
@@ -42,9 +42,8 @@ namespace DotVVM.Framework.Tests.Runtime
 
             var requestMock = new Mock<IHttpRequest>();
             requestMock.SetupGet(m => m.Url).Returns(new Uri("http://localhost:8628/Sample1"));
-            requestMock.SetupGet(m => m.Path).Returns(new DotvvmHttpPathString(new PathString("/Sample1")));
             requestMock.SetupGet(m => m.PathBase).Returns(new DotvvmHttpPathString(new PathString("")));
-			requestMock.SetupGet(m => m.Scheme).Returns("http");
+			requestMock.SetupGet(m => m.Url.Scheme).Returns("http");
             requestMock.SetupGet(m => m.Method).Returns("GET");
             requestMock.SetupGet(m => m.Headers).Returns(new DotvvmHeaderCollection(new HeaderDictionary(new Dictionary<string, string[]>())));
 

--- a/src/DotVVM.Framework/Diagnostics/DiagnosticsRequestTracer.cs
+++ b/src/DotVVM.Framework/Diagnostics/DiagnosticsRequestTracer.cs
@@ -84,7 +84,7 @@ namespace DotVVM.Framework.Diagnostics
             {
                 RequestType = RequestTypeFromContext(request),
                 Method = request.HttpContext.Request.Method,
-                Url = request.HttpContext.Request.Path.Value,
+                Url = request.HttpContext.Request.Url.AbsolutePath,
                 Headers = request.HttpContext.Request.Headers.Select(HttpHeaderItem.FromKeyValuePair)
                     .ToList(),
                 ViewModelJson = request.ReceivedViewModelJson?.GetValue("viewModel")?.ToString()

--- a/src/DotVVM.Framework/Hosting/IHttpRequest.cs
+++ b/src/DotVVM.Framework/Hosting/IHttpRequest.cs
@@ -7,13 +7,16 @@ namespace DotVVM.Framework.Hosting
     {
         IHttpContext HttpContext { get; }
         string Method { get; }
+        [Obsolete("Use the Url.Scheme property instead")]
         string Scheme { get; }
         string ContentType { get; }
         bool IsHttps { get; }
+        [Obsolete("Use the Url property instead")]
         IPathString Path { get; }
         IPathString PathBase { get; }
         Stream Body { get; }
         IQueryCollection Query { get; }
+        [Obsolete("Use the Url.Query property instead")]
         string QueryString { get; }
         ICookieCollection Cookies { get; }
         IHeaderCollection Headers { get; }

--- a/src/DotVVM.Framework/Hosting/Middlewares/DotvvmMiddlewareBase.cs
+++ b/src/DotVVM.Framework/Hosting/Middlewares/DotvvmMiddlewareBase.cs
@@ -17,7 +17,7 @@
         /// <returns></returns>
         public static string GetCleanRequestUrl(IHttpContext context)
         {
-            return context.Request.Path.Value.TrimStart('/').TrimEnd('/');
+            return context.Request.Url.AbsolutePath.TrimStart('/').TrimEnd('/');
         }
     }
 }

--- a/src/DotVVM.Framework/Hosting/Middlewares/DotvvmRoutingMiddleware.cs
+++ b/src/DotVVM.Framework/Hosting/Middlewares/DotvvmRoutingMiddleware.cs
@@ -41,9 +41,9 @@ namespace DotVVM.Framework.Hosting.Middlewares
         public static RouteBase FindMatchingRoute(IEnumerable<RouteBase> routes, IDotvvmRequestContext context, out IDictionary<string, object> parameters)
         {
             string url;
-            if (!TryParseGooglebotHashbangEscapedFragment(context.HttpContext.Request.QueryString, out url))
+            if (!TryParseGooglebotHashbangEscapedFragment(context.HttpContext.Request.Url.Query, out url))
             {
-                url = context.HttpContext.Request.Path.Value;
+                url = context.HttpContext.Request.Url.AbsolutePath;
             }
             url = url.Trim('/');
 

--- a/src/DotVVM.Tracing.MiniProfiler.Owin/MiniProfilerActionFilter.cs
+++ b/src/DotVVM.Tracing.MiniProfiler.Owin/MiniProfilerActionFilter.cs
@@ -8,7 +8,7 @@ namespace DotVVM.Tracing.MiniProfiler.Owin
     {
         protected override Task OnPageLoadedAsync(IDotvvmRequestContext context)
         {
-            var name = $"{context.HttpContext.Request.Method} {context.HttpContext.Request.Path.Value}";
+            var name = $"{context.HttpContext.Request.Method} {context.HttpContext.Request.Url.AbsolutePath}";
             AddMiniProfilerName(context, name);
 
             return base.OnPageLoadedAsync(context);
@@ -16,7 +16,7 @@ namespace DotVVM.Tracing.MiniProfiler.Owin
 
         protected override Task OnCommandExecutingAsync(IDotvvmRequestContext context, ActionInfo actionInfo)
         {
-            var name = $"POSTBACK {context.HttpContext.Request.Path.Value}";
+            var name = $"POSTBACK {context.HttpContext.Request.Url.AbsolutePath}";
             AddMiniProfilerName(context, name);
 
             return base.OnCommandExecutingAsync(context, actionInfo);


### PR DESCRIPTION
Made `IHttpRequest` properties `Path`, `Sheme` and `QueryString` obsolete.

Replaced `Path` with `Url.AbsolutePath`, `Scheme` with `Url.Scheme` and `QueryString` with `Url.Query`. I left the property `PathBase` because i did not know what to replace it with.

issue https://github.com/riganti/dotvvm/issues/432