### PR TITLE
IDotvvmStartup signature changed 

### DIFF
--- a/src/DotVVM.Compiler/OwinInitializer.cs
+++ b/src/DotVVM.Compiler/OwinInitializer.cs
@@ -42,7 +42,7 @@ namespace DotVVM.Compiler
             var startupClass = webSiteAssembly.CustomAttributes?.Where(s => s.AttributeType == typeof(Microsoft.Owin.OwinStartupAttribute)).FirstOrDefault()?.ConstructorArguments[0].Value as Type;
             //if (startupClass != null)
             //{
-                
+
             //    var configureMethod = startupClass.GetRuntimeMethods().FirstOrDefault(s =>
             //        s.Name == "Configuration" && s.GetParameters().Length == 1 &&
             //        s.GetParameters()[0].ParameterType == typeof(IAppBuilder));
@@ -62,6 +62,7 @@ namespace DotVVM.Compiler
 
             if (startup == null && configureServices.Length == 0) throw new Exception($"Could not find ConfigureServices method, nor a IDotvvmStartup implementation.");
 
+            IServiceCollection collection = null;
             var config = DotvvmConfiguration.CreateDefault(
                 services => {
                     if (viewStaticCompilerCompiler != null)
@@ -70,7 +71,9 @@ namespace DotVVM.Compiler
                         services.AddSingleton<IControlResolver, OfflineCompilationControlResolver>();
                         services.TryAddSingleton<IViewModelProtector, FakeViewModelProtector>();
                     }
+                    startup.ConfigureServices(new DotvvmServiceCollection(services));
                     registerServices?.Invoke(services);
+                    collection = services;
                     foreach (var cs in configureServices)
                         cs.Invoke(cs.IsStatic ? null : Activator.CreateInstance(cs.DeclaringType), new object[] { services });
                 });
@@ -88,6 +91,6 @@ namespace DotVVM.Compiler
             return config;
         }
 
-       
+
     }
 }

--- a/src/DotVVM.Framework.Hosting.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/src/DotVVM.Framework.Hosting.AspNetCore/ApplicationBuilderExtensions.cs
@@ -26,28 +26,9 @@ namespace Microsoft.AspNetCore.Builder
         /// A value indicating whether to show detailed error page if an exception occurs. It is enabled by default
         /// if <see cref="HostingEnvironmentExtensions.IsDevelopment" /> returns <c>true</c>.
         /// </param>
-        public static DotvvmConfiguration UseDotVVM<TStartup>(this IApplicationBuilder app, string applicationRootPath = null, bool? useErrorPages = null)
-            where TStartup : IDotvvmStartup, new()
+        public static DotvvmConfiguration UseDotVVM(this IApplicationBuilder app, string applicationRootPath, bool? useErrorPages = null)
         {
-            var config = app.UseDotVVM(applicationRootPath, useErrorPages);
-            new TStartup().Configure(config, applicationRootPath);
-            return config;
-        }
-
-        /// <summary>
-        /// Adds DotVVM to the <see cref="IApplicationBuilder" /> request execution pipeline.
-        /// </summary>
-        /// <param name="app">The <see cref="IApplicationBuilder" /> instance.</param>
-        /// <param name="applicationRootPath">
-        /// The path to application's root directory. It is used to resolve paths to views, etc.
-        /// The default value is equal to <see cref="IHostingEnvironment.ContentRootPath" />.
-        /// </param>
-        /// <param name="useErrorPages">
-        /// A value indicating whether to show detailed error page if an exception occurs. It is enabled by default
-        /// if <see cref="HostingEnvironmentExtensions.IsDevelopment" /> returns <c>true</c>.
-        /// </param>
-        public static DotvvmConfiguration UseDotVVM(this IApplicationBuilder app, string applicationRootPath, bool? useErrorPages)
-        {
+            var startup = app.ApplicationServices.GetRequiredService<IDotvvmStartup>();
             var env = app.ApplicationServices.GetRequiredService<IHostingEnvironment>();
             var config = app.ApplicationServices.GetRequiredService<DotvvmConfiguration>();
 
@@ -65,6 +46,8 @@ namespace Microsoft.AspNetCore.Builder
                 new DotvvmReturnedFileMiddleware(),
                 new DotvvmRoutingMiddleware()
             }.Where(t => t != null).ToArray());
+
+            startup.Configure(config, applicationRootPath);
 
             return config;
         }

--- a/src/DotVVM.Framework/Configuration/IDotvvmStartup.cs
+++ b/src/DotVVM.Framework/Configuration/IDotvvmStartup.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DotVVM.Framework.Configuration
 {
     public interface IDotvvmStartup
     {
         void Configure(DotvvmConfiguration config, string applicationPath);
+        void ConfigureServices(IDotvvmServiceCollection serviceCollection);
     }
 }

--- a/src/DotVVM.Framework/DependencyInjection/DotvvmBuilderExtensions.cs
+++ b/src/DotVVM.Framework/DependencyInjection/DotvvmBuilderExtensions.cs
@@ -12,21 +12,21 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds file system temporary file storages to the application. See <see cref="IUploadedFileStorage" />
         /// and <see cref="IReturnedFileStorage" /> for more details.
         /// </summary>
-        /// <param name="options">The <see cref="IDotvvmOptions" /> instance.</param>
+        /// <param name="serviceCollection">The <see cref="IDotvvmServiceCollection" /> instance.</param>
         /// <param name="tempPath">The absolute or relative path to directory where to store temporary files.</param>
-        public static IDotvvmOptions AddDefaultTempStorages(this IDotvvmOptions options, string tempPath)
-            => options.AddDefaultTempStorages(tempPath, TimeSpan.FromMinutes(30));
+        public static IDotvvmServiceCollection AddDefaultTempStorages(this IDotvvmServiceCollection serviceCollection, string tempPath)
+            => serviceCollection.AddDefaultTempStorages(tempPath, TimeSpan.FromMinutes(30));
 
         /// <summary>
         /// Adds file system temporary file storages to the application. See <see cref="IUploadedFileStorage" />
         /// and <see cref="IReturnedFileStorage" /> for more details.
         /// </summary>
-        /// <param name="options">The <see cref="IDotvvmOptions" /> instance.</param>
+        /// <param name="serviceCollection">The <see cref="IDotvvmServiceCollection" /> instance.</param>
         /// <param name="tempPath">The absolute or relative path to directory where to store temporary files.</param>
         /// <param name="autoDeleteInterval">The interval to delete the temporary files after.</param>
-        public static IDotvvmOptions AddDefaultTempStorages(this IDotvvmOptions options, string tempPath, TimeSpan autoDeleteInterval)
+        public static IDotvvmServiceCollection AddDefaultTempStorages(this IDotvvmServiceCollection serviceCollection, string tempPath, TimeSpan autoDeleteInterval)
         {
-            return options
+            return serviceCollection
                 .AddUploadedFileStorage(Path.Combine(tempPath, "uploadedFiles"), autoDeleteInterval)
                 .AddReturnedFileStorage(Path.Combine(tempPath, "returnedFiles"), autoDeleteInterval);
         }
@@ -34,49 +34,49 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Adds file system uploaded file storage to the application. See <see cref="IUploadedFileStorage" /> for more details.
         /// </summary>
-        /// <param name="options">The <see cref="IDotvvmOptions" /> instance.</param>
+        /// <param name="serviceCollection">The <see cref="IDotvvmServiceCollection" /> instance.</param>
         /// <param name="tempPath">The absolute or relative path to directory where to store temporary files.</param>
-        public static IDotvvmOptions AddUploadedFileStorage(this IDotvvmOptions options, string tempPath)
-            => options.AddUploadedFileStorage(tempPath, TimeSpan.FromMinutes(30));
+        public static IDotvvmServiceCollection AddUploadedFileStorage(this IDotvvmServiceCollection serviceCollection, string tempPath)
+            => serviceCollection.AddUploadedFileStorage(tempPath, TimeSpan.FromMinutes(30));
 
         /// <summary>
         /// Adds file system uploaded file storage to the application. See <see cref="IUploadedFileStorage" /> for more details.
         /// </summary>
-        /// <param name="options">The <see cref="IDotvvmOptions" /> instance.</param>
+        /// <param name="serviceCollection">The <see cref="IDotvvmServiceCollection" /> instance.</param>
         /// <param name="tempPath">The absolute or relative path to directory where to store temporary files.</param>
         /// <param name="autoDeleteInterval">The interval to delete the temporary files after.</param>
-        public static IDotvvmOptions AddUploadedFileStorage(this IDotvvmOptions options, string tempPath, TimeSpan autoDeleteInterval)
+        public static IDotvvmServiceCollection AddUploadedFileStorage(this IDotvvmServiceCollection serviceCollection, string tempPath, TimeSpan autoDeleteInterval)
         {
-            options.Services.TryAddSingleton<IUploadedFileStorage>(s =>
+            serviceCollection.Services.TryAddSingleton<IUploadedFileStorage>(s =>
             {
                 var fullPath = Path.Combine(s.GetService<DotvvmConfiguration>().ApplicationPhysicalPath, tempPath);
                 return new FileSystemUploadedFileStorage(fullPath, autoDeleteInterval);
             });
-            return options;
+            return serviceCollection;
         }
 
         /// <summary>
         /// Adds file system returned file storage to the application. See <see cref="IReturnedFileStorage" /> for more details.
         /// </summary>
-        /// <param name="options">The <see cref="IDotvvmOptions" /> instance.</param>
+        /// <param name="serviceCollection">The <see cref="IDotvvmServiceCollection" /> instance.</param>
         /// <param name="tempPath">The absolute or relative path to directory where to store temporary files.</param>
-        public static IDotvvmOptions AddReturnedFileStorage(this IDotvvmOptions options, string tempPath)
-            => options.AddReturnedFileStorage(tempPath, TimeSpan.FromMinutes(30));
+        public static IDotvvmServiceCollection AddReturnedFileStorage(this IDotvvmServiceCollection serviceCollection, string tempPath)
+            => serviceCollection.AddReturnedFileStorage(tempPath, TimeSpan.FromMinutes(30));
 
         /// <summary>
         /// Adds file system returned file storage to the application. See <see cref="IReturnedFileStorage" /> for more details.
         /// </summary>
-        /// <param name="options">The <see cref="IDotvvmOptions" /> instance.</param>
+        /// <param name="serviceCollection">The <see cref="IDotvvmServiceCollection" /> instance.</param>
         /// <param name="tempPath">The absolute or relative path to directory where to store temporary files.</param>
         /// <param name="autoDeleteInterval">The interval to delete the temporary files after.</param>
-        public static IDotvvmOptions AddReturnedFileStorage(this IDotvvmOptions options, string tempPath, TimeSpan autoDeleteInterval)
+        public static IDotvvmServiceCollection AddReturnedFileStorage(this IDotvvmServiceCollection serviceCollection, string tempPath, TimeSpan autoDeleteInterval)
         {
-            options.Services.TryAddSingleton<IReturnedFileStorage>(s =>
+            serviceCollection.Services.TryAddSingleton<IReturnedFileStorage>(s =>
             {
                 var fullPath = Path.Combine(s.GetService<DotvvmConfiguration>().ApplicationPhysicalPath, tempPath);
                 return new FileSystemReturnedFileStorage(fullPath, autoDeleteInterval);
             });
-            return options;
+            return serviceCollection;
         }
 
     }

--- a/src/DotVVM.Framework/DependencyInjection/DotvvmServiceCollection.cs
+++ b/src/DotVVM.Framework/DependencyInjection/DotvvmServiceCollection.cs
@@ -6,16 +6,16 @@ namespace Microsoft.Extensions.DependencyInjection
     /// <summary>
     /// Allows fine grained configuration of DotVVM services.
     /// </summary>
-    public class DotvvmOptions : IDotvvmOptions
+    public class DotvvmServiceCollection : IDotvvmServiceCollection
     {
         /// <inheritdoc />
         public IServiceCollection Services { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DotvvmOptions" /> class.
+        /// Initializes a new instance of the <see cref="DotvvmServiceCollection" /> class.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
-        public DotvvmOptions(IServiceCollection services)
+        public DotvvmServiceCollection(IServiceCollection services)
         {
             Services = services ?? throw new ArgumentNullException(nameof(services));
         }

--- a/src/DotVVM.Framework/DependencyInjection/IDotvvmServiceCollection.cs
+++ b/src/DotVVM.Framework/DependencyInjection/IDotvvmServiceCollection.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Extensions.DependencyInjection
     /// <summary>
     /// An interface for configuring DotVVM services.
     /// </summary>
-    public interface IDotvvmOptions
+    public interface IDotvvmServiceCollection
     {
         /// <summary>
         /// Gets the <see cref="IServiceCollection" /> where DotVVM services are configured.

--- a/src/DotVVM.Samples.BasicSamples.Api.AspNetCore/DotvvmStartup.cs
+++ b/src/DotVVM.Samples.BasicSamples.Api.AspNetCore/DotvvmStartup.cs
@@ -1,4 +1,5 @@
 ﻿using DotVVM.Framework.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DotVVM.Samples.BasicSamples.Api.AspNetCore
 {
@@ -7,6 +8,11 @@ namespace DotVVM.Samples.BasicSamples.Api.AspNetCore
         public void Configure(DotvvmConfiguration config, string applicationPath)
         {
             config.RouteTable.Add("Generator", "", "Views/Generator.dothtml");
+        }
+
+        public void ConfigureServices(IDotvvmServiceCollection serviceCollection)
+        {
+                serviceCollection.AddDefaultTempStorages("temp");
         }
     }
 }

--- a/src/DotVVM.Samples.BasicSamples.Api.AspNetCore/Startup.cs
+++ b/src/DotVVM.Samples.BasicSamples.Api.AspNetCore/Startup.cs
@@ -37,9 +37,7 @@ namespace DotVVM.Samples.BasicSamples.Api.AspNetCore
                     opt.SerializerSettings.ContractResolver = new Newtonsoft.Json.Serialization.DefaultContractResolver();
                 });
 
-            services.AddDotVVM(options => {
-                options.AddDefaultTempStorages("temp");
-            });
+            services.AddDotVVM<DotvvmStartup>();
 
             services.AddSwaggerGen(options => {
                 options.SwaggerDoc("v1", new Info() { Title = "DotVVM Test API", Version = "v1" });
@@ -73,7 +71,7 @@ namespace DotVVM.Samples.BasicSamples.Api.AspNetCore
 
             app.UseMvc();
             
-            app.UseDotVVM<DotvvmStartup>(env.ContentRootPath);
+            app.UseDotVVM(env.ContentRootPath);
 
             SeedDatabase();
         }

--- a/src/DotVVM.Samples.BasicSamples.AspNetCore/Startup.cs
+++ b/src/DotVVM.Samples.BasicSamples.AspNetCore/Startup.cs
@@ -55,19 +55,12 @@ namespace DotVVM.Samples.BasicSamples
 
             services.AddLocalization(o => o.ResourcesPath = "Resources");
 
-            services.AddDotVVM(options =>
-            {
-                CommonConfiguration.ConfigureServices(options.Services);
-                options.AddDefaultTempStorages("Temp");
-            });
+            services.AddDotVVM<DotvvmStartup>();
 
             services.Configure<BindingCompilationOptions>(o => {
                 o.TransformerClasses.Add(new BindingTestResolvers());
             });
-
-            services.AddSingleton<IGreetingComputationService, HelloGreetingComputationService>();
-
-            services.AddScoped<ViewModelScopedDependency>();
+  
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
@@ -87,7 +80,7 @@ namespace DotVVM.Samples.BasicSamples
                 }
             });
 
-            var config = app.UseDotVVM<DotvvmStartup>(GetApplicationPath(env));
+            var config = app.UseDotVVM(GetApplicationPath(env));
             config.RouteTable.Add("AuthorizedPresenter", "ComplexSamples/Auth/AuthorizedPresenter", provider => new AuthorizedPresenter());
 
             app.UseStaticFiles();

--- a/src/DotVVM.Samples.BasicSamples.Owin/Startup.cs
+++ b/src/DotVVM.Samples.BasicSamples.Owin/Startup.cs
@@ -53,13 +53,7 @@ namespace DotVVM.Samples.BasicSamples
                     )
                 }
             );
-            var config = app.UseDotVVM<DotvvmStartup>(GetApplicationPath(), options: b =>
-            {
-                CommonConfiguration.ConfigureServices(b.Services);
-                b.AddDefaultTempStorages("Temp");
-                b.Services.AddScoped<ViewModelScopedDependency>();
-                b.Services.AddSingleton<IGreetingComputationService, HelloGreetingComputationService>();
-            });
+            var config = app.UseDotVVM<DotvvmStartup>(GetApplicationPath());
             config.RouteTable.Add("AuthorizedPresenter", "ComplexSamples/Auth/AuthorizedPresenter", provider => new AuthorizedPresenter());
 
             app.UseStaticFiles();

--- a/src/DotVVM.Samples.Common/DotvvmStartup.cs
+++ b/src/DotVVM.Samples.Common/DotvvmStartup.cs
@@ -13,8 +13,11 @@ using DotVVM.Framework.ViewModel.Serialization;
 using DotVVM.Samples.BasicSamples.Controls;
 using DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.Redirect;
 using DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.Serialization;
+using DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.StaticCommand;
 using DotVVM.Samples.Common;
+using DotVVM.Samples.Common.ViewModels.FeatureSamples.DependencyInjection;
 using DotVVM.Samples.Common.ViewModels.FeatureSamples.ServerSideStyles;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DotVVM.Samples.BasicSamples
 {
@@ -43,6 +46,14 @@ namespace DotVVM.Samples.BasicSamples
 
             config.RegisterApiGroup(typeof(GithubApiClient.GithubApiClient), "https://api.github.com/", "Scripts/GithubApiClient.js", "_github", customFetchFunction: "basicAuthenticatedFetch");
             config.RegisterApiClient(typeof(AzureFunctionsApi.Client), "https://dotvvmazurefunctionstest.azurewebsites.net/", "Scripts/AzureFunctionsApiClient.js", "_azureFuncApi");
+        }
+
+        public void ConfigureServices(IDotvvmServiceCollection services)
+        {
+            CommonConfiguration.ConfigureServices(services.Services);
+            services.AddDefaultTempStorages("Temp");
+            services.Services.AddScoped<ViewModelScopedDependency>();
+            services.Services.AddSingleton<IGreetingComputationService, HelloGreetingComputationService>();
         }
 
         public static void AddStyles(DotvvmConfiguration config)
@@ -120,5 +131,7 @@ namespace DotVVM.Samples.BasicSamples
             config.Markup.AutoDiscoverControls(new DefaultControlRegistrationStrategy(config, "sample", "Views/FeatureSamples/StaticCommand/"));
             config.Markup.AutoDiscoverControls(new DefaultControlRegistrationStrategy(config, "sample", "Views/Errors/"));
         }
+
+        
     }
 }


### PR DESCRIPTION
These changes are needed for Dotvvm.Compiler operability. We cannot evaluate Configure method in  Startup.cs everytime compilatior is started. This could cause demages in DB, or just execute something unsafe. So we decided to change structure of IDotvvmStartup to be able mark (register) services that are necessary for dotvvm compilation. 

IDotvvmStartup - added ConfigureServices needed for dotvvm compiler - BREAKING CHANGE
Moved generic parameter from UseDotVVM() to AddDotVVM on aspnet core - BREAKING CHANGE