### PR TITLE
Added multiple override options to server-side style

### DIFF
--- a/src/DotVVM.Framework/Compilation/Styles/CompileTimeStyleBase.cs
+++ b/src/DotVVM.Framework/Compilation/Styles/CompileTimeStyleBase.cs
@@ -25,9 +25,11 @@ namespace DotVVM.Framework.Compilation.Styles
             {
                 foreach (var prop in SetProperties)
                 {
-                    if (!control.Properties.ContainsKey(prop.Key) || prop.Value.Append)
+                    if (!control.Properties.ContainsKey(prop.Key)
+                        || prop.Value.Type == StyleOverrideOptions.Append
+                        || prop.Value.Type == StyleOverrideOptions.Overwrite)
                     {
-                        control.SetProperty(prop.Value.Value, prop.Value.Append, out string error);
+                        control.SetProperty(prop.Value.Value, prop.Value.Type == StyleOverrideOptions.Overwrite, out string error);
                     }
                 }
             }
@@ -51,12 +53,12 @@ namespace DotVVM.Framework.Compilation.Styles
         public struct PropertyInsertionInfo
         {
             public readonly ResolvedPropertySetter Value;
-            public readonly bool Append;
+            public readonly StyleOverrideOptions Type;
 
-            public PropertyInsertionInfo(ResolvedPropertySetter value, bool append)
+            public PropertyInsertionInfo(ResolvedPropertySetter value, StyleOverrideOptions type)
             {
                 this.Value = value;
-                this.Append = append;
+                this.Type = type;
             }
         }
     }

--- a/src/DotVVM.Framework/Compilation/Styles/StyleBuilder.cs
+++ b/src/DotVVM.Framework/Compilation/Styles/StyleBuilder.cs
@@ -29,7 +29,7 @@ namespace DotVVM.Framework.Compilation.Styles
 
         private static DotvvmProperty GetProperty(string name)
         {
-            var field = typeof(T).GetField(name + "Property", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.FlattenHierarchy);
+            var field = typeof(T).GetField(name + "Property", BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy);
             return field.GetValue(null) as DotvvmProperty;
         }
 
@@ -39,22 +39,22 @@ namespace DotVVM.Framework.Compilation.Styles
             return SetDotvvmProperty(GetProperty(propertyName), value);
         }
 
-        public StyleBuilder<T> SetDotvvmProperty(ResolvedPropertySetter setter, bool append = true)
+        public StyleBuilder<T> SetDotvvmProperty(ResolvedPropertySetter setter, StyleOverrideOptions options = StyleOverrideOptions.Overwrite)
         {
-            style.SetProperties[setter.Property] = new CompileTimeStyleBase.PropertyInsertionInfo(setter, append);
+            style.SetProperties[setter.Property] = new CompileTimeStyleBase.PropertyInsertionInfo(setter, options);
             return this;
         }
 
-        public StyleBuilder<T> SetDotvvmProperty(DotvvmProperty property, object value, bool append = true) => 
-            SetDotvvmProperty(new ResolvedPropertyValue(property, value), append);
+        public StyleBuilder<T> SetDotvvmProperty(DotvvmProperty property, object value, StyleOverrideOptions options = StyleOverrideOptions.Overwrite) =>
+            SetDotvvmProperty(new ResolvedPropertyValue(property, value), options);
 
-        public StyleBuilder<T> SetAttribute(string attribute, object value, bool append = false) => 
-            SetPropertyGroupMember("", attribute, value, append);
+        public StyleBuilder<T> SetAttribute(string attribute, object value, StyleOverrideOptions options = StyleOverrideOptions.Ignore) =>
+            SetPropertyGroupMember("", attribute, value, options);
 
-        public StyleBuilder<T> SetPropertyGroupMember(string prefix, string memberName, object value, bool append = true)
+        public StyleBuilder<T> SetPropertyGroupMember(string prefix, string memberName, object value, StyleOverrideOptions options = StyleOverrideOptions.Overwrite)
         {
-            var prop = DotvvmPropertyGroup .GetPropertyGroups(typeof(T)).Single(p => p.Prefixes.Contains(prefix));
-            return SetDotvvmProperty(prop.GetDotvvmProperty(memberName), value, append);
+            var prop = DotvvmPropertyGroup.GetPropertyGroups(typeof(T)).Single(p => p.Prefixes.Contains(prefix));
+            return SetDotvvmProperty(prop.GetDotvvmProperty(memberName), value, options);
         }
 
         public StyleBuilder<T> WithCondition(Func<StyleMatchContext, bool> condition)
@@ -94,5 +94,12 @@ namespace DotVVM.Framework.Compilation.Styles
                 return Matcher != null ? Matcher(matchInfo) : true;
             }
         }
+    }
+
+    public enum StyleOverrideOptions
+    {
+        Ignore,
+        Overwrite,
+        Append
     }
 }

--- a/src/DotVVM.Samples.Common/DotvvmStartup.cs
+++ b/src/DotVVM.Samples.Common/DotvvmStartup.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Reflection;
 using DotVVM.Framework.Binding;
 using DotVVM.Framework.Compilation.Parser;
+using DotVVM.Framework.Compilation.Styles;
 using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.ResourceManagement;
@@ -57,11 +58,12 @@ namespace DotVVM.Samples.BasicSamples
             // All style samples
             config.Styles.Register<Controls.ServerSideStylesControl>()
                 .SetAttribute("value", "Text changed")
-                .SetDotvvmProperty(Controls.ServerSideStylesControl.CustomProperty, "Custom property changed", false)
-                .SetAttribute("class", "Class changed", true);
+                .SetDotvvmProperty(Controls.ServerSideStylesControl.CustomProperty, "Custom property changed")
+                .SetAttribute("class", "Class changed", StyleOverrideOptions.Overwrite);
             config.Styles.Register("customTagName")
-                .SetAttribute("noAppend", "Attribute changed")
-                .SetAttribute("append", "Attribute changed", true);
+                .SetAttribute("ignore", "Attribute ignored", StyleOverrideOptions.Ignore)
+                .SetAttribute("overwrite", "Attribute changed", StyleOverrideOptions.Overwrite)
+                .SetAttribute("append", "Attribute appended", StyleOverrideOptions.Append);
             config.Styles.Register<Controls.ServerSideStylesControl>(c => c.HasProperty(Controls.ServerSideStylesControl.CustomProperty), false)
                 .SetAttribute("derivedAttr", "Derived attribute");
             config.Styles.Register<Controls.ServerSideStylesControl>(c => c.HasProperty(Controls.ServerSideStylesControl.AddedProperty))

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/ServerSideStyles/ServerSideStyles.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/ServerSideStyles/ServerSideStyles.dothtml
@@ -23,7 +23,8 @@
 
         <customTagName id="htmlControlWithAttr"
                        append="Default attribute"
-                       noAppend="Default attribute">
+                       overwrite="Default attribute"
+                       ignore="Default attribute">
             Custom html control with default attributes
         </customTagName>
     </div>

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/ServerSideStyles/ServerSideStyles_MatchingViewModel.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/ServerSideStyles/ServerSideStyles_MatchingViewModel.dothtml
@@ -22,8 +22,9 @@
         <br />
 
         <customTagName id="htmlControlWithAttr"
-                       append="Default attribute"
-                       noAppend="Default attribute">
+                       ignore="Default attribute"
+                       overwrite="Default attribute"
+                       append="Default attribute">
             Custom html control with default attributes
         </customTagName>
     </div>


### PR DESCRIPTION
This PR improves server-side style registration with multiple override options:
* `Append` - this options actually append value in a attribute/property
* `Overwrite` - behavior is the same as `append == true` before this PR (overwrites attribute value)
* `Ignore` - behavior is the same as `append == false` before this PR (ignores attribute with value)


The PR resolves #487