### PR TITLE
RouteLink control: query parameters not updating bugfix 

### DIFF
--- a/src/DotVVM.Framework/Controls/RouteLinkHelpers.cs
+++ b/src/DotVVM.Framework/Controls/RouteLinkHelpers.cs
@@ -18,8 +18,10 @@ namespace DotVVM.Framework.Controls
         public static void WriteRouteLinkHrefAttribute(RouteLink control, IHtmlWriter writer, IDotvvmRequestContext context)
         {
             // Render client-side knockout expression only if there exists a parameter with value binding
-            var containsBinding = control.Params.RawValues.Any(p => p.Value is IValueBinding)
-                || control.GetValueRaw(RouteLink.UrlSuffixProperty) is IValueBinding;
+            var containsBinding =
+                control.QueryParameters.RawValues.Any(p => p.Value is IValueBinding) ||
+                control.Params.RawValues.Any(p => p.Value is IValueBinding) ||
+                control.GetValueRaw(RouteLink.UrlSuffixProperty) is IValueBinding;
 
             if (containsBinding)
             {

--- a/src/DotVVM.Samples.BasicSamples.AspNetCore/Web.config
+++ b/src/DotVVM.Samples.BasicSamples.AspNetCore/Web.config
@@ -9,6 +9,7 @@
         <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Development" />
         <environmentVariable name="DOTNET_ADDITIONAL_DEPS" value="C:\Program Files\dotnet\additionalDeps\Microsoft.AspNetCore.ApplicationInsights.HostingStartup" />
         <environmentVariable name="ASPNETCORE_HOSTINGSTARTUPASSEMBLIES" value="Microsoft.AspNetCore.ApplicationInsights.HostingStartup" />
+        <environmentVariable name="COMPLUS_ForceENC" value="1" />
       </environmentVariables>
     </aspNetCore>
   </system.webServer>

--- a/src/DotVVM.Samples.BasicSamples.AspNetCore/Web.config
+++ b/src/DotVVM.Samples.BasicSamples.AspNetCore/Web.config
@@ -9,7 +9,6 @@
         <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Development" />
         <environmentVariable name="DOTNET_ADDITIONAL_DEPS" value="C:\Program Files\dotnet\additionalDeps\Microsoft.AspNetCore.ApplicationInsights.HostingStartup" />
         <environmentVariable name="ASPNETCORE_HOSTINGSTARTUPASSEMBLIES" value="Microsoft.AspNetCore.ApplicationInsights.HostingStartup" />
-        <environmentVariable name="COMPLUS_ForceENC" value="1" />
       </environmentVariables>
     </aspNetCore>
   </system.webServer>

--- a/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
+++ b/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
@@ -35,6 +35,7 @@
     <None Remove="Views\ControlSamples\MultiSelect\hardcoded.dothtml" />
     <None Remove="Views\ControlSamples\RadioButton\Nullable.dothtml" />
     <None Remove="Views\ControlSamples\Repeater\NamedTemplate.dothtml" />
+    <None Remove="Views\ControlSamples\RouteLink\RouteLinkQueryParameters.dothtml" />
     <None Remove="Views\ControlSamples\UpdateProgress\UpdateProgressQueues.dothtml" />
     <None Remove="Views\ControlSamples\ValidationSummary\MessagesRendering.dothtml" />
     <None Remove="Views\ControlSamples\ValidationSummary\Performance.dothtml" />

--- a/src/DotVVM.Samples.Common/ViewModels/ControlSamples/RouteLink/RouteLinkQueryParametersViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/ControlSamples/RouteLink/RouteLinkQueryParametersViewModel.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.ControlSamples.RouteLink
+{
+    public class RouteLinkQueryParametersViewModel : DotvvmViewModelBase
+    {
+        public int TestInteger { get; set; } = 5;
+        public string TestString { get; set; } = "default";
+    }
+}
+

--- a/src/DotVVM.Samples.Common/Views/ControlSamples/RouteLink/RouteLinkQueryParameters.dothtml
+++ b/src/DotVVM.Samples.Common/Views/ControlSamples/RouteLink/RouteLinkQueryParameters.dothtml
@@ -1,0 +1,25 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.ControlSamples.RouteLink.RouteLinkQueryParametersViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+    <ul>
+        <li>
+            <dot:RouteLink class="link" Text="Test link" RouteName="ControlSamples_RouteLink_RouteLinkQueryParameters" Query-string="{value: TestString}" Query-int="{value: TestInteger}" />
+        </li>
+        <li>
+            <dot:LinkButton class="static-command" Click="{staticCommand: TestString = "change_static"; TestInteger = 6}" Text="Change static command" />
+        </li>
+        <li>
+            <dot:LinkButton class="command" Click="{command: TestString = "change"; TestInteger = 7}" Text="Change command" />
+        </li>
+    </ul>
+</body>
+</html>
+
+

--- a/src/DotVVM.Samples.Tests/Control/RouteLinkTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/RouteLinkTests.cs
@@ -130,7 +130,7 @@ namespace DotVVM.Samples.Tests.Control
                 browser.First(".static-command").Click();
 
                 browser.First(".link").Click();
-                AssertUI.Url(browser, "/ControlSamples/RouteLink/RouteLinkQueryParameters?int=7&string=change_static", UrlKind.Relative, UriComponents.PathAndQuery);
+                AssertUI.Url(browser, "/ControlSamples/RouteLink/RouteLinkQueryParameters?int=6&string=change_static", UrlKind.Relative, UriComponents.PathAndQuery);
             });
         }
 

--- a/src/DotVVM.Samples.Tests/Control/RouteLinkTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/RouteLinkTests.cs
@@ -94,6 +94,46 @@ namespace DotVVM.Samples.Tests.Control
             });
         }
 
+        [Fact]
+        [SampleReference(nameof(SamplesRouteUrls.ControlSamples_RouteLink_RouteLinkQueryParameters))]
+        public void Control_RouteLink_QueryParameters_DefaultValue()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.ControlSamples_RouteLink_RouteLinkQueryParameters);
+
+                browser.First(".link").Click();
+                AssertUI.Url(browser, "/ControlSamples/RouteLink/RouteLinkQueryParameters?int=5&string=default", UrlKind.Relative, UriComponents.PathAndQuery);
+            });
+        }
+
+        [Fact]
+        [SampleReference(nameof(SamplesRouteUrls.ControlSamples_RouteLink_RouteLinkQueryParameters))]
+        public void Control_RouteLink_QueryParameters_CommandChangedValue()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.ControlSamples_RouteLink_RouteLinkQueryParameters);
+
+                browser.First(".command").Click();
+
+                browser.First(".link").Click();
+                AssertUI.Url(browser, "/ControlSamples/RouteLink/RouteLinkQueryParameters?int=7&string=change", UrlKind.Relative, UriComponents.PathAndQuery);
+            });
+        }
+
+        [Fact]
+        [SampleReference(nameof(SamplesRouteUrls.ControlSamples_RouteLink_RouteLinkQueryParameters))]
+        public void Control_RouteLink_QueryParameters_StaticCommandChangedValue()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.ControlSamples_RouteLink_RouteLinkQueryParameters);
+
+                browser.First(".static-command").Click();
+
+                browser.First(".link").Click();
+                AssertUI.Url(browser, "/ControlSamples/RouteLink/RouteLinkQueryParameters?int=7&string=change_static", UrlKind.Relative, UriComponents.PathAndQuery);
+            });
+        }
+
         public RouteLinkTests(ITestOutputHelper output) : base(output)
         {
         }

--- a/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
@@ -110,6 +110,7 @@ namespace DotVVM.Testing.Abstractions
         public const string ControlSamples_RoleView_RoleViewTest = "ControlSamples/RoleView/RoleViewTest";
         public const string ControlSamples_RouteLink_RouteLinkEnabled = "ControlSamples/RouteLink/RouteLinkEnabled";
         public const string ControlSamples_RouteLink_RouteLinkEnabledFalse = "ControlSamples/RouteLink/RouteLinkEnabledFalse";
+        public const string ControlSamples_RouteLink_RouteLinkQueryParameters = "ControlSamples/RouteLink/RouteLinkQueryParameters";
         public const string ControlSamples_RouteLink_RouteLinkSpaUrlGen = "ControlSamples/RouteLink/RouteLinkSpaUrlGen";
         public const string ControlSamples_RouteLink_RouteLinkUrlGen = "ControlSamples/RouteLink/RouteLinkUrlGen";
         public const string ControlSamples_RouteLink_TestRoute = "ControlSamples/RouteLink/TestRoute";


### PR DESCRIPTION
fixes #779