### PR TITLE
Added double quotes around file name in Content-Disposition header.

### DIFF
--- a/src/DotVVM.Framework/Hosting/Middlewares/DotvvmReturnedFileMiddleware.cs
+++ b/src/DotVVM.Framework/Hosting/Middlewares/DotvvmReturnedFileMiddleware.cs
@@ -32,7 +32,7 @@ namespace DotVVM.Framework.Hosting.Middlewares
             var id = Guid.Parse(context.Request.Query["id"]);
             using (var stream = returnedFileStorage.GetFile(id, out metadata))
             {
-                context.Response.Headers["Content-Disposition"] = "attachment; filename=" + metadata.FileName;
+                context.Response.Headers["Content-Disposition"] = "attachment; filename=\"" + metadata.FileName + "\"";
                 context.Response.ContentType = metadata.MimeType;
                 if (metadata.AdditionalHeaders != null)
                 {


### PR DESCRIPTION
This fixes an issue with file names containing spaces in Firefox.
For example if file name is something like "aaa bbb ccc.txt", Firefox (without the double quotes) would try saving it as just "aaa". 