### PR TITLE
Fixed redirect on invalid language code

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/DotvvmTestHelper.cs
+++ b/src/DotVVM.Framework.Tests.Common/DotvvmTestHelper.cs
@@ -73,14 +73,14 @@ namespace DotVVM.Framework.Tests
         public static TestDotvvmRequestContext CreateContext(DotvvmConfiguration configuration)
         {
             IServiceProvider services = configuration.ServiceProvider.CreateScope().ServiceProvider;
-            var context = new TestDotvvmRequestContext()
-            {
+            var context = new TestDotvvmRequestContext() {
                 Configuration = configuration,
                 Services = services,
                 CsrfToken = "Test CSRF Token",
                 ModelState = new ModelState(),
                 ResourceManager = services.GetService<ResourceManagement.ResourceManager>(),
-                HttpContext = new TestHttpContext()
+                HttpContext = new TestHttpContext(),
+                Parameters = new Dictionary<string, object>()
             };
             return context;
         }

--- a/src/DotVVM.Framework.Tests.Common/Routing/LocalizablePresenterTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Routing/LocalizablePresenterTests.cs
@@ -15,23 +15,25 @@ namespace DotVVM.Framework.Tests.Routing
     [TestClass]
     public class LocalizablePresenterTests
     {
-        DotvvmConfiguration configuration = DotvvmTestHelper.DefaultConfig;
 
         [TestMethod]
         public void LocalizablePresenter_RedirectsOnInvalidLanguageCode()
         {
-            var config = DotvvmTestHelper.DefaultConfig;
+            var config = DotvvmConfiguration.CreateDefault();
             var presenterFactory = LocalizablePresenter.BasedOnParameter("Lang");
 
             config.RouteTable.Add("Test", "test/Lang", "test", new { Lang = "en" }, presenterFactory);
-            var localizablePresenter = presenterFactory(configuration.ServiceProvider);
-            var context = DotvvmTestHelper.CreateContext(configuration);
+
+            var context = DotvvmTestHelper.CreateContext(config);
             context.Parameters["Lang"] = "cz";
             context.Route = config.RouteTable.First();
+
             var httpRequest = new TestHttpContext();
             httpRequest.Request = new TestHttpRequest(httpRequest) { PathBase = "" };
             httpRequest.Request.Headers.Add(HostingConstants.SpaContentPlaceHolderHeaderName, new string[0]);
+
             context.HttpContext = httpRequest;
+            var localizablePresenter = presenterFactory(config.ServiceProvider);
 
             Assert.ThrowsException<DotvvmInterruptRequestExecutionException>(() =>
                 localizablePresenter.ProcessRequest(context));

--- a/src/DotVVM.Framework.Tests.Common/Routing/LocalizablePresenterTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Routing/LocalizablePresenterTests.cs
@@ -1,0 +1,42 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DotVVM.Framework.Routing;
+using DotVVM.Framework.Configuration;
+using DotVVM.Framework.Hosting;
+using System.Threading.Tasks;
+using DotVVM.Framework.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace DotVVM.Framework.Tests.Routing
+{
+    [TestClass]
+    public class LocalizablePresenterTests
+    {
+        DotvvmConfiguration configuration = DotvvmTestHelper.DefaultConfig;
+
+        [TestMethod]
+        public void LocalizablePresenter_RedirectsOnInvalidLanguageCode()
+        {
+            var config = DotvvmTestHelper.DefaultConfig;
+            var presenterFactory = LocalizablePresenter.BasedOnParameter("Lang");
+
+            config.RouteTable.Add("Test", "test/Lang", "test", new { Lang = "en" }, presenterFactory);
+            var localizablePresenter = presenterFactory(configuration.ServiceProvider);
+            var context = DotvvmTestHelper.CreateContext(configuration);
+            context.Parameters["Lang"] = "cz";
+            context.Route = config.RouteTable.First();
+            var httpRequest = new TestHttpContext();
+            httpRequest.Request = new TestHttpRequest(httpRequest) { PathBase = "" };
+            httpRequest.Request.Headers.Add(HostingConstants.SpaContentPlaceHolderHeaderName, new string[0]);
+            context.HttpContext = httpRequest;
+
+            Assert.ThrowsException<DotvvmInterruptRequestExecutionException>(() =>
+                localizablePresenter.ProcessRequest(context));
+        }
+
+
+    }
+}

--- a/src/DotVVM.Framework/Hosting/LocalizablePresenter.cs
+++ b/src/DotVVM.Framework/Hosting/LocalizablePresenter.cs
@@ -49,7 +49,7 @@ namespace DotVVM.Framework.Hosting
         {
             void redirect(IDotvvmRequestContext context)
             {
-                var routeParameters = context.Parameters.ToDictionary(e => e.Key, e => (object)e.Value);
+                var routeParameters = context.Parameters.ToDictionary(e => e.Key, e => e.Value);
                 if (context.Configuration.DefaultCulture.Equals(routeParameters[name]))
                     throw new Exception($"The specified default culture is probably invalid");
                 routeParameters[name] = context.Configuration.DefaultCulture;

--- a/src/DotVVM.Framework/Hosting/LocalizablePresenter.cs
+++ b/src/DotVVM.Framework/Hosting/LocalizablePresenter.cs
@@ -49,7 +49,7 @@ namespace DotVVM.Framework.Hosting
         {
             void redirect(IDotvvmRequestContext context)
             {
-                var routeParameters = context.Parameters.ToDictionary(e => e.Key, e => e.Value);
+                var routeParameters = context.Parameters.ToDictionary(e => e.Key, e => (object)e.Value);
                 if (context.Configuration.DefaultCulture.Equals(routeParameters[name]))
                     throw new Exception($"The specified default culture is probably invalid");
                 routeParameters[name] = context.Configuration.DefaultCulture;
@@ -77,7 +77,7 @@ namespace DotVVM.Framework.Hosting
                 url.Query =
                     context.HttpContext.Request.Query
                     .Where(q => q.Key != name)
-                    .Concat(new [] { new KeyValuePair<string, string>(name, context.Configuration.DefaultCulture) })
+                    .Concat(new[] { new KeyValuePair<string, string>(name, context.Configuration.DefaultCulture) })
                     .Select(q => Uri.EscapeUriString(q.Key) + "=" + Uri.EscapeUriString(q.Value)).Apply(s => string.Join("&", s));
                 if (url.ToString() == context.HttpContext.Request.Url.ToString())
                     throw new Exception($"The specified default culture is probably invalid");
@@ -105,7 +105,7 @@ namespace DotVVM.Framework.Hosting
                         doRedirect(context); // it seems that when a culture does not exists, the constructor throws an exception on Mono, but returns an instance on .NET Core (with LCID = 4096)
                     return result;
                 }
-                catch(CultureNotFoundException)
+                catch (CultureNotFoundException)
                 {
                     doRedirect(context);
                     Debug.Assert(false);

--- a/src/DotVVM.Framework/Hosting/LocalizablePresenter.cs
+++ b/src/DotVVM.Framework/Hosting/LocalizablePresenter.cs
@@ -77,7 +77,7 @@ namespace DotVVM.Framework.Hosting
                 url.Query =
                     context.HttpContext.Request.Query
                     .Where(q => q.Key != name)
-                    .Concat(new[] { new KeyValuePair<string, string>(name, context.Configuration.DefaultCulture) })
+                    .Concat(new[]{ new KeyValuePair<string, string>(name, context.Configuration.DefaultCulture) })
                     .Select(q => Uri.EscapeUriString(q.Key) + "=" + Uri.EscapeUriString(q.Value)).Apply(s => string.Join("&", s));
                 if (url.ToString() == context.HttpContext.Request.Url.ToString())
                     throw new Exception($"The specified default culture is probably invalid");
@@ -105,7 +105,7 @@ namespace DotVVM.Framework.Hosting
                         doRedirect(context); // it seems that when a culture does not exists, the constructor throws an exception on Mono, but returns an instance on .NET Core (with LCID = 4096)
                     return result;
                 }
-                catch (CultureNotFoundException)
+                catch(CultureNotFoundException)
                 {
                     doRedirect(context);
                     Debug.Assert(false);

--- a/src/DotVVM.Framework/Routing/RouteBase.cs
+++ b/src/DotVVM.Framework/Routing/RouteBase.cs
@@ -153,7 +153,14 @@ namespace DotVVM.Framework.Routing
         /// </summary>
         public static void AddOrUpdateParameterCollection(IDictionary<string, object> targetCollection, object anonymousObject)
         {
-            if (anonymousObject is IEnumerable<KeyValuePair<string, object>> pairs)
+            if (anonymousObject is IEnumerable<KeyValuePair<string, string>> stringPairs)
+            {
+                foreach (var item in stringPairs)
+                {
+                    targetCollection[item.Key] = item.Value;
+                }
+            }
+            else if (anonymousObject is IEnumerable<KeyValuePair<string, object>> pairs)
             {
                 foreach (var item in pairs)
                 {

--- a/src/DotVVM.Framework/Routing/RouteBase.cs
+++ b/src/DotVVM.Framework/Routing/RouteBase.cs
@@ -153,9 +153,9 @@ namespace DotVVM.Framework.Routing
         /// </summary>
         public static void AddOrUpdateParameterCollection(IDictionary<string, object> targetCollection, object anonymousObject)
         {
-            if (anonymousObject is IEnumerable<KeyValuePair<string, string>>)
+            if (anonymousObject is IEnumerable<KeyValuePair<string, object>> pairs)
             {
-                foreach (KeyValuePair<string, string> item in (IEnumerable<KeyValuePair<string, string>>)anonymousObject)
+                foreach (var item in pairs)
                 {
                     targetCollection[item.Key] = item.Value;
                 }


### PR DESCRIPTION
Currently, when LocalizableProvider is given an invalid language code the exception is thrown instead of redirecting to default language.
This is happening because the dictionary with route parameters is treated as an anonymous object during copying of values. This behaviour results in copying of dictionary properties (Count, Keys, Values) instead of key value pairs.

This pull request addresses this issue by adding support for Dictionarystring, object> to method RouteBase. AddOrUpdateParameterCollection.

![image](https://user-images.githubusercontent.com/5333577/66778414-e0468300-eecb-11e9-8a4c-3108c3966202.png)
