### PR TITLE
Returned files support changing the Content-Disposition header type

### DIFF
--- a/src/DotVVM.Framework/Hosting/DotvvmRequestContextExtensions.cs
+++ b/src/DotVVM.Framework/Hosting/DotvvmRequestContextExtensions.cs
@@ -174,13 +174,13 @@ public static class DotvvmRequestContextExtensions
     /// <summary>
     /// Redirects the client to the specified file.
     /// </summary>
-    public static void ReturnFile(this IDotvvmRequestContext context, byte[] bytes, string fileName, string mimeType, IEnumerable<KeyValuePair<string, string>> additionalHeaders = null) =>
-        context.ReturnFile(new MemoryStream(bytes), fileName, mimeType, additionalHeaders);
+    public static void ReturnFile(this IDotvvmRequestContext context, byte[] bytes, string fileName, string mimeType, IEnumerable<KeyValuePair<string, string>> additionalHeaders = null, string attachmentDispositionType = null) =>
+        context.ReturnFile(new MemoryStream(bytes), fileName, mimeType, additionalHeaders, attachmentDispositionType);
 
     /// <summary>
     /// Redirects the client to the specified file.
     /// </summary>
-    public static void ReturnFile(this IDotvvmRequestContext context, Stream stream, string fileName, string mimeType, IEnumerable<KeyValuePair<string, string>> additionalHeaders = null)
+    public static void ReturnFile(this IDotvvmRequestContext context, Stream stream, string fileName, string mimeType, IEnumerable<KeyValuePair<string, string>> additionalHeaders = null, string attachmentDispositionType = null)
     {
         var returnedFileStorage = context.Services.GetService<IReturnedFileStorage>();
 
@@ -194,7 +194,8 @@ public static class DotvvmRequestContextExtensions
         {
             FileName = fileName,
             MimeType = mimeType,
-            AdditionalHeaders = additionalHeaders?.GroupBy(k => k.Key, k => k.Value)?.ToDictionary(k => k.Key, k => k.ToArray())
+            AdditionalHeaders = additionalHeaders?.GroupBy(k => k.Key, k => k.Value)?.ToDictionary(k => k.Key, k => k.ToArray()),
+            AttachmentDispositionType = attachmentDispositionType ?? "attachment"
         };
 
         var generatedFileId = returnedFileStorage.StoreFile(stream, metadata).Result;

--- a/src/DotVVM.Framework/Hosting/Middlewares/DotvvmReturnedFileMiddleware.cs
+++ b/src/DotVVM.Framework/Hosting/Middlewares/DotvvmReturnedFileMiddleware.cs
@@ -29,18 +29,17 @@ namespace DotVVM.Framework.Hosting.Middlewares
 
         private async Task RenderReturnedFile(IHttpContext context, IReturnedFileStorage returnedFileStorage)
         {
-            const string attachmentDispositionType = "attachment";
             ReturnedFileMetadata metadata;
 
             var id = Guid.Parse(context.Request.Query["id"]);
             using (var stream = returnedFileStorage.GetFile(id, out metadata))
             {
 #if DotNetCore
-                var contentDispositionValue = new ContentDispositionHeaderValue(attachmentDispositionType);
+                var contentDispositionValue = new ContentDispositionHeaderValue(metadata.AttachmentDispositionType);
                 contentDispositionValue.SetHttpFileName(metadata.FileName);
                 context.Response.Headers[HeaderNames.ContentDisposition] = contentDispositionValue.ToString();
 #else
-                var contentDispositionValue = new ContentDispositionHeaderValue(attachmentDispositionType)
+                var contentDispositionValue = new ContentDispositionHeaderValue(metadata.AttachmentDispositionType)
                 {
                     FileName = metadata.FileName,
                     FileNameStar = metadata.FileName

--- a/src/DotVVM.Framework/Storage/ReturnedFileMetadata.cs
+++ b/src/DotVVM.Framework/Storage/ReturnedFileMetadata.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Microsoft.Extensions.Primitives;
 
 namespace DotVVM.Framework.Storage
 {
@@ -7,5 +8,6 @@ namespace DotVVM.Framework.Storage
         public string FileName { get; set; }
         public string MimeType { get; set; }
         public Dictionary<string, string[]> AdditionalHeaders { get; set; }
+        public string AttachmentDispositionType { get; set; }
     }
 }

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/ReturnedFile/ReturnedFileSampleViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/ReturnedFile/ReturnedFileSampleViewModel.cs
@@ -15,5 +15,9 @@ namespace DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.ReturnedFile
         {
             Context.ReturnFile(Encoding.UTF8.GetBytes(Text), "file.txt", "text/plain");
         }
+        public void GetFileInline()
+        {
+            Context.ReturnFile(Encoding.UTF8.GetBytes(Text), "file.txt", "text/plain", attachmentDispositionType: "inline");
+        }
     }
 }

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/ReturnedFile/ReturnedFileSample.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/ReturnedFile/ReturnedFileSample.dothtml
@@ -11,6 +11,7 @@
     <%-- TODO: UI Test --%>
     <dot:TextBox Text="{value: Text}" Type="Multiline"></dot:TextBox>
     <dot:Button Text="Get File" Click="{command: GetFile()}" />
+    <dot:Button Text="Get File Inline" Click="{command: GetFileInline()}" />
 </body>
 </html>
 

--- a/src/DotVVM.Samples.Tests/Feature/ReturnedFileTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/ReturnedFileTests.cs
@@ -2,6 +2,7 @@
 using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
 using OpenQA.Selenium;
+using Riganti.Selenium.Core;
 using Riganti.Selenium.Core.Abstractions;
 using Xunit;
 using Xunit.Abstractions;
@@ -26,6 +27,20 @@ namespace DotVVM.Samples.Tests.Feature
         {
             RunInAllBrowsers(browser => {
                 ReturnedFileDownload(browser, "");
+            });
+        }
+
+        [Fact]
+        [SampleReference(nameof(SamplesRouteUrls.FeatureSamples_ReturnedFile_ReturnedFileSample))]
+        public void Feature_ReturnedFile_ReturnedFileSample_Inline()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_ReturnedFile_ReturnedFileSample);
+
+                browser.First("textarea").SendKeys("hello world");
+                browser.Last("input[type=button]").Click();
+
+                AssertUI.TextEquals(browser.First("pre"), "hello world");
             });
         }
 


### PR DESCRIPTION
One of the customers asked us to support different `Content-Disposition` headers - he needs `inline` instead of `attachment` which was hard-coded.