### PR TITLE
Removed usages of synchronous AspNetCore API

### DIFF
--- a/src/DotVVM.Framework.Hosting.AspNetCore/Hosting/Middlewares/DotvvmErrorPageMiddleware.cs
+++ b/src/DotVVM.Framework.Hosting.AspNetCore/Hosting/Middlewares/DotvvmErrorPageMiddleware.cs
@@ -23,20 +23,17 @@ namespace DotVVM.Framework.Hosting.Middlewares
 
         public async Task Invoke(HttpContext context)
         {
-            Exception error = null;
             try
             {
                 await next(context);
             }
             catch (Exception ex)
             {
-                error = ex;
-            }
+                if (context.Response.HasStarted)
+                    throw; // the response has already started, don't do anything, we can't write anyway
 
-            if (error != null)
-            {
                 context.Response.StatusCode = 500;
-                await RenderErrorResponse(context, error);
+                await RenderErrorResponse(context, ex);
             }
         }
 
@@ -45,10 +42,9 @@ namespace DotVVM.Framework.Hosting.Middlewares
         /// </summary>
         public Task RenderErrorResponse(HttpContext context, Exception error)
         {
-            context.Response.ContentType = "text/html";
-
             try
             {
+                context.Response.ContentType = "text/html";
 
                 var text = (Formatter ?? (Formatter = CreateDefaultWithDemystifier()))
                     .ErrorHtml(error, DotvvmMiddleware.ConvertHttpContext(context));
@@ -56,21 +52,26 @@ namespace DotVVM.Framework.Hosting.Middlewares
             }
             catch (Exception exc)
             {
-                context.Response.ContentType = "text/plain";
-                try
-                {
-                    using (var writer = new StreamWriter(context.Response.Body))
-                    {
-                        writer.WriteLine("Error in Dotvvm Application:");
-                        writer.WriteLine(error.ToString());
-                        writer.WriteLine();
-                        writer.WriteLine("Error occurred while displaying the error page. This is internal error and should not happened, please report it:");
-                        writer.WriteLine(exc.ToString());
-                    }
-                }
-                catch { }
-                throw new Exception("Error occurred inside dotvvm error handler, this is internal error and should not happen; \n Original error:" + error.ToString(), exc);
+                return RenderFallbackMessage(context, error, exc);
             }
+        }
+
+        private static async Task RenderFallbackMessage(HttpContext context, Exception error, Exception exc)
+        {
+            try
+            {
+                context.Response.ContentType = "text/plain";
+                using (var writer = new StreamWriter(context.Response.Body))
+                {
+                    await writer.WriteLineAsync("Error in Dotvvm Application:");
+                    await writer.WriteLineAsync(error.ToString());
+                    await writer.WriteLineAsync();
+                    await writer.WriteLineAsync("Error occurred while displaying the error page. This is internal error and should not happened, please report it:");
+                    await writer.WriteLineAsync(exc.ToString());
+                }
+            }
+            catch { }
+            throw new Exception("Error occurred inside dotvvm error handler, this is internal error and should not happen; \n Original error:" + error.ToString(), exc);
         }
 
         private ErrorFormatter CreateDefaultWithDemystifier()

--- a/src/DotVVM.Framework/Hosting/DotvvmRequestContextExtensions.cs
+++ b/src/DotVVM.Framework/Hosting/DotvvmRequestContextExtensions.cs
@@ -128,7 +128,11 @@ public static class DotvvmRequestContextExtensions
         if (!context.ModelState.IsValid)
         {
             context.HttpContext.Response.ContentType = "application/json";
-            context.HttpContext.Response.Write(context.Services.GetRequiredService<IViewModelSerializer>().SerializeModelState(context));
+            context.HttpContext.Response
+                .WriteAsync(context.Services.GetRequiredService<IViewModelSerializer>().SerializeModelState(context))
+                .GetAwaiter().GetResult();
+            //   ^ we just wait for this Task. This API never was async and the response size is small enough that we can't quite safely wait for the result
+            //     .GetAwaiter().GetResult() preserves stack traces across async calls, thus I like it more that .Wait()
             throw new DotvvmInterruptRequestExecutionException(InterruptReason.ModelValidationFailed, "The ViewModel contains validation errors!");
         }
     }

--- a/src/DotVVM.Framework/Hosting/HttpRedirectService.cs
+++ b/src/DotVVM.Framework/Hosting/HttpRedirectService.cs
@@ -41,7 +41,11 @@ namespace DotVVM.Framework.Hosting
             {
                 httpContext.Response.StatusCode = 200;
                 httpContext.Response.ContentType = "application/json";
-                httpContext.Response.Write(DefaultViewModelSerializer.GenerateRedirectActionResponse(url, replaceInHistory, allowSpaRedirect));
+                httpContext.Response
+                    .WriteAsync(DefaultViewModelSerializer.GenerateRedirectActionResponse(url, replaceInHistory, allowSpaRedirect))
+                    .GetAwaiter().GetResult();
+               //   ^ we just wait for this Task. Redirect API never was async and the response size is small enough that we can't quite safely wait for the result
+               //     .GetAwaiter().GetResult() preserves stack traces across async calls, thus I like it more that .Wait()
             }
         }
     }


### PR DESCRIPTION
With .NET Core 3, it sometimes throws an exception when you use that.
So, even in places where we need to use a synchronous write, I have
simply changed that to WriteAsync().GetAwaiter().GetResult()