### PR TITLE
Render adapter

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Runtime/DotvvmControlTestBase.cs
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/DotvvmControlTestBase.cs
@@ -6,6 +6,7 @@ using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.Controls.Infrastructure;
 using DotVVM.Framework.Hosting;
+using DotVVM.Framework.Routing;
 using DotVVM.Framework.Runtime;
 using DotVVM.Framework.Testing;
 using Microsoft.Extensions.DependencyInjection;
@@ -32,7 +33,8 @@ namespace DotVVM.Framework.Tests.Runtime
             return new TestDotvvmRequestContext() {
                 Configuration = configuration,
                 ResourceManager = new ResourceManagement.ResourceManager(configuration.Resources),
-                ViewModel = viewModel
+                ViewModel = viewModel,
+                Route = new DotvvmRoute(url: string.Empty, virtualPath: string.Empty, name: string.Empty, null, provider => provider.GetRequiredService<IDotvvmPresenter>(), configuration)
             };
         }
 

--- a/src/DotVVM.Framework/Configuration/DotvvmExperimentalFeaturesConfiguration.cs
+++ b/src/DotVVM.Framework/Configuration/DotvvmExperimentalFeaturesConfiguration.cs
@@ -15,6 +15,9 @@ namespace DotVVM.Framework.Configuration
         [JsonProperty("serverSideViewModelCache", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public DotvvmExperimentalFeatureFlag ServerSideViewModelCache { get; private set; } = new DotvvmExperimentalFeatureFlag();
 
+        [JsonProperty("ControlRenderAdapters", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public DotvvmExperimentalFeatureFlag ControlRenderAdapters { get; private set; } = new DotvvmExperimentalFeatureFlag();
+
         public void Freeze()
         {
             LazyCsrfToken.Freeze();

--- a/src/DotVVM.Framework/Controls/DotvvmControl.cs
+++ b/src/DotVVM.Framework/Controls/DotvvmControl.cs
@@ -294,20 +294,20 @@ namespace DotVVM.Framework.Controls
             else
                 AddAttributesToRender(writer, context);
 
-            var renderBeginTagAdapter = renderAdapter?.AddAttributesToRender;
+            var renderBeginTagAdapter = renderAdapter?.RenderBeginTag;
             if (renderBeginTagAdapter != null)
                 renderBeginTagAdapter(this, writer, context);
             else
                 RenderBeginTag(writer, context);
 
 
-            var renderContentsAdapter = renderAdapter?.AddAttributesToRender;
+            var renderContentsAdapter = renderAdapter?.RenderContents;
             if (renderContentsAdapter != null)
                 renderContentsAdapter(this, writer, context);
             else
                 RenderContents(writer, context);
 
-            var renderEndTagAdapter = renderAdapter?.AddAttributesToRender;
+            var renderEndTagAdapter = renderAdapter?.RenderEndTag;
             if (renderEndTagAdapter != null)
                 renderEndTagAdapter(this, writer, context);
             else
@@ -467,7 +467,7 @@ namespace DotVVM.Framework.Controls
             if (!context.Configuration.ExperimentalFeatures.ControlRenderAdapters.IsEnabledForRoute(routeRouteName))
                 return null;
 
-            return (IRenderAdapter?)GetValue(Internal.RenderAdapterProperty);
+            return (IRenderAdapter?)GetValueRaw(Internal.RenderAdapterProperty);
         }
 
         /// <summary>

--- a/src/DotVVM.Framework/Controls/IRenderAdapter.cs
+++ b/src/DotVVM.Framework/Controls/IRenderAdapter.cs
@@ -1,0 +1,14 @@
+﻿#nullable enable
+using System;
+using DotVVM.Framework.Hosting;
+
+namespace DotVVM.Framework.Controls
+{
+    public interface IRenderAdapter
+    {
+        Action<IDotvvmControl, IHtmlWriter, IDotvvmRequestContext>? AddAttributesToRender { get; }
+        Action<IDotvvmControl, IHtmlWriter, IDotvvmRequestContext>? RenderBeginTag { get; }
+        Action<IDotvvmControl, IHtmlWriter, IDotvvmRequestContext>? RenderContents { get; }
+        Action<IDotvvmControl, IHtmlWriter, IDotvvmRequestContext>? RenderEndTag { get; }
+    }
+}

--- a/src/DotVVM.Framework/Controls/IRenderAdapter.cs
+++ b/src/DotVVM.Framework/Controls/IRenderAdapter.cs
@@ -6,9 +6,24 @@ namespace DotVVM.Framework.Controls
 {
     public interface IRenderAdapter
     {
+        /// <summary>
+        /// Alternative implementation for AddAttributesToRender
+        /// </summary>
         Action<IDotvvmControl, IHtmlWriter, IDotvvmRequestContext>? AddAttributesToRender { get; }
+
+        /// <summary>
+        /// Alternative implementation for RenderBeginTag
+        /// </summary>
         Action<IDotvvmControl, IHtmlWriter, IDotvvmRequestContext>? RenderBeginTag { get; }
+
+        /// <summary>
+        /// Alternative implementation for RenderContents
+        /// </summary>
         Action<IDotvvmControl, IHtmlWriter, IDotvvmRequestContext>? RenderContents { get; }
+
+        /// <summary>
+        /// Alternative implementation for RenderEndTag
+        /// </summary>
         Action<IDotvvmControl, IHtmlWriter, IDotvvmRequestContext>? RenderEndTag { get; }
     }
 }

--- a/src/DotVVM.Framework/Controls/Internal.cs
+++ b/src/DotVVM.Framework/Controls/Internal.cs
@@ -56,6 +56,9 @@ namespace DotVVM.Framework.Controls
 
         public static DotvvmProperty CurrentIndexBindingProperty =
             DotvvmProperty.Register<IValueBinding?, Internal>(() => CurrentIndexBindingProperty);
+
+        public static DotvvmProperty RenderAdapterProperty =
+            DotvvmProperty.Register<IRenderAdapter?, Internal>(() => RenderAdapterProperty);
     }
 
     public static class InternalPropertyExtensions

--- a/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
+++ b/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
@@ -49,6 +49,7 @@
     <None Remove="Views\Errors\InvalidLocationFallback.dothtml" />
     <None Remove="Views\Errors\ResourceCircularDependency.dothtml" />
     <None Remove="Views\FeatureSamples\Caching\CachedValues.dothtml" />
+    <None Remove="Views\FeatureSamples\ControlRenderAdapters\BasicControlRenderAdapter.dothtml" />
     <None Remove="Views\FeatureSamples\Localization\Globalize.dothtml" />
     <None Remove="Views\FeatureSamples\PostBack\RecursiveTextRepeater.dotcontrol" />
     <None Remove="Views\FeatureSamples\PostBack\RecursiveTextRepeater2.dotcontrol" />

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/ControlRenderAdapters/BasicControlRenderAdapterViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/ControlRenderAdapters/BasicControlRenderAdapterViewModel.cs
@@ -11,15 +11,24 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.ControlRenderAdapters
     {
         public BasicControlRenderAdapterViewModel()
         {
-            Context.Configuration.ExperimentalFeatures.ControlRenderAdapters.Enabled = true;
         }
 
         public override Task Init()
         {
-            var literal = Context.View.FindControlByClientId<Literal>("replaced");
-            literal.SetValue(Internal.RenderAdapterProperty, new TestControlRenderAdapter());
+            Context.Configuration.ExperimentalFeatures.ControlRenderAdapters.Enabled = true;
+
             return base.Init();
         }
+
+        public override Task PreRender()
+        {
+
+            var literal = Context.View.FindControlByClientId<TextBox>("replaced");
+            literal.SetValueRaw(Internal.RenderAdapterProperty, new TestControlRenderAdapter());
+            return base.PreRender();
+        }
+
+
     }
 }
 

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/ControlRenderAdapters/BasicControlRenderAdapterViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/ControlRenderAdapters/BasicControlRenderAdapterViewModel.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.ControlRenderAdapters
+{
+    public class BasicControlRenderAdapterViewModel : DotvvmViewModelBase
+    {
+        public BasicControlRenderAdapterViewModel()
+        {
+            Context.Configuration.ExperimentalFeatures.ControlRenderAdapters.Enabled = true;
+        }
+
+        public override Task Init()
+        {
+            var literal = Context.View.FindControlByClientId<Literal>("replaced");
+            literal.SetValue(Internal.RenderAdapterProperty, new TestControlRenderAdapter());
+            return base.Init();
+        }
+    }
+}
+

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/ControlRenderAdapters/TestControlRenderAdapter.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/ControlRenderAdapters/TestControlRenderAdapter.cs
@@ -14,6 +14,7 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.ControlRenderAdapters
 
         private void AddAttributesToRenderImp(IDotvvmControl control, IHtmlWriter writer, IDotvvmRequestContext context)
         {
+            writer.AddAttribute("id", "replaced");
             writer.AddAttribute("test", "testValue");
         }
 

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/ControlRenderAdapters/TestControlRenderAdapter.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/ControlRenderAdapters/TestControlRenderAdapter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Hosting;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.ControlRenderAdapters
+{
+    public class TestControlRenderAdapter : IRenderAdapter
+    {
+        public Action<IDotvvmControl, IHtmlWriter, IDotvvmRequestContext> AddAttributesToRender => AddAttributesToRenderImp;
+        public Action<IDotvvmControl, IHtmlWriter, IDotvvmRequestContext> RenderBeginTag => RenderBeginTagImp;
+        public Action<IDotvvmControl, IHtmlWriter, IDotvvmRequestContext> RenderContents => RenderContentsImp;
+        public Action<IDotvvmControl, IHtmlWriter, IDotvvmRequestContext> RenderEndTag => RenderEndTagImp;
+
+
+        private void AddAttributesToRenderImp(IDotvvmControl control, IHtmlWriter writer, IDotvvmRequestContext context)
+        {
+            writer.AddAttribute("test", "testValue");
+        }
+
+        private void RenderBeginTagImp(IDotvvmControl control, IHtmlWriter writer, IDotvvmRequestContext context)
+        {
+            writer.RenderBeginTag("div");
+        }
+
+        private void RenderContentsImp(IDotvvmControl control, IHtmlWriter writer, IDotvvmRequestContext context)
+        {
+            writer.WriteText("REPLACEMENT TEXT");
+        }
+
+        private void RenderEndTagImp(IDotvvmControl control, IHtmlWriter writer, IDotvvmRequestContext context)
+        {
+            writer.RenderEndTag();
+        }
+    }
+}

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/ControlRenderAdapters/BasicControlRenderAdapter.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/ControlRenderAdapters/BasicControlRenderAdapter.dothtml
@@ -8,8 +8,8 @@
     <title></title>
 </head>
 <body>
-    <dot:Literal ID="standard" Text="TEXT" RenderSpanElement="true" />
-    <dot:Literal ID="replaced" Text="TEXT" RenderSpanElement="true" />
+    <dot:TextBox ID="standard" Text="TEXT" />
+    <dot:TextBox ID="replaced" Text="TEXT" />
 
 </body>
 </html>

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/ControlRenderAdapters/BasicControlRenderAdapter.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/ControlRenderAdapters/BasicControlRenderAdapter.dothtml
@@ -1,0 +1,17 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.ControlRenderAdapters.BasicControlRenderAdapterViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+    <dot:Literal ID="standard" Text="TEXT" RenderSpanElement="true" />
+    <dot:Literal ID="replaced" Text="TEXT" RenderSpanElement="true" />
+
+</body>
+</html>
+
+

--- a/src/DotVVM.Samples.Tests/Feature/RenderAdapterTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/RenderAdapterTests.cs
@@ -1,5 +1,6 @@
 ﻿using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
+using OpenQA.Selenium;
 using Riganti.Selenium.Core;
 using Xunit;
 using Xunit.Abstractions;
@@ -18,14 +19,14 @@ namespace DotVVM.Samples.Tests.Feature
             RunInAllBrowsers(browser => {
                 browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_RenderAdapter_Basic);
 
-                var standard = browser.Single("standard");
+                var standard = browser.Single("standard", By.Id);
 
                 AssertUI.TagName(standard, "span");
                 AssertUI.HasNotAttribute(standard, "test");
                 AssertUI.InnerTextEquals(standard, "TEXT");
 
 
-                var replaced = browser.Single("replaced");
+                var replaced = browser.Single("replaced", By.Id);
                 AssertUI.TagName(replaced, "div");
                 AssertUI.HasAttribute(replaced, "test");
                 AssertUI.InnerTextEquals(replaced, "REPLACEMENT TEXT");

--- a/src/DotVVM.Samples.Tests/Feature/RenderAdapterTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/RenderAdapterTests.cs
@@ -17,11 +17,11 @@ namespace DotVVM.Samples.Tests.Feature
         public void Feature_RenderAdapter_Basic()
         {
             RunInAllBrowsers(browser => {
-                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_RenderAdapter_Basic);
+                browser.NavigateToUrl("http://localhost:5407/" + SamplesRouteUrls.FeatureSamples_RenderAdapter_Basic);
 
                 var standard = browser.Single("standard", By.Id);
 
-                AssertUI.TagName(standard, "span");
+                AssertUI.TagName(standard, "input");
                 AssertUI.HasNotAttribute(standard, "test");
                 AssertUI.InnerTextEquals(standard, "TEXT");
 

--- a/src/DotVVM.Samples.Tests/Feature/RenderAdapterTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/RenderAdapterTests.cs
@@ -1,0 +1,35 @@
+﻿using DotVVM.Samples.Tests.Base;
+using DotVVM.Testing.Abstractions;
+using Riganti.Selenium.Core;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DotVVM.Samples.Tests.Feature
+{
+    public class RenderAdapterTests : AppSeleniumTest
+    {
+        public RenderAdapterTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void Feature_RenderAdapter_Basic()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_RenderAdapter_Basic);
+
+                var standard = browser.Single("standard");
+
+                AssertUI.TagName(standard, "span");
+                AssertUI.HasNotAttribute(standard, "test");
+                AssertUI.InnerTextEquals(standard, "TEXT");
+
+
+                var replaced = browser.Single("replaced");
+                AssertUI.TagName(replaced, "div");
+                AssertUI.HasAttribute(replaced, "test");
+                AssertUI.InnerTextEquals(replaced, "REPLACEMENT TEXT");
+            });
+        }
+    }
+}

--- a/src/DotVVM.Samples.Tests/Feature/RenderAdapterTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/RenderAdapterTests.cs
@@ -17,7 +17,7 @@ namespace DotVVM.Samples.Tests.Feature
         public void Feature_RenderAdapter_Basic()
         {
             RunInAllBrowsers(browser => {
-                browser.NavigateToUrl("http://localhost:5407/" + SamplesRouteUrls.FeatureSamples_RenderAdapter_Basic);
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_RenderAdapter_Basic);
 
                 var standard = browser.Single("standard", By.Id);
 

--- a/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.cs
+++ b/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.cs
@@ -2,6 +2,8 @@
 {
     public partial class SamplesRouteUrls
     {
+        public static string FeatureSamples_RenderAdapter_Basic = "FeatureSamples/ControlRenderAdapters/BasicControlRenderAdapter";
+
         public const string FeatureSamples_PostbackConcurrency_DefaultMode =
             "FeatureSamples/PostbackConcurrency/PostbackConcurrencyMode?concurrency=Default";
 


### PR DESCRIPTION
Render adapter adds ability to provide custom implementation for control render methods.

This feature currently has to be turned on using experimental flag `ControlRenderAdapters`.
Custom implementation of render methods is provided to the controls as `IRenderAdapter` via DotvvmProperty `Internal.RenderAdapterProperty`.