### PR TITLE
Improved error handling of binding errors

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/DotVVM.Framework.Tests.Common.csproj
+++ b/src/DotVVM.Framework.Tests.Common/DotVVM.Framework.Tests.Common.csproj
@@ -22,6 +22,8 @@
     <ProjectReference Include="..\DotVVM.Framework\DotVVM.Framework.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Ben.Demystifier" Version="0.1.4" />
+    <PackageReference Include="CheckTestOutput" Version="0.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Moq" Version="4.8.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />

--- a/src/DotVVM.Framework.Tests.Common/Runtime/RuntimeErrorTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/RuntimeErrorTests.cs
@@ -1,0 +1,120 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using DotVVM.Framework.Configuration;
+using DotVVM.Framework.Hosting;
+using DotVVM.Framework.ResourceManagement;
+using DotVVM.Framework.ResourceManagement.ClientGlobalize;
+using System.Globalization;
+using DotVVM.Framework.Compilation.Parser;
+using System.Reflection;
+using DotVVM.Framework.Binding;
+using Microsoft.Extensions.DependencyInjection;
+using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Compilation.ControlTree;
+using CheckTestOutput;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using DotVVM.Framework.Binding.Properties;
+using DotVVM.Framework.Utils;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Compilation;
+
+namespace DotVVM.Framework.Tests.Runtime
+{
+    static class CheckExtensions
+    {
+        static string FormatException(Exception exception)
+        {
+            var topFrame = new EnhancedStackTrace(exception).FirstOrDefault(m => !m.MethodInfo.DeclaringType.Namespace.StartsWith("DotVVM.Framework.Binding"))?.MethodInfo.ToString();
+            var msg = $"{exception.GetType().Name} occurred: {exception.Message}";
+            if (topFrame != null) msg += $"\n    at {topFrame}";
+            if (exception is AggregateException aggregateException && aggregateException.InnerExceptions.Count > 1)
+            {
+                var inner = aggregateException.InnerExceptions.Select(FormatException).StringJoin("\n\n");
+                return $"{msg}\n\n{inner}";
+            }
+            else
+            {
+                var inner = exception.InnerException?.Apply(FormatException);
+
+                if (inner == null)
+                    return msg;
+                else
+                    return $"{msg}\n\n{inner}";
+            }
+        }
+
+        public static void CheckException(this OutputChecker check, Action action, string checkName = null, string fileExtension = "txt", [CallerMemberName] string memberName = null, [CallerFilePath] string sourceFilePath = null)
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception exception)
+            {
+                var error = FormatException(exception);
+                check.CheckString(error, checkName, fileExtension, memberName, sourceFilePath);
+                return;
+            }
+            throw new Exception("Expected test to fail.");
+        }
+    }
+
+    [TestClass]
+    public class RuntimeErrorTests
+    {
+        OutputChecker check = new OutputChecker("testoutputs");
+        DotvvmConfiguration config = DotvvmTestHelper.DefaultConfig;
+        BindingCompilationService bindingService => config.ServiceProvider.GetService<BindingCompilationService>();
+
+        [TestMethod]
+        public void NonExistentBindingProperty()
+        {
+            var binding = ValueBindingExpression.CreateBinding(bindingService, a => 12, DataContextStack.Create(typeof(string)));
+
+            check.CheckException(() => binding.GetProperty<OriginalStringBindingProperty>());
+        }
+
+        [TestMethod]
+        public void PropertyResolverFailure()
+        {
+            var binding = ValueBindingExpression.CreateBinding(bindingService.WithoutInitialization(), a => config.ToString(), DataContextStack.Create(typeof(string)));
+            //                                                                ^ disables initialization check
+
+            check.CheckException(() => binding.GetProperty<KnockoutExpressionBindingProperty>());
+        }
+
+        [TestMethod]
+        public void InitResolverFailure()
+        {
+
+            check.CheckException(() => ValueBindingExpression.CreateBinding(bindingService, a => config.ToString(), DataContextStack.Create(typeof(string))));
+        }
+
+        [TestMethod]
+        public void DataContextStack_ToString()
+        {
+            var parent = DataContextStack.Create(typeof(string), DataContextStack.Create(typeof(RuntimeErrorTests)));
+            var d = DataContextStack.Create(
+                typeof(int),
+                parent,
+                imports: new [] { new NamespaceImport("System"), new NamespaceImport("System.Text", "Text") },
+                extensionParameters: new [] { new CurrentCollectionIndexExtensionParameter() });
+
+            check.CheckString(d.ToString());
+        }
+
+        [TestMethod]
+        public void CantFindDataContextSpace()
+        {
+            var binding = ValueBindingExpression.CreateBinding(bindingService, a => false, DataContextStack.Create(typeof(string)));
+            var control = new HtmlGenericControl("div");
+            control.SetValue(Internal.DataContextTypeProperty, DataContextStack.Create(typeof(string), DataContextStack.Create(typeof(int))));
+            control.SetBinding(c => c.Visible, binding);
+            check.CheckException(() => control.Visible.ToString());
+        }
+    }
+}

--- a/src/DotVVM.Framework.Tests.Common/Runtime/testoutputs/RuntimeErrorTests.CantFindDataContextSpace.txt
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/testoutputs/RuntimeErrorTests.CantFindDataContextSpace.txt
@@ -1,0 +1,2 @@
+NotSupportedException occurred: Could not find DataContext space of binding '{ValueBindingExpression`1: False}'. The DataContextType property of the binding does not correspond to DataContextType of the HtmlGenericControl not any of its ancestor. Control's context is (type=System.String, par=[Int32]), binding's context is (type=System.String).
+    at object DotVVM.Framework.Controls.DotvvmBindableObject.EvalPropertyValue(DotvvmProperty property, object value)

--- a/src/DotVVM.Framework.Tests.Common/Runtime/testoutputs/RuntimeErrorTests.DataContextStack_ToString.txt
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/testoutputs/RuntimeErrorTests.DataContextStack_ToString.txt
@@ -1,0 +1,1 @@
+(type=System.Int32, imports=[import(System), import(Text=System.Text)], ext=[_index: Int32], par=[String, RuntimeErrorTests])

--- a/src/DotVVM.Framework.Tests.Common/Runtime/testoutputs/RuntimeErrorTests.InitResolverFailure.txt
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/testoutputs/RuntimeErrorTests.InitResolverFailure.txt
@@ -1,0 +1,7 @@
+AggregateException occurred: Could not initialize binding '{ValueBindingExpression`1: value(DotVVM.Framework.Configuration.DotvvmConfiguration).ToString()}', requirement DotVVM.Framework.Binding.Properties.KnockoutExpressionBindingProperty was not met. (Unable to get property KnockoutExpressionBindingProperty of binding {ValueBindingExpression`1: value(DotVVM.Framework.Configuration.DotvvmConfiguration).ToString()}, unresolvable arguments. (Method Object.ToString can not be translated to Javascript))
+    at void DotVVM.Framework.Tests.Runtime.RuntimeErrorTests.InitResolverFailure()+() => { }
+
+BindingPropertyException occurred: Unable to get property KnockoutExpressionBindingProperty of binding {ValueBindingExpression`1: value(DotVVM.Framework.Configuration.DotvvmConfiguration).ToString()}, unresolvable arguments. (Method Object.ToString can not be translated to Javascript)
+
+NotSupportedException occurred: Method Object.ToString can not be translated to Javascript
+    at JsExpression DotVVM.Framework.Compilation.Javascript.JavascriptTranslationVisitor.TranslateMethodCall(MethodCallExpression expression)

--- a/src/DotVVM.Framework.Tests.Common/Runtime/testoutputs/RuntimeErrorTests.NonExistentBindingProperty.txt
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/testoutputs/RuntimeErrorTests.NonExistentBindingProperty.txt
@@ -1,0 +1,2 @@
+BindingPropertyException occurred: Unable to get property OriginalStringBindingProperty of binding {ValueBindingExpression`1: 12}, resolver not found.
+    at void DotVVM.Framework.Tests.Runtime.RuntimeErrorTests.NonExistentBindingProperty()+() => { }

--- a/src/DotVVM.Framework.Tests.Common/Runtime/testoutputs/RuntimeErrorTests.PropertyResolverFailure.txt
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/testoutputs/RuntimeErrorTests.PropertyResolverFailure.txt
@@ -1,0 +1,5 @@
+BindingPropertyException occurred: Unable to get property KnockoutExpressionBindingProperty of binding {ValueBindingExpression`1: value(DotVVM.Framework.Configuration.DotvvmConfiguration).ToString()}, unresolvable arguments. (Method Object.ToString can not be translated to Javascript)
+    at void DotVVM.Framework.Tests.Runtime.RuntimeErrorTests.PropertyResolverFailure()+() => { }
+
+NotSupportedException occurred: Method Object.ToString can not be translated to Javascript
+    at JsExpression DotVVM.Framework.Compilation.Javascript.JavascriptTranslationVisitor.TranslateMethodCall(MethodCallExpression expression)

--- a/src/DotVVM.Framework/Binding/BindingCompilationService.cs
+++ b/src/DotVVM.Framework/Binding/BindingCompilationService.cs
@@ -73,7 +73,7 @@ namespace DotVVM.Framework.Binding
 
             Exception checkArguments(object[] arguments) =>
                 arguments.OfType<Exception>().ToArray() is var exceptions && exceptions.Any() ?
-                new AggregateException($"Could not resolve '{type}'.", exceptions) :
+                new BindingPropertyException(binding, type, "unresolvable arguments", exceptions) :
                 null;
 
             if (resolver != null)
@@ -91,7 +91,7 @@ namespace DotVVM.Framework.Binding
                     if (checkArguments(arguments) is Exception exc) return exc;
                     value = postProcessor.ExceptionSafeDynamicInvoke(arguments) ?? value;
                 }
-                return value ?? new InvalidOperationException($"Could not resolve binding property '{type}'.");
+                return value ?? new BindingPropertyException(binding, type, "resolver returned null");
             }
             if (typeof(Delegate).IsAssignableFrom(type))
             {
@@ -100,7 +100,7 @@ namespace DotVVM.Framework.Binding
                     return expressionCompiler.Compile(lambda);
                 else return result;
             }
-            else return new InvalidOperationException($"Could not resolve binding property '{type}', resolver not found."); // don't throw the exception, since it creates noise for debugger
+            else return new BindingPropertyException(binding, type, "resolver not found"); // don't throw the exception, since it creates noise for debugger
         }
 
         protected Exception GetException(IBinding binding, string message) =>

--- a/src/DotVVM.Framework/Binding/BindingHelper.cs
+++ b/src/DotVVM.Framework/Binding/BindingHelper.cs
@@ -73,7 +73,7 @@ namespace DotVVM.Framework.Binding
                 if (a.properties.Contains(DotvvmBindableObject.DataContextProperty)) changes++;
             }
 
-            throw new NotSupportedException($"Could not find DataContextSpace of binding '{binding}'.");
+            throw new NotSupportedException($"Could not find DataContext space of binding '{binding}'. The DataContextType property of the binding does not correspond to DataContextType of the {control.GetType().Name} not any of its ancestor. Control's context is {controlContext}, binding's context is {bindingContext}.");
         }
 
         /// <summary>

--- a/src/DotVVM.Framework/Binding/BindingPropertyException.cs
+++ b/src/DotVVM.Framework/Binding/BindingPropertyException.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DotVVM.Framework.Binding.Expressions;
+
+namespace DotVVM.Framework.Binding
+{
+    public class BindingPropertyException: Exception
+    {
+        public IBinding Binding { get; }
+        public Type Property { get; }
+        public string CoreMessage { get; }
+        private Lazy<string> msg;
+        public override string Message => msg.Value;
+
+        static string GetMessage(IBinding binding, Type property, string message, Exception innerException)
+        {
+            var m = $"Unable to get property {property.Name} of binding {binding?.ToString() ?? "{Unknown binding}"}";
+            var suffix = innerException == null ? "." : ". (" + innerException.Message + ")";
+            if (message == null) return m + suffix;
+            else return m + ", " + message + suffix;
+        }
+
+        public BindingPropertyException(IBinding binding, Type property, string message) : this(binding, property, message, (Exception)null) { }
+        public BindingPropertyException(IBinding binding, Type property, Exception innerException) : this(binding, property, null, innerException) { }
+        public BindingPropertyException(IBinding binding, Type property, string message, Exception[] innerExceptions)
+            : this(
+                binding,
+                property,
+                message,
+                innerExceptions.Length > 1 ? new AggregateException(innerExceptions) : innerExceptions.SingleOrDefault()
+            ) { }
+        public BindingPropertyException(IBinding binding, Type property, string message, Exception innerException) : base((string)null, innerException)
+        {
+            this.Binding = binding;
+            this.Property = property;
+            this.CoreMessage = message;
+            this.msg = new Lazy<string>(() => GetMessage(Binding, Property, CoreMessage, innerException));
+        }
+    }
+}

--- a/src/DotVVM.Framework/Binding/Expressions/BindingExpression.cs
+++ b/src/DotVVM.Framework/Binding/Expressions/BindingExpression.cs
@@ -18,11 +18,11 @@ namespace DotVVM.Framework.Binding.Expressions
             public readonly object Value;
             public readonly Exception Error;
 
-            public object GetValue(ErrorHandlingMode errorMode) =>
+            public object GetValue(ErrorHandlingMode errorMode, Func<Exception, Exception> exceptionFactory) =>
                 Error == null ? Value :
                 errorMode == ErrorHandlingMode.ReturnNull ? null :
                 errorMode == ErrorHandlingMode.ReturnException ? Error :
-                throw new AggregateException(Error);
+                throw exceptionFactory(Error);
 
             public PropValue(object value, Exception error = null)
             {
@@ -38,6 +38,26 @@ namespace DotVVM.Framework.Binding.Expressions
 
         public BindingExpression(BindingCompilationService service, IEnumerable<object> properties)
         {
+            this.toStringValue = new Lazy<string>(() => {
+                // using Lazy improves performance a bit and most importantly handles StackOverflowException that could occur when OriginalStringBindingProperty getter fails
+                string value;
+                try
+                {
+                    value =
+                        this.GetProperty<OriginalStringBindingProperty>(ErrorHandlingMode.ReturnNull)?.Code ??
+                        this.GetProperty<ParsedExpressionBindingProperty>(ErrorHandlingMode.ReturnNull)?.Expression?.ToString() ??
+                        this.GetProperty<KnockoutExpressionBindingProperty>(ErrorHandlingMode.ReturnNull)?.Code?.ToString(o => new Compilation.Javascript.CodeParameterAssignment($"${o.GetHashCode()}", Compilation.Javascript.OperatorPrecedence.Max)) ??
+                        this.GetProperty<KnockoutJsExpressionBindingProperty>(ErrorHandlingMode.ReturnNull)?.Expression?.ToString() ??
+                        "... unrepresentable binding content ...";
+                }
+                catch (Exception ex)
+                {
+                    // Binding.ToString is used in error handling, so it should not fail
+                    value = $"Unable to get binding string due to {ex.GetType().Name}: {ex.Message}";
+                }
+                return $"{{{this.GetType().Name}: {value}}}";
+            });
+
             foreach (var prop in properties)
                 if (prop != null) this.properties[prop.GetType()] = new PropValue(prop);
             this.bindingService = service;
@@ -66,18 +86,35 @@ namespace DotVVM.Framework.Binding.Expressions
             this.properties.TryAdd(typeof(BindingResolverCollection), new PropValue(null, noResolversException));
         }
 
-        public object GetProperty(Type type, ErrorHandlingMode errorMode = ErrorHandlingMode.ThrowException) =>
-            properties.GetOrAdd(type, ComputeProperty).GetValue(errorMode);
+        static Func<Exception, Exception> GetExceptionFactory(IBinding contextBinding, Type propType) =>
+            innerException =>
+            innerException is BindingPropertyException bpe && bpe.StackTrace == null && bpe.Binding == contextBinding && bpe.Property == propType ?
+            new BindingPropertyException(bpe.Binding, bpe.Property, bpe.CoreMessage, bpe.InnerException) :
+            new BindingPropertyException(contextBinding, propType, innerException);
 
-
-        public override string ToString()
+        public object GetProperty(Type type, ErrorHandlingMode errorMode = ErrorHandlingMode.ThrowException)
         {
-            var value = this.GetProperty<ParsedExpressionBindingProperty>(ErrorHandlingMode.ReturnNull)?.Expression?.ToString() ??
-                this.GetProperty<OriginalStringBindingProperty>(ErrorHandlingMode.ReturnNull)?.Code ??
-                this.GetProperty<KnockoutJsExpressionBindingProperty>(ErrorHandlingMode.ReturnNull)?.Expression?.ToString() ??
-                this.GetProperty<KnockoutExpressionBindingProperty>(ErrorHandlingMode.ReturnNull)?.Code?.ToString(o => new Compilation.Javascript.CodeParameterAssignment($"${o.GetHashCode()}", Compilation.Javascript.OperatorPrecedence.Max));
-            return $"{{{GetType().Name}: {value}}}";
+            if (!properties.TryGetValue(type, out var result))
+            {
+                var r = ComputeProperty(type);
+                if (r.Error != null)
+                {
+                    // overwrite previous error, this has a chance of being more descriptive (due to blocked recursion)
+                    properties[type] = r;
+                    result = r;
+                }
+                else
+                {
+                    // don't overwrite value, it has to be singleton
+                    result = properties.GetOrAdd(type, r);
+                }
+            }
+            return result.GetValue(errorMode, GetExceptionFactory(this, type));
         }
+
+
+        Lazy<string> toStringValue;
+        public override string ToString() => toStringValue.Value;
 
         IEnumerable<object> ICloneableBinding.GetAllComputedProperties()
         {

--- a/src/DotVVM.Framework/Compilation/ControlTree/DataContextStack.cs
+++ b/src/DotVVM.Framework/Compilation/ControlTree/DataContextStack.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using DotVVM.Framework.Compilation.ControlTree.Resolved;
+using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Compilation.ControlTree
 {
@@ -122,6 +123,18 @@ namespace DotVVM.Framework.Compilation.ControlTree
                 hashCode = (hashCode * 13) ^ (DataContextType?.FullName?.GetHashCode() ?? 0);
                 return hashCode;
             }
+        }
+
+        public override string ToString()
+        {
+            var features = new [] {
+                $"type={this.DataContextType.FullName}",
+                this.NamespaceImports.Any() ? "imports=[" + string.Join(", ", this.NamespaceImports) + "]" : null,
+                this.ExtensionParameters.Any() ? "ext=[" + string.Join(", ", this.ExtensionParameters.Select(e => e.Identifier + ": " + e.ParameterType.Name)) + "]" : null,
+                this.BindingPropertyResolvers.Any() ? "resolvers=[" + string.Join(", ", this.BindingPropertyResolvers.Select(s => s.Method)) + "]" : null,
+                this.Parent != null ? "par=[" + string.Join(", ", this.Parents().Select(p => p.Name)) + "]" : null
+            };
+            return "(" + features.Where(a => a != null).StringJoin(", ") + ")";
         }
 
 

--- a/src/DotVVM.Framework/Compilation/DotvvmCompilationException.cs
+++ b/src/DotVVM.Framework/Compilation/DotvvmCompilationException.cs
@@ -7,6 +7,7 @@ using DotVVM.Framework.Compilation.Parser;
 
 namespace DotVVM.Framework.Compilation
 {
+    [Serializable]
     public class DotvvmCompilationException : Exception
     {
 

--- a/src/DotVVM.Framework/Compilation/NamespaceImport.cs
+++ b/src/DotVVM.Framework/Compilation/NamespaceImport.cs
@@ -34,5 +34,7 @@ namespace DotVVM.Framework.Compilation
 
         public override int GetHashCode() =>
             unchecked(((Namespace?.GetHashCode() ?? 0) * 397) ^ (Alias?.GetHashCode() ?? 0));
+
+		public override string ToString() => "import(" + (Alias == null ? Namespace : Alias + "=" + Namespace) + ")";
     }
 }

--- a/src/DotVVM.Framework/Hosting/ErrorPages/ErrorFormatter.cs
+++ b/src/DotVVM.Framework/Hosting/ErrorPages/ErrorFormatter.cs
@@ -8,6 +8,8 @@ using System.Net;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Binding.Expressions;
 using DotVVM.Framework.Compilation;
 using DotVVM.Framework.Runtime.Commands;
 using DotVVM.Framework.Utils;
@@ -312,6 +314,17 @@ namespace DotVVM.Framework.Hosting.ErrorPages
             return template.TransformText();
         }
 
+        static (string name, object value) StripBindingProperty(string name, object value)
+        {
+            var t = value.GetType();
+            var fields = t.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            if (fields.Length != 1 || !fields[0].IsInitOnly)
+                return (name, value);
+
+            return (name + "." + fields[0].Name, fields[0].GetValue(value));
+        }
+
+
         public static ErrorFormatter CreateDefault()
         {
             var f = new ErrorFormatter();
@@ -319,6 +332,17 @@ namespace DotVVM.Framework.Hosting.ErrorPages
             f.Formatters.Add((e, o) => new ExceptionSectionFormatter(f.LoadException(e), "Raw Stack Trace", "raw_stack_trace"));
             f.Formatters.Add((e, o) => DictionarySection.Create("Cookies", "cookies", o.Request.Cookies));
             f.Formatters.Add((e, o) => DictionarySection.Create("Request Headers", "reqHeaders", o.Request.Headers));
+            f.Formatters.Add((e, o) => {
+                var b = e.AllInnerExceptions().OfType<BindingPropertyException>().Select(a => a.Binding).OfType<ICloneableBinding>().FirstOrDefault();
+                if (b == null) return null;
+                return DictionarySection.Create("Binding", "binding",
+                    new []{ new KeyValuePair<object, object>("Type", b.GetType().FullName) }
+                    .Concat(
+                        b.GetAllComputedProperties()
+                        .Select(a => StripBindingProperty(a.GetType().Name, a))
+                        .Select(a => new KeyValuePair<object, object>(a.name, a.value))
+                    ).ToArray());
+            });
             f.AddInfoLoader<ReflectionTypeLoadException>(e => new ExceptionAdditionalInfo {
                 Title = "Loader Exceptions",
                 Objects = e.LoaderExceptions.Select(lde => lde.GetType().Name + ": " + lde.Message).ToArray(),


### PR DESCRIPTION
Improved error messages of unresolvable binding properties, failures to
find data context stack and error page when error occurs in a binding.

Also added tests for that using CheckTestOutput, I'm sending it as a PR maily to test that is works with our CI and that it works on Windows.