### PR TITLE
Made TokenBase mutable as the VS Extension needs that

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Parser/Dothtml/VSExtensionContractTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Parser/Dothtml/VSExtensionContractTests.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using DotVVM.Framework.Compilation.Parser.Dothtml.Parser;
 using DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -14,6 +16,12 @@ namespace DotVVM.Framework.Tests.Common.Parser.Dothtml
 
             var tokenizer = new DothtmlTokenizer();
             tokenizer.Tokenize("some not very interesting text <!-- Comment -->");
+            var parser = new DothtmlParser();
+            var tree = parser.Parse(tokenizer.Tokens);
+
+            var textNode = tree.EnumerateNodes().OfType<DothtmlLiteralNode>().Single();
+            Assert.AreEqual("some not very interesting text ", textNode.Value);
+
             var text = tokenizer.Tokens[0];
             var comment = tokenizer.Tokens[2];
             Assert.AreEqual(text.Type, DothtmlTokenType.Text);
@@ -25,6 +33,8 @@ namespace DotVVM.Framework.Tests.Common.Parser.Dothtml
             text.Text = "some little bit more interesting text";
             text.Length = text.Text.Length;
             comment.StartPosition = "some little bit more interesting text".Length;
+
+            Assert.AreEqual("some little bit more interesting text", textNode.Value);
         }
     }
 }

--- a/src/DotVVM.Framework.Tests.Common/Parser/Dothtml/VSExtensionContractTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Parser/Dothtml/VSExtensionContractTests.cs
@@ -1,0 +1,30 @@
+using DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotVVM.Framework.Tests.Common.Parser.Dothtml
+{
+    /// Contains test cases that ensure that API exported for our VS Extension works correctly
+    [TestClass]
+    public class VSExtensionContractTests
+    {
+        [TestMethod]
+        public void MutableTokens()
+        {
+            // for incremental updates of the tree, the Text and Position must be accessible
+
+            var tokenizer = new DothtmlTokenizer();
+            tokenizer.Tokenize("some not very interesting text <!-- Comment -->");
+            var text = tokenizer.Tokens[0];
+            var comment = tokenizer.Tokens[2];
+            Assert.AreEqual(text.Type, DothtmlTokenType.Text);
+            Assert.AreEqual(tokenizer.Tokens[1].Type, DothtmlTokenType.OpenComment);
+            Assert.AreEqual(comment.Type, DothtmlTokenType.CommentBody);
+            Assert.AreEqual(tokenizer.Tokens[3].Type, DothtmlTokenType.CloseComment);
+            Assert.AreEqual(4, tokenizer.Tokens.Count);
+
+            text.Text = "some little bit more interesting text";
+            text.Length = text.Text.Length;
+            comment.StartPosition = "some little bit more interesting text".Length;
+        }
+    }
+}

--- a/src/DotVVM.Framework/Compilation/Parser/TokenBase.cs
+++ b/src/DotVVM.Framework/Compilation/Parser/TokenBase.cs
@@ -12,17 +12,17 @@ namespace DotVVM.Framework.Compilation.Parser
             ColumnNumber = columnNumber;
         }
 
-        public int StartPosition { get; }
+        public int StartPosition { get; set; }
 
-        public int Length { get; }
+        public int Length { get; set; }
 
         public int EndPosition => StartPosition + Length;
 
-        public string Text { get; }
+        public string Text { get; set; }
 
-        public int LineNumber { get; }
+        public int LineNumber { get; set; }
 
-        public int ColumnNumber { get; }
+        public int ColumnNumber { get; set; }
 
         public TokenError? Error { get; set; }
 


### PR DESCRIPTION
After discussion with @Mylan719 about migrating the entire parser and resolver to pure functional programming using very nice concepts such as zippers (also knows as Roslyn Red-Greed tree) and performance of this thing, we decided we have different plans for the next year so I added back the setters :)