### PR TITLE
use DisplayAttribute for PropertyName in ViewModelValidationRuleTranslator

### DIFF
--- a/src/DotVVM.Framework/ViewModel/Validation/ViewModelPropertyValidationRule.cs
+++ b/src/DotVVM.Framework/ViewModel/Validation/ViewModelPropertyValidationRule.cs
@@ -19,13 +19,19 @@ namespace DotVVM.Framework.ViewModel.Validation
         public ValidationAttribute SourceValidationAttribute { get; set; }
 
         [JsonIgnore]
-        public string PropertyName { get; set; }
+        public string PropertyName => PropertyNameResolver?.Invoke() ?? StaticPropertyName;
 
-        public ViewModelPropertyValidationRule(ValidationAttribute sourceValidationAttribute, string propertyName,
+        [JsonIgnore]
+        public string StaticPropertyName { get; set; }
+
+        [JsonIgnore]
+        public Func<string> PropertyNameResolver { get; set; }
+
+        public ViewModelPropertyValidationRule(ValidationAttribute sourceValidationAttribute, string staticPropertyName,
             string clientRuleName = null, params object[] parameters)
         {
             SourceValidationAttribute = sourceValidationAttribute ?? throw new ArgumentNullException(nameof(sourceValidationAttribute));
-            PropertyName = propertyName ?? throw new ArgumentNullException(nameof(propertyName));
+            StaticPropertyName = staticPropertyName ?? throw new ArgumentNullException(nameof(staticPropertyName));
             ClientRuleName = clientRuleName;
             Parameters = parameters;
         }

--- a/src/DotVVM.Framework/ViewModel/Validation/ViewModelValidationRuleTranslator.cs
+++ b/src/DotVVM.Framework/ViewModel/Validation/ViewModelValidationRuleTranslator.cs
@@ -16,6 +16,11 @@ namespace DotVVM.Framework.ViewModel.Validation
             {
                 var validationRule = new ViewModelPropertyValidationRule(sourceValidationAttribute: attribute, propertyName: property.Name);
                 // TODO: extensibility
+
+                var displayAttribute = property.GetCustomAttribute<DisplayAttribute>();
+                if (displayAttribute != null)
+                    validationRule.PropertyName = displayAttribute.GetName();
+
                 if (attribute is RequiredAttribute)
                 {
                     validationRule.ClientRuleName = "required";

--- a/src/DotVVM.Framework/ViewModel/Validation/ViewModelValidationRuleTranslator.cs
+++ b/src/DotVVM.Framework/ViewModel/Validation/ViewModelValidationRuleTranslator.cs
@@ -14,12 +14,12 @@ namespace DotVVM.Framework.ViewModel.Validation
         {
             foreach (var attribute in validationAttributes)
             {
-                var validationRule = new ViewModelPropertyValidationRule(sourceValidationAttribute: attribute, propertyName: property.Name);
+                var validationRule = new ViewModelPropertyValidationRule(sourceValidationAttribute: attribute, staticPropertyName: property.Name);
                 // TODO: extensibility
 
                 var displayAttribute = property.GetCustomAttribute<DisplayAttribute>();
                 if (displayAttribute != null)
-                    validationRule.PropertyName = displayAttribute.GetName();
+                    validationRule.PropertyNameResolver = () => displayAttribute.GetName();
 
                 if (attribute is RequiredAttribute)
                 {


### PR DESCRIPTION
This pull request adds ability to use DisplayAttribute to localize property name in client side validation.

`[Display(Name = nameof(Resources.Fields.City), ResourceType = typeof(Resources.Fields))]
        [Required(ErrorMessageResourceName = nameof(Resources.ValidationMessages.Required), ErrorMessageResourceType = typeof(Resources.ValidationMessages))]
        public string City { get; set; }`