### PR TITLE
Dotvvm view compilation service

### DIFF
--- a/src/DotVVM.Framework.Hosting.AspNetCore/ServiceCollectionExtensions.cs
+++ b/src/DotVVM.Framework.Hosting.AspNetCore/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.AspNetCore.Builder;
 using System.Reflection;
+using DotVVM.Framework.Compilation;
 using DotVVM.Framework.Runtime;
 using DotVVM.Framework.Hosting.AspNetCore;
 
@@ -64,7 +65,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton<IEnvironmentNameProvider, DotvvmEnvironmentNameProvider>();
             services.TryAddScoped<DotvvmRequestContextStorage>(_ => new DotvvmRequestContextStorage());
             services.TryAddScoped<IDotvvmRequestContext>(s => s.GetRequiredService<DotvvmRequestContextStorage>().Context);
-
+            services.AddSingleton<IDotvvmViewCompilationService, DotvvmViewCompilationService>();
             services.AddTransient<IDotvvmWarningSink, AspNetCoreLoggerWarningSink>();
         }
     }

--- a/src/DotVVM.Framework/Compilation/CompilationState.cs
+++ b/src/DotVVM.Framework/Compilation/CompilationState.cs
@@ -1,0 +1,12 @@
+﻿namespace DotVVM.Framework.Compilation
+{
+    public enum CompilationState
+    {
+        None = 1,
+        InProcess = 2,
+        CompletedSuccessfully = 3,
+        CompilationFailed = 4,
+        CompilationWarning = 5,
+        NonCompilable = 6
+    }
+}

--- a/src/DotVVM.Framework/Compilation/DotHtmlFileInfo.cs
+++ b/src/DotVVM.Framework/Compilation/DotHtmlFileInfo.cs
@@ -1,47 +1,39 @@
 ﻿using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 
 namespace DotVVM.Framework.Compilation
 {
-    public class DotHtmlFileInfo
+    public sealed class DotHtmlFileInfo
     {
-        public CompilationState Status { get; set; }
-        public string Exception { get; set; }
-        public string TagName { get; set; }
-        public string Namespace { get; set; }
-        public string Assembly { get; set; }
-        public string TagPrefix { get; set; }
-        public string Url { get; set; }
-
-        /// <summary>Gets key of route.</summary>
-        public string RouteName { get; set; }
-
-        /// <summary>Gets the default values of the optional parameters.</summary>
-        public List<string> DefaultValues { get; set; }
+        public CompilationState Status { get; internal set; }
+        public string Exception { get; internal set; }
 
         /// <summary>Gets or sets the virtual path to the view.</summary>
-        public string VirtualPath { get; set; }
+        public string VirtualPath { get; }
 
-        public bool HasParameters { get; set; }
+        public string TagName { get; }
+        public string Namespace { get; }
+        public string Assembly { get; }
+        public string TagPrefix { get; }
+        public string Url { get; }
+        public string RouteName { get; }
+        public ImmutableArray<string>? DefaultValues { get; }
+        public bool? HasParameters { get; }
 
-
-        private sealed class VirtualPathEqualityComparer : IEqualityComparer<DotHtmlFileInfo>
+        public DotHtmlFileInfo(string virtualPath, string tagName = null, string nameSpace = null, string assembly = null, string tagPrefix = null, string url = null, string routeName = null, ImmutableArray<string>? defaultValues = null, bool? hasParameters = null)
         {
-            public bool Equals(DotHtmlFileInfo x, DotHtmlFileInfo y)
-            {
-                if (ReferenceEquals(x, y)) return true;
-                if (ReferenceEquals(x, null)) return false;
-                if (ReferenceEquals(y, null)) return false;
-                if (x.GetType() != y.GetType()) return false;
-                return x.VirtualPath == y.VirtualPath;
-            }
+            VirtualPath = virtualPath;
+            Status = !string.IsNullOrWhiteSpace(virtualPath) ? CompilationState.None : CompilationState.NonCompilable;
 
-            public int GetHashCode(DotHtmlFileInfo obj)
-            {
-                return (obj.VirtualPath != null ? obj.VirtualPath.GetHashCode() : 0);
-            }
+            TagName = tagName;
+            Namespace = nameSpace;
+            Assembly = assembly;
+            TagPrefix = tagPrefix;
+            Url = url;
+            RouteName = routeName;
+            DefaultValues = defaultValues;
+            HasParameters = hasParameters;
         }
-
-        public static IEqualityComparer<DotHtmlFileInfo> VirtualPathComparer { get; } = new VirtualPathEqualityComparer();
     }
 }

--- a/src/DotVVM.Framework/Compilation/DotHtmlFileInfo.cs
+++ b/src/DotVVM.Framework/Compilation/DotHtmlFileInfo.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace DotVVM.Framework.Compilation
+{
+    public class DotHtmlFileInfo
+    {
+        public CompilationState Status { get; set; }
+        public string Exception { get; set; }
+        public string TagName { get; set; }
+        public string Namespace { get; set; }
+        public string Assembly { get; set; }
+        public string TagPrefix { get; set; }
+        public string Url { get; set; }
+
+        /// <summary>Gets key of route.</summary>
+        public string RouteName { get; set; }
+
+        /// <summary>Gets the default values of the optional parameters.</summary>
+        public List<string> DefaultValues { get; set; }
+
+        /// <summary>Gets or sets the virtual path to the view.</summary>
+        public string VirtualPath { get; set; }
+
+        public bool HasParameters { get; set; }
+
+
+        private sealed class VirtualPathEqualityComparer : IEqualityComparer<DotHtmlFileInfo>
+        {
+            public bool Equals(DotHtmlFileInfo x, DotHtmlFileInfo y)
+            {
+                if (ReferenceEquals(x, y)) return true;
+                if (ReferenceEquals(x, null)) return false;
+                if (ReferenceEquals(y, null)) return false;
+                if (x.GetType() != y.GetType()) return false;
+                return x.VirtualPath == y.VirtualPath;
+            }
+
+            public int GetHashCode(DotHtmlFileInfo obj)
+            {
+                return (obj.VirtualPath != null ? obj.VirtualPath.GetHashCode() : 0);
+            }
+        }
+
+        public static IEqualityComparer<DotHtmlFileInfo> VirtualPathComparer { get; } = new VirtualPathEqualityComparer();
+    }
+}

--- a/src/DotVVM.Framework/Compilation/DotvvmViewCompilationService.cs
+++ b/src/DotVVM.Framework/Compilation/DotvvmViewCompilationService.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using DotVVM.Framework.Compilation.Parser;
+using DotVVM.Framework.Configuration;
+using DotVVM.Framework.Controls.Infrastructure;
+using DotVVM.Framework.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DotVVM.Framework.Compilation
+{
+    public class DotvvmViewCompilationService : IDotvvmViewCompilationService
+    {
+        private readonly DotvvmConfiguration dotvvmConfiguration;
+
+        private bool EverythingIsCompiled => controls != null && routes != null && masterPages != null && masterPages.Concat(controls).Concat(routes).All(t => t.Status != CompilationState.None);
+        public IEnumerable<DotHtmlFileInfo> FilesWithErrors => !EverythingIsCompiled ? Enumerable.Empty<DotHtmlFileInfo>() :
+            masterPages.Concat(controls).Concat(routes).Where(t => t.Status == CompilationState.CompilationFailed);
+
+        private List<DotHtmlFileInfo> masterPages;
+        public List<DotHtmlFileInfo> GetMasterPages()
+        {
+
+            if (masterPages == null) InitMasterPagesCollection();
+            return masterPages;
+        }
+
+        private List<DotHtmlFileInfo> controls;
+        public List<DotHtmlFileInfo> GetControls()
+        {
+            if (controls == null)
+            {
+                lock (loadControlsLocker)
+                {
+                    if (controls == null)
+                        controls = dotvvmConfiguration.Markup.Controls.Where(s => !string.IsNullOrWhiteSpace(s.Src))
+                            .Select(s => new DotHtmlFileInfo() {
+                                TagName = s.TagName,
+                                VirtualPath = s.Src,
+                                Namespace = s.Namespace,
+                                Assembly = s.Assembly,
+                                TagPrefix = s.TagPrefix,
+                                Status = CompilationState.None
+                            }).ToList();
+                }
+            }
+            return controls;
+        }
+
+        protected List<DotHtmlFileInfo> routes;
+        public List<DotHtmlFileInfo> GetRoutes()
+        {
+            if (routes == null)
+            {
+
+                if (routes == null)
+                {
+                    lock (loadRoutesLocker)
+                    {
+                        if (routes == null)
+                            routes = dotvvmConfiguration.RouteTable.Select(r => new DotHtmlFileInfo() {
+                                VirtualPath = r.VirtualPath,
+                                Url = r.Url,
+                                HasParameters = r.ParameterNames.Any(),
+                                DefaultValues = r.DefaultValues.Select(s => s.Key + ":" + s.Value?.ToString()).ToList(),
+                                RouteName = r.RouteName,
+                                Status = (string.IsNullOrWhiteSpace(r.VirtualPath) || !IsDotvvmPresenter(r))
+                                    ? CompilationState.NonCompilable
+                                    : CompilationState.None
+                            }).ToList();
+                    }
+                }
+            }
+            return routes;
+        }
+
+        public DotvvmViewCompilationService(DotvvmConfiguration dotvvmConfiguration)
+        {
+            this.dotvvmConfiguration = dotvvmConfiguration;
+        }
+
+        private static object loadMasterPagesLocker = new object();
+        private void InitMasterPagesCollection()
+        {
+            if (masterPages == null)
+            {
+                lock (loadMasterPagesLocker)
+                {
+                    if (masterPages == null) masterPages = new List<DotHtmlFileInfo>();
+                }
+            }
+        }
+
+        private static object loadControlsLocker = new object();
+        private static object loadRoutesLocker = new object();
+
+        private bool IsDotvvmPresenter(RouteBase r)
+        {
+            var presenter = r.GetPresenter(dotvvmConfiguration.ServiceProvider);
+            return presenter.GetType().IsInstanceOfType(dotvvmConfiguration.RouteTable.GetDefaultPresenter(dotvvmConfiguration.ServiceProvider));
+        }
+
+        public async Task<bool> CompileAll(bool buildInParallel=true, bool forceRecompile = false)
+        {
+            if (EverythingIsCompiled && !forceRecompile)
+                return !FilesWithErrors.Any();
+
+            List<DotHtmlFileInfo> controlsToCompile;
+            List<DotHtmlFileInfo> routesToCompile;
+            if (forceRecompile)
+            {
+                routesToCompile = routes;
+                controlsToCompile = controls;
+            }
+            else
+            {
+                routesToCompile = routes.Where(t => t.Status == CompilationState.None).ToList();
+                controlsToCompile = controls.Where(t => t.Status == CompilationState.None).ToList();
+            }
+
+
+            var tempMasterPages = new ConcurrentBag<DotHtmlFileInfo>();
+            var compileTasks = routesToCompile.Select(a => new Task(() => BuildView(a, tempMasterPages))).ToList();
+
+            compileTasks.AddRange(controlsToCompile.Select(a => new Task(() => BuildView(a, tempMasterPages))).ToList());
+
+            await ExecuteCompileTasks(compileTasks,buildInParallel);
+
+            while (tempMasterPages.Count > 0)
+            {
+                masterPages = masterPages.Union(tempMasterPages).Distinct(DotHtmlFileInfo.VirtualPathComparer).ToList();
+
+                //.NET Standard 2.1 - better replace with tempMasterPages.Clear()
+                tempMasterPages = new ConcurrentBag<DotHtmlFileInfo>();
+
+                var masterPagesTasks = masterPages.Select(i => new Task(() => BuildView(i, tempMasterPages))).ToList();
+                await ExecuteCompileTasks(masterPagesTasks, buildInParallel);
+            }
+
+            OrderByErrors();
+            return !FilesWithErrors.Any();
+        }
+
+        private async Task ExecuteCompileTasks(List<Task> compileTasks, bool buildInParallel)
+        {
+            if (buildInParallel)
+            {
+                await Task.WhenAll(compileTasks.ToArray());
+            }
+            else
+            {
+                foreach (var task in compileTasks)
+                {
+                    task.RunSynchronously();
+                }
+            }
+        }
+
+        protected virtual void OrderByErrors()
+        {
+            routes = routes.OrderByDescending(r => r.Status).ToList();
+            masterPages = masterPages.OrderByDescending(mp => mp.Status).ToList();
+            controls = controls.OrderByDescending(c => c.Status).ToList();
+        }
+
+        public bool BuildView(DotHtmlFileInfo file, ConcurrentBag<DotHtmlFileInfo> tempList)
+        {
+
+            if (file.Status != CompilationState.NonCompilable)
+            {
+                try
+                {
+                    var controlFactory = dotvvmConfiguration.ServiceProvider.GetRequiredService<IControlBuilderFactory>();
+
+                    var pageBuilder = controlFactory.GetControlBuilder(file.VirtualPath);
+
+                    var compiledControl = pageBuilder.builder.Value.BuildControl(controlFactory, dotvvmConfiguration.ServiceProvider);
+
+                    if (compiledControl is DotvvmView view && view.Directives.TryGetValue(
+                        ParserConstants.MasterPageDirective,
+                        out var masterPage))
+                    {
+                        if (masterPages.All(s => s.VirtualPath != masterPage) &&
+                            tempList.All(s => s.VirtualPath != masterPage))
+                        {
+                            tempList.Add(new DotHtmlFileInfo() {
+                                VirtualPath = masterPage
+                            });
+                        }
+                    }
+
+                    file.Status = CompilationState.CompletedSuccessfully;
+                    file.Exception = null;
+                }
+                catch (Exception e)
+                {
+                    file.Status = CompilationState.CompilationFailed;
+                    file.Exception = e.Message;
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/src/DotVVM.Framework/Compilation/DotvvmViewCompilationService.cs
+++ b/src/DotVVM.Framework/Compilation/DotvvmViewCompilationService.cs
@@ -1,148 +1,143 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using DotVVM.Framework.Compilation.Parser;
 using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Controls.Infrastructure;
-using DotVVM.Framework.Routing;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace DotVVM.Framework.Compilation
 {
     public class DotvvmViewCompilationService : IDotvvmViewCompilationService
     {
+        private IControlBuilderFactory controlBuilderFactory;
         private readonly DotvvmConfiguration dotvvmConfiguration;
 
-        public IEnumerable<DotHtmlFileInfo> GetFilesWithFailedCompilation()
-        {
-            return GetMasterPages().Concat(GetControls()).Concat(GetRoutes())
-                .Where(t => t.Status == CompilationState.CompilationFailed);
-        }
-
-        private List<DotHtmlFileInfo> masterPages;
-        public List<DotHtmlFileInfo> GetMasterPages()
-        {
-            if (masterPages == null) InitMasterPagesCollection();
-            return masterPages;
-        }
-
-        private List<DotHtmlFileInfo> controls;
-        private static object loadControlsLocker = new object();
-        public List<DotHtmlFileInfo> GetControls()
-        {
-            if (controls == null)
-            {
-                lock (loadControlsLocker)
-                {
-                    if (controls == null)
-                        controls = dotvvmConfiguration.Markup.Controls.Where(s => !string.IsNullOrWhiteSpace(s.Src))
-                            .Select(s => new DotHtmlFileInfo() {
-                                TagName = s.TagName,
-                                VirtualPath = s.Src,
-                                Namespace = s.Namespace,
-                                Assembly = s.Assembly,
-                                TagPrefix = s.TagPrefix,
-                                Status = CompilationState.None
-                            }).ToList();
-                }
-            }
-            return controls;
-        }
-
-        protected List<DotHtmlFileInfo> routes;
-        private static object loadRoutesLocker = new object();
-        public List<DotHtmlFileInfo> GetRoutes()
-        {
-            if (routes == null)
-            {
-
-                if (routes == null)
-                {
-                    lock (loadRoutesLocker)
-                    {
-                        if (routes == null)
-                            routes = dotvvmConfiguration.RouteTable.Select(r => new DotHtmlFileInfo() {
-                                VirtualPath = r.VirtualPath,
-                                Url = r.Url,
-                                HasParameters = r.ParameterNames.Any(),
-                                DefaultValues = r.DefaultValues.Select(s => s.Key + ":" + s.Value?.ToString()).ToList(),
-                                RouteName = r.RouteName,
-                                Status = (string.IsNullOrWhiteSpace(r.VirtualPath) || !IsDotvvmPresenter(r))
-                                    ? CompilationState.NonCompilable
-                                    : CompilationState.None
-                            }).ToList();
-                    }
-                }
-            }
-            return routes;
-        }
-
-        public DotvvmViewCompilationService(DotvvmConfiguration dotvvmConfiguration)
+        public DotvvmViewCompilationService(DotvvmConfiguration dotvvmConfiguration, IControlBuilderFactory controlBuilderFactory)
         {
             this.dotvvmConfiguration = dotvvmConfiguration;
+            this.controlBuilderFactory = controlBuilderFactory;
+            masterPages = new Lazy<ConcurrentDictionary<string, DotHtmlFileInfo>>(InitMasterPagesCollection);
+            controls = new Lazy<ConcurrentBag<DotHtmlFileInfo>>(InitControls);
+            routes = new Lazy<ConcurrentBag<DotHtmlFileInfo>>(InitRoutes);
         }
 
-        private static object loadMasterPagesLocker = new object();
-        private void InitMasterPagesCollection()
+        public ImmutableArray<DotHtmlFileInfo> GetFilesWithFailedCompilation()
         {
-            if (masterPages == null)
+            return masterPages.Value.Values.Concat(controls.Value).Concat(routes.Value)
+                .Where(t => t.Status == CompilationState.CompilationFailed).ToImmutableArray();
+        }
+
+        private Lazy<ConcurrentDictionary<string, DotHtmlFileInfo>> masterPages;
+        private ConcurrentDictionary<string, DotHtmlFileInfo> InitMasterPagesCollection()
+        {
+            return new ConcurrentDictionary<string, DotHtmlFileInfo>();
+        }
+        public ImmutableArray<DotHtmlFileInfo> GetMasterPages()
+        {
+            return masterPages.Value.Values.ToImmutableArray();
+        }
+
+        private Lazy<ConcurrentBag<DotHtmlFileInfo>> controls;
+        private ConcurrentBag<DotHtmlFileInfo> InitControls()
+        {
+            return new ConcurrentBag<DotHtmlFileInfo>(
+                dotvvmConfiguration.Markup.Controls.Where(s => !string.IsNullOrWhiteSpace(s.Src))
+                    .Select(s => new DotHtmlFileInfo(s.Src, tagPrefix: s.TagPrefix, tagName: s.TagName,
+                        nameSpace: s.Namespace, assembly: s.Assembly)));
+        }
+
+        public ImmutableArray<DotHtmlFileInfo> GetControls()
+        {
+            return controls.Value.ToImmutableArray();
+        }
+
+        private Lazy<ConcurrentBag<DotHtmlFileInfo>> routes;
+        private ConcurrentBag<DotHtmlFileInfo> InitRoutes()
+        {
+            return new ConcurrentBag<DotHtmlFileInfo>(dotvvmConfiguration.RouteTable.Select(r =>
+                new DotHtmlFileInfo(r.VirtualPath,
+                    url: r.Url,
+                    hasParameters: r.ParameterNames.Any(),
+                    defaultValues: r.DefaultValues.Select(s => s.Key + ":" + s.Value).ToImmutableArray(),
+                    routeName: r.RouteName)));
+        }
+
+        public ImmutableArray<DotHtmlFileInfo> GetRoutes()
+        {
+            return routes.Value.ToImmutableArray();
+        }
+        private IEnumerable<DotHtmlFileInfo> GetFilesToBeCompiled()
+        {
+            return Enumerable.Union(controls.Value, routes.Value).Where(t => t.Status == CompilationState.None);
+        }
+
+        static readonly SemaphoreSlim compilationSemaphore = new SemaphoreSlim(1);
+
+        public async Task<bool> CompileAll(bool buildInParallel = true, bool forceRecompile = false)
+        {
+            var exclusiveMode = false;
+            try
             {
-                lock (loadMasterPagesLocker)
+                IEnumerable<DotHtmlFileInfo> filesToCompile = null;
+                if (forceRecompile)
                 {
-                    if (masterPages == null) masterPages = new List<DotHtmlFileInfo>();
+                    filesToCompile = controls.Value.Union(routes.Value);
+                }
+                else
+                {
+                    filesToCompile = GetFilesToBeCompiled();
+                    if (filesToCompile.Any())
+                    {
+                        await compilationSemaphore.WaitAsync(); //LOCK
+
+                        exclusiveMode = true;
+                        filesToCompile = GetFilesToBeCompiled();
+                        if (!filesToCompile.Any())
+                            return GetFilesWithFailedCompilation().Any();
+                    }
+                }
+                var discoveredMasterPages = new ConcurrentDictionary<string, DotHtmlFileInfo>();
+
+
+                Func<DotHtmlFileInfo, Task> CreateCompilationTask()
+                {
+                    return t => new Task(() => {
+                        BuildView(t, out var masterPage);
+                        if (masterPage != null && masterPage.Status == CompilationState.None) discoveredMasterPages.TryAdd(masterPage.VirtualPath, masterPage);
+                    });
+                }
+
+                var compileTasks = filesToCompile.Select(CreateCompilationTask()).ToArray();
+                await ExecuteCompileTasks(compileTasks, buildInParallel);
+
+                while (discoveredMasterPages.Any())
+                {
+                    compileTasks = discoveredMasterPages.ToArray().Select(t => t.Value).Select(CreateCompilationTask()).ToArray();
+                    discoveredMasterPages = new ConcurrentDictionary<string, DotHtmlFileInfo>();
+
+                    await ExecuteCompileTasks(compileTasks, buildInParallel);
                 }
             }
-        }
-        
-        private bool IsDotvvmPresenter(RouteBase r)
-        {
-            var presenter = r.GetPresenter(dotvvmConfiguration.ServiceProvider);
-            return presenter.GetType().IsInstanceOfType(dotvvmConfiguration.RouteTable.GetDefaultPresenter(dotvvmConfiguration.ServiceProvider));
-        }
-
-        public async Task<bool> CompileAll(bool buildInParallel=true, bool forceRecompile = false)
-        {
-            List<DotHtmlFileInfo> controlsToCompile;
-            List<DotHtmlFileInfo> routesToCompile;
-            if (forceRecompile)
+            finally
             {
-                routesToCompile = routes;
-                controlsToCompile = controls;
-            }
-            else
-            {
-                routesToCompile = routes.Where(t => t.Status == CompilationState.None).ToList();
-                controlsToCompile = controls.Where(t => t.Status == CompilationState.None).ToList();
-            }
-            
-            var tempMasterPages = new ConcurrentBag<DotHtmlFileInfo>();
-            var compileTasks = routesToCompile.Select(a => new Task(() => BuildView(a, tempMasterPages))).ToList();
-
-            compileTasks.AddRange(controlsToCompile.Select(a => new Task(() => BuildView(a, tempMasterPages))).ToList());
-
-            await ExecuteCompileTasks(compileTasks,buildInParallel);
-
-            while (tempMasterPages.Count > 0)
-            {
-                masterPages = masterPages.Union(tempMasterPages).Distinct(DotHtmlFileInfo.VirtualPathComparer).ToList();
-
-                //.NET Standard 2.1 - better replace with tempMasterPages.Clear()
-                tempMasterPages = new ConcurrentBag<DotHtmlFileInfo>();
-
-                var masterPagesTasks = masterPages.Select(i => new Task(() => BuildView(i, tempMasterPages))).ToList();
-                await ExecuteCompileTasks(masterPagesTasks, buildInParallel);
+                if (exclusiveMode) compilationSemaphore.Release(); //UNLOCK
             }
 
-            OrderByErrors();
             return !GetFilesWithFailedCompilation().Any();
         }
 
-        private async Task ExecuteCompileTasks(List<Task> compileTasks, bool buildInParallel)
+        private async Task ExecuteCompileTasks(ICollection<Task> compileTasks, bool buildInParallel)
         {
             if (buildInParallel)
             {
+                foreach (var task in compileTasks)
+                {
+                    task.Start();
+                }
                 await Task.WhenAll(compileTasks.ToArray());
             }
             else
@@ -154,36 +149,21 @@ namespace DotVVM.Framework.Compilation
             }
         }
 
-        protected virtual void OrderByErrors()
+        public bool BuildView(DotHtmlFileInfo file, out DotHtmlFileInfo masterPage)
         {
-            routes = routes.OrderByDescending(r => r.Status).ToList();
-            masterPages = masterPages.OrderByDescending(mp => mp.Status).ToList();
-            controls = controls.OrderByDescending(c => c.Status).ToList();
-        }
-
-        public bool BuildView(DotHtmlFileInfo file, ConcurrentBag<DotHtmlFileInfo> foundMasterpages=null)
-        {
-
+            masterPage = null;
             if (file.Status != CompilationState.NonCompilable)
             {
                 try
                 {
-                    var controlFactory = dotvvmConfiguration.ServiceProvider.GetRequiredService<IControlBuilderFactory>();
+                    var pageBuilder = controlBuilderFactory.GetControlBuilder(file.VirtualPath);
 
-                    var pageBuilder = controlFactory.GetControlBuilder(file.VirtualPath);
+                    var compiledControl = pageBuilder.builder.Value.BuildControl(controlBuilderFactory, dotvvmConfiguration.ServiceProvider);
 
-                    var compiledControl = pageBuilder.builder.Value.BuildControl(controlFactory, dotvvmConfiguration.ServiceProvider);
-
-                    if (compiledControl is DotvvmView view && foundMasterpages!=null &&
-                        view.Directives.TryGetValue(ParserConstants.MasterPageDirective,out var masterPage))
+                    if (compiledControl is DotvvmView view &&
+                        view.Directives.TryGetValue(ParserConstants.MasterPageDirective, out var masterPagePath))
                     {
-                        if (masterPages.All(s => s.VirtualPath != masterPage) &&
-                            foundMasterpages.All(s => s.VirtualPath != masterPage))
-                        {
-                            foundMasterpages.Add(new DotHtmlFileInfo() {
-                                VirtualPath = masterPage
-                            });
-                        }
+                        masterPage = masterPages.Value.GetOrAdd(masterPagePath, new DotHtmlFileInfo(masterPagePath));
                     }
 
                     file.Status = CompilationState.CompletedSuccessfully;

--- a/src/DotVVM.Framework/Compilation/IDotvvmViewCompilationService.cs
+++ b/src/DotVVM.Framework/Compilation/IDotvvmViewCompilationService.cs
@@ -6,13 +6,41 @@ namespace DotVVM.Framework.Compilation
 {
     public interface IDotvvmViewCompilationService
     {
-        IEnumerable<DotHtmlFileInfo> FilesWithErrors { get; }
+        /// <summary>
+        /// Gets all DotHtmlFileInfos with Status CompilationFailed from last compilation.
+        /// </summary>
+        IEnumerable<DotHtmlFileInfo> GetFilesWithFailedCompilation();
 
+        /// <summary>
+        /// Returns all currently known masterpages.
+        /// </summary>
         List<DotHtmlFileInfo> GetMasterPages();
+
+        /// <summary>
+        /// Returns all discovered controls.
+        /// </summary>
         List<DotHtmlFileInfo> GetControls();
+
+        /// <summary>
+        /// Returns all discovered routes.
+        /// </summary>
+        /// <returns></returns>
         List<DotHtmlFileInfo> GetRoutes();
 
+        /// <summary>
+        /// Compiles all routes,controls and masterpages which have been not compiled before.
+        /// </summary>
+        /// <param name="buildInParallel">Compilation would run in parallel if set to true.</param>
+        /// <param name="forceRecompile">Everything will be recompiled if set to true.</param>
+        /// <returns>False if any errors are found</returns>
         Task<bool> CompileAll(bool buildInParallel, bool forceRecompile = false);
-        bool BuildView(DotHtmlFileInfo file, ConcurrentBag<DotHtmlFileInfo> tempList);
+
+        /// <summary>
+        /// Builds given DotHtml file.
+        /// </summary>
+        /// <param name="file">File to compile</param>
+        /// <param name="foundMasterpages">All found masterpages would be added to this collection during file compilation.</param>
+        /// <returns></returns>
+        bool BuildView(DotHtmlFileInfo file, ConcurrentBag<DotHtmlFileInfo> foundMasterpages = null);
     }
 }

--- a/src/DotVVM.Framework/Compilation/IDotvvmViewCompilationService.cs
+++ b/src/DotVVM.Framework/Compilation/IDotvvmViewCompilationService.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace DotVVM.Framework.Compilation
+{
+    public interface IDotvvmViewCompilationService
+    {
+        IEnumerable<DotHtmlFileInfo> FilesWithErrors { get; }
+
+        List<DotHtmlFileInfo> GetMasterPages();
+        List<DotHtmlFileInfo> GetControls();
+        List<DotHtmlFileInfo> GetRoutes();
+
+        Task<bool> CompileAll(bool buildInParallel, bool forceRecompile = false);
+        bool BuildView(DotHtmlFileInfo file, ConcurrentBag<DotHtmlFileInfo> tempList);
+    }
+}

--- a/src/DotVVM.Framework/Compilation/IDotvvmViewCompilationService.cs
+++ b/src/DotVVM.Framework/Compilation/IDotvvmViewCompilationService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 
 namespace DotVVM.Framework.Compilation
@@ -9,38 +10,30 @@ namespace DotVVM.Framework.Compilation
         /// <summary>
         /// Gets all DotHtmlFileInfos with Status CompilationFailed from last compilation.
         /// </summary>
-        IEnumerable<DotHtmlFileInfo> GetFilesWithFailedCompilation();
-
+        ImmutableArray<DotHtmlFileInfo> GetFilesWithFailedCompilation();
+        
         /// <summary>
         /// Returns all currently known masterpages.
         /// </summary>
-        List<DotHtmlFileInfo> GetMasterPages();
+        ImmutableArray<DotHtmlFileInfo> GetMasterPages();
 
         /// <summary>
         /// Returns all discovered controls.
         /// </summary>
-        List<DotHtmlFileInfo> GetControls();
+        ImmutableArray<DotHtmlFileInfo> GetControls();
 
         /// <summary>
         /// Returns all discovered routes.
         /// </summary>
         /// <returns></returns>
-        List<DotHtmlFileInfo> GetRoutes();
-
+        ImmutableArray<DotHtmlFileInfo> GetRoutes();
+        
         /// <summary>
-        /// Compiles all routes,controls and masterpages which have been not compiled before.
+        /// Compiles all view which have not been compiled yet.
         /// </summary>
-        /// <param name="buildInParallel">Compilation would run in parallel if set to true.</param>
-        /// <param name="forceRecompile">Everything will be recompiled if set to true.</param>
-        /// <returns>False if any errors are found</returns>
-        Task<bool> CompileAll(bool buildInParallel, bool forceRecompile = false);
-
-        /// <summary>
-        /// Builds given DotHtml file.
-        /// </summary>
-        /// <param name="file">File to compile</param>
-        /// <param name="foundMasterpages">All found masterpages would be added to this collection during file compilation.</param>
-        /// <returns></returns>
-        bool BuildView(DotHtmlFileInfo file, ConcurrentBag<DotHtmlFileInfo> foundMasterpages = null);
+        /// <param name="buildInParallel">If set, than the compilations will be performed in parallel.</param>
+        /// <param name="forceRecompile">If set, than everything will be recompiled.</param>
+        /// <returns>Returns whether compilation was successful.</returns>
+        Task<bool> CompileAll(bool buildInParallel=true, bool forceRecompile = false);
     }
 }


### PR DESCRIPTION
Added service that allows users to compile DotHTML on demand. This feature was extracted from DotVVM status page.

This is possibly first of two pull requests. U would like to added way how to compile every view during startup (using this service) just by changing DotVVM configuration.