### PR TITLE
private AddRequiredResourceCore => public AddRequiredResource

### DIFF
--- a/src/DotVVM.Framework/ResourceManagement/ResourceManager.cs
+++ b/src/DotVVM.Framework/ResourceManagement/ResourceManager.cs
@@ -114,6 +114,16 @@ namespace DotVVM.Framework.ResourceManagement
             });
         }
 
+        /// <summary>
+        /// Adds the required inline script.
+        /// </summary>
+        public void AddRequiredInlineScript(string name, string code, params string[] dependentResourceNames)
+        {
+            AddRequiredResourceCore(name, new InlineScriptResource(code) {
+                Dependencies = dependentResourceNames,
+            });
+        }
+
         private static IResourceLocation CreateRelativeResourceLocation(string url)
         {
             return url.StartsWith("~/", StringComparison.Ordinal) ?
@@ -127,6 +137,16 @@ namespace DotVVM.Framework.ResourceManagement
         public void AddRequiredStylesheetFile(string name, string url, params string[] dependentResourceNames)
         {
             AddRequiredResourceCore(name, new StylesheetResource(CreateRelativeResourceLocation(url)) {
+                Dependencies = dependentResourceNames,
+            });
+        }
+
+        /// <summary>
+        /// Adds the required inline stylesheet.
+        /// </summary>
+        public void AddRequiredInlineStylesheet(string name, string code, params string[] dependentResourceNames)
+        {
+            AddRequiredResourceCore(name, new InlineStylesheetResource(code) {
                 Dependencies = dependentResourceNames,
             });
         }

--- a/src/DotVVM.Framework/ResourceManagement/ResourceManager.cs
+++ b/src/DotVVM.Framework/ResourceManagement/ResourceManager.cs
@@ -114,16 +114,6 @@ namespace DotVVM.Framework.ResourceManagement
             });
         }
 
-        /// <summary>
-        /// Adds the required inline script.
-        /// </summary>
-        public void AddRequiredInlineScript(string name, string code, params string[] dependentResourceNames)
-        {
-            AddRequiredResourceCore(name, new InlineScriptResource(code) {
-                Dependencies = dependentResourceNames,
-            });
-        }
-
         private static IResourceLocation CreateRelativeResourceLocation(string url)
         {
             return url.StartsWith("~/", StringComparison.Ordinal) ?
@@ -137,16 +127,6 @@ namespace DotVVM.Framework.ResourceManagement
         public void AddRequiredStylesheetFile(string name, string url, params string[] dependentResourceNames)
         {
             AddRequiredResourceCore(name, new StylesheetResource(CreateRelativeResourceLocation(url)) {
-                Dependencies = dependentResourceNames,
-            });
-        }
-
-        /// <summary>
-        /// Adds the required inline stylesheet.
-        /// </summary>
-        public void AddRequiredInlineStylesheet(string name, string code, params string[] dependentResourceNames)
-        {
-            AddRequiredResourceCore(name, new InlineStylesheetResource(code) {
                 Dependencies = dependentResourceNames,
             });
         }

--- a/src/DotVVM.Framework/ResourceManagement/ResourceManager.cs
+++ b/src/DotVVM.Framework/ResourceManagement/ResourceManager.cs
@@ -49,7 +49,7 @@ namespace DotVVM.Framework.ResourceManagement
                 ThrowResourceNotFound(name);
             }
 
-            AddRequiredResourceCore(name, resource!);
+            AddRequiredResource(name, resource!);
         }
 
         /// <summary>
@@ -64,19 +64,22 @@ namespace DotVVM.Framework.ResourceManagement
                 var resourceId = Convert.ToBase64String(sha.ComputeHash(Encoding.Unicode.GetBytes(template)));
                 if (!requiredResources.ContainsKey(resourceId))
                 {
-                    AddRequiredResourceCore(resourceId, new TemplateResource(template));
+                    AddRequiredResource(resourceId, new TemplateResource(template));
                 }
 
                 return resourceId;
             }
         }
-
-        private void AddRequiredResourceCore(IResource resource) => AddRequiredResourceCore("__noname_" + nonameCtr++, resource);
+        /// <summary>
+        /// Adds the resource with unique name.
+        /// </summary>
+        /// <param name="resource"></param>
+        public void AddRequiredResource(IResource resource) => AddRequiredResource("__noname_" + nonameCtr++, resource);
 
         /// <summary>
         /// Adds the resource and checks name conflicts.
         /// </summary>
-        private void AddRequiredResourceCore(string name, IResource resource)
+        public void AddRequiredResource(string name, IResource resource)
         {
             if (requiredResources.TryGetValue(name, out var originalResource))
             {
@@ -109,7 +112,7 @@ namespace DotVVM.Framework.ResourceManagement
         /// </summary>
         public void AddRequiredScriptFile(string name, string url, params string[] dependentResourceNames)
         {
-            AddRequiredResourceCore(name, new ScriptResource(CreateRelativeResourceLocation(url)) {
+            AddRequiredResource(name, new ScriptResource(CreateRelativeResourceLocation(url)) {
                 Dependencies = dependentResourceNames,
             });
         }
@@ -126,7 +129,7 @@ namespace DotVVM.Framework.ResourceManagement
         /// </summary>
         public void AddRequiredStylesheetFile(string name, string url, params string[] dependentResourceNames)
         {
-            AddRequiredResourceCore(name, new StylesheetResource(CreateRelativeResourceLocation(url)) {
+            AddRequiredResource(name, new StylesheetResource(CreateRelativeResourceLocation(url)) {
                 Dependencies = dependentResourceNames,
             });
         }
@@ -136,7 +139,7 @@ namespace DotVVM.Framework.ResourceManagement
         /// </summary>
         public void AddStartupScript(string name, string javascriptCode, params string[] dependentResourceNames)
         {
-            AddRequiredResourceCore(name, new InlineScriptResource(javascriptCode) { Dependencies = dependentResourceNames });
+            AddRequiredResource(name, new InlineScriptResource(javascriptCode) { Dependencies = dependentResourceNames });
         }
 
         /// <summary>
@@ -144,7 +147,7 @@ namespace DotVVM.Framework.ResourceManagement
         /// </summary>
         public void AddStartupScript(string javascriptCode, params string[] dependentResourceNames)
         {
-            AddRequiredResourceCore(new InlineScriptResource(javascriptCode) { Dependencies = dependentResourceNames });
+            AddRequiredResource(new InlineScriptResource(javascriptCode) { Dependencies = dependentResourceNames });
         }
 
         /// <summary>


### PR DESCRIPTION
~~Added two methods to ResourceManager (similar methods are already present)
public void AddRequiredInlineScript(string name, string code, params string[] dependentResourceNames)~~

~~public void AddRequiredInlineStylesheet(string name, string code, params string[] dependentResourceNames)~~

After consultation with @exyi We've decided that it would be better to make AddRequiredResourceCore public (and rename it to AddRequiredResource)