### PR TITLE
Fixed IncludeInPage with resource binding

### DIFF
--- a/src/DotVVM.Framework/Controls/DotvvmControl.cs
+++ b/src/DotVVM.Framework/Controls/DotvvmControl.cs
@@ -253,7 +253,7 @@ namespace DotVVM.Framework.Controls
 
         private void RenderEndWithDataBindAttribute(IHtmlWriter writer)
         {
-            if (HasBinding(IncludeInPageProperty))
+            if (HasValueBinding(IncludeInPageProperty))
             {
                 writer.WriteKnockoutDataBindEndComment();
             }

--- a/src/DotVVM.Framework/Controls/DotvvmControl.cs
+++ b/src/DotVVM.Framework/Controls/DotvvmControl.cs
@@ -213,6 +213,11 @@ namespace DotVVM.Framework.Controls
         /// </summary>
         protected virtual void RenderControl(IHtmlWriter writer, IDotvvmRequestContext context)
         {
+            if (HasBinding<ResourceBindingExpression>(IncludeInPageProperty) && !IncludeInPage)
+            {
+                return;
+            }
+
             RenderBeginWithDataBindAttribute(writer);
 
             foreach (var item in properties)
@@ -240,7 +245,7 @@ namespace DotVVM.Framework.Controls
             }
 
             // if the IncludeInPage has binding, render the "if" binding
-            if (HasBinding(IncludeInPageProperty))
+            if (HasValueBinding(IncludeInPageProperty))
             {
                 writer.WriteKnockoutDataBindComment("if", this, IncludeInPageProperty);
             }

--- a/src/DotVVM.Framework/Controls/UpdateProgress.cs
+++ b/src/DotVVM.Framework/Controls/UpdateProgress.cs
@@ -14,7 +14,6 @@ namespace DotVVM.Framework.Controls
     /// </summary>
     public class UpdateProgress : HtmlGenericControl
     {
-
         /// <summary>
         /// Gets or sets the delay (in ms) after which the content inside UpdateProgress control is shown
         /// </summary>

--- a/src/DotVVM.Samples.Common/Views/ControlSamples/IncludeInPageProperty/IncludeInPage.dothtml
+++ b/src/DotVVM.Samples.Common/Views/ControlSamples/IncludeInPageProperty/IncludeInPage.dothtml
@@ -139,6 +139,29 @@
             </EmptyDataTemplate>
         </dot:GridView>
     </div>
+
+    <div class="block">
+        <h2>Resource binding</h2>
+        <table>
+            <thead>
+                <tr>
+                    <th>#0</th>
+                    <th>#1</th>
+                    <th>#2</th>
+                    <th>#3</th>
+                </tr>
+            </thead>
+            <dot:Repeater WrapperTagName="tbody"
+                          DataSource="{value: Rows}">
+                <dot:Repeater WrapperTagName="tr"
+                              DataSource="{value: _this}"
+                              IncludeInPage="{resource: _root.IncludeInPage}"
+                              data-ui="repeater-second">
+                    <td>{{value: _this}}</td>
+                </dot:Repeater>
+            </dot:Repeater>
+        </table>
+    </div>
     <div class="switch">
         <dot:Button Click="{command: IncludeInPage = !IncludeInPage}"
                     data-ui="switch-includeInPage">


### PR DESCRIPTION
Resource binding inside `IncludeInPage` throws `NullReferenceException` in `Render` method.

When the binding is evaluated to false we shouldn't render the control at all.