### PR TITLE
Added an API for caching the created binding

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Binding/BindingCacheTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/BindingCacheTests.cs
@@ -26,6 +26,7 @@ namespace DotVVM.Framework.Binding
             var binding2 = ValueBindingExpression.CreateThisBinding<string>(service, dataContext);
             var binding3 = ValueBindingExpression.CreateThisBinding<object>(service, dataContext);
             var binding4 = ValueBindingExpression.CreateThisBinding<string>(service, DataContextStack.Create(typeof(string), dataContext));
+            var binding5 = ValueBindingExpression.CreateThisBinding<string>(service, DataContextStack.Create(typeof(string), dataContext));
 
             Assert.AreEqual(binding1, binding2);
             Assert.AreNotEqual(binding1, binding3);
@@ -33,6 +34,7 @@ namespace DotVVM.Framework.Binding
             Assert.AreNotEqual(binding2, binding3);
             Assert.AreNotEqual(binding2, binding4);
             Assert.AreNotEqual(binding3, binding4);
+            Assert.AreEqual(binding4, binding5);
         }
     }
 }

--- a/src/DotVVM.Framework.Tests.Common/Binding/BindingCacheTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/BindingCacheTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Compilation.ControlTree;
+using DotVVM.Framework.Configuration;
+using DotVVM.Framework.Runtime.Caching;
+using DotVVM.Framework.Tests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DotVVM.Framework.Binding
+{
+    [TestClass]
+    public class BindingCacheTests
+    {
+        private BindingCompilationService service = DotvvmTestHelper.DefaultConfig.ServiceProvider.GetService<BindingCompilationService>();
+
+        [TestMethod]
+        public void ThisBinding()
+        {
+            var dataContext = DataContextStack.Create(typeof(string));
+
+            var binding1 = ValueBindingExpression.CreateThisBinding<string>(service, dataContext);
+            var binding2 = ValueBindingExpression.CreateThisBinding<string>(service, dataContext);
+            var binding3 = ValueBindingExpression.CreateThisBinding<object>(service, dataContext);
+            var binding4 = ValueBindingExpression.CreateThisBinding<string>(service, DataContextStack.Create(typeof(string), dataContext));
+
+            Assert.AreEqual(binding1, binding2);
+            Assert.AreNotEqual(binding1, binding3);
+            Assert.AreNotEqual(binding1, binding4);
+            Assert.AreNotEqual(binding2, binding3);
+            Assert.AreNotEqual(binding2, binding4);
+            Assert.AreNotEqual(binding3, binding4);
+        }
+    }
+}

--- a/src/DotVVM.Framework.Tests.Common/Binding/BindingCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/BindingCompilationTests.cs
@@ -30,7 +30,7 @@ namespace DotVVM.Framework.Tests.Binding
         [TestInitialize]
         public void INIT()
         {
-            this.configuration = DotvvmTestHelper.CreateConfiguration();
+            this.configuration = DotvvmTestHelper.DefaultConfig;
             this.bindingService = configuration.ServiceProvider.GetRequiredService<BindingCompilationService>();
         }
 

--- a/src/DotVVM.Framework.Tests.Common/Binding/CommandResolverTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/CommandResolverTests.cs
@@ -25,7 +25,7 @@ namespace DotVVM.Framework.Tests.Binding
         [TestInitialize]
         public void INIT()
         {
-            this.configuration = DotvvmTestHelper.CreateConfiguration();
+            this.configuration = DotvvmTestHelper.DefaultConfig;
             this.bindingService = configuration.ServiceProvider.GetRequiredService<BindingCompilationService>();
         }
 

--- a/src/DotVVM.Framework.Tests.Common/Binding/JavascriptCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/JavascriptCompilationTests.cs
@@ -89,7 +89,7 @@ namespace DotVVM.Framework.Tests.Binding
                 context = DataContextStack.Create(contexts[i], context);
             }
             var expressionTree = expr(BindingExpressionBuilder.GetParameters(context).ToDictionary(e => e.Name, e => (Expression)e));
-            var configuration = DotvvmTestHelper.CreateConfiguration();
+            var configuration = DotvvmTestHelper.DefaultConfig;
             var jsExpression = new JsParenthesizedExpression(configuration.ServiceProvider.GetRequiredService<JavascriptTranslator>().CompileToJavascript(expressionTree, context));
             jsExpression.AcceptVisitor(new KnockoutObservableHandlingVisitor(true));
             JsTemporaryVariableResolver.ResolveVariables(jsExpression);

--- a/src/DotVVM.Framework.Tests.Common/DotvvmTestHelper.cs
+++ b/src/DotVVM.Framework.Tests.Common/DotvvmTestHelper.cs
@@ -5,6 +5,7 @@ using System.Security;
 using System.Text;
 using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Hosting;
+using DotVVM.Framework.Runtime.Caching;
 using DotVVM.Framework.Security;
 using DotVVM.Framework.Testing;
 using Microsoft.Extensions.DependencyInjection;
@@ -49,7 +50,11 @@ namespace DotVVM.Framework.Tests
         public static void RegisterMoqServices(IServiceCollection services)
         {
             services.TryAddSingleton<IViewModelProtector, FakeProtector>();
+            services.TryAddSingleton<IDotvvmCacheAdapter, SimpleDictionaryCacheAdapter>();
         }
+
+        private static Lazy<DotvvmConfiguration> _defaultConfig = new Lazy<DotvvmConfiguration>(() => CreateConfiguration());
+        public static DotvvmConfiguration DefaultConfig => _defaultConfig.Value;
 
         public static DotvvmConfiguration CreateConfiguration(Action<IServiceCollection> customServices = null) =>
             DotvvmConfiguration.CreateDefault(s => {

--- a/src/DotVVM.Framework.Tests.Common/Routing/DotvvmRouteTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Routing/DotvvmRouteTests.cs
@@ -14,7 +14,7 @@ namespace DotVVM.Framework.Tests.Routing
     [TestClass]
     public class DotvvmRouteTests
     {
-        DotvvmConfiguration configuration = DotvvmTestHelper.CreateConfiguration();
+        DotvvmConfiguration configuration = DotvvmTestHelper.DefaultConfig;
 
         [TestMethod]
         public void DotvvmRoute_IsMatch_RouteMustNotStartWithSlash()

--- a/src/DotVVM.Framework.Tests.Common/Runtime/DotvvmControlTestBase.cs
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/DotvvmControlTestBase.cs
@@ -22,7 +22,7 @@ namespace DotVVM.Framework.Tests.Runtime
         [TestInitialize]
         public virtual void Initialize()
         {
-            Configuration = DotvvmTestHelper.CreateConfiguration();
+            Configuration = DotvvmTestHelper.DefaultConfig;
             BindingService = Configuration.ServiceProvider.GetRequiredService<BindingCompilationService>();
         }
 

--- a/src/DotVVM.Framework/Binding/BindingCompilationService.cs
+++ b/src/DotVVM.Framework/Binding/BindingCompilationService.cs
@@ -62,7 +62,6 @@ namespace DotVVM.Framework.Binding
             if (type == typeof(BindingCompilationService)) return this;
             if (type.IsAssignableFrom(binding.GetType())) return binding;
 
-            var typeName = type.ToString();
             var additionalResolvers = GetAdditionalResolvers(binding);
             var bindingResolvers = GetResolversForBinding(binding.GetType());
 

--- a/src/DotVVM.Framework/Binding/BindingProperties.cs
+++ b/src/DotVVM.Framework/Binding/BindingProperties.cs
@@ -203,18 +203,6 @@ namespace DotVVM.Framework.Binding.Properties
     }
 
     /// <summary>
-    /// Determines whether binding properties can be assigned after initialization. Runtime-used binding should never be mutable.
-    /// </summary>
-    public sealed class IsMutableBindingProperty
-    {
-        public readonly bool IsMutable;
-        public IsMutableBindingProperty(bool isMutable)
-        {
-            this.IsMutable = isMutable;
-        }
-    }
-
-    /// <summary>
     /// Contains the property where the binding is assigned.
     /// </summary>
     public sealed class AssignedPropertyBindingProperty

--- a/src/DotVVM.Framework/Binding/DotvvmBindingCacheHelper.cs
+++ b/src/DotVVM.Framework/Binding/DotvvmBindingCacheHelper.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Runtime.Caching;
+
+namespace DotVVM.Framework.Binding
+{
+    public class DotvvmBindingCacheHelper
+    {
+        private readonly IDotvvmCacheAdapter cache;
+        private readonly BindingCompilationService compilationService;
+
+        public DotvvmBindingCacheHelper(IDotvvmCacheAdapter cache, BindingCompilationService compilationService)
+        {
+            this.cache = cache ?? throw new ArgumentNullException(nameof(cache));
+            this.compilationService = compilationService;
+        }
+
+        public T CachedCreate<T>(string identifier, object[] keys, Func<T> factory) where T: IBinding
+        {
+            return this.cache.GetOrAdd(new CacheKey(typeof(T), identifier, keys), _ => new DotvvmCachedItem<T>(factory(), DotvvmCacheItemPriority.High));
+        }
+
+        public T CachedCreate<T>(string identifier, object[] keys, object[] properties) where T: IBinding
+        {
+            return CachedCreate<T>(identifier, keys, () => (T)BindingFactory.CreateBinding(this.compilationService, typeof(T), properties));
+        }
+
+        internal static void CheckEqualsImplementation(object k)
+        {
+            // whitelist for some common singletons
+            if (k is DotvvmProperty) return;
+
+            var t = k.GetType();
+            var eqMethod = t.GetMethod("Equals", BindingFlags.Public | BindingFlags.Instance, null, new [] { typeof(object) }, null);
+            if (eqMethod.GetBaseDefinition().DeclaringType == typeof(object))
+            {
+                throw new Exception($"Instance of type {t} can not be used as a cache key, because it does not have Object.Equals method overridden. If you really want to use referential equality (you are using a singleton as a cache key or something like that), you can wrap in Tuple<T>.");
+            }
+        }
+
+        class CacheKey: IEquatable<CacheKey>
+        {
+            private readonly object[] keys;
+            private readonly Type type;
+            private readonly string id;
+
+            public CacheKey(Type type, string id, object[] keys)
+            {
+                this.type = type ?? throw new ArgumentNullException(nameof(type));
+                this.id = id ?? throw new ArgumentNullException("Cache identifier can't be null", nameof(id));
+                this.keys = keys ?? throw new ArgumentNullException(nameof(keys));
+            }
+            public bool Equals(CacheKey other)
+            {
+                if (other == null || other.keys.Length != keys.Length || other.type != type || id != other.id) return false;
+                for (int i = 0; i < keys.Length; i++)
+                {
+                    if (!object.Equals(other.keys[i], this.keys[i]))
+                        return false;
+                }
+                return true;
+            }
+            public override bool Equals(object obj) => Equals(obj as CacheKey);
+            public override int GetHashCode()
+            {
+                var hash = 234567643 ^ keys.Length ^ id.GetHashCode() ^ type.GetHashCode();
+                foreach (var k in keys)
+                {
+                    hash *= 17;
+                    hash += k?.GetHashCode() ?? 0;
+                }
+                return hash;
+            }
+        }
+
+        // public class RefEqualityBox<T> : IEquatable<RefEqualityBox<T>>
+        //     where T: class
+        // {
+        //     public RefEqualityBox(T obj)
+        //     {
+        //         Obj = obj;
+        //     }
+
+        //     public T Obj { get; }
+
+        //     public bool Equals(RefEqualityBox<T> other)
+        //     {
+        //         return object.ReferenceEquals(Obj, other.Obj);
+        //     }
+        // }
+    }
+}

--- a/src/DotVVM.Framework/Binding/DotvvmBindingCacheHelper.cs
+++ b/src/DotVVM.Framework/Binding/DotvvmBindingCacheHelper.cs
@@ -18,7 +18,7 @@ namespace DotVVM.Framework.Binding
             this.compilationService = compilationService;
         }
 
-        public T CachedCreate<T>(string identifier, object[] keys, Func<T> factory) where T: IBinding
+        public T CreateCachedBinding<T>(string identifier, object[] keys, Func<T> factory) where T: IBinding
         {
             return this.cache.GetOrAdd(new CacheKey(typeof(T), identifier, keys), _ => {
                 foreach (var k in keys)
@@ -27,9 +27,9 @@ namespace DotVVM.Framework.Binding
             });
         }
 
-        public T CachedCreate<T>(string identifier, object[] keys, object[] properties) where T: IBinding
+        public T CreateCachedBinding<T>(string identifier, object[] keys, object[] properties) where T: IBinding
         {
-            return CachedCreate<T>(identifier, keys, () => (T)BindingFactory.CreateBinding(this.compilationService, typeof(T), properties));
+            return CreateCachedBinding<T>(identifier, keys, () => (T)BindingFactory.CreateBinding(this.compilationService, typeof(T), properties));
         }
 
         internal static void CheckEqualsImplementation(object k)
@@ -39,7 +39,7 @@ namespace DotVVM.Framework.Binding
 
             var t = k.GetType();
             var eqMethod = t.GetMethod("Equals", BindingFlags.Public | BindingFlags.Instance, null, new [] { typeof(object) }, null);
-            if (eqMethod.GetBaseDefinition().DeclaringType != typeof(object) || eqMethod.DeclaringType == typeof(object))
+            if (eqMethod?.GetBaseDefinition().DeclaringType != typeof(object) || eqMethod.DeclaringType == typeof(object))
             {
                 throw new Exception($"Instance of type {t} can not be used as a cache key, because it does not have Object.Equals method overridden. If you really want to use referential equality (you are using a singleton as a cache key or something like that), you can wrap in Tuple<T>.");
             }
@@ -79,21 +79,5 @@ namespace DotVVM.Framework.Binding
                 return hash;
             }
         }
-
-        // public class RefEqualityBox<T> : IEquatable<RefEqualityBox<T>>
-        //     where T: class
-        // {
-        //     public RefEqualityBox(T obj)
-        //     {
-        //         Obj = obj;
-        //     }
-
-        //     public T Obj { get; }
-
-        //     public bool Equals(RefEqualityBox<T> other)
-        //     {
-        //         return object.ReferenceEquals(Obj, other.Obj);
-        //     }
-        // }
     }
 }

--- a/src/DotVVM.Framework/Binding/Expressions/BindingExpression.cs
+++ b/src/DotVVM.Framework/Binding/Expressions/BindingExpression.cs
@@ -11,7 +11,7 @@ using DotVVM.Framework.Runtime.Filters;
 namespace DotVVM.Framework.Binding.Expressions
 {
     [BindingCompilationRequirements(optional: new[] { typeof(BindingResolverCollection) })]
-    public abstract class BindingExpression : IBinding, IMutableBinding, ICloneableBinding
+    public abstract class BindingExpression : IBinding, ICloneableBinding
     {
         struct PropValue
         {
@@ -68,19 +68,6 @@ namespace DotVVM.Framework.Binding.Expressions
 
         public object GetProperty(Type type, ErrorHandlingMode errorMode = ErrorHandlingMode.ThrowException) =>
             properties.GetOrAdd(type, ComputeProperty).GetValue(errorMode);
-
-        bool IMutableBinding.IsMutable => this.GetProperty<IsMutableBindingProperty>(ErrorHandlingMode.ReturnNull)?.IsMutable ?? false;
-        void IMutableBinding.AddProperty(object property)
-        {
-            if (!((IMutableBinding)this).IsMutable) throw new InvalidOperationException("Binding is frozen, can add property.");
-            if (this.properties.TryAdd(property.GetType(), new PropValue(property)))
-                throw new InvalidOperationException("Property already exists.");
-            foreach (var prop in properties)
-            {
-                // remove all error properties
-                if (prop.Value.Error != null) properties.TryRemove(prop.Key, out var _);
-            }
-        }
 
 
         public override string ToString()

--- a/src/DotVVM.Framework/Binding/Expressions/IBinding.cs
+++ b/src/DotVVM.Framework/Binding/Expressions/IBinding.cs
@@ -16,11 +16,6 @@ namespace DotVVM.Framework.Binding.Expressions
         //IList<Delegate> AdditionalServices { get; }
     }
 
-    public interface IMutableBinding: IBinding
-    {
-        void AddProperty(object property);
-        bool IsMutable { get; }
-    }
 
     public interface ICloneableBinding: IBinding
     {

--- a/src/DotVVM.Framework/Binding/Expressions/ValueBindingExpression.cs
+++ b/src/DotVVM.Framework/Binding/Expressions/ValueBindingExpression.cs
@@ -66,9 +66,11 @@ namespace DotVVM.Framework.Binding.Expressions
 
         #region Helpers
 
+        /// Creates binding {value: _this} for a specific data context. Note that the result is cached (non-deterministically, using the <see cref="DotVVM.Framework.Runtime.Caching.IDotvvmCacheAdapter" />)
         public static ValueBindingExpression<T> CreateThisBinding<T>(BindingCompilationService service, DataContextStack dataContext) =>
-            CreateBinding<T>(service, o => (T)o[0], dataContext);
+            service.Cache.CachedCreate("ValueBindingExpression.ThisBinding", new [] { dataContext }, () => CreateBinding<T>(service, o => (T)o[0], dataContext));
 
+        /// Crates a new value binding expression from the specified .NET delegate and Javascript expression. Note that this operation is not very cheap and the result is not cached.
         public static ValueBindingExpression<T> CreateBinding<T>(BindingCompilationService service, Func<object[], T> func, JsExpression expression, DataContextStack dataContext = null) =>
             new ValueBindingExpression<T>(service, new object[] {
                 new BindingDelegate((o, c) => func(o)),
@@ -77,6 +79,7 @@ namespace DotVVM.Framework.Binding.Expressions
                 dataContext
             });
 
+        /// Crates a new value binding expression from the specified .NET delegate and Javascript expression. Note that this operation is not very cheap and the result is not cached.
         public static ValueBindingExpression<T> CreateBinding<T>(BindingCompilationService service, Func<object[], T> func, ParametrizedCode expression, DataContextStack dataContext = null) =>
             new ValueBindingExpression<T>(service, new object[] {
                 new BindingDelegate((o, c) => func(o)),
@@ -85,6 +88,7 @@ namespace DotVVM.Framework.Binding.Expressions
                 dataContext
             });
 
+        /// Crates a new value binding expression from the specified Linq.Expression. Note that this operation is quite expansive and the result is not cached (you are supposed to do it and NOT invoke this function for every request).
         public static ValueBindingExpression<T> CreateBinding<T>(BindingCompilationService service, Expression<Func<object[], T>> expr, DataContextStack dataContext)
         {
             var visitor = new ViewModelAccessReplacer(expr.Parameters.Single());

--- a/src/DotVVM.Framework/Binding/Expressions/ValueBindingExpression.cs
+++ b/src/DotVVM.Framework/Binding/Expressions/ValueBindingExpression.cs
@@ -68,7 +68,7 @@ namespace DotVVM.Framework.Binding.Expressions
 
         /// Creates binding {value: _this} for a specific data context. Note that the result is cached (non-deterministically, using the <see cref="DotVVM.Framework.Runtime.Caching.IDotvvmCacheAdapter" />)
         public static ValueBindingExpression<T> CreateThisBinding<T>(BindingCompilationService service, DataContextStack dataContext) =>
-            service.Cache.CachedCreate("ValueBindingExpression.ThisBinding", new [] { dataContext }, () => CreateBinding<T>(service, o => (T)o[0], dataContext));
+            service.Cache.CreateCachedBinding("ValueBindingExpression.ThisBinding", new [] { dataContext }, () => CreateBinding<T>(service, o => (T)o[0], dataContext));
 
         /// Crates a new value binding expression from the specified .NET delegate and Javascript expression. Note that this operation is not very cheap and the result is not cached.
         public static ValueBindingExpression<T> CreateBinding<T>(BindingCompilationService service, Func<object[], T> func, JsExpression expression, DataContextStack dataContext = null) =>

--- a/src/DotVVM.Framework/Testing/SimpleDictionaryCacheAdapter.cs
+++ b/src/DotVVM.Framework/Testing/SimpleDictionaryCacheAdapter.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using DotVVM.Framework.Hosting;
+using DotVVM.Framework.Runtime.Caching;
+
+namespace DotVVM.Framework.Testing
+{
+    public class SimpleDictionaryCacheAdapter : IDotvvmCacheAdapter
+    {
+        ConcurrentDictionary<object, object> cache = new ConcurrentDictionary<object, object>();
+        public T Get<T>(object key) => GetOrAdd<object, T>(key, null);
+
+        public T GetOrAdd<Tkey, T>(Tkey key, Func<Tkey, DotvvmCachedItem<T>> factoryFunc)
+        {
+            if (factoryFunc == null)
+                return (T)cache[key];
+            else
+                return (T)cache.GetOrAdd(key, _ => factoryFunc(key).Value);
+        }
+
+        public object Remove(object key)
+        {
+            cache.TryRemove(key, out var obj);
+            return obj;
+        }
+    }
+}


### PR DESCRIPTION
I have added an API to BindingCompilationService for easy creation of binding using the new `IDotvvmCacheAdapter`.

```C#

service.Cache.CachedCreate(
    "Identifier of the operation",
//   ^ unique identifier to prevent collisions
    new [] { dataContext, otherParameter },
//           ^ Array of keys that are only used to distinguish the cache entries
    () => new ValueBindingExpression(...))
//        ^ the actual logic that create the binding in case it's not in the cache

```
And there is also a second overload that takes the binding properties instead of a factory function:

```C#

service.Cache.CachedCreate(
    "Identifier of the operation",
    new [] { dataContext, otherParameter },
    new object[] { dataContext, new OriginalStringBindingProperty(...), ... })
```

I have also changed the ValueBindingExpression.CreateThisBinding to use this cached overload and added some tests for that. Also note that the method checks that all keys have overridden `Object.Equals` to prevent unwanted cache busting by some instance compared by reference.

There is added mock interface for the cache for testing and optimized the way configuration is used in tests.
