### PR TITLE
Added HandleAsImmutableObject attribute

### DIFF
--- a/src/DotVVM.Framework/Compilation/ControlTree/DataContextStack.cs
+++ b/src/DotVVM.Framework/Compilation/ControlTree/DataContextStack.cs
@@ -11,6 +11,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
     /// <summary>
     /// Represents compile-time DataContext info - Type of current DataContext, it's parent and other available parameters
     /// </summary>
+    [HandleAsImmutableObjectInDotvvmPropertyAttribute]
     public sealed class DataContextStack : IDataContextStack
     {
         public DataContextStack Parent { get; }

--- a/src/DotVVM.Framework/Compilation/HandleAsImmutableObjectInDotvvmPropertyAttribute.cs
+++ b/src/DotVVM.Framework/Compilation/HandleAsImmutableObjectInDotvvmPropertyAttribute.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DotVVM.Framework.Compilation
+{
+    /// <summary>
+    /// Tells the DotVVM view compiler that instance of a marked type may be used in DotvvmProperty. It is supposed to be immutable, as it will be shared accross all requests and controls with the same property setter.
+    /// </summary>
+    public class HandleAsImmutableObjectInDotvvmPropertyAttribute : Attribute
+    {
+    }
+}

--- a/src/DotVVM.Framework/Compilation/RoslynValueEmitter.cs
+++ b/src/DotVVM.Framework/Compilation/RoslynValueEmitter.cs
@@ -230,7 +230,7 @@ namespace DotVVM.Framework.Compilation
         public static DotvvmProperty[][] _ViewImmutableObjects_PropArray = new DotvvmProperty[16][];
         public static object[][] _ViewImmutableObjects_ObjArray = new object[16][];
         public static object[] _ViewImmutableObjects = new object[16];
-        private static Func<Type, bool> IsImmutableObject = t => typeof(IBinding).IsAssignableFrom(t) || t == typeof(DataContextStack);
+        private static Func<Type, bool> IsImmutableObject = t => typeof(IBinding).IsAssignableFrom(t) || t.GetCustomAttribute<HandleAsImmutableObjectInDotvvmPropertyAttribute>() is object;
         private static int _viewObjectsCount = 0;
         private static int _viewObjectsCount_PropArray = 0;
         private static int _viewObjectsCount_ObjArray = 0;


### PR DESCRIPTION
The attribute convinces the dotvvm compiler, that it can only emit a
reference to this object as it can be safely shared accros all controls
in the application lifetime.

One application is to set a custom object by s server-side style.

Note that the attribute name is so ugly on purpose. I don't really want it to be well discoverable, as would just complain that the serializer cannot handle immutable object even though they are marked by dotvvm (compiler) attribute...

cc @MichalTichy, this should solve your issue