### PR TITLE
Easier creation of LoadFromQueryableAsync extension method

### DIFF
--- a/src/DotVVM.Core/Controls/GridViewDataSet.cs
+++ b/src/DotVVM.Core/Controls/GridViewDataSet.cs
@@ -96,7 +96,7 @@ namespace DotVVM.Framework.Controls
         /// of items is retrieved.
         /// </summary>
         /// <param name="queryable">The <see cref="IQueryable{T}" /> to modify.</param>
-        protected virtual IQueryable<T> ApplyFilteringToQueryable(IQueryable<T> queryable)
+        public virtual IQueryable<T> ApplyFilteringToQueryable(IQueryable<T> queryable)
         {
             return queryable;
         }
@@ -106,7 +106,7 @@ namespace DotVVM.Framework.Controls
         /// of items is retrieved.
         /// </summary>
         /// <param name="queryable">The <see cref="IQueryable{T}" /> to modify.</param>
-        protected virtual IQueryable<T> ApplyOptionsToQueryable(IQueryable<T> queryable)
+        public virtual IQueryable<T> ApplyOptionsToQueryable(IQueryable<T> queryable)
         {
             queryable = ApplySortingToQueryable(queryable);
             queryable = ApplyPagingToQueryable(queryable);
@@ -162,7 +162,7 @@ namespace DotVVM.Framework.Controls
         /// of items is retrieved.
         /// </summary>
         /// <param name="queryable">The <see cref="IQueryable{T}" /> to modify.</param>
-        protected virtual IQueryable<T> ApplyPagingToQueryable(IQueryable<T> queryable)
+        public virtual IQueryable<T> ApplyPagingToQueryable(IQueryable<T> queryable)
         {
             return PagingOptions != null && PagingOptions.PageSize > 0 ?
                 queryable.Skip(PagingOptions.PageSize * PagingOptions.PageIndex).Take(PagingOptions.PageSize) :


### PR DESCRIPTION
We'll need to wait until .NET Core 3.0 is released to be able to make `LoadFromQueryableAsync` method (as explained in #670) since `ToListAsync` and `CountAsync` are declared in EF Core assemblies and we didn't want DotVVM to depend on that.

However, to allow users making their own implementation of `LoadFromQueryableAsync` as an extension method, I have changed several methods on `GridViewDataSet` to be public. 

Making an extension method for `LoadFromQueryableAsync` can now be done like this:

```
        public static async Task LoadFromQueryableAsync(this GridViewDataSet<T> dataSet, IQueryable<T> source)
        {
            source = dataSet.ApplyFilteringToQueryable(source);
            dataSet.Items = await dataSet.ApplyOptionsToQueryable(source).ToListAsync();
            dataSet.PagingOptions.TotalItemsCount = await source.CountAsync();
            dataSet.IsRefreshRequired = false;
        }
```

This also fixed one inconsistency we had on `GridViewDataSet` - all `Apply*ToQueryable` except for `ApplySortingToQueryable` were protected while `ApplySortingToQueryable` was already public. Now they are all public.