### PR TITLE
 Redesigned resource link controls

### DIFF
--- a/src/DotVVM.Framework/Controls/HtmlGenericControl.cs
+++ b/src/DotVVM.Framework/Controls/HtmlGenericControl.cs
@@ -124,7 +124,7 @@ namespace DotVVM.Framework.Controls
         }
 
         /// <summary>
-        /// Verifies that the control hasn't any HTML attributes or Visible or DataContext bindings set.
+        /// Verifies that the control hasn't any HTML attributes, css classes or Visible or DataContext bindings set.
         /// </summary>
         protected virtual void EnsureNoAttributesSet()
         {
@@ -135,7 +135,7 @@ namespace DotVVM.Framework.Controls
         }
 
         /// <summary>
-        /// Renders the control begin tag.
+        /// Renders the control begin tag if <see cref="RendersHtmlTag" /> == true.
         /// </summary>
         protected override void RenderBeginTag(IHtmlWriter writer, IDotvvmRequestContext context)
         {
@@ -146,10 +146,16 @@ namespace DotVVM.Framework.Controls
         }
 
         /// <summary>
-        /// Renders the control end tag.
+        /// Renders the control end tag if <see cref="RendersHtmlTag" /> == true. Also renders required resource i before the end tag, if it is a `head` or `body` element
         /// </summary>
         protected override void RenderEndTag(IHtmlWriter writer, IDotvvmRequestContext context)
         {
+            // render resource link. If the Render is onvoked multiple times the resources are rendered on the first invocation.
+            if (TagName == "head")
+                new HeadResourceLinks().Render(writer, context);
+            else if (TagName == "body")
+                new BodyResourceLinks().Render(writer, context);
+
             if (RendersHtmlTag)
             {
                 writer.RenderEndTag();

--- a/src/DotVVM.Framework/Controls/Infrastructure/HeadResourceLinks.cs
+++ b/src/DotVVM.Framework/Controls/Infrastructure/HeadResourceLinks.cs
@@ -6,24 +6,23 @@ using DotVVM.Framework.Runtime;
 using DotVVM.Framework.ResourceManagement;
 using DotVVM.Framework.Hosting;
 
-namespace DotVVM.Framework.Controls.Infrastructure
+namespace DotVVM.Framework.Controls
 {
     /// <summary>
-    /// Renders the stylesheet links. This control must be on every page just before the end of head element.
+    /// Renders the resource links with RenderPosition = Head. This control must be on every page, usually just before the end of head element.
     /// </summary>
     public class HeadResourceLinks : DotvvmControl
     {
-
-        /// <summary>
-        /// Renders the control into the specified writer.
-        /// </summary>
         protected override void RenderControl(IHtmlWriter writer, IDotvvmRequestContext context)
         {
             // render resource links
-            var resources = context.ResourceManager.GetNamedResourcesInOrder().Where(r => r.Resource.RenderPosition == ResourceRenderPosition.Head);
-            foreach (var resource in resources)
+            var resourceManager = context.ResourceManager;
+            if (resourceManager.HeadRendered) return;
+            resourceManager.HeadRendered = true; // set the flag before the resources are rendered, so they can't add more resources to the list  during the rende
+            foreach (var resource in resourceManager.GetNamedResourcesInOrder())
             {
-                resource.RenderResourceCached(writer, context);
+                if (resource.Resource.RenderPosition == ResourceRenderPosition.Head)
+                    resource.RenderResourceCached(writer, context);
             }
         }
     }

--- a/src/DotVVM.Framework/Controls/Infrastructure/HeadResourceLinks.cs
+++ b/src/DotVVM.Framework/Controls/Infrastructure/HeadResourceLinks.cs
@@ -18,7 +18,7 @@ namespace DotVVM.Framework.Controls
             // render resource links
             var resourceManager = context.ResourceManager;
             if (resourceManager.HeadRendered) return;
-            resourceManager.HeadRendered = true; // set the flag before the resources are rendered, so they can't add more resources to the list  during the rende
+            resourceManager.HeadRendered = true; // set the flag before the resources are rendered, so they can't add more resources to the list during the render
             foreach (var resource in resourceManager.GetNamedResourcesInOrder())
             {
                 if (resource.Resource.RenderPosition == ResourceRenderPosition.Head)

--- a/src/DotVVM.Framework/ResourceManagement/ResourceManager.cs
+++ b/src/DotVVM.Framework/ResourceManagement/ResourceManager.cs
@@ -24,6 +24,9 @@ namespace DotVVM.Framework.ResourceManagement
             get { return requiredResourcesOrdered.AsReadOnly(); }
         }
 
+        internal bool HeadRendered;
+        internal bool BodyRendered;
+
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ResourceManager"/> class.
@@ -64,6 +67,8 @@ namespace DotVVM.Framework.ResourceManagement
             }
             else
             {
+                if (this.IsAlreadyRendered(resource.RenderPosition))
+                    throw new Exception($"Can't add {resource.GetType().Name} '{name}' to {resource.RenderPosition}, it is already rendered.");
                 foreach (var dep in resource.Dependencies)
                 {
                     AddRequiredResource(dep);
@@ -72,6 +77,11 @@ namespace DotVVM.Framework.ResourceManagement
                 requiredResources[name] = resource;
             }
         }
+
+        /// Checks whether the resource position is already rendered.
+        private bool IsAlreadyRendered(ResourceRenderPosition position) =>
+            position == ResourceRenderPosition.Head && HeadRendered ||
+            position == ResourceRenderPosition.Body && BodyRendered;
 
         /// <summary>
         /// Adds the required script file.

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/Resources/OnlineNonameResourceLoad.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/Resources/OnlineNonameResourceLoad.dothtml
@@ -11,5 +11,9 @@
 		<dot:Button Text="Alert" Click="{command: Alert()}" />
 
 	</div>
+	<dot:BodyResourceLinks />
+	<script>
+		if (!window.dotvvm)
+			alert("DotVVM scripts were not loaded before this one ;(");
 </body>
 </html>

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/Resources/OnlineNonameResourceLoad.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/Resources/OnlineNonameResourceLoad.dothtml
@@ -15,5 +15,6 @@
 	<script>
 		if (!window.dotvvm)
 			alert("DotVVM scripts were not loaded before this one ;(");
+	</script>
 </body>
 </html>


### PR DESCRIPTION
You can now explicitly say "I want to have the resources rendered here" using <dot:HeadResourceLinks /> or <dot:BodyResourceLinks />. The resources are rendered on the first place where this control occurs.

HtmlGenericControl renders this control implicitly if the TagName is body or head (I have moved the logic from DefaultOutputRenderer, I think that it should improve performance)

ResourceManager now knows if the resources have been already rendered and it will throw an exception when a new one is added. This is potentially a runtime breaking change, but it should only throw on code that is actually incorrect.