### PR TITLE
DotVVM CLI supports installation as a global tool

### DIFF
--- a/src/DotVVM.CommandLine/DotVVM.CommandLine.csproj
+++ b/src/DotVVM.CommandLine/DotVVM.CommandLine.csproj
@@ -4,9 +4,11 @@
     <AssemblyTitle>DotVVM.CommandLine</AssemblyTitle>
     <AssemblyName>dotnet-dotvvm</AssemblyName>
     <VersionPrefix>2.2.0.1</VersionPrefix>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyOriginatorKeyFile>dotvvmwizard.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>dotvvm</ToolCommandName>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>DotVVM.CommandLine</PackageId>
     <PackageVersion>2.2.0.1</PackageVersion>


### PR DESCRIPTION
I have upgraded `DotVVM.CommandLine` to .NET Core 2.1 and added a few property groups to support installation as a global tool.