### PR TITLE
Disabled nested and unsupported bindings in GetValue

### DIFF
--- a/src/DotVVM.Framework/Controls/DotvvmBindableObject.cs
+++ b/src/DotVVM.Framework/Controls/DotvvmBindableObject.cs
@@ -81,7 +81,7 @@ namespace DotVVM.Framework.Controls
         internal object EvalPropertyValue(DotvvmProperty property, object value)
         {
             if (property.IsBindingProperty) return value;
-            while (value is IBinding)
+            if (value is IBinding)
             {
                 DotvvmBindableObject control = this;
                 // DataContext is always bound to it's parent, setting it right here is a bit faster
@@ -94,6 +94,10 @@ namespace DotVVM.Framework.Controls
                 else if (value is ICommandBinding command)
                 {
                     value = command.GetCommandDelegate(control);
+                }
+                else
+                {
+                    throw new NotSupportedException($"Can not evaluate binding {value} of type {value.GetType().Name}.");
                 }
             }
             return value;

--- a/src/DotVVM.Framework/Controls/DotvvmBindableObject.cs
+++ b/src/DotVVM.Framework/Controls/DotvvmBindableObject.cs
@@ -97,7 +97,7 @@ namespace DotVVM.Framework.Controls
                 }
                 else
                 {
-                    throw new NotSupportedException($"Can not evaluate binding {value} of type {value.GetType().Name}.");
+                    throw new NotSupportedException($"Cannot evaluate binding {value} of type {value.GetType().Name}.");
                 }
             }
             return value;


### PR DESCRIPTION
This simple change disables evaluation of bindings returned by binding.
This was supported for very long time, but never had any practical usage
(as far as I know). With DotVVM 2.0 is became quite impractical to have
a binding that would return another binding, since it should also
declare it's return type. The binding also should be translatable to JS
and in that case it can not return another binding at all.

This "feature" now only creates quite unpredictable runtime decision
about the result type and I think we can safely remove it.

Another problem arises when you store something that is actually not
evaluatable - an IBinding instance that is not ICommandBinding nor
IStaticValueBinding. In that case, it simply hang in an infinite loop,
which is clearly a bug. With this change, it will throw an exception,
it's safer that silently returning it and it will not break any
currently working scenario.