### PR TITLE
Fixed dependency injection into markup controls

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Runtime/DefaultViewCompilerTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/DefaultViewCompilerTests.cs
@@ -220,6 +220,27 @@ test <dot:Literal><a /></dot:Literal>";
         }
 
         [TestMethod]
+        public void DefaultViewCompiler_CodeGeneration_MarkupControlWithDI()
+        {
+            var markup = @"@viewModel System.Object, mscorlib
+<cc:Test5 />";
+            var page = CompileMarkup(markup, new Dictionary<string, string>()
+            {
+                { "test5.dothtml", $"@baseType {typeof(TestMarkupDIControl)}\n@viewModel System.Object, mscorlib\n<dot:Literal Text='aaa' />" }
+            });
+
+            Assert.IsInstanceOfType(page, typeof(DotvvmView));
+            Assert.IsInstanceOfType(page.Children[0], typeof(TestMarkupDIControl));
+
+            var control = (TestMarkupDIControl)page.Children[0];
+            Assert.IsNotNull(control.config);
+
+            var literal = page.Children[0].Children[0].Children[0];
+            Assert.IsInstanceOfType(literal, typeof(Literal));
+            Assert.AreEqual("aaa", ((Literal)literal).Text);
+        }
+
+        [TestMethod]
         public void DefaultViewCompiler_CodeGeneration_MarkupControl_InTemplate()
         {
             var markup = string.Format("@viewModel {0}, {1}\r\n", typeof(ViewCompilerTestViewModel).FullName, typeof(ViewCompilerTestViewModel).GetTypeInfo().Assembly.GetName().Name) +
@@ -436,6 +457,7 @@ test <dot:Literal><a /></dot:Literal>";
             context.Configuration.Markup.Controls.Add(new DotvvmControlConfiguration() { TagPrefix = "cc", TagName = "Test2", Src = "test2.dothtml" });
             context.Configuration.Markup.Controls.Add(new DotvvmControlConfiguration() { TagPrefix = "cc", TagName = "Test3", Src = "test3.dothtml" });
             context.Configuration.Markup.Controls.Add(new DotvvmControlConfiguration() { TagPrefix = "cc", TagName = "Test4", Src = "test4.dothtml" });
+            context.Configuration.Markup.Controls.Add(new DotvvmControlConfiguration() { TagPrefix = "cc", TagName = "Test5", Src = "test5.dothtml" });
             context.Configuration.Markup.AddCodeControls("ff", typeof(TestControl));
             context.Configuration.Markup.AddAssembly(typeof(DefaultViewCompilerTests).GetTypeInfo().Assembly.GetName().Name);
 
@@ -476,6 +498,16 @@ test <dot:Literal><a /></dot:Literal>";
     public class TestControl : DotvvmMarkupControl
     {
 
+    }
+
+    public class TestMarkupDIControl : DotvvmMarkupControl
+    {
+        public readonly DotvvmConfiguration config;
+
+        public TestMarkupDIControl(DotvvmConfiguration configuration)
+        {
+            this.config = configuration;
+        }
     }
 
     public class TestDIControl : DotvvmControl

--- a/src/DotVVM.Framework/Compilation/DefaultViewCompilerCodeEmitter.cs
+++ b/src/DotVVM.Framework/Compilation/DefaultViewCompilerCodeEmitter.cs
@@ -31,7 +31,6 @@ namespace DotVVM.Framework.Compilation
 
         public const string ControlBuilderFactoryParameterName = "controlBuilderFactory";
         public const string ServiceProviderParameterName = "services";
-        public const string BuildControlFunctionName = nameof(IControlBuilder.BuildControl);
         public const string BuildTemplateFunctionName = "BuildTemplate";
 
         private Dictionary<GroupedDotvvmProperty, string> cachedGroupedDotvvmProperties = new Dictionary<GroupedDotvvmProperty, string>();


### PR DESCRIPTION
As pointed out in Gitter by @kamm85, the dependency injection into controls did not work with markup montrols, this change should fix it.