### PR TITLE
API for runtime warnings

### DIFF
--- a/src/DotVVM.Framework.Hosting.AspNetCore/AspNetCoreLoggerWarningSink.cs
+++ b/src/DotVVM.Framework.Hosting.AspNetCore/AspNetCoreLoggerWarningSink.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DotVVM.Framework.Runtime;
+using Microsoft.Extensions.Logging;
+
+namespace DotVVM.Framework.Hosting.AspNetCore
+{
+    public class AspNetCoreLoggerWarningSink: IDotvvmWarningSink
+    {
+        private ILogger logger;
+
+        public AspNetCoreLoggerWarningSink(ILogger<AspNetCoreLoggerWarningSink> logger = null)
+        {
+            this.logger = logger;
+        }
+
+        public void RuntimeWarning(DotvvmRuntimeWarning warning)
+        {
+            logger?.Log(LogLevel.Warning, "{0}", warning);
+        }
+    }
+}

--- a/src/DotVVM.Framework.Hosting.AspNetCore/ServiceCollectionExtensions.cs
+++ b/src/DotVVM.Framework.Hosting.AspNetCore/ServiceCollectionExtensions.cs
@@ -8,6 +8,8 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.AspNetCore.Builder;
 using System.Reflection;
+using DotVVM.Framework.Runtime;
+using DotVVM.Framework.Hosting.AspNetCore;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -62,6 +64,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton<IEnvironmentNameProvider, DotvvmEnvironmentNameProvider>();
             services.TryAddScoped<DotvvmRequestContextStorage>(_ => new DotvvmRequestContextStorage());
             services.TryAddScoped<IDotvvmRequestContext>(s => s.GetRequiredService<DotvvmRequestContextStorage>().Context);
+
+            services.AddTransient<IDotvvmWarningSink, AspNetCoreLoggerWarningSink>();
         }
     }
 }

--- a/src/DotVVM.Framework/Controls/DotvvmBindableObjectHelper.cs
+++ b/src/DotVVM.Framework/Controls/DotvvmBindableObjectHelper.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using DotVVM.Framework.Binding;
 using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Configuration;
+using DotVVM.Framework.Hosting;
 
 namespace DotVVM.Framework.Controls
 {
@@ -43,5 +46,67 @@ namespace DotVVM.Framework.Controls
         public static TProperty GetValue<TControl, TProperty>(this TControl control, Expression<Func<TControl, TProperty>> prop)
             where TControl : DotvvmBindableObject
             => control.GetValue<TProperty>(control.GetDotvvmProperty(prop));
+
+        internal static object TryGeyValue(this DotvvmBindableObject control, DotvvmProperty property)
+        {
+            try
+            {
+                return control.GetValue(property);
+            }
+            catch
+            {
+                return property.DefaultValue;
+            }
+        }
+
+        public static string DebugString(this DotvvmBindableObject control, DotvvmConfiguration config = null, bool multiline = true)
+        {
+            if (control == null) return "null";
+
+            config = config ?? (control.TryGeyValue(Internal.RequestContextProperty) as IDotvvmRequestContext)?.Configuration;
+
+            var type = control.GetType();
+            var properties = (from kvp in control.Properties
+                              let p = kvp.Key
+                              let rawValue = kvp.Value
+                              where p.DeclaringType != typeof(Internal)
+                              let isAttached = !p.DeclaringType.IsAssignableFrom(type)
+                              orderby !isAttached, p.Name
+                              let name = isAttached ? p.DeclaringType.Name + "." + p.Name : p.Name
+                              let value = rawValue == null ? "<null>" :
+                                          rawValue is ITemplate ? "<a template>" :
+                                          rawValue is DotvvmBindableObject ? $"<control {rawValue.GetType()}>" :
+                                          rawValue is IEnumerable<DotvvmBindableObject> controlCollection ? $"<{controlCollection.Count()} controls>" :
+                                          rawValue is IEnumerable<object> collection ? string.Join(", ", collection) :
+                                          rawValue.ToString()
+                              let croppedValue = value.Length > 41 ? value.Substring(0, 40) + "…" : value
+                              select new { p, name, croppedValue, value, isAttached }
+                             ).ToArray();
+
+            var location = (file: control.TryGeyValue(Internal.MarkupFileNameProperty) as string, line: control.TryGeyValue(Internal.MarkupLineNumberProperty) as int? ?? -1);
+            var reg = config.Markup.Controls.FirstOrDefault(c => c.Namespace == type.Namespace && Type.GetType(c.Namespace + "." + type.Name + ", " + c.Assembly) == type) ??
+                      config.Markup.Controls.FirstOrDefault(c => c.Namespace == type.Namespace) ??
+                      config.Markup.Controls.FirstOrDefault(c => c.Assembly == type.Assembly.GetName().Name);
+            var ns = reg?.TagPrefix ?? "?";
+            var tagName = type == typeof(HtmlGenericControl) ? ((HtmlGenericControl)control).TagName : ns + ":" + type.Name;
+
+            var dothtmlString = $"<{tagName} ";
+            var prefixLength = dothtmlString.Length;
+
+            foreach (var p in properties)
+            {
+                if (multiline && p != properties[0])
+                    dothtmlString += "\n" + new string(' ', prefixLength);
+                dothtmlString += $"{p.name}={p.croppedValue}";
+            }
+            dothtmlString += "/>";
+
+            var from = (location.file)
+                     + (location.line >= 0 ? ":" + location.line : "");
+            if (!String.IsNullOrWhiteSpace(from))
+                from = (multiline ? "\n" : " ") + "from " + from.Trim();
+
+            return dothtmlString + from;
+        }
     }
 }

--- a/src/DotVVM.Framework/Controls/DotvvmControl.cs
+++ b/src/DotVVM.Framework/Controls/DotvvmControl.cs
@@ -179,6 +179,8 @@ namespace DotVVM.Framework.Controls
         {
             this.Children.ValidateParentsLifecycleEvents(); // debug check
 
+            writer.SetErrorContext(this);
+
             if (properties.Contains(PostBack.UpdateProperty))
             {
                 AddDotvvmUniqueIdAttribute();

--- a/src/DotVVM.Framework/Controls/HtmlWriter.cs
+++ b/src/DotVVM.Framework/Controls/HtmlWriter.cs
@@ -204,7 +204,7 @@ namespace DotVVM.Framework.Controls
             writer.Write("/>");
 
             if (this.enableWarnings && !IsSelfClosing(name))
-                Warn($"Element {name} is not self closing but is rendered as so. It may interpreted as a start tag without the end tag by the browsers.");
+                Warn($"Element {name} is not self-closing but is rendered as so. It may be interpreted as a start tag without an end tag by the browsers.");
         }
 
         private Dictionary<string, string> attributeMergeTable = new Dictionary<string, string>(23);
@@ -368,7 +368,7 @@ namespace DotVVM.Framework.Controls
                 writer.Write(">");
 
                 if (this.enableWarnings && IsSelfClosing(tag))
-                    Warn($"Element {tag} is self closing but contains content. The browser may interpret the start tag as self-closing and put the 'content' into it's parent.");
+                    Warn($"Element {tag} is self-closing but contains content. The browser may interpret the start tag as self-closing and put the 'content' into its parent.");
             }
             else
             {

--- a/src/DotVVM.Framework/Controls/HtmlWriter.cs
+++ b/src/DotVVM.Framework/Controls/HtmlWriter.cs
@@ -10,6 +10,7 @@ using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Hosting;
 using DotVVM.Framework.Resources;
 using DotVVM.Framework.Runtime;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DotVVM.Framework.Controls
 {
@@ -19,13 +20,16 @@ namespace DotVVM.Framework.Controls
     public class HtmlWriter : IHtmlWriter
     {
         private readonly TextWriter writer;
-        private readonly bool debug;
         private readonly IDotvvmRequestContext requestContext;
+        private readonly bool debug;
+        private readonly bool enableWarnings;
 
+        private DotvvmBindableObject errorContext;
         private List<(string name, string val, string separator, bool allowAppending)> attributes = new List<(string, string, string separator, bool allowAppending)>();
         private OrderedDictionary dataBindAttributes = new OrderedDictionary();
         private Stack<string> openTags = new Stack<string>();
         private bool tagFullyOpen = true;
+        private RuntimeWarningCollector WarningCollector => requestContext.Services.GetRequiredService<RuntimeWarningCollector>();
 
         public static bool IsSelfClosing(string s)
         {
@@ -60,6 +64,13 @@ namespace DotVVM.Framework.Controls
             this.writer = writer;
             this.requestContext = requestContext;
             this.debug = requestContext.Configuration.Debug;
+            this.enableWarnings = this.WarningCollector.Enabled;
+        }
+
+        internal void Warn(string message, Exception ex = null)
+        {
+            Debug.Assert(this.enableWarnings);
+            this.WarningCollector.Warn(new DotvvmRuntimeWarning(message, ex, this.errorContext));
         }
 
         public static string GetSeparatorForAttribute(string attributeName)
@@ -191,6 +202,9 @@ namespace DotVVM.Framework.Controls
         {
             RenderBeginTagCore(name);
             writer.Write("/>");
+
+            if (this.enableWarnings && !IsSelfClosing(name))
+                Warn($"Element {name} is not self closing but is rendered as so. It may interpreted as a start tag without the end tag by the browsers.");
         }
 
         private Dictionary<string, string> attributeMergeTable = new Dictionary<string, string>(23);
@@ -352,6 +366,9 @@ namespace DotVVM.Framework.Controls
                 writer.Write("</");
                 writer.Write(tag);
                 writer.Write(">");
+
+                if (this.enableWarnings && IsSelfClosing(tag))
+                    Warn($"Element {tag} is self closing but contains content. The browser may interpret the start tag as self-closing and put the 'content' into it's parent.");
             }
             else
             {
@@ -379,6 +396,7 @@ namespace DotVVM.Framework.Controls
             writer.Write(text ?? "");
         }
 
+        public void SetErrorContext(DotvvmBindableObject obj) => this.errorContext = obj;
     }
     public class HtmlElementInfo
     {

--- a/src/DotVVM.Framework/Controls/IHtmlWriter.cs
+++ b/src/DotVVM.Framework/Controls/IHtmlWriter.cs
@@ -69,5 +69,10 @@ namespace DotVVM.Framework.Controls
         /// This method is typically used from <see cref="IHtmlAttributeTransformer"/> implementations.
         /// </summary>
         void WriteHtmlAttribute(string attributeName, string attributeValue);
+
+        /// <summary>
+        /// Passes information about the currently rendered control to the HtmlWriter. Used only to provide more accurate error/warning/debug information, does not alter the main behavior.
+        /// </summary>
+        void SetErrorContext(DotvvmBindableObject obj);
     }
 }

--- a/src/DotVVM.Framework/Controls/Infrastructure/BodyResourceLinks.cs
+++ b/src/DotVVM.Framework/Controls/Infrastructure/BodyResourceLinks.cs
@@ -7,6 +7,7 @@ using DotVVM.Framework.Hosting;
 using DotVVM.Framework.ResourceManagement;
 using Newtonsoft.Json;
 using DotVVM.Framework.ViewModel.Serialization;
+using DotVVM.Framework.Runtime;
 
 namespace DotVVM.Framework.Controls
 {
@@ -36,7 +37,23 @@ namespace DotVVM.Framework.Controls
 window.dotvvm.domUtils.onDocumentReady(function () {{
     window.dotvvm.init('root', {JsonConvert.ToString(CultureInfo.CurrentCulture.Name, '"', StringEscapeHandling.EscapeHtml)});
 }});");
+            writer.WriteUnencodedText(RenderWarnings(context));
             writer.RenderEndTag();
+        }
+
+        internal static string RenderWarnings(IDotvvmRequestContext context)
+        {
+            var result = "";
+            // propagate warnings to JS console
+            var collector = context.Services.GetService<RuntimeWarningCollector>();
+            if (!collector.Enabled) return result;
+
+            foreach (var w in collector.GetWarnings())
+            {
+                var msg = JsonConvert.ToString(w.ToString(), '"', StringEscapeHandling.EscapeHtml);
+                result += $"console.warn({msg});\n";
+            }
+            return result;
         }
     }
 }

--- a/src/DotVVM.Framework/DependencyInjection/DotVVMServiceCollectionExtensions.cs
+++ b/src/DotVVM.Framework/DependencyInjection/DotVVMServiceCollectionExtensions.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton<IHttpRedirectService, DefaultHttpRedirectService>();
             services.TryAddSingleton<IExpressionToDelegateCompiler, DefaultExpressionToDelegateCompiler>();
 
-
+            services.TryAddScoped<RuntimeWarningCollector>();
             services.TryAddScoped<AggregateRequestTracer, AggregateRequestTracer>();
             services.TryAddScoped<ResourceManager, ResourceManager>();
             services.TryAddSingleton(s => DotvvmConfiguration.CreateDefault(s));

--- a/src/DotVVM.Framework/DotVVM.Framework.csproj
+++ b/src/DotVVM.Framework/DotVVM.Framework.csproj
@@ -25,7 +25,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="..\DotVVM.Compiler\bin\$(Configuration)\net461\DotVVM.Compiler.exe">

--- a/src/DotVVM.Framework/Hosting/DotvvmPresenter.cs
+++ b/src/DotVVM.Framework/Hosting/DotvvmPresenter.cs
@@ -272,6 +272,9 @@ namespace DotVVM.Framework.Hosting
                     var postBackUpdates = OutputRenderer.RenderPostbackUpdatedControls(context, page);
                     ViewModelSerializer.AddPostBackUpdatedControls(context, postBackUpdates);
 
+                    // resources must be added after the HTML is rendered - some controls may request resources in the render phase
+                    ViewModelSerializer.AddNewResources(context);
+
                     await OutputRenderer.WriteViewModelResponse(context, page);
                 }
                 await requestTracer.TraceEvent(RequestTracingConstants.OutputRendered, context);

--- a/src/DotVVM.Framework/Runtime/DotvvmRuntimeWarning.cs
+++ b/src/DotVVM.Framework/Runtime/DotvvmRuntimeWarning.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Utils;
+
+namespace DotVVM.Framework.Runtime
+{
+    public class DotvvmRuntimeWarning
+    {
+        public DotvvmRuntimeWarning(string message, Exception relatedException = null, DotvvmBindableObject relatedControl = null)
+        {
+            this.Message = message ?? throw new ArgumentNullException(nameof(message));
+            this.RelatedException = relatedException;
+            this.RelatedControl = relatedControl;
+        }
+
+        public string Message { get; }
+        public Exception RelatedException { get; }
+        public DotvvmBindableObject RelatedControl { get; }
+
+        public override string ToString()
+        {
+            var sections = new string[] {
+                Message,
+                RelatedControl?.Apply(c => "related to:\n" + c.DebugString()),
+                RelatedException?.ToString(),
+            };
+            return string.Join("\n\n", sections.Where(s => s is object));
+        }
+    }
+}

--- a/src/DotVVM.Framework/Runtime/IDotvvmWarningSink.cs
+++ b/src/DotVVM.Framework/Runtime/IDotvvmWarningSink.cs
@@ -1,0 +1,7 @@
+namespace DotVVM.Framework.Runtime
+{
+    public interface IDotvvmWarningSink
+    {
+        void RuntimeWarning(DotvvmRuntimeWarning warning);
+    }
+}

--- a/src/DotVVM.Framework/Runtime/RuntimeWarningCollector.cs
+++ b/src/DotVVM.Framework/Runtime/RuntimeWarningCollector.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using DotVVM.Framework.Configuration;
+using DotVVM.Framework.Controls;
+using Microsoft.Extensions.Options;
+
+namespace DotVVM.Framework.Runtime
+{
+
+    /// <summary>
+    /// A request-scoped service used to collect warnings for debugging. By default these warnings are displayed in browser console and pushed to ASP.NET Core logging (thus probably displayed in the web server console).
+    ///
+    /// Although this is request scoped, it is thread-safe.
+    /// </summary>
+    public class RuntimeWarningCollector
+    {
+        IDotvvmWarningSink[] sinks;
+        ConcurrentStack<DotvvmRuntimeWarning> warnings = new ConcurrentStack<DotvvmRuntimeWarning>();
+        public bool Enabled { get; }
+
+        public RuntimeWarningCollector(IEnumerable<IDotvvmWarningSink> sinks, DotvvmConfiguration config)
+        {
+            this.Enabled = config.Debug;
+            this.sinks = sinks.ToArray();
+        }
+
+        public void Warn(DotvvmRuntimeWarning warning)
+        {
+            if (!Enabled) return;
+
+            this.warnings.Push(warning);
+            foreach (var s in sinks)
+                s.RuntimeWarning(warning);
+        }
+
+
+        public List<DotvvmRuntimeWarning> GetWarnings() => warnings.ToList();
+
+        // public void Warn(string message, Exception relatedException = null, DotvvmBindableObject relatedControl = null) =>
+        //     Warn(message, relatedException, relatedControl);
+    }
+}

--- a/src/DotVVM.Framework/ViewModel/Serialization/DefaultViewModelSerializer.cs
+++ b/src/DotVVM.Framework/ViewModel/Serialization/DefaultViewModelSerializer.cs
@@ -101,8 +101,6 @@ namespace DotVVM.Framework.ViewModel.Serialization
             if (context.IsPostBack || context.IsSpaRequest)
             {
                 result["action"] = "successfulCommand";
-                var renderedResources = new HashSet<string>(context.ReceivedViewModelJson?["renderedResources"]?.Values<string>() ?? new string[] { });
-                result["resources"] = BuildResourcesJson(context, rn => !renderedResources.Contains(rn));
             }
             else
             {
@@ -112,6 +110,12 @@ namespace DotVVM.Framework.ViewModel.Serialization
             if (validationRules?.Count > 0) result["validationRules"] = validationRules;
 
             context.ViewModelJson = result;
+        }
+
+        public void AddNewResources(IDotvvmRequestContext context)
+        {
+            var renderedResources = new HashSet<string>(context.ReceivedViewModelJson?["renderedResources"]?.Values<string>() ?? new string[] { });
+            context.ViewModelJson["resources"] = BuildResourcesJson(context, rn => !renderedResources.Contains(rn));
         }
 
         public string BuildStaticCommandResponse(IDotvvmRequestContext context, object result)
@@ -153,12 +157,20 @@ namespace DotVVM.Framework.ViewModel.Serialization
             {
                 if (predicate(resource.Name))
                 {
-                    using (var str = new StringWriter())
-                    {
-                        resourceObj[resource.Name] = JValue.CreateString(resource.GetRenderedTextCached(context));
-                    }
+                    resourceObj[resource.Name] = JValue.CreateString(resource.GetRenderedTextCached(context));
                 }
             }
+
+            // propagate warnings to JS Console
+            var warningScript = BodyResourceLinks.RenderWarnings(context);
+            if (warningScript != "")
+            {
+                var name = "warnings" + Guid.NewGuid();
+                var resource = new NamedResource(name, new InlineScriptResource(warningScript));
+
+                resourceObj[resource.Name] = JValue.CreateString(resource.GetRenderedTextCached(context));
+            }
+
             return resourceObj;
         }
 

--- a/src/DotVVM.Framework/ViewModel/Serialization/IViewModelSerializer.cs
+++ b/src/DotVVM.Framework/ViewModel/Serialization/IViewModelSerializer.cs
@@ -20,5 +20,6 @@ namespace DotVVM.Framework.ViewModel.Serialization
         ActionInfo ResolveCommand(IDotvvmRequestContext context, DotvvmView view);
 
         void AddPostBackUpdatedControls(IDotvvmRequestContext context, IEnumerable<(string name, string html)> postbackUpdatedControls);
+        void AddNewResources(IDotvvmRequestContext context);
     }
 }

--- a/src/DotVVM.Samples.BasicSamples.AspNetCore/Startup.cs
+++ b/src/DotVVM.Samples.BasicSamples.AspNetCore/Startup.cs
@@ -25,6 +25,11 @@ namespace DotVVM.Samples.BasicSamples
 
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddLogging(b => {
+                b.AddConsole();
+                b.SetMinimumLevel(LogLevel.Information);
+            });
+
             services.AddAuthentication("Scheme1")
                 .AddCookie("Scheme1", o => {
                     o.LoginPath = new PathString("/ComplexSamples/Auth/Login");

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/Warnings/SelfClosingTagsViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/Warnings/SelfClosingTagsViewModel.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.Warnings
+{
+    public class SelfClosingTagsViewModel : DotvvmViewModelBase
+    {
+    
+    }
+}
+

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/Warnings/SelfClosingTags.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/Warnings/SelfClosingTags.dothtml
@@ -1,0 +1,31 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.Warnings.SelfClosingTagsViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+
+    <p>
+        Should print warnings in the JS Console and in the web server log that self closing tags should not contain content.
+    </p>
+
+    <input id="always_rendered_input">
+        Content is not allowed in the input tag
+    </input>
+
+    <div PostBack.Update>
+        <input id="rendered in postback" IncludeInPage="{resource: Context.IsPostBack}">
+            Content is not allowed in the input tag
+        </input>
+    </div>
+
+    <dot:Button Click="{command: 0}">Postback will come with more warnings.</dot:Button>
+
+</body>
+</html>
+
+


### PR DESCRIPTION
RuntimeWarningCollector is a service, where a new warning will can be
added using the `Warn` method. Warning is an instance of
DotvvmRuntimeWarning, contains a message and may contain a reference to
an exception and a bindable object.

By default, warnings are collected in Debug mode. They are displayed in
browser JS console and forwarded to Asp.Net Core logging.

IDotvvmWarningSink is extensibility point for people that want to
collect these warnings on their own.

As a demo, HtmlWriter reports warnings when elements that should be
always self-closing contain some content, as the browser will interpret
the content as sibling.

related to #745, but does not close it since this PR introduces only the infrastructure.

Also note that I had to move rendering of resources in postback after rendering of `PostBack.Update` controls. Since we support resource registration in the `Render` phase, this would need to be done anyway. I have altered `IHtmlWriter` and `IViewModelSerializer`, but these interfaces are so bound to the implementations in framework, that I don't believe somebody has implemented them...


The public API looks like this:

```C#
namespace DotVVM.Framework.Runtime
{
    public interface IDotvvmWarningSink
    {
        void RuntimeWarning(DotvvmRuntimeWarning warning);
    }
    public class DotvvmRuntimeWarning
    {
        public DotvvmRuntimeWarning(string message, Exception relatedException = null, DotvvmBindableObject relatedControl = null);

        public string Message { get; }
        public Exception RelatedException { get; }
        public DotvvmBindableObject RelatedControl { get; }

        public override string ToString();
    }

    public class RuntimeWarningCollector
    {
        public bool Enabled { get; }

        public RuntimeWarningCollector(IEnumerable<IDotvvmWarningSink> sinks, DotvvmConfiguration config);

        public void Warn(DotvvmRuntimeWarning warning);


        public List<DotvvmRuntimeWarning> GetWarnings() => warnings.ToList();
    }
}
```