### PR TITLE
Fixed assembly loading bug for net framework

### DIFF
--- a/src/DotVVM.Framework/Compilation/ControlTree/DefaultControlResolver.cs
+++ b/src/DotVVM.Framework/Compilation/ControlTree/DefaultControlResolver.cs
@@ -61,10 +61,10 @@ namespace DotVVM.Framework.Compilation.ControlTree
             // the current AppDomain, to return all assemblies we traverse recursively all referenced Assemblies
             var allTypes = loadedAssemblies
                 .SelectRecursively(a => a.GetReferencedAssemblies().Where(an => visitedAssemblies.Add(an.FullName)).Select(an => Assembly.Load(an)))
-                .Distinct()
                 .Where(a => a.GetReferencedAssemblies().Any(r => r.Name == dotvvmAssembly))
+                .Distinct()
                 .Concat(new[] { typeof(DotvvmControl).GetTypeInfo().Assembly })
-                .SelectMany(a => a.GetLoadableTypes()).Where(t => t.GetTypeInfo().IsClass).ToList();
+                .SelectMany(a => a.GetLoadableTypes()).Where(t => t.GetTypeInfo().IsClass);
 #endif
 
             foreach (var type in allTypes)

--- a/src/DotVVM.Framework/Compilation/ControlTree/DefaultControlResolver.cs
+++ b/src/DotVVM.Framework/Compilation/ControlTree/DefaultControlResolver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -13,7 +14,6 @@ namespace DotVVM.Framework.Compilation.ControlTree
 {
     public class DefaultControlResolver : ControlResolverBase
     {
-
         private readonly IControlBuilderFactory controlBuilderFactory;
 
         private static object locker = new object();
@@ -44,10 +44,29 @@ namespace DotVVM.Framework.Compilation.ControlTree
         {
             // PERF: too many allocations - type.GetCustomAttribute<T> does ~220k allocs -> 4MB, get all types allocates additional 1.5MB
             var dotvvmAssembly = typeof(DotvvmControl).GetTypeInfo().Assembly.GetName().Name;
+
+#if DotNetCore
             var allTypes = ReflectionUtils.GetAllAssemblies()
+               .Where(a => a.GetReferencedAssemblies().Any(r => r.Name == dotvvmAssembly))
+               .Concat(new[] { typeof(DotvvmControl).GetTypeInfo().Assembly })
+               .SelectMany(a => a.GetLoadableTypes()).Where(t => t.GetTypeInfo().IsClass).ToList();
+#else
+ 
+            var loadedAssemblies = ReflectionUtils.GetAllAssemblies()
+                .Where(a => a.GetReferencedAssemblies().Any(r => r.Name == dotvvmAssembly));
+
+            var visitedAssemblies = new HashSet<string>();
+
+            // ReflectionUtils.GetAllAssemblies() in netframework returns only assemblies which have already been loaded into
+            // the current AppDomain, to return all assemblies we traverse recursively all referenced Assemblies
+            var allTypes = loadedAssemblies
+                .SelectRecursively(a => a.GetReferencedAssemblies().Where(an => visitedAssemblies.Add(an.FullName)).Select(an => Assembly.Load(an)))
+                .Distinct()
                 .Where(a => a.GetReferencedAssemblies().Any(r => r.Name == dotvvmAssembly))
                 .Concat(new[] { typeof(DotvvmControl).GetTypeInfo().Assembly })
                 .SelectMany(a => a.GetLoadableTypes()).Where(t => t.GetTypeInfo().IsClass).ToList();
+#endif
+
             foreach (var type in allTypes)
             {
                 if (type.GetTypeInfo().GetCustomAttribute<ContainsDotvvmPropertiesAttribute>(true) != null)
@@ -62,7 +81,6 @@ namespace DotVVM.Framework.Compilation.ControlTree
                 }
             }
         }
-
 
         /// <summary>
         /// Resolves the control metadata for specified type.


### PR DESCRIPTION
Call `AppDomain.CurrentDomain.GetAssemblies()` only returns currently loaded assemblies and thus not all assemblies with DotvvmControl could be loaded and so not all static constructors were invoked and registered.

Should DotVVM invoke static constructors on all controls in assemblies using assembly scanning? What if all assemblies with `DotvvmControl` would be registered in a list and only those would be scanned? I know it would requrie user to call a registration/extension method at `DotvvmStartup`, but it seems better approad to e.