### PR TITLE
Fixed race condition in queued postbacks

### DIFF
--- a/src/DotVVM.Framework/Resources/Scripts/DotVVM.d.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/DotVVM.d.ts
@@ -97,7 +97,7 @@ declare class DotvvmAfterPostBackEventArgs implements PostbackEventArgs {
     postbackOptions: PostbackOptions;
     serverResponseObject: any;
     commandResult: any;
-    xhr?: XMLHttpRequest | undefined;
+    xhr: XMLHttpRequest | undefined;
     isHandled: boolean;
     wasInterrupted: boolean;
     readonly postbackClientId: number;
@@ -107,7 +107,7 @@ declare class DotvvmAfterPostBackEventArgs implements PostbackEventArgs {
     constructor(postbackOptions: PostbackOptions, serverResponseObject: any, commandResult?: any, xhr?: XMLHttpRequest | undefined);
 }
 declare class DotvvmAfterPostBackWithRedirectEventArgs extends DotvvmAfterPostBackEventArgs {
-    private _redirectPromise?;
+    private _redirectPromise;
     readonly redirectPromise: Promise<DotvvmNavigationEventArgs> | undefined;
     constructor(postbackOptions: PostbackOptions, serverResponseObject: any, commandResult?: any, xhr?: XMLHttpRequest, _redirectPromise?: Promise<DotvvmNavigationEventArgs> | undefined);
 }
@@ -122,7 +122,7 @@ declare class DotvvmNavigationEventArgs implements DotvvmEventArgs {
     viewModel: any;
     viewModelName: string;
     serverResponseObject: any;
-    xhr?: XMLHttpRequest | undefined;
+    xhr: XMLHttpRequest | undefined;
     isHandled: boolean;
     constructor(viewModel: any, viewModelName: string, serverResponseObject: any, xhr?: XMLHttpRequest | undefined);
 }
@@ -138,8 +138,8 @@ declare class DotvvmRedirectEventArgs implements DotvvmEventArgs {
 }
 declare class DotvvmFileUpload {
     showUploadDialog(sender: HTMLElement): void;
-    private getIframe;
-    private openUploadDialog;
+    private getIframe(sender);
+    private openUploadDialog(iframe);
     createUploadId(sender: HTMLElement, iframe: HTMLElement): void;
     reportProgress(targetControlId: any, isBusy: boolean, progress: number, result: DotvvmFileUploadData[] | string): void;
 }
@@ -162,7 +162,7 @@ declare class DotvvmFileSize {
     FormattedText: KnockoutObservable<string>;
 }
 declare class DotvvmGlobalize {
-    private getGlobalize;
+    private getGlobalize();
     format(format: string, ...values: any[]): string;
     formatString(format: string, value: any): any;
     parseDotvvmDate(value: string): Date | null;
@@ -199,10 +199,10 @@ interface AdditionalPostbackData {
 }
 declare class PostbackOptions {
     readonly postbackId: number;
-    readonly sender?: HTMLElement | undefined;
+    readonly sender: HTMLElement | undefined;
     readonly args: any[];
-    readonly viewModel?: any;
-    readonly viewModelName?: string | undefined;
+    readonly viewModel: any;
+    readonly viewModelName: string | undefined;
     readonly additionalPostbackData: AdditionalPostbackData;
     constructor(postbackId: number, sender?: HTMLElement | undefined, args?: any[], viewModel?: any, viewModelName?: string | undefined);
 }
@@ -236,22 +236,22 @@ declare class DotvvmSerialization {
     deserializePrimitive(viewModel: any, target?: any): any;
     deserializeDate(viewModel: any, target?: any): any;
     deserializeArray(viewModel: any, target?: any, deserializeAll?: boolean): any;
-    private rebuildArrayFromScratch;
-    private updateArrayItems;
+    private rebuildArrayFromScratch(viewModel, target, deserializeAll);
+    private updateArrayItems(viewModel, target, deserializeAll);
     deserializeObject(viewModel: any, target: any, deserializeAll: boolean): any;
-    private copyProperty;
-    private copyPropertyMetadata;
-    private extendToObservableArrayIfRequired;
-    private wrapObservableObjectOrArray;
-    private isPrimitive;
-    private isOptionsProperty;
-    private isObservableArray;
+    private copyProperty(value, unwrappedTarget, prop, deserializeAll, options);
+    private copyPropertyMetadata(unwrappedTarget, prop, viewModel);
+    private extendToObservableArrayIfRequired(observable);
+    private wrapObservableObjectOrArray<T>(obj);
+    private isPrimitive(viewModel);
+    private isOptionsProperty(prop);
+    private isObservableArray(target);
     serialize(viewModel: any, opt?: ISerializationOptions): any;
     validateType(value: any, type: string): boolean;
-    private findObject;
+    private findObject(obj, matcher);
     flatSerialize(viewModel: any): any;
     getPureObject(viewModel: any): {};
-    private pad;
+    private pad(value, digits);
     serializeDate(date: string | Date | null, convertToUtc?: boolean): string | null;
 }
 interface Document {
@@ -294,6 +294,7 @@ interface IDotvvmPostbackHandlerCollection {
 declare class DotVVM {
     private postBackCounter;
     private lastStartedPostack;
+    private arePostbackDisabled;
     private fakeRedirectAnchor;
     private resourceSigns;
     private isViewModelUpdating;
@@ -309,7 +310,7 @@ declare class DotVVM {
     private suppressOnDisabledElementHandler;
     private beforePostbackEventPostbackHandler;
     private isPostBackRunningHandler;
-    private createWindowSetTimeoutHandler;
+    private createWindowSetTimeoutHandler(time);
     private windowSetTimeoutHandler;
     private commonConcurrencyHandler;
     private defaultConcurrencyPostbackHandler;
@@ -333,52 +334,53 @@ declare class DotVVM {
     isPostbackRunning: KnockoutObservable<boolean>;
     updateProgressChangeCounter: KnockoutObservable<number>;
     init(viewModelName: string, culture: string): void;
-    private handlePopState;
-    private handleHashChangeWithHistory;
-    private handleHashChange;
-    private persistViewModel;
-    private backUpPostBackConter;
-    private isPostBackStillActive;
-    private fetchCsrfToken;
+    private handlePopState(viewModelName, event, inSpaPage);
+    private handleHashChangeWithHistory(viewModelName, spaPlaceHolder, isInitialPageLoad);
+    private handleHashChange(viewModelName, spaPlaceHolder, isInitialPageLoad);
+    private persistViewModel(viewModelName);
+    private backUpPostBackConter();
+    private isPostBackStillActive(currentPostBackCounter);
+    private fetchCsrfToken(viewModelName);
     staticCommandPostback(viewModelName: string, sender: HTMLElement, command: string, args: any[], callback?: (_: any) => void, errorCallback?: (errorInfo: {
         xhr?: XMLHttpRequest | undefined;
         error?: any;
     }) => void): void;
-    private processPassedId;
+    private processPassedId(id, context);
     protected getPostbackHandler(name: string): (options: any) => DotvvmPostbackHandler;
-    private isPostbackHandler;
+    private isPostbackHandler(obj);
     findPostbackHandlers(knockoutContext: any, config: ClientFriendlyPostbackHandlerConfiguration[]): DotvvmPostbackHandler[];
-    private sortHandlers;
-    private applyPostbackHandlersCore;
+    private sortHandlers(handlers);
+    private applyPostbackHandlersCore(callback, options, handlers?);
     applyPostbackHandlers(callback: (options: PostbackOptions) => Promise<PostbackCommitFunction | undefined>, sender: HTMLElement, handlers?: ClientFriendlyPostbackHandlerConfiguration[], args?: any[], context?: any, viewModel?: any, viewModelName?: string): Promise<DotvvmAfterPostBackEventArgs>;
     postbackCore(options: PostbackOptions, path: string[], command: string, controlUniqueId: string, context: any, commandArgs?: any[]): Promise<() => Promise<DotvvmAfterPostBackEventArgs>>;
     handleSpaNavigation(element: HTMLElement): Promise<DotvvmNavigationEventArgs>;
     handleSpaNavigationCore(url: string | null): Promise<DotvvmNavigationEventArgs>;
     postBack(viewModelName: string, sender: HTMLElement, path: string[], command: string, controlUniqueId: string, context?: any, handlers?: ClientFriendlyPostbackHandlerConfiguration[], commandArgs?: any[]): Promise<DotvvmAfterPostBackEventArgs>;
-    private loadResourceList;
-    private loadResourceElements;
-    private getSpaPlaceHolder;
-    private navigateCore;
-    private handleRedirect;
-    private performRedirect;
-    private fixSpaUrlPrefix;
-    private removeVirtualDirectoryFromUrl;
-    private addLeadingSlash;
-    private concatUrl;
+    private loadResourceList(resources, callback);
+    private loadResourceElements(elements, offset, callback);
+    private getSpaPlaceHolder();
+    private navigateCore(viewModelName, url, handlePageNavigating?);
+    private handleRedirect(resultObject, viewModelName, replace?);
+    private disablePostbacks();
+    private performRedirect(url, replace, useHistoryApiSpaRedirect?);
+    private fixSpaUrlPrefix(url);
+    private removeVirtualDirectoryFromUrl(url, viewModelName);
+    private addLeadingSlash(url);
+    private concatUrl(url1, url2);
     patch(source: any, patch: any): any;
     diff(source: any, modified: any): any;
     readonly diffEqual: {};
-    private updateDynamicPathFragments;
-    private postJSON;
-    private getJSON;
+    private updateDynamicPathFragments(context, path);
+    private postJSON(url, method, postData, success, error, preprocessRequest?);
+    private getJSON(url, method, spaPlaceHolderUniqueId, success, error);
     getXHR(): XMLHttpRequest;
-    private cleanUpdatedControls;
-    private restoreUpdatedControls;
+    private cleanUpdatedControls(resultObject, updatedControls?);
+    private restoreUpdatedControls(resultObject, updatedControls, applyBindingsOnEachControl);
     unwrapArrayExtension(array: any): any;
     buildRouteUrl(routePath: string, params: any): string;
     buildUrlSuffix(urlSuffix: string, query: any): string;
-    private isPostBackProhibited;
-    private addKnockoutBindingHandlers;
+    private isPostBackProhibited(element);
+    private addKnockoutBindingHandlers();
 }
 declare class DotvvmValidationContext {
     valueToValidate: any;
@@ -484,8 +486,8 @@ declare class DotvvmValidation {
      * Adds validation errors from the server to the appropriate arrays
      */
     showValidationErrorsFromServer(args: DotvvmAfterPostBackEventArgs): void;
-    private static hasErrors;
-    private applyValidatorOptions;
+    private static hasErrors(observable);
+    private applyValidatorOptions(validator, observable, validatorOptions);
 }
 declare var dotvvm: DotVVM;
 declare class DotvvmEvaluator {
@@ -495,9 +497,9 @@ declare class DotvvmEvaluator {
     tryEval(func: () => any): any;
     isObservableArray(instance: any): instance is KnockoutObservableArray<any>;
     wrapObservable(func: () => any, isArray?: boolean): KnockoutComputed<any>;
-    private updateObservable;
-    private updateObservableArray;
-    private getExpressionResult;
+    private updateObservable(getObservable, value);
+    private updateObservableArray(getObservableArray, fnName, args);
+    private getExpressionResult(func);
 }
 declare type ApiComputed<T> = KnockoutObservable<T | null> & {
     refreshValue: (throwOnError?: boolean) => PromiseLike<any> | undefined;

--- a/src/DotVVM.Framework/Resources/Scripts/DotVVM.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/DotVVM.ts
@@ -1010,8 +1010,10 @@ class DotVVM {
 
     private disablePostbacks() {
         this.lastStartedPostack = -1 // this stops further commits
-        for (const q in Object.keys(this.postbackQueues)) {
-            this.postbackQueues[q].queue.length = 0
+        for (const q in this.postbackQueues) {
+            if (this.postbackQueues.hasOwnProperty(q)) {
+                this.postbackQueues[q].queue.length = 0
+            }
         }
         // disable all other postbacks
         // but not in SPA mode, since we'll need them for the next page

--- a/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
+++ b/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
@@ -50,6 +50,7 @@
     <None Remove="Views\Errors\ResourceCircularDependency.dothtml" />
     <None Remove="Views\FeatureSamples\Caching\CachedValues.dothtml" />
     <None Remove="Views\FeatureSamples\Localization\Globalize.dothtml" />
+    <None Remove="Views\FeatureSamples\PostbackConcurrency\StressTest.dothtml" />
     <None Remove="Views\FeatureSamples\PostBack\RecursiveTextRepeater.dotcontrol" />
     <None Remove="Views\FeatureSamples\PostBack\RecursiveTextRepeater2.dotcontrol" />
     <None Remove="Views\FeatureSamples\PostBack\UniqueIdGenerationOnPostbackUpdate.dothtml" />

--- a/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
+++ b/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
@@ -50,6 +50,7 @@
     <None Remove="Views\Errors\ResourceCircularDependency.dothtml" />
     <None Remove="Views\FeatureSamples\Caching\CachedValues.dothtml" />
     <None Remove="Views\FeatureSamples\Localization\Globalize.dothtml" />
+    <None Remove="Views\FeatureSamples\PostbackConcurrency\RedirectPostbackQueue.dothtml" />
     <None Remove="Views\FeatureSamples\PostbackConcurrency\StressTest.dothtml" />
     <None Remove="Views\FeatureSamples\PostBack\RecursiveTextRepeater.dotcontrol" />
     <None Remove="Views\FeatureSamples\PostBack\RecursiveTextRepeater2.dotcontrol" />

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackConcurrency/RedirectPostbackQueueMasterViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackConcurrency/RedirectPostbackQueueMasterViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.PostbackConcurrency
+{
+    public class RedirectPostbackQueueMasterViewModel : DotvvmViewModelBase
+    {
+    }
+}

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackConcurrency/RedirectPostbackQueueViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackConcurrency/RedirectPostbackQueueViewModel.cs
@@ -14,7 +14,7 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.PostbackConcurrency
 
         public override async Task Init()
         {
-            if (Context.Query.ContainsKey("time"))
+            if (!Context.IsPostBack && Context.Query.ContainsKey("time"))
             {
                 await Task.Delay(5000);
             }

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackConcurrency/RedirectPostbackQueueViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackConcurrency/RedirectPostbackQueueViewModel.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.PostbackConcurrency
+{
+    public class RedirectPostbackQueueViewModel : RedirectPostbackQueueMasterViewModel
+    {
+
+        public int Value { get; set; }
+
+        public override async Task Init()
+        {
+            if (Context.Query.ContainsKey("time"))
+            {
+                await Task.Delay(5000);
+            }
+
+            await base.Init();
+        }
+
+        public void Increment()
+        {
+            Value++;
+        }
+
+        public void IncrementWithWait()
+        {
+            Thread.Sleep(5000);
+            Value++;
+        }
+
+        public void Redirect()
+        {
+            Thread.Sleep(2000);
+            Context.RedirectToRoute(Context.Route.RouteName, query: new { time = Environment.TickCount });
+        }
+
+    }
+}

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackConcurrency/StressTestViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackConcurrency/StressTestViewModel.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.PostbackConcurrency
+{
+    public class StressTestViewModel : DotvvmViewModelBase
+    {
+
+        public int Value { get; set; }
+
+        [Bind(Direction.ServerToClientFirstRequest)]
+        public int RejectedCount { get; set; }
+
+        [Bind(Direction.ServerToClientFirstRequest)]
+        public int BeforePostback { get; set; }
+
+        [Bind(Direction.ServerToClientFirstRequest)]
+        public int AfterPostback { get; set; }
+
+        public void Increment()
+        {
+            Value++;
+            Thread.Sleep(0);
+        }
+
+    }
+}

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackConcurrency/RedirectPostbackQueue.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackConcurrency/RedirectPostbackQueue.dothtml
@@ -1,0 +1,27 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.PostbackConcurrency.RedirectPostbackQueueViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+
+    <h1>Redirect should cancel waiting postbacks</h1>
+
+    <h2>Value: <span class="result">{{value: Value}}</span></h2>
+
+    <p>Click the first button and the second button immediately - the value should not be incremented to 1 when the page is reloading.</p>
+
+    <div PostBack.Concurrency="Queue">
+        <dot:Button Text="Redirect (blocks for 2 + 5 seconds)" Click="{command: Redirect()}" />
+        <dot:Button Text="Increment" Click="{command: Increment()}" />
+        <%--<dot:Button Text="Increment (after 5 seconds)" Click="{command: IncrementWithWait()}" />--%>
+    </div>
+
+</body>
+</html>
+
+

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackConcurrency/RedirectPostbackQueueSpa.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackConcurrency/RedirectPostbackQueueSpa.dothtml
@@ -1,0 +1,19 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.PostbackConcurrency.RedirectPostbackQueueViewModel, DotVVM.Samples.Common
+@masterPage Views/FeatureSamples/PostbackConcurrency/RedirectPostbackQueueSpaMaster.dotmaster
+
+<dot:Content ContentPlaceHolderID="MainContent">
+
+    <h1>Redirect should cancel waiting postbacks in SPA</h1>
+    
+    <h2>Value: <span class="result">{{value: Value}}</span></h2>
+
+    <p>Click the first button and the second button immediately - the value should not be incremented to 1 when the page is reloading.</p>
+    <p>Click the first button and the third button immediately - the value should not be incremented to 1 after the page is reloaded.</p>
+
+    <div PostBack.Concurrency="Queue">
+        <dot:Button Text="Redirect (blocks for 2 + 5 seconds)" Click="{command: Redirect()}" />
+        <dot:Button Text="Increment" Click="{command: Increment()}" />
+        <dot:Button Text="Increment (after 5 seconds)" Click="{command: IncrementWithWait()}" />
+    </div>
+
+</dot:Content>

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackConcurrency/RedirectPostbackQueueSpaMaster.dotmaster
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackConcurrency/RedirectPostbackQueueSpaMaster.dotmaster
@@ -1,0 +1,17 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.PostbackConcurrency.RedirectPostbackQueueMasterViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+
+    <dot:SpaContentPlaceHolder ID="MainContent" />
+    
+</body>
+</html>
+
+

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackConcurrency/StressTest.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackConcurrency/StressTest.dothtml
@@ -10,9 +10,9 @@
 <body>
 
     <h1>Value: <span class="result-value">{{value: Value}}</span></h1>
-    <p>beforePostback count: <span class="result-rejected">{{value: BeforePostback}}</span></p>
+    <p>beforePostback count: <span class="result-before">{{value: BeforePostback}}</span></p>
     <p>postbackRejected count: <span class="result-rejected">{{value: RejectedCount}}</span></p>
-    <p>afterPostback count: <span class="result-rejected">{{value: AfterPostback}}</span></p>
+    <p>afterPostback count: <span class="result-after">{{value: AfterPostback}}</span></p>
 
     <div PostBack.Concurrency="Default">
         <dot:Button Text="Default Mode" Click="{command: Increment()}" ID="DefaultButton" />

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackConcurrency/StressTest.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackConcurrency/StressTest.dothtml
@@ -1,0 +1,59 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.PostbackConcurrency.StressTestViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+
+    <h1>Value: <span class="result-value">{{value: Value}}</span></h1>
+    <p>beforePostback count: <span class="result-rejected">{{value: BeforePostback}}</span></p>
+    <p>postbackRejected count: <span class="result-rejected">{{value: RejectedCount}}</span></p>
+    <p>afterPostback count: <span class="result-rejected">{{value: AfterPostback}}</span></p>
+
+    <div PostBack.Concurrency="Default">
+        <dot:Button Text="Default Mode" Click="{command: Increment()}" ID="DefaultButton" />
+        <input type="button" value="Trigger 100x" onclick="trigger100('DefaultButton');" />
+    </div>
+    <div PostBack.Concurrency="Deny">
+        <dot:Button Text="Deny Mode" Click="{command: Increment()}" ID="DenyButton" />
+        <input type="button" value="Trigger 100x" onclick="trigger100('DenyButton');" />
+    </div>
+    <div PostBack.Concurrency="Queue">
+        <dot:Button Text="Queue Mode" Click="{command: Increment()}" ID="QueueButton" />
+        <input type="button" value="Trigger 100x" onclick="trigger100('QueueButton');" />
+    </div>
+
+    <dot:InlineScript Dependencies="dotvvm">
+dotvvm.events.postbackRejected.subscribe(function () {
+    dotvvm.viewModels.root.viewModel.RejectedCount(dotvvm.viewModels.root.viewModel.RejectedCount() + 1);
+});
+dotvvm.events.beforePostback.subscribe(function () {
+    dotvvm.viewModels.root.viewModel.BeforePostback(dotvvm.viewModels.root.viewModel.BeforePostback() + 1);
+});
+dotvvm.events.afterPostback.subscribe(function (args) {
+    dotvvm.viewModels.root.viewModel.AfterPostback(dotvvm.viewModels.root.viewModel.AfterPostback() + 1);
+    console.log(args);
+});
+    
+function trigger100(buttonId) {
+    var button = document.getElementById(buttonId);
+    var next = function(j) {
+        if (j < 100) {
+            window.setTimeout(function () {
+                button.click();
+                next(j + 1);
+            }, Math.random() * 1);
+        }
+    }
+    next(0);
+}   
+    </dot:InlineScript>
+
+</body>
+</html>
+
+

--- a/src/DotVVM.Samples.Tests/Feature/PostbackConcurrencyTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/PostbackConcurrencyTests.cs
@@ -1,4 +1,5 @@
-﻿using DotVVM.Samples.Tests.Base;
+﻿using System.Threading;
+using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
 using Riganti.Selenium.Core;
 using Riganti.Selenium.Core.Abstractions.Attributes;
@@ -118,6 +119,129 @@ namespace DotVVM.Samples.Tests.Feature
                     AssertUI.InnerTextEquals(postbackIndexSpan, "1");
                     AssertUI.InnerTextEquals(lastActionSpan, "long");
                 }, 6000);
+            });
+        }
+
+        [Fact]
+        [SampleReference(SamplesRouteUrls.FeatureSamples_PostbackConcurrency_StressTest)]
+        public void Feature_PostbackConcurrency_StressTest_Default()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_PostbackConcurrency_StressTest);
+
+                browser.ElementAt("input[type=button]", 1).Click();
+
+                Thread.Sleep(10000);
+                var before = int.Parse(browser.Single(".result-before").GetInnerText().Trim());
+                var rejected = int.Parse(browser.Single(".result-rejected").GetInnerText().Trim());
+                var after = int.Parse(browser.Single(".result-after").GetInnerText().Trim());
+                var value = int.Parse(browser.Single(".result-value").GetInnerText().Trim());
+
+                Assert.True(0 < value && value <= 100);
+                Assert.Equal(100, before);
+                Assert.Equal(100, after);
+                Assert.Equal(0, rejected);
+            });
+        }
+
+        [Fact]
+        [SampleReference(SamplesRouteUrls.FeatureSamples_PostbackConcurrency_StressTest)]
+        public void Feature_PostbackConcurrency_StressTest_Deny()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_PostbackConcurrency_StressTest);
+
+                browser.ElementAt("input[type=button]", 3).Click();
+
+                Thread.Sleep(10000);
+                var before = int.Parse(browser.Single(".result-before").GetInnerText().Trim());
+                var rejected = int.Parse(browser.Single(".result-rejected").GetInnerText().Trim());
+                var after = int.Parse(browser.Single(".result-after").GetInnerText().Trim());
+                var value = int.Parse(browser.Single(".result-value").GetInnerText().Trim());
+
+                Assert.True(0 < value && value <= 100);
+                Assert.Equal(100, before + rejected);
+                Assert.Equal(100, after);
+            });
+        }
+
+        [Fact]
+        [SampleReference(SamplesRouteUrls.FeatureSamples_PostbackConcurrency_StressTest)]
+        public void Feature_PostbackConcurrency_StressTest_Queue()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_PostbackConcurrency_StressTest);
+
+                browser.ElementAt("input[type=button]", 5).Click();
+
+                Thread.Sleep(10000);
+                var before = int.Parse(browser.Single(".result-before").GetInnerText().Trim());
+                var rejected = int.Parse(browser.Single(".result-rejected").GetInnerText().Trim());
+                var after = int.Parse(browser.Single(".result-after").GetInnerText().Trim());
+                var value = int.Parse(browser.Single(".result-value").GetInnerText().Trim());
+
+                Assert.Equal(100, value);
+                Assert.Equal(100, before);
+                Assert.Equal(100, after);
+                Assert.Equal(0, rejected);
+            });
+        }
+
+        [Fact]
+        public void Feature_PostbackConcurrency_RedirectPostbackQueue()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_PostbackConcurrency_RedirectPostbackQueue);
+
+                browser.ElementAt("input[type=button]", 0).Click();
+                browser.ElementAt("input[type=button]", 1).Click();
+
+                while (!browser.CurrentUrl.Contains("?time"))
+                {
+                    Thread.Sleep(100);
+                    AssertUI.TextNotEquals(browser.Single(".result"), "1");
+                }
+            });
+        }
+
+        [Fact]
+        public void Feature_PostbackConcurrency_RedirectPostbackQueueSpa_PostbackDuringRedirect()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_PostbackConcurrency_RedirectPostbackQueueSpa);
+
+                browser.ElementAt("input[type=button]", 0).Click();
+                browser.ElementAt("input[type=button]", 1).Click();
+
+                while (!browser.CurrentUrl.Contains("?time"))
+                {
+                    Thread.Sleep(100);
+                    AssertUI.TextNotEquals(browser.Single(".result"), "1");
+                }
+            });
+        }
+
+        [Fact]
+        [SampleReference(SamplesRouteUrls.FeatureSamples_PostbackConcurrency_RedirectPostbackQueueSpa)]
+        public void Feature_PostbackConcurrency_RedirectPostbackQueueSpa_PostbackFromPreviousPage()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_PostbackConcurrency_RedirectPostbackQueueSpa);
+
+                browser.ElementAt("input[type=button]", 0).Click();
+                browser.ElementAt("input[type=button]", 2).Click();
+
+                while (!browser.CurrentUrl.Contains("?time"))
+                {
+                    Thread.Sleep(100);
+                    AssertUI.TextNotEquals(browser.Single(".result"), "1");
+                }
+
+                for (int i = 0; i < 8; i++)
+                {
+                    AssertUI.TextNotEquals(browser.Single(".result"), "1");
+                    Thread.Sleep(1000);
+                }
             });
         }
     }

--- a/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
@@ -232,6 +232,9 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_PostBack_SuppressPostBackHandler = "FeatureSamples/PostBack/SuppressPostBackHandler";
         public const string FeatureSamples_PostBack_UniqueIdGenerationOnPostbackUpdate = "FeatureSamples/PostBack/UniqueIdGenerationOnPostbackUpdate";
         public const string FeatureSamples_PostbackConcurrency_PostbackConcurrencyMode = "FeatureSamples/PostbackConcurrency/PostbackConcurrencyMode";
+        public const string FeatureSamples_PostbackConcurrency_RedirectPostbackQueue = "FeatureSamples/PostbackConcurrency/RedirectPostbackQueue";
+        public const string FeatureSamples_PostbackConcurrency_RedirectPostbackQueueSpa = "FeatureSamples/PostbackConcurrency/RedirectPostbackQueueSpa";
+        public const string FeatureSamples_PostbackConcurrency_StressTest = "FeatureSamples/PostbackConcurrency/StressTest";
         public const string FeatureSamples_Redirect_Redirect = "FeatureSamples/Redirect/Redirect";
         public const string FeatureSamples_Redirect_Redirect_StaticCommand = "FeatureSamples/Redirect/Redirect_StaticCommand";
         public const string FeatureSamples_RenderSettingsModeServer_RenderSettingModeServerProperty = "FeatureSamples/RenderSettingsModeServer/RenderSettingModeServerProperty";


### PR DESCRIPTION
This PR fixes two issues:

* When there are multiple postbacks in a concurrency queue, more of them started executing simultaneously
* When the server responds with a redirect response, the next postbacks from queue were started (during the load of the new page)