### PR TITLE
Removed suppression of errors in Styles unless value binding is rendered

### DIFF
--- a/src/DotVVM.Framework/Controls/HtmlGenericControl.cs
+++ b/src/DotVVM.Framework/Controls/HtmlGenericControl.cs
@@ -281,7 +281,8 @@ namespace DotVVM.Framework.Controls
                         writer.AddStyleAttribute(styleProperty.GroupMemberName, value);
                     }
                 }
-                catch { }
+                // suppress all errors when we have rendered the value binding anyway
+                catch when (HasValueBinding(styleProperty)) { }
             }
 
             if (cssStylesBindingGroup != null)

--- a/src/DotVVM.Framework/Controls/HtmlGenericControl.cs
+++ b/src/DotVVM.Framework/Controls/HtmlGenericControl.cs
@@ -256,7 +256,7 @@ namespace DotVVM.Framework.Controls
                     if (true.Equals(this.GetValue(cssClass)))
                         writer.AddAttribute("class", cssClass.GroupMemberName, append: true, appendSeparator: " ");
                 }
-                catch { }
+                catch when (HasValueBinding(cssClass)) { }
             }
 
             if (!cssClassBindingGroup.IsEmpty) writer.AddKnockoutDataBind("css", cssClassBindingGroup);


### PR DESCRIPTION
Before this change, all errors caused by control.GetValue(Style-something)
were suppressed. With this change, only error caused by value bindings
that can also be evaluated in JS are suppressed.