### PR TITLE
Add es2015.iterable to tsconfig.json

### DIFF
--- a/src/DotVVM.Framework/tsconfig.json
+++ b/src/DotVVM.Framework/tsconfig.json
@@ -8,7 +8,7 @@
     "outFile": "Resources/Scripts/DotVVM.js",
     "declaration": true,
     "strictNullChecks": true,
-    "lib": ["dom", "es2015.promise", "es5"]
+    "lib": ["dom", "es2015.promise", "es2015.iterable", "es5"]
   },
   "files": [
     "Resources/Scripts/DotVVM.Polyfills.ts",


### PR DESCRIPTION
`tsc` doesn't seem to be willing to compile DotVVM otherwise.