### PR TITLE
Fixed persisted viewmodel in Chrome

### DIFF
--- a/src/DotVVM.Framework/Controls/Infrastructure/BodyResourceLinks.cs
+++ b/src/DotVVM.Framework/Controls/Infrastructure/BodyResourceLinks.cs
@@ -30,7 +30,8 @@ namespace DotVVM.Framework.Controls
 
             // render the serialized viewmodel
             var serializedViewModel = ((DotvvmRequestContext) context).GetSerializedViewModel();
-            writer.AddAttribute("type", "hidden");
+            writer.AddAttribute("type", "text");
+            writer.AddAttribute("style", "display:none!important;");
             writer.AddAttribute("id", "__dot_viewmodel_root");
             writer.AddAttribute("value", serializedViewModel);
             writer.RenderSelfClosingTag("input");

--- a/src/DotVVM.Framework/Controls/Infrastructure/BodyResourceLinks.cs
+++ b/src/DotVVM.Framework/Controls/Infrastructure/BodyResourceLinks.cs
@@ -32,6 +32,7 @@ namespace DotVVM.Framework.Controls
             var serializedViewModel = ((DotvvmRequestContext) context).GetSerializedViewModel();
             writer.AddAttribute("type", "text");
             writer.AddAttribute("style", "display:none!important;");
+            writer.AddAttribute("autocomplete", "off");
             writer.AddAttribute("id", "__dot_viewmodel_root");
             writer.AddAttribute("value", serializedViewModel);
             writer.RenderSelfClosingTag("input");


### PR DESCRIPTION
See #685 for more information. Maybe we should add an setting in `DotvvmConfiguration` to configure this behaviour incase someone uses an element selector that searches for `input[type=hidden]` in his code.

---

fixes #685 