### PR TITLE
Added a script to complete xml documentation with <summary> tags

### DIFF
--- a/src/DotVVM.Core/ViewModel/AllowStaticCommandAttribute.cs
+++ b/src/DotVVM.Core/ViewModel/AllowStaticCommandAttribute.cs
@@ -2,6 +2,7 @@
 
 namespace DotVVM.Framework.ViewModel
 {
+    /// Allows remote invocation of this method from a staticCommand binding
     public class AllowStaticCommandAttribute: Attribute
     {
     }

--- a/src/Tools/add-summary-comments.fsx
+++ b/src/Tools/add-summary-comments.fsx
@@ -1,0 +1,40 @@
+#!/usr/bin/fsharpi
+
+#r "System.Xml.Linq"
+open System
+open System.Xml.Linq
+let rootElements = Set.ofList [ "example"; "code"; "exception"; "include";  "returns"; "param"; "permission"; "remark"; "seealso"; "value"; "typeparam" ]
+let filePath : string option =
+    if fsi.CommandLineArgs.Length <> 2 then
+        None
+    else
+        Some fsi.CommandLineArgs.[1]
+let xml =
+    match filePath with
+    | Some file -> XDocument.Load(file)
+    | None -> XDocument.Parse(Console.In.ReadToEnd())
+let n = XName.Get
+// get elements that does not contain <summary>
+let rawTexts = xml.Root.Element(n "members").Elements(n "member") |> Seq.filter (fun e -> e.Elements(n "summary") |> Seq.isEmpty)
+for doccomment in rawTexts do
+    let nodes =
+        doccomment.Nodes()
+        |> Seq.filter (function
+                   | :? XElement as element ->
+                       // filter non-global elements
+                       not <| Set.contains element.Name.LocalName rootElements
+                   | :? XText as text ->
+                       not <| String.IsNullOrEmpty text.Value
+                   | _ -> true)
+        |> Seq.toArray
+    for n in nodes do
+        n.Remove()
+
+    if nodes.Length > 0 then
+        doccomment.AddFirst(
+            XElement(n "summary", box nodes)
+        )
+
+match filePath with
+| Some file -> xml.Save(file)
+| None -> xml.Save(Console.Out)

--- a/src/Tools/build/publish.ps1
+++ b/src/Tools/build/publish.ps1
@@ -58,6 +58,7 @@ function SetVersion() {
 }
 
 function BuildPackages() {
+	$transformComments = [System.IO.Path]::GetFullPath("Tools/add-summary-comments.fsx")
 	foreach ($package in $packages) {
 		cd .\$($package.Directory)
 		
@@ -68,7 +69,12 @@ function BuildPackages() {
 			& dotnet restore --source $nugetRestoreAltSource --source https://nuget.org/api/v2/ | Out-Host
 		}
 		
-		& dotnet pack | Out-Host
+		& dotnet build --no-incremental --configuration Release | Out-Host
+		foreach($commentFile in (ls ./bin/Release/*/*.xml)) {
+			fsi $transformComments $commentFile
+			echo "Processed doccomment file $commentFile"
+		}
+		& dotnet pack --configuration Release --no-build | Out-Host
 		cd ..
 	}
 }


### PR DESCRIPTION
It will allow us to write comments without the `<summary>` tags - the script completes them when the package is published.

I simply don't like the verbosity of XML comments with the `summary` tags, it feels much nicer to write comments without the mess around. And it's not required by 

To be honest, I don't like that at all. I don't want to mess the codebase with VisualStudio hacks. The `summary` element is simply totally ugly and it's not required:
* By specification - the specification actually does not force any rules here, the comment just has to be valid XML. There are just recommended tags that have defined meaning.
* By all sane tools I know - Omnisharp and JetBrains Rider work.
![image](https://user-images.githubusercontent.com/7894687/34460408-c1ebcc04-ee04-11e7-9af0-380b87c8590e.png)
![image](https://user-images.githubusercontent.com/7894687/34460410-dfc2bf6c-ee04-11e7-85fe-f9fa66f72dca.png)

Unfortunatelly VisualStudio is not one of the sane tools, so I have written this script to mitigate the issues.

I have not removed any `<summary>` tags in the PR, but I'm totally going to do that when it's merged into master (just want to avoid a ton merge conflicts)

cc @adamjez @djanosik @tomasherceg What do you think?