### PR TITLE
LinkButton and FileUpload empty href

### DIFF
--- a/src/DotVVM.Framework/Controls/FileUpload.cs
+++ b/src/DotVVM.Framework/Controls/FileUpload.cs
@@ -210,7 +210,7 @@ namespace DotVVM.Framework.Controls
             writer.AddAttribute("class", "dotvvm-upload-button");
             writer.AddKnockoutDataBind("visible", "!IsBusy()");
             writer.RenderBeginTag("span");
-            writer.AddAttribute("href", "#");
+            writer.AddAttribute("href", "c");
             writer.AddAttribute("onclick", "dotvvm.fileUpload.showUploadDialog(this); return false;");
             writer.RenderBeginTag("a");
             writer.WriteText(UploadButtonText);

--- a/src/DotVVM.Framework/Controls/FileUpload.cs
+++ b/src/DotVVM.Framework/Controls/FileUpload.cs
@@ -210,7 +210,7 @@ namespace DotVVM.Framework.Controls
             writer.AddAttribute("class", "dotvvm-upload-button");
             writer.AddKnockoutDataBind("visible", "!IsBusy()");
             writer.RenderBeginTag("span");
-            writer.AddAttribute("href", "c");
+            writer.AddAttribute("href", "javascript:;");
             writer.AddAttribute("onclick", "dotvvm.fileUpload.showUploadDialog(this); return false;");
             writer.RenderBeginTag("a");
             writer.WriteText(UploadButtonText);

--- a/src/DotVVM.Framework/Controls/LinkButton.cs
+++ b/src/DotVVM.Framework/Controls/LinkButton.cs
@@ -26,7 +26,7 @@ namespace DotVVM.Framework.Controls
                 throw new DotvvmControlException(this, "The <dot:LinkButton> control cannot have both inner content and the Text property set!");
             }
 
-            writer.AddAttribute("href", "#");
+            writer.AddAttribute("href", "javascript:;");
 
 			var textbinding = GetValueBinding(TextProperty);
 			if (textbinding != null) writer.AddKnockoutDataBind("text", textbinding.GetKnockoutBindingExpression(this));


### PR DESCRIPTION
LinkButton and File now are using javascript:; instead of # inside the href attribute when no link is set.

This change solves the problem of # being added to the URL