### PR TITLE
Added overload to CreateValidationResult in ValidationErrorFactory

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/ViewModel/ViewModelValidatorTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/ViewModel/ViewModelValidatorTests.cs
@@ -112,10 +112,20 @@ namespace DotVVM.Framework.Tests.ViewModel
             Assert.AreEqual("Children()[0]().ConditionalRequired", results[0].PropertyPath);
         }
 
+        [TestMethod]
+        public void ViewModelValidator_ValidationErrorFactoryWithValidationContextSupplied()
+        {
+            var testViewModel = new TestViewModel7();
+            var validator = CreateValidator();
+            var results = validator.ValidateViewModel(testViewModel).OrderBy(n => n.PropertyPath).ToList();
+
+            Assert.AreEqual(1, results.Count);
+            Assert.AreEqual("IsChecked", results[0].PropertyPath);
+        }
+
 
         public class TestViewModel
         {
-
             [Required]
             public string Text { get; set; }
 
@@ -172,17 +182,13 @@ namespace DotVVM.Framework.Tests.ViewModel
             }
         }
 
-
         public class TestViewModel5
         {
-
             public TestViewModel5Child Child { get; set; }
-
         }
 
         public class TestViewModel5Child : IValidatableObject
         {
-
             public bool IsChecked { get; set; }
 
             public string ConditionalRequired { get; set; }
@@ -198,9 +204,21 @@ namespace DotVVM.Framework.Tests.ViewModel
 
         public class TestViewModel6
         {
-
             public List<TestViewModel5Child> Children { get; set; }
+        }
 
+        public class TestViewModel7 : IValidatableObject
+        {
+            public bool IsChecked { get; set; }
+
+            public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+            {
+                if (!IsChecked)
+                {
+                    yield return ValidationErrorFactory.CreateValidationResult<TestViewModel7>(validationContext,
+                        "Value is required when the field is checked!", vm => vm.IsChecked);
+                }
+            }
         }
     }
 

--- a/src/DotVVM.Framework/ViewModel/Validation/ViewModelValidator.cs
+++ b/src/DotVVM.Framework/ViewModel/Validation/ViewModelValidator.cs
@@ -3,17 +3,22 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using DotVVM.Framework.Configuration;
 using DotVVM.Framework.ViewModel.Serialization;
 
 namespace DotVVM.Framework.ViewModel.Validation
 {
-    public class ViewModelValidator: IViewModelValidator
+    public class ViewModelValidator : IViewModelValidator
     {
         private readonly IViewModelSerializationMapper viewModelSerializationMapper;
+        private readonly Func<IServiceProvider> serviceProviderFactory;
+        private readonly Dictionary<object, object> validationItems;
 
-        public ViewModelValidator(IViewModelSerializationMapper viewModelMapper)
+        public ViewModelValidator(IViewModelSerializationMapper viewModelMapper, DotvvmConfiguration dotvvmConfiguration)
         {
             this.viewModelSerializationMapper = viewModelMapper;
+            this.serviceProviderFactory = serviceProviderFactory;
+            this.validationItems = new Dictionary<object, object> { { typeof(DotvvmConfiguration), dotvvmConfiguration} };
         }
 
         /// <summary>
@@ -71,15 +76,14 @@ namespace DotVVM.Framework.ViewModel.Validation
                 // validate the property
                 if (property.ValidationRules.Any())
                 {
-                    var context = new ValidationContext(viewModel) { MemberName = property.Name };
+                    var context = new ValidationContext(viewModel, validationItems) { MemberName = property.Name };
 
                     foreach (var rule in property.ValidationRules)
                     {
                         var propertyResult = rule.SourceValidationAttribute?.GetValidationResult(value, context);
                         if (propertyResult != ValidationResult.Success)
                         {
-                            yield return new ViewModelValidationError()
-                            {
+                            yield return new ViewModelValidationError() {
                                 PropertyPath = path,
                                 ErrorMessage = rule.ErrorMessage
                             };
@@ -103,7 +107,8 @@ namespace DotVVM.Framework.ViewModel.Validation
 
             if (viewModel is IValidatableObject)
             {
-                foreach (var error in ((IValidatableObject)viewModel).Validate(new ValidationContext(viewModel)))
+                foreach (var error in ((IValidatableObject)viewModel).Validate(
+                    new ValidationContext(viewModel, validationItems)))
                 {
                     var paths = new List<string>();
                     if (error.MemberNames != null)
@@ -120,8 +125,7 @@ namespace DotVVM.Framework.ViewModel.Validation
 
                     foreach (var memberPath in paths)
                     {
-                        yield return new ViewModelValidationError()
-                        {
+                        yield return new ViewModelValidationError() {
                             PropertyPath = memberPath,
                             ErrorMessage = error.ErrorMessage
                         };

--- a/src/DotVVM.Framework/ViewModel/Validation/ViewModelValidator.cs
+++ b/src/DotVVM.Framework/ViewModel/Validation/ViewModelValidator.cs
@@ -11,13 +11,11 @@ namespace DotVVM.Framework.ViewModel.Validation
     public class ViewModelValidator : IViewModelValidator
     {
         private readonly IViewModelSerializationMapper viewModelSerializationMapper;
-        private readonly Func<IServiceProvider> serviceProviderFactory;
         private readonly Dictionary<object, object> validationItems;
 
         public ViewModelValidator(IViewModelSerializationMapper viewModelMapper, DotvvmConfiguration dotvvmConfiguration)
         {
             this.viewModelSerializationMapper = viewModelMapper;
-            this.serviceProviderFactory = serviceProviderFactory;
             this.validationItems = new Dictionary<object, object> { { typeof(DotvvmConfiguration), dotvvmConfiguration} };
         }
 


### PR DESCRIPTION
This new overload doesn't require `DotvvmConfiguration` object or object which implements `IDotvvmViewModel`.

I would like to also add `IServiceProvider` to `ValidationContext` to support custom validation which requires additional services. How can I resolve `IServiceProvider`, that is properly scoped, in `ViewModelValidator` ? @exyi 