### PR TITLE
Support presenter factories on route groups

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Routing/RouteTableGroupTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Routing/RouteTableGroupTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using DotVVM.Framework.Configuration;
+using DotVVM.Framework.Hosting;
 using DotVVM.Framework.Routing;
 using DotVVM.Framework.Tests.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -167,6 +168,20 @@ namespace DotVVM.Framework.Tests.Common.Routing
             table.AddGroup("Group", null, null, opt => {
                 opt.Add("Article", "", provider => provider.GetRequiredService<TestPresenter>(), null);
             });
+            Assert.IsInstanceOfType(table.First().GetPresenter(configuration.ServiceProvider), typeof(TestPresenter));
+        }
+
+        [TestMethod]
+        public void RouteTableGroup_DefaultPresenterFactory()
+        {
+            var configuration = DotvvmConfiguration.CreateDefault(services => {
+                services.TryAddScoped<TestPresenter>();
+            });
+
+            var table = new DotvvmRouteTable(configuration);
+            table.AddGroup("Group", null, null, opt => {
+                opt.Add("Article", "");
+            }, p => p.GetRequiredService<TestPresenter>());
             Assert.IsInstanceOfType(table.First().GetPresenter(configuration.ServiceProvider), typeof(TestPresenter));
         }
     }

--- a/src/DotVVM.Framework/Routing/DotvvmRouteTable.cs
+++ b/src/DotVVM.Framework/Routing/DotvvmRouteTable.cs
@@ -2,11 +2,8 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Hosting;
-using DotVVM.Framework.Runtime;
-using DotVVM.Framework.Security;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DotVVM.Framework.Routing
@@ -17,22 +14,12 @@ namespace DotVVM.Framework.Routing
     public class DotvvmRouteTable : IEnumerable<RouteBase>
     {
         private readonly DotvvmConfiguration configuration;
-
-        private List<KeyValuePair<string, RouteBase>> list = new List<KeyValuePair<string, RouteBase>>();
-
-        /// <summary>
-        /// Dictionary for faster checking of duplicate entries when adding.
-        /// </summary>
-        private Dictionary<string, RouteBase> dictionary = new Dictionary<string, RouteBase>(StringComparer.OrdinalIgnoreCase);
-
-        /// <summary>
-        /// Dictionary for groups of RouteTables.
-        /// </summary>
-        private Dictionary<string, DotvvmRouteTable> routeTableGroups = new Dictionary<string, DotvvmRouteTable>();
-
-        /// <summary>
-        /// Contains information about the group of this RouteTable.
-        /// </summary>
+        private List<KeyValuePair<string, RouteBase>> list
+            = new List<KeyValuePair<string, RouteBase>>();
+        private Dictionary<string, RouteBase> dictionary
+            = new Dictionary<string, RouteBase>(StringComparer.OrdinalIgnoreCase);
+        private Dictionary<string, DotvvmRouteTable> routeTableGroups
+            = new Dictionary<string, DotvvmRouteTable>();
         private RouteTableGroup group = null;
 
         /// <summary>
@@ -63,7 +50,12 @@ namespace DotVVM.Framework.Routing
         /// <param name="urlPrefix">Url prefix of added routes</param>
         /// <param name="virtualPathPrefix">Virtual path prefix of added routes</param>
         /// <param name="content">Contains routes to be added</param>
-        public void AddGroup(string groupName, string urlPrefix, string virtualPathPrefix, Action<DotvvmRouteTable> content)
+        /// <param name="presenterFactory">Default presenter factory common to all routes in the group</param>
+        public void AddGroup(string groupName,
+            string urlPrefix,
+            string virtualPathPrefix,
+            Action<DotvvmRouteTable> content,
+            Func<IServiceProvider, IDotvvmPresenter> presenterFactory = null)
         {
             if (string.IsNullOrEmpty(groupName))
             {
@@ -77,7 +69,13 @@ namespace DotVVM.Framework.Routing
             virtualPathPrefix = CombinePath(group?.VirtualPathPrefix, virtualPathPrefix);
 
             var newGroup = new DotvvmRouteTable(configuration);
-            newGroup.group = new RouteTableGroup(groupName, group?.RouteNamePrefix + groupName + "_", urlPrefix, virtualPathPrefix, Add);
+            newGroup.group = new RouteTableGroup(
+                groupName: groupName,
+                routeNamePrefix: group?.RouteNamePrefix + groupName + "_",
+                urlPrefix: urlPrefix,
+                virtualPathPrefix: virtualPathPrefix,
+                addToParentRouteTable: Add,
+                presenterFactory: presenterFactory);
 
             content(newGroup);
             routeTableGroups.Add(groupName, newGroup);
@@ -87,7 +85,7 @@ namespace DotVVM.Framework.Routing
         /// Creates the default presenter factory.
         /// </summary>
         public IDotvvmPresenter GetDefaultPresenter(IServiceProvider provider) =>
-            provider.GetRequiredService<IDotvvmPresenter>();
+            group?.PresenterFactory(provider) ?? provider.GetRequiredService<IDotvvmPresenter>();
 
         /// <summary>
         /// Adds the specified route name.
@@ -96,6 +94,7 @@ namespace DotVVM.Framework.Routing
         /// <param name="url">The URL.</param>
         /// <param name="virtualPath">The virtual path of the Dothtml file.</param>
         /// <param name="defaultValues">The default values.</param>
+        /// <param name="presenterFactory">Delegate creating the presenter handling this route</param>
         public void Add(string routeName, string url, string virtualPath, object defaultValues = null, Func<IServiceProvider, IDotvvmPresenter> presenterFactory = null)
         {
             Add(group?.RouteNamePrefix + routeName, new DotvvmRoute(CombinePath(group?.UrlPrefix, url), CombinePath(group?.VirtualPathPrefix, virtualPath), defaultValues, presenterFactory ?? GetDefaultPresenter, configuration));
@@ -109,9 +108,9 @@ namespace DotVVM.Framework.Routing
         /// <param name="url">The URL.</param>
         /// <param name="defaultValues">The default values.</param>
         /// <param name="presenterFactory">The presenter factory.</param>
-        public void Add(string routeName, string url, Func<IServiceProvider, IDotvvmPresenter> presenterFactory, object defaultValues = null)
+        public void Add(string routeName, string url, Func<IServiceProvider, IDotvvmPresenter> presenterFactory = null, object defaultValues = null)
         {
-            Add(group?.RouteNamePrefix + routeName, new DotvvmRoute(CombinePath(group?.UrlPrefix, url), group?.VirtualPathPrefix, defaultValues, presenterFactory, configuration));
+            Add(group?.RouteNamePrefix + routeName, new DotvvmRoute(CombinePath(group?.UrlPrefix, url), group?.VirtualPathPrefix, defaultValues, presenterFactory ?? GetDefaultPresenter, configuration));
         }
 
 

--- a/src/DotVVM.Framework/Routing/RouteTableGroup.cs
+++ b/src/DotVVM.Framework/Routing/RouteTableGroup.cs
@@ -1,25 +1,37 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using DotVVM.Framework.Hosting;
 
 namespace DotVVM.Framework.Routing
 {
     public class RouteTableGroup
     {
-        public Action<string, RouteBase> AddToParentRouteTable { get; private set; }
+        public Action<string, RouteBase> AddToParentRouteTable { get; }
 
-        public string GroupName { get; private set; }
-        public string RouteNamePrefix { get; private set; }
-        public string UrlPrefix { get; private set; }
-        public string VirtualPathPrefix { get; private set; }
+        public string GroupName { get; }
 
-        public RouteTableGroup(string groupName, string routeNamePrefix, string urlPrefix, string virtualPathPrefix, Action<string, RouteBase> addToParentRouteTable)
+        public string RouteNamePrefix { get; }
+
+        public string UrlPrefix { get; }
+
+        public string VirtualPathPrefix { get; }
+
+        public Func<IServiceProvider, IDotvvmPresenter> PresenterFactory { get; }
+
+        public RouteTableGroup(string groupName,
+            string routeNamePrefix,
+            string urlPrefix,
+            string virtualPathPrefix,
+            Action<string, RouteBase> addToParentRouteTable,
+            Func<IServiceProvider, IDotvvmPresenter> presenterFactory)
         {
             GroupName = groupName;
             RouteNamePrefix = routeNamePrefix;
             UrlPrefix = urlPrefix;
             VirtualPathPrefix = virtualPathPrefix;
             AddToParentRouteTable = addToParentRouteTable;
+            PresenterFactory = presenterFactory;
         }
     }
 }

--- a/src/DotVVM.Framework/Routing/RouteTableGroup.cs
+++ b/src/DotVVM.Framework/Routing/RouteTableGroup.cs
@@ -7,24 +7,16 @@ namespace DotVVM.Framework.Routing
 {
     public class RouteTableGroup
     {
-        public Action<string, RouteBase> AddToParentRouteTable { get; }
-
-        public string GroupName { get; }
-
-        public string RouteNamePrefix { get; }
-
-        public string UrlPrefix { get; }
-
-        public string VirtualPathPrefix { get; }
+        public Action<string, RouteBase> AddToParentRouteTable { get; private set; }
 
         public Func<IServiceProvider, IDotvvmPresenter> PresenterFactory { get; }
 
-        public RouteTableGroup(string groupName,
-            string routeNamePrefix,
-            string urlPrefix,
-            string virtualPathPrefix,
-            Action<string, RouteBase> addToParentRouteTable,
-            Func<IServiceProvider, IDotvvmPresenter> presenterFactory)
+        public string GroupName { get; private set; }
+        public string RouteNamePrefix { get; private set; }
+        public string UrlPrefix { get; private set; }
+        public string VirtualPathPrefix { get; private set; }
+
+        public RouteTableGroup(string groupName, string routeNamePrefix, string urlPrefix, string virtualPathPrefix, Action<string, RouteBase> addToParentRouteTable, Func<IServiceProvider, IDotvvmPresenter> presenterFactory)
         {
             GroupName = groupName;
             RouteNamePrefix = routeNamePrefix;


### PR DESCRIPTION
Closes #661.

Please note that I had to change the signature of `DotvvmRouteTable.Add(string routeName, string url, Func<IServiceProvider, IDotvvmPresenter> presenterFactory, object defaultValues = null)` to `DotvvmRouteTable.Add(string routeName, string url, Func<IServiceProvider, IDotvvmPresenter> presenterFactory = null, object defaultValues = null)` (presenterFactory is optional now) to make it work.