### PR TITLE
Added ContentDisposition header encoding using *.Net.Http packages

### DIFF
--- a/src/DotVVM.Framework/DotVVM.Framework.csproj
+++ b/src/DotVVM.Framework/DotVVM.Framework.csproj
@@ -83,12 +83,14 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.0.2" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="1.0.0" />
     <Reference Include="System" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/DotVVM.Framework/Hosting/Middlewares/DotvvmReturnedFileMiddleware.cs
+++ b/src/DotVVM.Framework/Hosting/Middlewares/DotvvmReturnedFileMiddleware.cs
@@ -40,8 +40,11 @@ namespace DotVVM.Framework.Hosting.Middlewares
                 contentDispositionValue.SetHttpFileName(metadata.FileName);
                 context.Response.Headers[HeaderNames.ContentDisposition] = contentDispositionValue.ToString();
 #else
-                var contentDispositionValue = new ContentDispositionHeaderValue(attachmentDispositionType);
-                contentDispositionValue.FileName = metadata.FileName;
+                var contentDispositionValue = new ContentDispositionHeaderValue(attachmentDispositionType)
+                {
+                    FileName = metadata.FileName,
+                    FileNameStar = metadata.FileName
+                };
                 context.Response.Headers["Content-Disposition"] = contentDispositionValue.ToString();
 #endif
                 context.Response.ContentType = metadata.MimeType;

--- a/src/DotVVM.Framework/Hosting/Middlewares/DotvvmReturnedFileMiddleware.cs
+++ b/src/DotVVM.Framework/Hosting/Middlewares/DotvvmReturnedFileMiddleware.cs
@@ -2,17 +2,19 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Storage;
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
+#if DotNetCore
+using Microsoft.Net.Http.Headers;
+#else
+using System.Net.Http.Headers;
+#endif
 
 namespace DotVVM.Framework.Hosting.Middlewares
 {
-    //TODO: Code reveiw
     public class DotvvmReturnedFileMiddleware : IMiddleware
     {
-
         public async Task<bool> Handle(IDotvvmRequestContext request)
         {
             var url = DotvvmMiddlewareBase.GetCleanRequestUrl(request.HttpContext);
@@ -27,12 +29,21 @@ namespace DotVVM.Framework.Hosting.Middlewares
 
         private async Task RenderReturnedFile(IHttpContext context, IReturnedFileStorage returnedFileStorage)
         {
+            const string attachmentDispositionType = "attachment";
             ReturnedFileMetadata metadata;
 
             var id = Guid.Parse(context.Request.Query["id"]);
             using (var stream = returnedFileStorage.GetFile(id, out metadata))
             {
-                context.Response.Headers["Content-Disposition"] = "attachment; filename=\"" + metadata.FileName + "\"";
+#if DotNetCore
+                var contentDispositionValue = new ContentDispositionHeaderValue(attachmentDispositionType);
+                contentDispositionValue.SetHttpFileName(metadata.FileName);
+                context.Response.Headers[HeaderNames.ContentDisposition] = contentDispositionValue.ToString();
+#else
+                var contentDispositionValue = new ContentDispositionHeaderValue(attachmentDispositionType);
+                contentDispositionValue.FileName = metadata.FileName;
+                context.Response.Headers["Content-Disposition"] = contentDispositionValue.ToString();
+#endif
                 context.Response.ContentType = metadata.MimeType;
                 if (metadata.AdditionalHeaders != null)
                 {


### PR DESCRIPTION
Added encoding of filename for Content-Disposition header.

Encoding is handled in `ContentDispositionHeaderValue` type which is in `System.Net.Http` assembly for .net framework or `Microsoft.Net.Http.Headers` package for .net standard. 
It is okay to add these dependencies? @exyi 

Relates to #589 