### PR TITLE
Rendering debug info about resources

### DIFF
--- a/src/DotVVM.Framework/Controls/Infrastructure/BodyResourceLinks.cs
+++ b/src/DotVVM.Framework/Controls/Infrastructure/BodyResourceLinks.cs
@@ -21,11 +21,7 @@ namespace DotVVM.Framework.Controls
             var resourceManager = context.ResourceManager;
             if (resourceManager.BodyRendered) return;
             resourceManager.BodyRendered = true;  // set the flag before the resources are rendered, so they can't add more resources to the list during the render
-            foreach (var resource in resourceManager.GetNamedResourcesInOrder())
-            {
-                if (resource.Resource.RenderPosition == ResourceRenderPosition.Body)
-                    resource.RenderResourceCached(writer, context);
-            }
+            ResourcesRenderer.RenderResources(resourceManager, writer, context, ResourceRenderPosition.Body);
 
             // render the serialized viewmodel
             var serializedViewModel = ((DotvvmRequestContext) context).GetSerializedViewModel();

--- a/src/DotVVM.Framework/Controls/Infrastructure/HeadResourceLinks.cs
+++ b/src/DotVVM.Framework/Controls/Infrastructure/HeadResourceLinks.cs
@@ -21,17 +21,7 @@ namespace DotVVM.Framework.Controls
             resourceManager.HeadRendered = true;
 
             // render resource links and preloads
-            foreach (var resource in resourceManager.GetNamedResourcesInOrder())
-            {
-                if (resource.Resource.RenderPosition == ResourceRenderPosition.Head)
-                {
-                    resource.RenderResourceCached(writer, context);
-                }
-                else if (resource.Resource is IPreloadResource preloadResource)
-                {
-                    preloadResource.RenderPreloadLink(writer, context, resource.Name);
-                }
-            }
+            ResourcesRenderer.RenderResources(resourceManager, writer, context, ResourceRenderPosition.Head);
         }
     }
 }

--- a/src/DotVVM.Framework/ResourceManagement/ResourcesRenderer.cs
+++ b/src/DotVVM.Framework/ResourceManagement/ResourcesRenderer.cs
@@ -17,6 +17,39 @@ namespace DotVVM.Framework.ResourceManagement
             writer.WriteUnencodedText(resource.GetRenderedTextCached(context));
         }
 
+        static void WriteResourceInfo(NamedResource resource, IHtmlWriter writer, bool preload)
+        {
+            var comment = $"Resource {resource.Name} of type {resource.Resource.GetType().Name}.";
+            if (resource.Resource is ILinkResource linkResource)
+                comment += $" Pointing to {string.Join(", ", linkResource.GetLocations().Select(l => l.GetType().Name))}.";
+
+            if (preload) comment = "[preload link] " + comment;
+
+            writer.WriteUnencodedText("\n    <!-- ");
+            writer.WriteText(comment);
+            writer.WriteUnencodedText(" -->\n    ");
+            //                               ^~~~ most likely this info will be written directly in the <body> or <head>, so it should be indented by one level.
+            //                                    we don't have any better way to know how we should indent
+        }
+
+        public static void RenderResources(ResourceManager resourceManager, IHtmlWriter writer, IDotvvmRequestContext context, ResourceRenderPosition position)
+        {
+            var writeDebugInfo = context.Configuration.Debug;
+            foreach (var resource in resourceManager.GetNamedResourcesInOrder())
+            {
+                if (resource.Resource.RenderPosition == position)
+                {
+                    if (writeDebugInfo) WriteResourceInfo(resource, writer, preload: false);
+                    resource.RenderResourceCached(writer, context);
+                }
+                else if (position == ResourceRenderPosition.Head && resource.Resource.RenderPosition != ResourceRenderPosition.Head && resource.Resource is IPreloadResource preloadResource)
+                {
+                    if (writeDebugInfo) WriteResourceInfo(resource, writer, preload: true);
+                    preloadResource.RenderPreloadLink(writer, context, resource.Name);
+                }
+            }
+        }
+
         public static string GetRenderedTextCached(this NamedResource resource, IDotvvmRequestContext context) =>
             // dont use cache when debug, so the resource can be refreshed when file is changed
             context.Configuration.Debug ?


### PR DESCRIPTION
This is a little enhancement for easier debugging of resources that were included in a page. In debug mode, it writes a comment before every rendered resource (before the <script>, <link> or other tag).
It includes name of the resource, it's type and types of it's locations.