### PR TITLE
Allow brackets in attributes name

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Parser/Dothtml/DothtmlTokenizerElementsTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Parser/Dothtml/DothtmlTokenizerElementsTests.cs
@@ -658,6 +658,52 @@ namespace DotVVM.Framework.Tests.Parser.Dothtml
         }
 
         [TestMethod]
+        public void DothtmlTokenizer_ElementParsing_AttributeNameStartWithSquareBracket()
+        {
+            var input = "<a [text]=\"'This is a attribute with special characters ' + (show ? 'true' : 'false')\"/>";
+
+            // parse
+            var tokenizer = new DothtmlTokenizer();
+            tokenizer.Tokenize(input);
+            CheckForErrors(tokenizer, input.Length);
+
+            var i = 0;
+            Assert.AreEqual(DothtmlTokenType.OpenTag, tokenizer.Tokens[i++].Type);
+            Assert.AreEqual(DothtmlTokenType.Text, tokenizer.Tokens[i++].Type);
+            Assert.AreEqual(DothtmlTokenType.WhiteSpace, tokenizer.Tokens[i++].Type);
+            Assert.AreEqual(DothtmlTokenType.Text, tokenizer.Tokens[i++].Type);
+            Assert.AreEqual(DothtmlTokenType.Equals, tokenizer.Tokens[i++].Type);
+            Assert.AreEqual(DothtmlTokenType.DoubleQuote, tokenizer.Tokens[i++].Type);
+            Assert.AreEqual(DothtmlTokenType.Text, tokenizer.Tokens[i++].Type);
+            Assert.AreEqual(DothtmlTokenType.DoubleQuote, tokenizer.Tokens[i++].Type);
+            Assert.AreEqual(DothtmlTokenType.Slash, tokenizer.Tokens[i++].Type);
+            Assert.AreEqual(DothtmlTokenType.CloseTag, tokenizer.Tokens[i++].Type);
+        }
+
+        [TestMethod]
+        public void DothtmlTokenizer_ElementParsing_AttributeNameStartWithRoundBracket()
+        {
+            var input = "<a (text)=\"'This is a attribute with special characters ' + (show ? 'true' : 'false')\"/>";
+
+            // parse
+            var tokenizer = new DothtmlTokenizer();
+            tokenizer.Tokenize(input);
+            CheckForErrors(tokenizer, input.Length);
+
+            var i = 0;
+            Assert.AreEqual(DothtmlTokenType.OpenTag, tokenizer.Tokens[i++].Type);
+            Assert.AreEqual(DothtmlTokenType.Text, tokenizer.Tokens[i++].Type);
+            Assert.AreEqual(DothtmlTokenType.WhiteSpace, tokenizer.Tokens[i++].Type);
+            Assert.AreEqual(DothtmlTokenType.Text, tokenizer.Tokens[i++].Type);
+            Assert.AreEqual(DothtmlTokenType.Equals, tokenizer.Tokens[i++].Type);
+            Assert.AreEqual(DothtmlTokenType.DoubleQuote, tokenizer.Tokens[i++].Type);
+            Assert.AreEqual(DothtmlTokenType.Text, tokenizer.Tokens[i++].Type);
+            Assert.AreEqual(DothtmlTokenType.DoubleQuote, tokenizer.Tokens[i++].Type);
+            Assert.AreEqual(DothtmlTokenType.Slash, tokenizer.Tokens[i++].Type);
+            Assert.AreEqual(DothtmlTokenType.CloseTag, tokenizer.Tokens[i++].Type);
+        }
+
+        [TestMethod]
         public void DothtmlTokenizer_ElementParsing_Invalid_AttributeName_MissingTagName()
         {
             var input = @"<a prefix:=''/>";

--- a/src/DotVVM.Framework/Compilation/Parser/Dothtml/Tokenizer/DothtmlTokenizer.cs
+++ b/src/DotVVM.Framework/Compilation/Parser/Dothtml/Tokenizer/DothtmlTokenizer.cs
@@ -19,8 +19,7 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
 
         public bool TokenizeBinding(string sourceText, bool usesDoubleBraces = false)
         {
-            return TokenizeInternal(sourceText, () => 
-            {
+            return TokenizeInternal(sourceText, () => {
                 ReadBinding(usesDoubleBraces);
                 //Finished?
                 Assert(Peek() == NullChar);
@@ -147,9 +146,14 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
             }
         }
 
+        private static readonly HashSet<char> EnabledIdentifierFirstChars = new HashSet<char>()
+        {
+            '_', '[', '('
+        };
+
         private static readonly HashSet<char> EnabledIdentifierChars = new HashSet<char>()
         {
-            ':', '_', '-', '.'
+            ':', '_', '-', '.', '[', ']', '(', ')'
         };
 
         /// <summary>
@@ -158,7 +162,7 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
         private bool ReadIdentifier(DothtmlTokenType tokenType, params char[] stopChars)
         {
             // read first character
-            if ((!char.IsLetter(Peek()) && Peek() != '_') || stopChars.Contains(Peek()))
+            if ((!char.IsLetter(Peek()) && !EnabledIdentifierFirstChars.Contains(Peek())) || stopChars.Contains(Peek()))
                 return false;
 
             // read identifier

--- a/src/DotVVM.Framework/Compilation/Parser/Dothtml/Tokenizer/DothtmlTokenizer.cs
+++ b/src/DotVVM.Framework/Compilation/Parser/Dothtml/Tokenizer/DothtmlTokenizer.cs
@@ -12,6 +12,23 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
     /// </summary>
     public class DothtmlTokenizer : TokenizerBase<DothtmlToken, DothtmlTokenType>
     {
+
+        private static readonly HashSet<char> AllowedAttributeFirstChars = new HashSet<char>()
+        {
+            '_', '[', '('
+        };
+
+        private static readonly HashSet<char> AllowedAttributeChars = new HashSet<char>()
+        {
+            ':', '_', '-', '.', '[', ']', '(', ')'
+        };
+
+        private static readonly HashSet<char> AllowedIdentifierChars = new HashSet<char>()
+        {
+            ':', '_', '-', '.'
+        };
+
+
         public override void Tokenize(string sourceText)
         {
             TokenizeInternal(sourceText, () => { ReadDocument(); return true; });
@@ -146,27 +163,35 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
             }
         }
 
-        private static readonly HashSet<char> EnabledIdentifierFirstChars = new HashSet<char>()
-        {
-            '_', '[', '('
-        };
-
-        private static readonly HashSet<char> EnabledIdentifierChars = new HashSet<char>()
-        {
-            ':', '_', '-', '.', '[', ']', '(', ')'
-        };
-
         /// <summary>
         /// Reads the identifier.
         /// </summary>
         private bool ReadIdentifier(DothtmlTokenType tokenType, params char[] stopChars)
         {
             // read first character
-            if ((!char.IsLetter(Peek()) && !EnabledIdentifierFirstChars.Contains(Peek())) || stopChars.Contains(Peek()))
+            if ((!char.IsLetter(Peek()) && Peek() != '_') || stopChars.Contains(Peek()))
                 return false;
 
             // read identifier
-            while ((Char.IsLetterOrDigit(Peek()) || EnabledIdentifierChars.Contains(Peek())) && !stopChars.Contains(Peek()))
+            while ((Char.IsLetterOrDigit(Peek()) || AllowedIdentifierChars.Contains(Peek())) && !stopChars.Contains(Peek()))
+            {
+                Read();
+            }
+            CreateToken(tokenType);
+            return true;
+        }
+
+        /// <summary>
+        /// Reads the attribute name.
+        /// </summary>
+        private bool ReadAttributeName(DothtmlTokenType tokenType, params char[] stopChars)
+        {
+            // read first character
+            if ((!char.IsLetter(Peek()) && !AllowedAttributeFirstChars.Contains(Peek())) || stopChars.Contains(Peek()))
+                return false;
+
+            // read identifier
+            while ((Char.IsLetterOrDigit(Peek()) || AllowedAttributeChars.Contains(Peek())) && !stopChars.Contains(Peek()))
             {
                 Read();
             }
@@ -401,10 +426,12 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
         /// </summary>
         private bool ReadTagOrAttributeName(bool isAttributeName)
         {
+            var readIdentifierFunc = isAttributeName ? (Func<DothtmlTokenType, char[], bool>)ReadAttributeName : (Func<DothtmlTokenType, char[], bool>)ReadIdentifier;
+
             if (Peek() != ':')
             {
                 // read the identifier
-                if (!ReadIdentifier(DothtmlTokenType.Text, ':'))
+                if (!readIdentifierFunc(DothtmlTokenType.Text, new[] { ':' }))
                 {
                     return false;
                 }
@@ -420,7 +447,7 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
                 Read();
                 CreateToken(DothtmlTokenType.Colon);
 
-                if (!ReadIdentifier(DothtmlTokenType.Text))
+                if (!readIdentifierFunc(DothtmlTokenType.Text, new char[] { }))
                 {
                     CreateToken(DothtmlTokenType.Text, errorProvider: t => CreateTokenError(t, DothtmlTokenType.OpenTag, DothtmlTokenizerErrors.MissingTagName));
                     return true;

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/Attribute/SpecialCharacters.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/Attribute/SpecialCharacters.dothtml
@@ -1,0 +1,13 @@
+@viewModel DotVVM.Samples.BasicSamples.Api.Common.Model.Order, DotVVM.Samples.BasicSamples.Api.Common
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>Hello from DotVVM!</title>
+</head>
+<body>
+    <div class="container">
+        <h1>Attribute special characters</h1>
+        <button [text]="'This is a attribute with special characters ' + (show ? 'true': 'false')" on="tap:setState({show: !showPassword})" (attr)=" {{world}}!">Show</button>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
I need to use [AMP Bind component](https://amp.dev/documentation/components/amp-bind/). So I have to allow brackets in attribute name

`<button [text]="'This is a attribute with special characters ' + (show ? 'true': 'false')">Show</button>`