### PR TITLE
Fixed GetDataContextType(DotvvmProperty)

### DIFF
--- a/src/DotVVM.Framework/Binding/BindingHelper.cs
+++ b/src/DotVVM.Framework/Binding/BindingHelper.cs
@@ -279,7 +279,7 @@ namespace DotVVM.Framework.Binding
             obj.SetDataContextType(dataSourceBinding.GetProperty<CollectionElementDataContextBindingProperty>().DataContext);
 
 
-        /// <summary> Return the expected data context type for this property. </summary>
+        /// <summary> Return the expected data context type for this property. Returns null if the type is unknown. </summary>
         public static DataContextStack GetDataContextType(this DotvvmProperty property, DotvvmBindableObject obj)
         {
             var dataContextType = obj.GetDataContextType();
@@ -301,7 +301,7 @@ namespace DotVVM.Framework.Binding
 
             var (childType, extensionParameters) = ApplyDataContextChange(dataContextType, property.DataContextChangeAttributes, obj, property);
 
-            if (childType == null) return dataContextType;
+            if (childType is null) return null; // childType is null in case there is some error in processing (e.g. enumerable was expected).
             else return DataContextStack.Create(childType, dataContextType, extensionParameters: extensionParameters.ToArray());
         }
 

--- a/src/DotVVM.Framework/Binding/BindingHelper.cs
+++ b/src/DotVVM.Framework/Binding/BindingHelper.cs
@@ -278,20 +278,10 @@ namespace DotVVM.Framework.Binding
         public static void SetDataContextTypeFromDataSource(this DotvvmBindableObject obj, IBinding dataSourceBinding) =>
             obj.SetDataContextType(dataSourceBinding.GetProperty<CollectionElementDataContextBindingProperty>().DataContext);
 
+
+        /// <summary> Return the expected data context type for this property. </summary>
         public static DataContextStack GetDataContextType(this DotvvmProperty property, DotvvmBindableObject obj)
         {
-            var propertyBinding = obj.GetBinding(property);
-
-            if (propertyBinding != null)
-            {
-                var propertyValue = propertyBinding.GetProperty(typeof(DataContextStack), ErrorHandlingMode.ReturnException);
-
-                if(propertyValue == null || propertyValue is DataContextStack)
-                {
-                    return (DataContextStack)propertyValue;
-                }
-            }
-
             var dataContextType = obj.GetDataContextType();
 
             if (dataContextType == null)


### PR DESCRIPTION
The method should return the type expected in this property, but used to look at the binding assigned into it. That can have a different type if it is assigned from a different property or created manually.