### PR TITLE
Inner element properties tweaks

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Runtime/ControlTree/DefaultControlTreeResolverTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/ControlTree/DefaultControlTreeResolverTests.cs
@@ -615,6 +615,20 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
             Assert.IsTrue(control.Properties.Any(p => p.Value is ResolvedPropertyControlCollection));
         }
 
+        [TestMethod]
+        public void ResolvedTree_GridViewWithColumns()
+        {
+            var root = ParseSource(@"
+@viewModel System.Collections.Generic.List<string>
+<dot:GridView DataSource='{value: _this}'>
+    <dot:GridViewTextColumn HeaderText='' ValueBinding='{value: _this}' />
+
+</dot:GridView>");
+            var control = root.Content.First(n => n.Metadata.Type == typeof(GridView));
+            Assert.AreEqual(0, control.Content.Count);
+            Assert.AreEqual(1, control.Properties[GridView.ColumnsProperty].CastTo<ResolvedPropertyControlCollection>().Controls.Count);
+        }
+
 
         [TestMethod]
         public void ResolvedTree_ViewModel_GenericType()

--- a/src/DotVVM.Framework/Compilation/ControlTree/ControlTreeResolverBase.cs
+++ b/src/DotVVM.Framework/Compilation/ControlTree/ControlTreeResolverBase.cs
@@ -170,7 +170,6 @@ namespace DotVVM.Framework.Compilation.ControlTree
                 if (node is DothtmlBindingNode)
                 {
                     // binding in text
-                    EnsureContentAllowed(parentMetadata, node);
                     return ProcessBindingInText(node, dataContext);
                 }
                 else if (node is DotHtmlCommentNode)
@@ -188,7 +187,6 @@ namespace DotVVM.Framework.Compilation.ControlTree
                 else if (node is DothtmlElementNode)
                 {
                     // HTML element
-                    EnsureContentAllowed(parentMetadata, node);
                     var element = (DothtmlElementNode)node;
                     return ProcessObjectElement(element, dataContext);
                 }
@@ -225,10 +223,6 @@ namespace DotVVM.Framework.Compilation.ControlTree
         private IAbstractControl ProcessText(DothtmlNode node, IControlResolverMetadata parentMetadata, IDataContextStack dataContext, DothtmlLiteralNode literalNode)
         {
             var whitespace = string.IsNullOrWhiteSpace(literalNode.Value);
-            if (!whitespace)
-            {
-                EnsureContentAllowed(parentMetadata, node);
-            }
 
             string text;
             if (literalNode.Escape)
@@ -791,17 +785,6 @@ namespace DotVVM.Framework.Compilation.ControlTree
                 wrapperType = new ResolvedTypeDescriptor(typeof(DotvvmView));
             }
             return wrapperType;
-        }
-
-        /// <summary>
-        /// Checks that the element can have inner contents.
-        /// </summary>
-        private void EnsureContentAllowed(IControlResolverMetadata controlMetadata, DothtmlNode node)
-        {
-            if (!controlMetadata.IsContentAllowed)
-            {
-                node.AddError($"The content is not allowed inside the control '{controlMetadata.Type.FullName}'!");
-            }
         }
 
         protected virtual bool IsCollectionProperty(IPropertyDescriptor property)


### PR DESCRIPTION
InnerElement properties are not limited to elements only - now, it can also contain literals, ...

When the default property is empty or whitespace it's not assigned (so it's null). However, when the name is specified, the whitespace content is included (when valid in this context).

The content is filtered by the specified collection type (e.g. GridViewColumn), error is reported only when the element is not asignable to the specified type and when it's not empty. So it will not fail when GridView.Columns contains whitespace or comment, but will fail when you'd specify a dotvvm control or text content.