### PR TITLE
Added LocalizablePresenter

### DIFF
--- a/src/DotVVM.Framework/Hosting/DotvvmRequestContextExtensions.cs
+++ b/src/DotVVM.Framework/Hosting/DotvvmRequestContextExtensions.cs
@@ -30,12 +30,14 @@ namespace DotVVM.Framework.Hosting
         /// <summary>
         /// Changes the current culture of this HTTP request.
         /// </summary>
+        [Obsolete("This method only assigns CultureInfo.CurrentCulture, which is not preserved in async methods. You should assign it manually, or use RequestLocalization middleware or LocalizablePresenter.")]
         public static void ChangeCurrentCulture(this IDotvvmRequestContext context, string cultureName)
             => context.ChangeCurrentCulture(cultureName, cultureName);
 
         /// <summary>
         /// Changes the current culture of this HTTP request.
         /// </summary>
+        [Obsolete("This method only assigns CultureInfo.CurrentCulture, which is not preserved in async methods. You should assign it manually, or use RequestLocalization middleware or LocalizablePresenter.")]
         public static void ChangeCurrentCulture(this IDotvvmRequestContext context, string cultureName, string uiCultureName)
         {
 #if DotNetCore

--- a/src/DotVVM.Framework/Hosting/LocalizablePresenter.cs
+++ b/src/DotVVM.Framework/Hosting/LocalizablePresenter.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DotVVM.Framework.Hosting
+{
+    public class LocalizablePresenter : IDotvvmPresenter
+    {
+        private readonly Func<IDotvvmRequestContext, Task> nextPresenter;
+        private readonly Func<IDotvvmRequestContext, CultureInfo> getCulture;
+
+        public LocalizablePresenter(
+            Func<IDotvvmRequestContext, CultureInfo> getCulture,
+            Func<IDotvvmRequestContext, Task> nextPresenter
+        )
+        {
+            this.getCulture = getCulture;
+            this.nextPresenter = nextPresenter;
+        }
+
+        public Task ProcessRequest(IDotvvmRequestContext context)
+        {
+            var culture = this.getCulture(context);
+            if (culture != null)
+                CultureInfo.CurrentCulture = CultureInfo.CurrentUICulture = culture;
+            return this.nextPresenter(context);
+        }
+
+        public static Func<LocalizablePresenter> BasedOnParameter(string name)
+        {
+            var presenter = new LocalizablePresenter(
+                context => context.Parameters.TryGetValue(name, out var value) && !string.IsNullOrEmpty(value as string) ? new CultureInfo((string)value) : null,
+                context => context.Services.GetRequiredService<IDotvvmPresenter>().ProcessRequest(context)
+            );
+            return () => presenter;
+        }
+
+        public static Func<LocalizablePresenter> BasedOnQuery(string name)
+        {
+            var presenter = new LocalizablePresenter(
+                context => context.Query.TryGetValue(name, out var value) && !string.IsNullOrEmpty(value as string) ? new CultureInfo((string)value) : null,
+                context => context.Services.GetRequiredService<IDotvvmPresenter>().ProcessRequest(context)
+            );
+            return () => presenter;
+        }
+    }
+}

--- a/src/DotVVM.Samples.Common/DotvvmStartup.cs
+++ b/src/DotVVM.Samples.Common/DotvvmStartup.cs
@@ -6,6 +6,7 @@ using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.ResourceManagement;
 using DotVVM.Framework.Routing;
+using DotVVM.Framework.Hosting;
 using DotVVM.Framework.ViewModel;
 using DotVVM.Framework.ViewModel.Serialization;
 using DotVVM.Samples.BasicSamples.Controls;
@@ -113,6 +114,9 @@ namespace DotVVM.Samples.BasicSamples
             config.RouteTable.Add("ControlSamples_SpaContentPlaceHolder_PageA", "ControlSamples/SpaContentPlaceHolder/PageA/{Id}", "Views/ControlSamples/SpaContentPlaceHolder/PageA.dothtml", new { Id = 0 });
             config.RouteTable.Add("ControlSamples_SpaContentPlaceHolder_PrefixRouteName_PageA", "ControlSamples/SpaContentPlaceHolder_PrefixRouteName/PageA/{Id}", "Views/ControlSamples/SpaContentPlaceHolder_PrefixRouteName/PageA.dothtml", new { Id = 0 });
             config.RouteTable.Add("FeatureSamples_ParameterBinding_ParameterBinding", "FeatureSamples/ParameterBinding/ParameterBinding/{A}", "Views/FeatureSamples/ParameterBinding/ParameterBinding.dothtml", new { A = 123 });
+            config.RouteTable.Add("FeatureSamples-Localization", "FeatureSamples/Localization", "Views/FeatureSamples/Localization/Localization.dothtml", presenterFactory: LocalizablePresenter.BasedOnQuery("lang"));
+            config.RouteTable.Add("FeatureSamples-Localization-Localization_NestedPage_Type", "FeatureSamples/Localization/Localization_NestedPage_Type", "Views/FeatureSamples/Localization/Localization_NestedPage_Type.dothtml", presenterFactory: LocalizablePresenter.BasedOnQuery("lang"));
+
             config.RouteTable.AutoDiscoverRoutes(new DefaultRouteStrategy(config));
             config.RouteTable.Add("RepeaterRouteLink-PageDetail", "ControlSamples/Repeater/RouteLink/{Id}", "Views/ControlSamples/Repeater/RouteLink.dothtml", new { Id = 0 });
             config.RouteTable.Add("RepeaterRouteLinkUrlSuffix-PageDetail", "ControlSamples/Repeater/RouteLinkUrlSuffix/{Id}", "Views/ControlSamples/Repeater/RouteLink.dothtml", new { Id = 0 });

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/Localization/LocalizationNestedViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/Localization/LocalizationNestedViewModel.cs
@@ -7,15 +7,6 @@ namespace DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.Localization
     {
         public override Task Init()
         {
-            if (Context.Query.ContainsKey("lang") && Context.Query["lang"] == "cs-CZ")
-            {
-                Context.ChangeCurrentCulture("cs-CZ");
-            }
-            else
-            {
-                Context.ChangeCurrentCulture("en-US");
-            }
-
             return base.Init();
         }
     }

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/Localization/LocalizationViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/Localization/LocalizationViewModel.cs
@@ -8,15 +8,6 @@ namespace DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.Localization
     {
         public override Task Init()
         {
-            if (Context.Query.ContainsKey("lang") && Context.Query["lang"] == "cs-CZ")
-            {
-                Context.ChangeCurrentCulture("cs-CZ");
-            }
-            else
-            {
-                Context.ChangeCurrentCulture("en-US");
-            }
-
             return base.Init();
         }
     }


### PR DESCRIPTION
It's a utility for localizing specific route based on route parameter or query string

Resolves #330. For localizing an entire application you can use standard [RequestLocalization](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/localization#localization-middleware) middleware, it's probably not going to be based on route parameters.

> But there is no solution for .NET 4.6 and OWIN.
It's called Asp.Net Core, you should migrate and this is one of the reasons.