### PR TITLE
Allowed bindings in attributes without quotes

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Parser/Dothtml/DothtmlParserTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Parser/Dothtml/DothtmlParserTests.cs
@@ -117,6 +117,18 @@ namespace DotVVM.Framework.Tests.Parser.Dothtml
             Assert.AreEqual("test", (innerElement.Attributes[0].ValueNode as DothtmlValueTextNode).Text);
         }
 
+        [TestMethod]
+        public void DothtmlParser_Valid_UnquotedAttributeWithWhitespace()
+        {
+            var markup = @"this <b>is<a href   =  test>test</a></b> a test";
+            var nodes = ParseMarkup(markup).Content;
+
+            var innerElement = (DothtmlElementNode)((DothtmlElementNode)nodes[1]).Content[1];
+            Assert.AreEqual(1, innerElement.Attributes.Count);
+            Assert.AreEqual("href", innerElement.Attributes[0].AttributeName);
+            Assert.IsNull(innerElement.Attributes[0].AttributePrefix);
+            Assert.AreEqual("test", (innerElement.Attributes[0].ValueNode as DothtmlValueTextNode).Text);
+        }
 
 
         [TestMethod]
@@ -181,6 +193,26 @@ namespace DotVVM.Framework.Tests.Parser.Dothtml
             Assert.AreEqual("href", ((DothtmlElementNode)nodes[1]).Attributes[0].AttributeName);
             Assert.AreEqual("value", (((DothtmlElementNode)nodes[1]).Attributes[0].ValueNode as DothtmlValueBindingNode).BindingNode.Name);
             Assert.AreEqual("test", (((DothtmlElementNode)nodes[1]).Attributes[0].ValueNode as DothtmlValueBindingNode).BindingNode.Value);
+        }
+
+        [TestMethod]
+        public void DothtmlParser_Valid_BindingInUnquotedAttributeValue()
+        {
+            var markup = @"this <a href={value: test}/>";
+            var nodes = ParseMarkup(markup).Content;
+
+            Assert.AreEqual(2, nodes.Count);
+
+            Assert.IsInstanceOfType(nodes[0], typeof(DothtmlLiteralNode));
+            Assert.AreEqual("this ", ((DothtmlLiteralNode)nodes[0]).Value);
+
+            Assert.IsInstanceOfType(nodes[1], typeof(DothtmlElementNode));
+            Assert.AreEqual("a", ((DothtmlElementNode)nodes[1]).FullTagName);
+            Assert.AreEqual(0, ((DothtmlElementNode)nodes[1]).Content.Count);
+
+            Assert.AreEqual("href", (nodes[1] as DothtmlElementNode).Attributes[0].AttributeName);
+            Assert.AreEqual("value", ((nodes[1] as DothtmlElementNode).Attributes[0].ValueNode as DothtmlValueBindingNode).BindingNode.Name);
+            Assert.AreEqual("test", ((nodes[1] as DothtmlElementNode).Attributes[0].ValueNode as DothtmlValueBindingNode).BindingNode.Value);
         }
 
         [TestMethod]
@@ -261,7 +293,7 @@ test";
         [TestMethod]
         public void DothtmlParser_SlashAttributeValue()
         {
-            var markup = "<a href=/>Test</a>";
+            var markup = "<a href='/'>Test</a>";
             var nodes = ParseMarkup(markup).Content;
 
             Assert.AreEqual(1, nodes.Count);
@@ -270,6 +302,21 @@ test";
             Assert.AreEqual(1, ael.Attributes.Count);
             Assert.AreEqual("href", ael.Attributes[0].AttributeName);
             Assert.AreEqual("/", (ael.Attributes[0].ValueNode as DothtmlValueTextNode).Text);
+        }
+
+        [TestMethod]
+        public void DothtmlParser_UnquotedSlashAttributeValue()
+        {
+            var markup = "<a href=/>Test</a>";
+            var nodes = ParseMarkup(markup).Content;
+
+            Assert.AreEqual(1, nodes.Count);
+            var ael = (DothtmlElementNode)nodes[0];
+            Assert.AreEqual("a", ael.FullTagName);
+            Assert.AreEqual(1, ael.Attributes.Count);
+            Assert.AreEqual("href", ael.Attributes[0].AttributeName);
+            Assert.AreEqual("", (ael.Attributes[0].ValueNode as DothtmlValueTextNode).Text);
+            Assert.IsTrue(ael.Tokens.Any(n => n.Error is object));
         }
 
         [TestMethod]

--- a/src/DotVVM.Framework/Compilation/Parser/Dothtml/Parser/DothtmlParser.cs
+++ b/src/DotVVM.Framework/Compilation/Parser/Dothtml/Parser/DothtmlParser.cs
@@ -385,7 +385,14 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
                 }
                 else
                 {
-                    attribute.ValueNode = ReadTextValue(false, false, DothtmlTokenType.Text);
+                    if (Peek().Type == DothtmlTokenType.OpenBinding)
+                    {
+                        attribute.ValueNode = ReadBindingValue(false, true);
+                    }
+                    else
+                    {
+                        attribute.ValueNode = ReadTextValue(false, false, DothtmlTokenType.Text);
+                    }
                     //these are not part of any attribute or value
                     SkipWhiteSpace();
                 }

--- a/src/DotVVM.Framework/Compilation/Parser/Dothtml/Tokenizer/DothtmlTokenizer.cs
+++ b/src/DotVVM.Framework/Compilation/Parser/Dothtml/Tokenizer/DothtmlTokenizer.cs
@@ -488,26 +488,39 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
                 else
                 {
                     // unquoted value
-                    if (Peek() == '>' || Peek() == '<')
-                    {
-                        CreateToken(DothtmlTokenType.Text, errorProvider: t => CreateTokenError(t, DothtmlTokenType.Text, DothtmlTokenizerErrors.MissingAttributeValue));
+                    if (!ReadUnquotedAttributeValue())
                         return false;
-                    }
-                    do
-                    {
-                        if (Read() == NullChar || Peek() == '<') { CreateToken(DothtmlTokenType.Text, errorProvider: t => CreateTokenError()); return false; }
-                    } while (!char.IsWhiteSpace(Peek()) && Peek() != '/' && Peek() != '>');
-                    CreateToken(DothtmlTokenType.Text);
                     SkipWhitespace();
                 }
             }
-            //else
-            //{
-            //    CreateToken(DothtmlTokenType.Equals, errorProvider: t => CreateTokenError());
-            //    CreateToken(DothtmlTokenType.Text, errorProvider: t => CreateTokenError(t, DothtmlTokenType.Text, DothtmlTokenizerErrors.MissingAttributeValue));
-            //    return false;
-            //}
 
+            return true;
+        }
+
+        public bool ReadUnquotedAttributeValue()
+        {
+            if (Peek() == '{')
+            {
+                ReadBinding(false);
+            }
+            else
+            {
+                while (!char.IsWhiteSpace(Peek()) && Peek() != '/' && Peek() != '>')
+                {
+                    if (Peek() == NullChar || Peek() == '<')
+                    {
+                        CreateToken(DothtmlTokenType.Text, errorProvider: t => CreateTokenError());
+                        return false;
+                    }
+                    Read();
+                }
+                if (DistanceSinceLastToken == 0)
+                {
+                    CreateToken(DothtmlTokenType.Text, errorProvider: t => CreateTokenError(t, DothtmlTokenType.Text, DothtmlTokenizerErrors.MissingAttributeValue));
+                    return false;
+                }
+                CreateToken(DothtmlTokenType.Text);
+            }
             return true;
         }
 

--- a/src/DotVVM.Framework/ViewModel/Serialization/IViewModelSerializer.cs
+++ b/src/DotVVM.Framework/ViewModel/Serialization/IViewModelSerializer.cs
@@ -12,7 +12,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
         string BuildStaticCommandResponse(IDotvvmRequestContext context, object result);
 
         string SerializeViewModel(IDotvvmRequestContext context);
-        
+
         string SerializeModelState(IDotvvmRequestContext context);
 
         void PopulateViewModel(IDotvvmRequestContext context, string serializedPostData);

--- a/src/DotVVM.Samples.Common/Views/Default.dothtml
+++ b/src/DotVVM.Samples.Common/Views/Default.dothtml
@@ -15,8 +15,8 @@
     </style>
 </head>
 <body>
-    <dot:Repeater WrapperTagName="ul" DataSource="{value: Routes }">
-        <li><a href="{value: Url}">{{value: RouteName}}</a></li>
+    <dot:Repeater WrapperTagName="ul" DataSource={value: Routes }>
+        <li><a href={value: Url}>{{value: RouteName}}</a></li>
     </dot:Repeater>
     <div>Number of Tests: {{value: Routes.Count}}</div>
 


### PR DESCRIPTION
Binding can be now written without quotes in attributes:

```
MyProperty={value: OtherProperty}
```

The quotes are basically redundant in the syntax, as the binding is
already "quoted" by the curly braces. IMHO, it makes more sense to write
them without quotes as it's just noise. And React (JSX) also has them without
quotes :) 