### PR TITLE
DotvvmRequestContextExtension are moved to global namespace.

### DIFF
--- a/src/DotVVM.Framework.Hosting.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/src/DotVVM.Framework.Hosting.AspNetCore/ApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Hosting;
@@ -60,10 +61,10 @@ namespace Microsoft.AspNetCore.Builder
 
             app.UseMiddleware<DotvvmMiddleware>(config, new List<IMiddleware> {
                 ActivatorUtilities.CreateInstance<DotvvmLocalResourceMiddleware>(app.ApplicationServices),
-                ActivatorUtilities.CreateInstance<DotvvmFileUploadMiddleware>(app.ApplicationServices),
+                DotvvmFileUploadMiddleware.TryCreate(app.ApplicationServices),
                 new DotvvmReturnedFileMiddleware(),
                 new DotvvmRoutingMiddleware()
-            });
+            }.Where(t => t != null).ToArray());
 
             return config;
         }

--- a/src/DotVVM.Framework.Hosting.Owin/AppBuilderExtensions.cs
+++ b/src/DotVVM.Framework.Hosting.Owin/AppBuilderExtensions.cs
@@ -58,10 +58,10 @@ namespace Owin
 
             app.Use<DotvvmMiddleware>(config, new List<IMiddleware> {
                 ActivatorUtilities.CreateInstance<DotvvmLocalResourceMiddleware>(config.ServiceProvider),
-                ActivatorUtilities.CreateInstance<DotvvmFileUploadMiddleware>(config.ServiceProvider),
+                DotvvmFileUploadMiddleware.TryCreate(config.ServiceProvider),
                 new DotvvmReturnedFileMiddleware(),
                 new DotvvmRoutingMiddleware()
-            });
+            }.Where(t => t != null).ToArray());
 
             return config;
         }

--- a/src/DotVVM.Framework/Hosting/DotvvmRequestContextExtensions.cs
+++ b/src/DotVVM.Framework/Hosting/DotvvmRequestContextExtensions.cs
@@ -14,185 +14,181 @@ using DotVVM.Framework.ViewModel.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using System.Threading;
 using DotVVM.Framework.Routing;
+using DotVVM.Framework.Hosting;
 
-namespace DotVVM.Framework.Hosting
+public static class DotvvmRequestContextExtensions
 {
-    public static class DotvvmRequestContextExtensions
+    /// <summary>
+    /// Gets the unique id of the SpaContentPlaceHolder that should be loaded.
+    /// </summary>
+    public static string GetSpaContentPlaceHolderUniqueId(this IDotvvmRequestContext context)
     {
-        /// <summary>
-        /// Gets the unique id of the SpaContentPlaceHolder that should be loaded.
-        /// </summary>
-        public static string GetSpaContentPlaceHolderUniqueId(this IDotvvmRequestContext context)
-        {
-            return DotvvmPresenter.DetermineSpaContentPlaceHolderUniqueId(context.HttpContext);
-        }
+        return DotvvmPresenter.DetermineSpaContentPlaceHolderUniqueId(context.HttpContext);
+    }
 
-        /// <summary>
-        /// Changes the current culture of this HTTP request.
-        /// </summary>
-        public static void ChangeCurrentCulture(this IDotvvmRequestContext context, string cultureName)
-            => context.ChangeCurrentCulture(cultureName, cultureName);
+    /// <summary>
+    /// Changes the current culture of this HTTP request.
+    /// </summary>
+    public static void ChangeCurrentCulture(this IDotvvmRequestContext context, string cultureName)
+        => context.ChangeCurrentCulture(cultureName, cultureName);
 
-        /// <summary>
-        /// Changes the current culture of this HTTP request.
-        /// </summary>
-        public static void ChangeCurrentCulture(this IDotvvmRequestContext context, string cultureName, string uiCultureName)
-        {
+    /// <summary>
+    /// Changes the current culture of this HTTP request.
+    /// </summary>
+    public static void ChangeCurrentCulture(this IDotvvmRequestContext context, string cultureName, string uiCultureName)
+    {
 #if DotNetCore
-            CultureInfo.CurrentCulture = new CultureInfo(cultureName);
-            CultureInfo.CurrentUICulture = new CultureInfo(uiCultureName);
+        CultureInfo.CurrentCulture = new CultureInfo(cultureName);
+        CultureInfo.CurrentUICulture = new CultureInfo(uiCultureName);
 #else
-            Thread.CurrentThread.CurrentCulture = new CultureInfo(cultureName);
-            Thread.CurrentThread.CurrentUICulture = new CultureInfo(uiCultureName);
+        Thread.CurrentThread.CurrentCulture = new CultureInfo(cultureName);
+        Thread.CurrentThread.CurrentUICulture = new CultureInfo(uiCultureName);
 #endif
-        }
+    }
 
-        /// <summary>
-        /// Gets the current UI culture of this HTTP request.
-        /// </summary>
-        [Obsolete("This just returns CultureInfo.CurrentUICulture")]
-        public static CultureInfo GetCurrentUICulture(this IDotvvmRequestContext context)
+    /// <summary>
+    /// Gets the current UI culture of this HTTP request.
+    /// </summary>
+    [Obsolete("This just returns CultureInfo.CurrentUICulture")]
+    public static CultureInfo GetCurrentUICulture(this IDotvvmRequestContext context)
+    {
+        return CultureInfo.CurrentUICulture;
+    }
+
+    /// <summary>
+    /// Gets the current culture of this HTTP request.
+    /// </summary>
+    [Obsolete("This just returns CultureInfo.CurrentCulture")]
+    public static CultureInfo GetCurrentCulture(this IDotvvmRequestContext context)
+    {
+        return CultureInfo.CurrentCulture;
+    }
+
+    /// <summary>
+    /// Interrupts the execution of the current request.
+    /// </summary>
+    [DebuggerHidden]
+    public static void InterruptRequest(this IDotvvmRequestContext context)
+    {
+        throw new DotvvmInterruptRequestExecutionException();
+    }
+
+    /// <summary>
+    /// Returns the redirect response and interrupts the execution of current request.
+    /// </summary>
+    public static void RedirectToUrl(this IDotvvmRequestContext context, string url, bool replaceInHistory = false, bool allowSpaRedirect = false)
+    {
+        context.SetRedirectResponse(context.TranslateVirtualPath(url), (int)HttpStatusCode.Redirect, replaceInHistory, allowSpaRedirect);
+        throw new DotvvmInterruptRequestExecutionException(InterruptReason.Redirect, url);
+    }
+
+    /// <summary>
+    /// Returns the redirect response and interrupts the execution of current request.
+    /// </summary>
+    public static void RedirectToRoute(this IDotvvmRequestContext context, string routeName, object newRouteValues = null, bool replaceInHistory = false, bool allowSpaRedirect = true, string urlSuffix = null, object query = null)
+    {
+        var route = context.Configuration.RouteTable[routeName];
+        var url = route.BuildUrl(context.Parameters, newRouteValues) + UrlHelper.BuildUrlSuffix(urlSuffix, query);
+
+        context.RedirectToUrl(url, replaceInHistory, allowSpaRedirect);
+    }
+
+    /// <summary>
+    /// Returns the permanent redirect response and interrupts the execution of current request.
+    /// </summary>
+    public static void RedirectToUrlPermanent(this IDotvvmRequestContext context, string url, bool replaceInHistory = false, bool allowSpaRedirect = false)
+    {
+        context.SetRedirectResponse(context.TranslateVirtualPath(url), (int)HttpStatusCode.MovedPermanently, replaceInHistory, allowSpaRedirect);
+        throw new DotvvmInterruptRequestExecutionException(InterruptReason.RedirectPermanent, url);
+    }
+
+    /// <summary>
+    /// Returns the permanent redirect response and interrupts the execution of current request.
+    /// </summary>
+    public static void RedirectToRoutePermanent(this IDotvvmRequestContext context, string routeName, object newRouteValues = null, bool replaceInHistory = false, bool allowSpaRedirect = true)
+    {
+        var route = context.Configuration.RouteTable[routeName];
+        var url = route.BuildUrl(context.Parameters, newRouteValues);
+        context.RedirectToUrlPermanent(url, replaceInHistory, allowSpaRedirect);
+    }
+
+    public static void SetRedirectResponse(this IDotvvmRequestContext context, string url, int statusCode = (int)HttpStatusCode.Redirect, bool replaceInHistory = false, bool allowSpaRedirect = false) =>
+        context.Services.GetService<IHttpRedirectService>()?.WriteRedirectReponse(context.HttpContext, url, statusCode, replaceInHistory, allowSpaRedirect);
+
+
+    /// <summary>
+    /// Ends the request execution when the <see cref="ModelState"/> is not valid and displays the validation errors in <see cref="ValidationSummary"/> control.
+    /// If it is, it does nothing.
+    /// </summary>
+    public static void FailOnInvalidModelState(this IDotvvmRequestContext context)
+    {
+        if (!context.ModelState.IsValid)
         {
-            return CultureInfo.CurrentUICulture;
+            context.HttpContext.Response.ContentType = "application/json";
+            context.HttpContext.Response.Write(context.Services.GetRequiredService<IViewModelSerializer>().SerializeModelState(context));
+            throw new DotvvmInterruptRequestExecutionException(InterruptReason.ModelValidationFailed, "The ViewModel contains validation errors!");
         }
+    }
 
-        /// <summary>
-        /// Gets the current culture of this HTTP request.
-        /// </summary>
-        [Obsolete("This just returns CultureInfo.CurrentCulture")]
-        public static CultureInfo GetCurrentCulture(this IDotvvmRequestContext context)
+    /// <summary>
+    /// Gets the serialized view model.
+    /// </summary>
+    public static string GetSerializedViewModel(this IDotvvmRequestContext context)
+    {
+        return context.Services.GetRequiredService<IViewModelSerializer>().SerializeViewModel(context);
+    }
+
+    /// <summary>
+    /// Translates the virtual path (~/something) to the domain relative path (/virtualDirectory/something). 
+    /// For example, when the app is configured to run in a virtual directory '/virtDir', the URL '~/myPage.dothtml' will be translated to '/virtDir/myPage.dothtml'.
+    /// </summary>
+    public static string TranslateVirtualPath(this IDotvvmRequestContext context, string virtualUrl)
+    {
+        return TranslateVirtualPath(virtualUrl, context.HttpContext);
+    }
+
+    /// <summary>
+    /// Translates the virtual path (~/something) to the domain relative path (/virtualDirectory/something). 
+    /// For example, when the app is configured to run in a virtual directory '/virtDir', the URL '~/myPage.dothtml' will be translated to '/virtDir/myPage.dothtml'.
+    /// </summary>
+    public static string TranslateVirtualPath(string virtualUrl, IHttpContext httpContext)
+    {
+        if (virtualUrl.StartsWith("~/", StringComparison.Ordinal))
         {
-            return CultureInfo.CurrentCulture;
-        }
-
-        /// <summary>
-        /// Interrupts the execution of the current request.
-        /// </summary>
-        [DebuggerHidden]
-        public static void InterruptRequest(this IDotvvmRequestContext context)
-        {
-            throw new DotvvmInterruptRequestExecutionException();
-        }
-
-        /// <summary>
-        /// Returns the redirect response and interrupts the execution of current request.
-        /// </summary>
-        public static void RedirectToUrl(this IDotvvmRequestContext context, string url, bool replaceInHistory = false, bool allowSpaRedirect = false)
-        {
-            context.SetRedirectResponse(context.TranslateVirtualPath(url), (int)HttpStatusCode.Redirect, replaceInHistory, allowSpaRedirect);
-            throw new DotvvmInterruptRequestExecutionException(InterruptReason.Redirect, url);
-        }
-
-        /// <summary>
-        /// Returns the redirect response and interrupts the execution of current request.
-        /// </summary>
-        public static void RedirectToRoute(this IDotvvmRequestContext context, string routeName, object newRouteValues = null, bool replaceInHistory = false, bool allowSpaRedirect = true, string urlSuffix = null, object query = null)
-        {
-            var route = context.Configuration.RouteTable[routeName];
-            var url = route.BuildUrl(context.Parameters, newRouteValues) + UrlHelper.BuildUrlSuffix(urlSuffix, query);
-
-            context.RedirectToUrl(url, replaceInHistory, allowSpaRedirect);
-        }
-
-        /// <summary>
-        /// Returns the permanent redirect response and interrupts the execution of current request.
-        /// </summary>
-        public static void RedirectToUrlPermanent(this IDotvvmRequestContext context, string url, bool replaceInHistory = false, bool allowSpaRedirect = false)
-        {
-            context.SetRedirectResponse(context.TranslateVirtualPath(url), (int)HttpStatusCode.MovedPermanently, replaceInHistory, allowSpaRedirect);
-            throw new DotvvmInterruptRequestExecutionException(InterruptReason.RedirectPermanent, url);
-        }
-
-        /// <summary>
-        /// Returns the permanent redirect response and interrupts the execution of current request.
-        /// </summary>
-        public static void RedirectToRoutePermanent(this IDotvvmRequestContext context, string routeName, object newRouteValues = null, bool replaceInHistory = false, bool allowSpaRedirect = true)
-        {
-            var route = context.Configuration.RouteTable[routeName];
-            var url = route.BuildUrl(context.Parameters, newRouteValues);
-            context.RedirectToUrlPermanent(url, replaceInHistory, allowSpaRedirect);
-        }
-
-        public static void SetRedirectResponse(this IDotvvmRequestContext context, string url, int statusCode = (int)HttpStatusCode.Redirect, bool replaceInHistory = false, bool allowSpaRedirect = false) =>
-            context.Services.GetService<IHttpRedirectService>()?.WriteRedirectReponse(context.HttpContext, url, statusCode, replaceInHistory, allowSpaRedirect);
-
-
-        /// <summary>
-        /// Ends the request execution when the <see cref="ModelState"/> is not valid and displays the validation errors in <see cref="ValidationSummary"/> control.
-        /// If it is, it does nothing.
-        /// </summary>
-        public static void FailOnInvalidModelState(this IDotvvmRequestContext context)
-        {
-            if (!context.ModelState.IsValid)
+            var url = DotvvmMiddlewareBase.GetVirtualDirectory(httpContext) + "/" + virtualUrl.Substring(2);
+            if (!url.StartsWith("/", StringComparison.Ordinal))
             {
-                context.HttpContext.Response.ContentType = "application/json";
-                context.HttpContext.Response.Write(context.Services.GetRequiredService<IViewModelSerializer>().SerializeModelState(context));
-                throw new DotvvmInterruptRequestExecutionException(InterruptReason.ModelValidationFailed, "The ViewModel contains validation errors!");
+                url = "/" + url;
             }
+            return url;
         }
-
-        /// <summary>
-        /// Gets the serialized view model.
-        /// </summary>
-        public static string GetSerializedViewModel(this IDotvvmRequestContext context)
+        else
         {
-            return context.Services.GetRequiredService<IViewModelSerializer>().SerializeViewModel(context);
+            return virtualUrl;
         }
+    }
 
-        /// <summary>
-        /// Translates the virtual path (~/something) to the domain relative path (/virtualDirectory/something). 
-        /// For example, when the app is configured to run in a virtual directory '/virtDir', the URL '~/myPage.dothtml' will be translated to '/virtDir/myPage.dothtml'.
-        /// </summary>
-        public static string TranslateVirtualPath(this IDotvvmRequestContext context, string virtualUrl)
+    /// <summary>
+    /// Redirects the client to the specified file.
+    /// </summary>
+    public static void ReturnFile(this IDotvvmRequestContext context, byte[] bytes, string fileName, string mimeType, IEnumerable<KeyValuePair<string, string>> additionalHeaders = null) =>
+        context.ReturnFile(new MemoryStream(bytes), fileName, mimeType, additionalHeaders);
+
+    /// <summary>
+    /// Redirects the client to the specified file.
+    /// </summary>
+    public static void ReturnFile(this IDotvvmRequestContext context, Stream stream, string fileName, string mimeType, IEnumerable<KeyValuePair<string, string>> additionalHeaders = null)
+    {
+        var returnedFileStorage = context.Services.GetService<IReturnedFileStorage>();
+        var metadata = new ReturnedFileMetadata()
         {
-            return TranslateVirtualPath(virtualUrl, context.HttpContext);
-        }
+            FileName = fileName,
+            MimeType = mimeType,
+            AdditionalHeaders = additionalHeaders?.GroupBy(k => k.Key, k => k.Value)?.ToDictionary(k => k.Key, k => k.ToArray())
+        };
 
-        /// <summary>
-        /// Translates the virtual path (~/something) to the domain relative path (/virtualDirectory/something). 
-        /// For example, when the app is configured to run in a virtual directory '/virtDir', the URL '~/myPage.dothtml' will be translated to '/virtDir/myPage.dothtml'.
-        /// </summary>
-        public static string TranslateVirtualPath(string virtualUrl, IHttpContext httpContext)
-        {
-            if (virtualUrl.StartsWith("~/", StringComparison.Ordinal))
-            {
-                var url = DotvvmMiddlewareBase.GetVirtualDirectory(httpContext) + "/" + virtualUrl.Substring(2);
-                if (!url.StartsWith("/", StringComparison.Ordinal))
-                {
-                    url = "/" + url;
-                }
-                return url;
-            }
-            else
-            {
-                return virtualUrl;
-            }
-        }
-
-        /// <summary>
-        /// Redirects the client to the specified file.
-        /// </summary>
-        public static void ReturnFile(this IDotvvmRequestContext context, byte[] bytes, string fileName, string mimeType, IEnumerable<KeyValuePair<string, string>> additionalHeaders = null) =>
-            context.ReturnFile(new MemoryStream(bytes), fileName, mimeType, additionalHeaders);
-
-        /// <summary>
-        /// Redirects the client to the specified file.
-        /// </summary>
-        public static void ReturnFile(this IDotvvmRequestContext context, Stream stream, string fileName, string mimeType, IEnumerable<KeyValuePair<string, string>> additionalHeaders = null)
-        {
-            var returnedFileStorage = context.Services.GetService<IReturnedFileStorage>();
-            var metadata = new ReturnedFileMetadata()
-            {
-                FileName = fileName,
-                MimeType = mimeType,
-                AdditionalHeaders = additionalHeaders?.GroupBy(k => k.Key, k => k.Value)?.ToDictionary(k => k.Key, k => k.ToArray())
-            };
-
-            var generatedFileId = returnedFileStorage.StoreFile(stream, metadata).Result;
-            context.SetRedirectResponse(context.TranslateVirtualPath("~/dotvvmReturnedFile?id=" + generatedFileId));
-            throw new DotvvmInterruptRequestExecutionException(InterruptReason.ReturnFile, fileName);
-        
-        }
-
+        var generatedFileId = returnedFileStorage.StoreFile(stream, metadata).Result;
+        context.SetRedirectResponse(context.TranslateVirtualPath("~/dotvvmReturnedFile?id=" + generatedFileId));
+        throw new DotvvmInterruptRequestExecutionException(InterruptReason.ReturnFile, fileName);
     }
 }

--- a/src/DotVVM.Framework/Hosting/Middlewares/DotvvmFileUploadMiddleware.cs
+++ b/src/DotVVM.Framework/Hosting/Middlewares/DotvvmFileUploadMiddleware.cs
@@ -10,6 +10,7 @@ using DotVVM.Framework.Controls;
 using DotVVM.Framework.Runtime;
 using DotVVM.Framework.Storage;
 using Microsoft.AspNet.WebUtilities;
+using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 
 namespace DotVVM.Framework.Hosting.Middlewares
@@ -25,6 +26,16 @@ namespace DotVVM.Framework.Hosting.Middlewares
         {
             this.outputRenderer = outputRenderer;
             this.fileStorage = fileStorage;
+        }
+
+        public static DotvvmFileUploadMiddleware TryCreate(IServiceProvider provider)
+        {
+            var renderer = provider.GetRequiredService<IOutputRenderer>();
+            var fileStorage = provider.GetService<IUploadedFileStorage>();
+            if (fileStorage != null)
+                return new DotvvmFileUploadMiddleware(renderer, fileStorage);
+            else
+                return null;
         }
 
         public async Task<bool> Handle(IDotvvmRequestContext request)

--- a/src/DotVVM.Framework/Hosting/Middlewares/DotvvmReturnedFileMiddleware.cs
+++ b/src/DotVVM.Framework/Hosting/Middlewares/DotvvmReturnedFileMiddleware.cs
@@ -8,17 +8,18 @@ using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DotVVM.Framework.Hosting.Middlewares
-{ 
+{
     //TODO: Code reveiw
     public class DotvvmReturnedFileMiddleware : IMiddleware
     {
+
         public async Task<bool> Handle(IDotvvmRequestContext request)
         {
             var url = DotvvmMiddlewareBase.GetCleanRequestUrl(request.HttpContext);
 
             if (url.StartsWith("dotvvmReturnedFile", StringComparison.Ordinal))
             {
-                await RenderReturnedFile(request.HttpContext, request.Services.GetService<IReturnedFileStorage>());
+                await RenderReturnedFile(request.HttpContext, request.Services.GetRequiredService<IReturnedFileStorage>());
                 return true;
             }
             else return false;


### PR DESCRIPTION
It has to be here to preserve backwards compatibility with DotVVM 1.x

Note that you can use https://github.com/riganti/dotvvm/pull/500/files?w=1 for diff without changed whitespace - I had to unindent the class to preserve sane formatting.