### PR TITLE
Fixed dependency cycle detection.

### DIFF
--- a/src/DotVVM.Framework/ResourceManagement/ResourceUtils.cs
+++ b/src/DotVVM.Framework/ResourceManagement/ResourceUtils.cs
@@ -21,7 +21,6 @@ namespace DotVVM.Framework.ResourceManagement
             string name,
             Func<string, IResource> findResource)
         {
-            var visited = new HashSet<IResource> { resource };
             var queue = new Queue<string>();
             foreach (var dependency in resource.Dependencies)
             {
@@ -35,13 +34,12 @@ namespace DotVVM.Framework.ResourceManagement
                 if (current is null)
                     continue;
 
-                if (visited.Contains(current))
+                if (resource == current)
                 {
                     // dependency cycle detected
                     throw new DotvvmResourceException($"Resource \"{name}\" has a cyclic " +
                         $"dependency.");
                 }
-                visited.Add(current);
                 foreach (var dependency in current.Dependencies)
                 {
                     queue.Enqueue(dependency);


### PR DESCRIPTION
The dependency cycle detection was detecting even cycles that were inside the tree. That caused false positive detection. 