### PR TITLE
Fix locating service configurator

### DIFF
--- a/src/DotVVM.Compiler/Resolving/DotvvmServiceConfiguratorResolver.cs
+++ b/src/DotVVM.Compiler/Resolving/DotvvmServiceConfiguratorResolver.cs
@@ -21,7 +21,7 @@ namespace DotVVM.Compiler.Resolving
                     $"Assembly '{assembly.FullName}' contains more the one implementaion of IDotvvmServiceConfigurator.");
             }
 
-            return resultTypes.Single();
+            return resultTypes.SingleOrDefault();
         }
 
         private MethodInfo ResolveConfigureServicesMethods(Type startupType)


### PR DESCRIPTION
Current implementation does not allow OWIN based DotVVM not to have implementation of `IDotVVMServiceConfigurator`. This should fix unexpected compiler errors in such cases. 