### PR TITLE
Redesigned how _index works

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Binding/JavascriptCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/JavascriptCompilationTests.cs
@@ -38,6 +38,8 @@ namespace DotVVM.Framework.Tests.Binding
         public string CompileBinding(string expression, Type[] contexts, Type expectedType)
         {
             var context = DataContextStack.Create(contexts.FirstOrDefault() ?? typeof(object), extensionParameters: new BindingExtensionParameter[]{
+                new CurrentCollectionIndexExtensionParameter(),
+                new BindingCollectionInfoExtensionParameter("_collection"),
                 new BindingPageInfoExtensionParameter(),
                 }.Concat(configuration.Markup.DefaultExtensionParameters).ToArray());
             for (int i = 1; i < contexts.Length; i++)
@@ -361,6 +363,27 @@ namespace DotVVM.Framework.Tests.Binding
         {
             var result = CompileBinding("GuidProp != Guid.Empty ? GuidProp.ToString() : ''", typeof(TestViewModel));
             Assert.AreEqual("GuidProp()!=\"00000000-0000-0000-0000-000000000000\"?GuidProp:\"\"", result);
+        }
+
+        [TestMethod]
+        public void StaticCommandCompilation_IndexParameter()
+        {
+            var result = CompileBinding("_index", new [] { typeof(TestViewModel)});
+            Assert.AreEqual("$index()", result);
+        }
+
+        [TestMethod]
+        public void StaticCommandCompilation_CollectionInfoParameter()
+        {
+            var result = CompileBinding("_collection.IsEven", typeof(TestViewModel));
+            Assert.AreEqual("$index()%2==0", result);
+        }
+
+        [TestMethod]
+        public void StaticCommandCompilation_IndexParameterInParent()
+        {
+            var result = CompileBinding("_index", new [] { typeof(TestViewModel), typeof(object), typeof(string) });
+            Assert.AreEqual("parentContext.$parentContext.$index()", result);
         }
     }
 

--- a/src/DotVVM.Framework.Tests.Common/Binding/JavascriptCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/JavascriptCompilationTests.cs
@@ -383,7 +383,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void StaticCommandCompilation_IndexParameterInParent()
         {
             var result = CompileBinding("_index", new [] { typeof(TestViewModel), typeof(object), typeof(string) });
-            Assert.AreEqual("parentContext.$parentContext.$index()", result);
+            Assert.AreEqual("$parentContext.$parentContext.$index()", result);
         }
     }
 

--- a/src/DotVVM.Framework.Tests.Common/Binding/StaticCommandCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/StaticCommandCompilationTests.cs
@@ -30,6 +30,7 @@ namespace DotVVM.Framework.Tests.Binding
             configuration.Markup.ImportedNamespaces.Add(new NamespaceImport("DotVVM.Framework.Tests.Binding"));
 
             var context = DataContextStack.Create(contexts.FirstOrDefault() ?? typeof(object), extensionParameters: new BindingExtensionParameter[]{
+                new CurrentCollectionIndexExtensionParameter(),
                 new BindingPageInfoExtensionParameter(),
                 new InjectedServiceExtensionParameter("injectedService", new ResolvedTypeDescriptor(typeof(TestService))),
                 }.Concat(configuration.Markup.DefaultExtensionParameters).ToArray());
@@ -115,6 +116,20 @@ namespace DotVVM.Framework.Tests.Binding
             var result = CompileBinding("SomeString = injectedService.Load(SomeString)", new[] { typeof(TestViewModel3) }, typeof(Func<string, string>));
 
             Assert.AreEqual("(function(a,b){return new Promise(function(resolve){dotvvm.staticCommandPostback(\"root\",a,\"WARNING/NOT/ENCRYPTED+++WyJEb3RWVk0uRnJhbWV3b3JrLlRlc3RzLkJpbmRpbmcuVGVzdFNlcnZpY2UsIERvdFZWTS5GcmFtZXdvcmsuVGVzdHMuQ29tbW9uIiwiTG9hZCIsIkFRQT0iXQ==\",[b.$data.SomeString()],function(r_0){resolve(b.$data.SomeString(r_0).SomeString());});});}(this,ko.contextFor(this)))", result);
+        }
+
+        [TestMethod]
+        public void StaticCommandCompilation_IndexParameter()
+        {
+            var result = CompileBinding("IntProp = _index", new [] { typeof(TestViewModel) });
+            Assert.AreEqual("(function(a){return Promise.resolve(a.$data.IntProp(a.$index()).IntProp());}(ko.contextFor(this)))", result);
+        }
+
+        [TestMethod]
+        public void StaticCommandCompilation_IndexParameterInParent()
+        {
+            var result = CompileBinding("_parent2.IntProp = _index", new [] { typeof(TestViewModel), typeof(object), typeof(string) });
+            Assert.AreEqual("(function(a){return Promise.resolve(a.$parents[1].IntProp(a.$parentContext.$parentContext.$index()).IntProp());}(ko.contextFor(this)))", result);
         }
     }
 

--- a/src/DotVVM.Framework/Binding/BindingHelper.cs
+++ b/src/DotVVM.Framework/Binding/BindingHelper.cs
@@ -278,16 +278,6 @@ namespace DotVVM.Framework.Binding
         public static void SetDataContextTypeFromDataSource(this DotvvmBindableObject obj, IBinding dataSourceBinding) =>
             obj.SetDataContextType(dataSourceBinding.GetProperty<CollectionElementDataContextBindingProperty>().DataContext);
 
-        public static void SetDataContextForItem(this DotvvmBindableObject obj, IValueBinding itemBinding, int index, object currentItem)
-        {
-            obj.SetBinding(DotvvmBindableObject.DataContextProperty, ValueBindingExpression.CreateBinding(
-                itemBinding.GetProperty<BindingCompilationService>().WithoutInitialization(),
-                j => currentItem,
-                itemBinding.KnockoutExpression.AssignParameters(p =>
-                    p == JavascriptTranslator.CurrentIndexParameter ? new CodeParameterAssignment(index.ToString(), OperatorPrecedence.Max) :
-                    default(CodeParameterAssignment))));
-        }
-
         public static DataContextStack GetDataContextType(this DotvvmProperty property, DotvvmBindableObject obj)
         {
             var propertyBinding = obj.GetBinding(property);

--- a/src/DotVVM.Framework/Compilation/ControlTree/BindingExtensionParameter.cs
+++ b/src/DotVVM.Framework/Compilation/ControlTree/BindingExtensionParameter.cs
@@ -76,7 +76,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
 
         public override JsExpression GetJsTranslation(JsExpression dataContext)
         {
-            return new JsSymbolicParameter(JavascriptTranslator.CurrentIndexParameter);
+            return dataContext.Member("$index").Invoke();
         }
     }
 
@@ -113,7 +113,13 @@ namespace DotVVM.Framework.Compilation.ControlTree
 
         public override JsExpression GetJsTranslation(JsExpression dataContext)
         {
-            return new JsObjectExpression();
+            JsExpression index() => dataContext.Clone().Member("$index").Invoke();
+            return new JsObjectExpression(
+                new JsObjectProperty(nameof(BindingCollectionInfo.Index), index()),
+                new JsObjectProperty(nameof(BindingCollectionInfo.IsFirst), new JsBinaryExpression(index(), BinaryOperatorType.Equal, new JsLiteral(0))),
+                new JsObjectProperty(nameof(BindingCollectionInfo.IsOdd), new JsBinaryExpression(new JsBinaryExpression(index(), BinaryOperatorType.Modulo, new JsLiteral(2)), BinaryOperatorType.Equal, new JsLiteral(1))),
+                new JsObjectProperty(nameof(BindingCollectionInfo.IsEven), new JsBinaryExpression(new JsBinaryExpression(index(), BinaryOperatorType.Modulo, new JsLiteral(2)), BinaryOperatorType.Equal, new JsLiteral(0)))
+            );
         }
     }
 

--- a/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslator.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslator.cs
@@ -21,7 +21,6 @@ namespace DotVVM.Framework.Compilation.Javascript
     {
         public static readonly CodeSymbolicParameter KnockoutContextParameter = new CodeSymbolicParameter("JavascriptTranslator.KnockoutContextParameter", CodeParameterAssignment.FromIdentifier("$context", true));
         public static readonly CodeSymbolicParameter KnockoutViewModelParameter = new CodeSymbolicParameter("JavascriptTranslator.KnockoutViewModelParameter", CodeParameterAssignment.FromIdentifier("$data", true));
-        public static readonly CodeSymbolicParameter CurrentIndexParameter = new CodeSymbolicParameter("JavascriptTranslator.CurrentIndexParameter", CodeParameterAssignment.FromIdentifier("$index()"));
         private readonly IViewModelSerializationMapper mapper;
 
         public IJavascriptMethodTranslator DefaultMethodTranslator { get; }
@@ -93,7 +92,6 @@ namespace DotVVM.Framework.Compilation.Javascript
             return expression.AssignParameters(o =>
                 o == KnockoutContextParameter ? context :
                 o == KnockoutViewModelParameter ? data :
-                o == CurrentIndexParameter ? CodeParameterAssignment.FromExpression(contextExpresion.Member("$index").Invoke()) :
                 default(CodeParameterAssignment)
             );
         }
@@ -127,7 +125,6 @@ namespace DotVVM.Framework.Compilation.Javascript
             return expression
                 .ToString(o => o == KnockoutContextParameter ? new CodeParameterAssignment(contextVariable) :
                                o == KnockoutViewModelParameter ? dataVariable :
-                               o == CurrentIndexParameter ? new ParametrizedCode.Builder { contextVariable, ".$index()" }.Build(OperatorPrecedence.Max) :
                                throw new Exception());
         }
     }

--- a/src/DotVVM.Framework/Controls/DataItemContainer.cs
+++ b/src/DotVVM.Framework/Controls/DataItemContainer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using DotVVM.Framework.Hosting;
 using DotVVM.Framework.Runtime;
+using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Controls
 {
@@ -34,6 +35,18 @@ namespace DotVVM.Framework.Controls
             }
             set { SetValue(Internal.UniqueIDProperty, value != null ? value.ToString() : null); }
         }
-        
+
+
+        protected override void RenderControl(IHtmlWriter writer, IDotvvmRequestContext context)
+        {
+            var maybeIndex = DataItemIndex;
+            if (maybeIndex is int index)
+                writer.WriteKnockoutDataBindComment("dotvvm-SSR-item", index.ToString());
+
+            base.RenderControl(writer, context);
+
+            if (maybeIndex is int)
+                writer.WriteKnockoutDataBindEndComment();
+        }
     }
 }

--- a/src/DotVVM.Framework/Controls/GridView.cs
+++ b/src/DotVVM.Framework/Controls/GridView.cs
@@ -199,7 +199,7 @@ namespace DotVVM.Framework.Controls
                     // create row
                     var placeholder = new DataItemContainer { DataItemIndex = index };
                     placeholder.SetDataContextTypeFromDataSource(dataSourceBinding);
-                    placeholder.SetDataContextForItem(itemBinding, index, item);
+                    placeholder.DataContext = item;
                     placeholder.SetValue(Internal.PathFragmentProperty, GetPathFragmentExpression() + "/[" + index + "]");
                     placeholder.ID = index.ToString();
                     Children.Add(placeholder);

--- a/src/DotVVM.Framework/Controls/Repeater.cs
+++ b/src/DotVVM.Framework/Controls/Repeater.cs
@@ -119,19 +119,16 @@ namespace DotVVM.Framework.Controls
         {
             TagName = WrapperTagName;
 
-            if (!RenderOnServer)
+            var (bindingName, bindingValue) = RenderOnServer ?
+                                              ("dotvvm-SSR-foreach", GetServerSideForeachBindingGroup()) :
+                                              ("foreach", GetForeachKnockoutBindingGroup());
+            if (RenderWrapperTag)
             {
-
-                if (RenderWrapperTag)
-                {
-                    //writer.AddKnockoutForeachDataBind(javascriptDataSourceExpression);
-
-                    writer.AddKnockoutDataBind("foreach", GetForeachKnockoutBindingGroup());
-                }
-                else
-                {
-                    writer.WriteKnockoutDataBindComment("foreach", GetForeachKnockoutBindingGroup().ToString());
-                }
+                writer.AddKnockoutDataBind(bindingName, bindingValue);
+            }
+            else
+            {
+                writer.WriteKnockoutDataBindComment(bindingName, bindingValue.ToString());
             }
 
             if (RenderWrapperTag)
@@ -139,6 +136,11 @@ namespace DotVVM.Framework.Controls
                 base.RenderBeginTag(writer, context);
             }
         }
+
+        private KnockoutBindingGroup GetServerSideForeachBindingGroup() =>
+            new KnockoutBindingGroup {
+                { "data", GetForeachDataBindExpression().GetKnockoutBindingExpression(this) }
+            };
 
         private KnockoutBindingGroup GetForeachKnockoutBindingGroup()
         {
@@ -204,17 +206,17 @@ namespace DotVVM.Framework.Controls
             return emptyDataContainer;
         }
 
-        private DotvvmControl GetItem(IDotvvmRequestContext context, object item = null, int index = -1, IValueBinding itemBinding = null)
+        private DotvvmControl GetItem(IDotvvmRequestContext context, object item = null, int? index = null)
         {
             var container = new DataItemContainer();
             container.SetDataContextTypeFromDataSource(GetBinding(DataSourceProperty));
-            if (item == null && index == -1)
+            if (item == null && index == null)
             {
                 SetUpClientItem(container);
             }
             else
             {
-                SetUpServerItem(context, item, index, itemBinding, container);
+                SetUpServerItem(context, item, (int)index, container);
             }
 
             ItemTemplate.BuildContent(context, container);
@@ -250,14 +252,14 @@ namespace DotVVM.Framework.Controls
                         {
                             Children.Add(GetSeparator(context));
                         }
-                        Children.Add(GetItem(context, item, index, itemBinding));
+                        Children.Add(GetItem(context, item, index));
                         index++;
                     }
                 }
             }
             else
             {
-                if(SeparatorTemplate != null)
+                if (SeparatorTemplate != null)
                 {
                     Children.Add(clientSeparator = GetSeparator(context));
                 }
@@ -278,10 +280,10 @@ namespace DotVVM.Framework.Controls
             container.SetValue(Internal.ClientIDFragmentProperty, GetValueRaw(Internal.CurrentIndexBindingProperty));
         }
 
-        private void SetUpServerItem(IDotvvmRequestContext context, object item, int index, IValueBinding itemBinding, DataItemContainer container)
+        private void SetUpServerItem(IDotvvmRequestContext context, object item, int index, DataItemContainer container)
         {
             container.DataItemIndex = index;
-            container.SetDataContextForItem(itemBinding, index, item);
+            container.DataContext = item;
             container.SetValue(Internal.PathFragmentProperty, GetPathFragmentExpression() + "/[" + index + "]");
             container.ID = index.ToString();
         }

--- a/src/DotVVM.Framework/Resources/Scripts/DotVVM.js
+++ b/src/DotVVM.Framework/Resources/Scripts/DotVVM.js
@@ -1847,16 +1847,44 @@ var DotVVM = /** @class */ (function () {
                 return { controlsDescendantBindings: true }; // do not apply binding again
             }
         };
+        var foreachCollectionSymbol = "$foreachCollectionSymbol";
+        ko.virtualElements.allowedBindings["dotvvm-SSR-foreach"] = true;
+        ko.bindingHandlers["dotvvm-SSR-foreach"] = {
+            init: function (element, valueAccessor, _allBindings, _viewModel, bindingContext) {
+                if (!bindingContext)
+                    throw new Error();
+                var value = valueAccessor();
+                var innerBindingContext = bindingContext.extend((_a = {}, _a[foreachCollectionSymbol] = value.data, _a));
+                element.innerBindingContext = innerBindingContext;
+                ko.applyBindingsToDescendants(innerBindingContext, element);
+                return { controlsDescendantBindings: true }; // do not apply binding again
+                var _a;
+            }
+        };
+        ko.virtualElements.allowedBindings["dotvvm-SSR-item"] = true;
+        ko.bindingHandlers["dotvvm-SSR-item"] = {
+            init: function (element, valueAccessor, _allBindings, _viewModel, bindingContext) {
+                if (!bindingContext)
+                    throw new Error();
+                var index = valueAccessor();
+                var collection = bindingContext[foreachCollectionSymbol];
+                var innerBindingContext = bindingContext.createChildContext(function () { return ko.unwrap((ko.unwrap(collection) || [])[index]); }).extend({ $index: ko.pureComputed(function () { return index; }) });
+                element.innerBindingContext = innerBindingContext;
+                ko.applyBindingsToDescendants(innerBindingContext, element);
+                return { controlsDescendantBindings: true }; // do not apply binding again
+            }
+        };
         ko.virtualElements.allowedBindings["withGridViewDataSet"] = true;
         ko.bindingHandlers["withGridViewDataSet"] = {
             init: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
                 if (!bindingContext)
                     throw new Error();
                 var value = valueAccessor();
-                var innerBindingContext = bindingContext.extend({ $gridViewDataSet: value });
+                var innerBindingContext = bindingContext.extend((_a = { $gridViewDataSet: value }, _a[foreachCollectionSymbol] = dotvvm.evaluator.getDataSourceItems(value), _a));
                 element.innerBindingContext = innerBindingContext;
                 ko.applyBindingsToDescendants(innerBindingContext, element);
                 return { controlsDescendantBindings: true }; // do not apply binding again
+                var _a;
             },
             update: function (element, valueAccessor, allBindings, viewModel, bindingContext) {
             }

--- a/src/DotVVM.Framework/tsconfig.json
+++ b/src/DotVVM.Framework/tsconfig.json
@@ -8,7 +8,7 @@
     "outFile": "Resources/Scripts/DotVVM.js",
     "declaration": true,
     "strictNullChecks": true,
-    "lib": ["dom", "es2015.promise", "es5", "es2015.symbol"]
+    "lib": ["dom", "es2015.promise", "es5"]
   },
   "files": [
     "Resources/Scripts/DotVVM.Polyfills.ts",

--- a/src/DotVVM.Framework/tsconfig.json
+++ b/src/DotVVM.Framework/tsconfig.json
@@ -8,7 +8,7 @@
     "outFile": "Resources/Scripts/DotVVM.js",
     "declaration": true,
     "strictNullChecks": true,
-    "lib": ["dom", "es2015.promise", "es5"]
+    "lib": ["dom", "es2015.promise", "es5", "es2015.symbol"]
   },
   "files": [
     "Resources/Scripts/DotVVM.Polyfills.ts",

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/BindingContexts/CollectionContextViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/BindingContexts/CollectionContextViewModel.cs
@@ -24,5 +24,8 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.BindingContexts
             "Eleventh",
             "Twelfth"
         };
+
+        [FromQuery("renderMode")]
+        public DotVVM.Framework.Controls.RenderMode RenderMode { get; set; } = DotVVM.Framework.Controls.RenderMode.Client;
     }
 }

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/BindingContexts/CollectionContext.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/BindingContexts/CollectionContext.dothtml
@@ -14,8 +14,8 @@
     </style>
 </head>
 <body>
-    <dot:Repeater DataSource="{value: Texts}">
-        <div class="block">
+    <dot:Repeater DataSource="{value: Texts}" RenderSettings.Mode="{resource: RenderMode}">
+        <div class="block" RenderSettings.Mode="Client">
             <span>The Text: </span>
             <span>{{value: _this}}</span>
             <br/>

--- a/src/DotVVM.Samples.Tests/Feature/BindingContextsTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/BindingContextsTests.cs
@@ -38,12 +38,15 @@ namespace DotVVM.Samples.Tests.Feature
         public void Feature_BindingContexts_CollectionContext()
         {
             RunInAllBrowsers(browser => {
-                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_BindingContexts_CollectionContext);
-                browser.Wait(1000);
+                foreach (var a in new [] { "Client", "Server" })
+                {
+                    browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_BindingContexts_CollectionContext + $"?renderMode={a}");
+                    browser.Wait(1000);
 
-                var elements = browser.FindElements(By.ClassName("collection-index"));
-                elements.ThrowIfSequenceEmpty();
-                elements.ForEach(e => e.CheckIfInnerTextEquals(elements.IndexOf(e).ToString()));
+                    var elements = browser.FindElements(By.ClassName("collection-index"));
+                    elements.ThrowIfSequenceEmpty();
+                    elements.ForEach(e => e.CheckIfInnerTextEquals(elements.IndexOf(e).ToString()));
+                }
             });
         }
     }


### PR DESCRIPTION
Removed JavascriptTranslator.CurrentIndex symbolic parameter, it's usage
is replaced with `$context.$index` (as we'd do with any other
non-special property of the knockout context). This fixes a bunch of
issues with data context shifting of the context.

Repeater and GridView in server rendering mode use dotvvm-SSR-foreach
and dotvvm-SSR-item binding handlers that:
1. Automatically assign `$index` in each template
2. Remove the DataSource expression from every item of the Repeated

Method BindingHelper.SetDataContextForItem was removed since it can't be
implemented without the CurrentIndexParameter in the ParametrizedCode.

This commit should fix issues with $index in server rendering, $index in
staticCommand and $index in somewhat deeply nested data contexts.