### PR TITLE
Added configuration for view precompilation.

### DIFF
--- a/src/DotVVM.Framework.Hosting.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/src/DotVVM.Framework.Hosting.AspNetCore/ApplicationBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using DotVVM.Framework.Compilation;
 using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Hosting;
 using DotVVM.Framework.Hosting.Middlewares;
@@ -73,6 +74,13 @@ namespace Microsoft.AspNetCore.Builder
                 new DotvvmReturnedFileMiddleware(),
                 new DotvvmRoutingMiddleware()
             }.Where(t => t != null).ToArray());
+
+            var compilationConfiguration = config.Markup.ViewCompilation;
+            if (compilationConfiguration.Mode != ViewCompilationMode.Lazy)
+            {
+                compilationConfiguration.Precompile(config);
+            }
+
             return config;
         }
     }

--- a/src/DotVVM.Framework.Hosting.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/src/DotVVM.Framework.Hosting.AspNetCore/ApplicationBuilderExtensions.cs
@@ -76,6 +76,7 @@ namespace Microsoft.AspNetCore.Builder
             }.Where(t => t != null).ToArray());
 
             var compilationConfiguration = config.Markup.ViewCompilation;
+            compilationConfiguration.Validate();
             if (compilationConfiguration.Mode != ViewCompilationMode.Lazy)
             {
                 compilationConfiguration.Precompile(config);

--- a/src/DotVVM.Framework.Hosting.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/src/DotVVM.Framework.Hosting.AspNetCore/ApplicationBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using DotVVM.Framework.Compilation;
 using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Hosting;
@@ -66,7 +67,7 @@ namespace Microsoft.AspNetCore.Builder
 
             modifyConfiguration?.Invoke(config);
             config.Freeze();
-
+            
             app.UseMiddleware<DotvvmMiddleware>(config, new List<IMiddleware> {
                 ActivatorUtilities.CreateInstance<DotvvmCsrfTokenMiddleware>(config.ServiceProvider),
                 ActivatorUtilities.CreateInstance<DotvvmLocalResourceMiddleware>(app.ApplicationServices),
@@ -76,11 +77,7 @@ namespace Microsoft.AspNetCore.Builder
             }.Where(t => t != null).ToArray());
 
             var compilationConfiguration = config.Markup.ViewCompilation;
-            compilationConfiguration.Validate();
-            if (compilationConfiguration.Mode != ViewCompilationMode.Lazy)
-            {
-                compilationConfiguration.Precompile(config);
-            }
+            compilationConfiguration.HandleViewCompilation(config);
 
             return config;
         }

--- a/src/DotVVM.Framework.Hosting.Owin/AppBuilderExtensions.cs
+++ b/src/DotVVM.Framework.Hosting.Owin/AppBuilderExtensions.cs
@@ -82,7 +82,7 @@ namespace Owin
 
             modifyConfiguration?.Invoke(config);
             config.Freeze();
-
+            
             app.Use<DotvvmMiddleware>(config, new List<IMiddleware> {
                 ActivatorUtilities.CreateInstance<DotvvmCsrfTokenMiddleware>(config.ServiceProvider),
                 ActivatorUtilities.CreateInstance<DotvvmLocalResourceMiddleware>(config.ServiceProvider),
@@ -90,13 +90,9 @@ namespace Owin
                 new DotvvmReturnedFileMiddleware(),
                 new DotvvmRoutingMiddleware()
             }.Where(t => t != null).ToArray());
-            
+
             var compilationConfiguration = config.Markup.ViewCompilation;
-            compilationConfiguration.Validate();
-            if (compilationConfiguration.Mode!=ViewCompilationMode.Lazy)
-            {
-                compilationConfiguration.Precompile(config);
-            }
+            compilationConfiguration.HandleViewCompilation(config);
 
             return config;
         }

--- a/src/DotVVM.Framework.Hosting.Owin/AppBuilderExtensions.cs
+++ b/src/DotVVM.Framework.Hosting.Owin/AppBuilderExtensions.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DotVVM.Framework.Compilation;
 using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Hosting;
 using DotVVM.Framework.Hosting.Middlewares;
@@ -87,6 +90,13 @@ namespace Owin
                 new DotvvmReturnedFileMiddleware(),
                 new DotvvmRoutingMiddleware()
             }.Where(t => t != null).ToArray());
+            
+            var compilationConfiguration = config.Markup.ViewCompilationConfiguration;
+            if (compilationConfiguration.ViewCompilationMode!=ViewCompilationMode.Lazy)
+            {
+                compilationConfiguration.Precompile(config);
+            }
+
             return config;
         }
     }

--- a/src/DotVVM.Framework.Hosting.Owin/AppBuilderExtensions.cs
+++ b/src/DotVVM.Framework.Hosting.Owin/AppBuilderExtensions.cs
@@ -68,6 +68,7 @@ namespace Owin
                 s.TryAddSingleton<ICookieManager, ChunkingCookieManager>();
                 s.TryAddScoped<DotvvmRequestContextStorage>(_ => new DotvvmRequestContextStorage());
                 s.TryAddScoped<IDotvvmRequestContext>(services => services.GetRequiredService<DotvvmRequestContextStorage>().Context);
+                s.AddSingleton<IDotvvmViewCompilationService, DotvvmViewCompilationService>();
                 configurator?.ConfigureServices(new DotvvmServiceCollection(s));
             }, serviceProviderFactoryMethod);
             config.Debug = debug;

--- a/src/DotVVM.Framework.Hosting.Owin/AppBuilderExtensions.cs
+++ b/src/DotVVM.Framework.Hosting.Owin/AppBuilderExtensions.cs
@@ -91,8 +91,9 @@ namespace Owin
                 new DotvvmRoutingMiddleware()
             }.Where(t => t != null).ToArray());
             
-            var compilationConfiguration = config.Markup.ViewCompilationConfiguration;
-            if (compilationConfiguration.ViewCompilationMode!=ViewCompilationMode.Lazy)
+            var compilationConfiguration = config.Markup.ViewCompilation;
+            compilationConfiguration.Validate();
+            if (compilationConfiguration.Mode!=ViewCompilationMode.Lazy)
             {
                 compilationConfiguration.Precompile(config);
             }

--- a/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.AuxOptions.json
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.AuxOptions.json
@@ -5,7 +5,10 @@
       {
         "namespace": "DotVVM.Framework.Binding.HelperNamespace"
       }
-    ]
+    ],
+    "ViewCompilation": {
+      "compileInParallel": true
+    }
   },
   "resources": {},
   "security": {},

--- a/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.ExperimentalFeatures.json
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.ExperimentalFeatures.json
@@ -4,7 +4,10 @@
       {
         "namespace": "DotVVM.Framework.Binding.HelperNamespace"
       }
-    ]
+    ],
+    "ViewCompilation": {
+      "compileInParallel": true
+    }
   },
   "resources": {},
   "security": {},

--- a/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.Markup.json
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.Markup.json
@@ -60,7 +60,10 @@
         },
         "Inherit": true
       }
-    ]
+    ],
+    "ViewCompilation": {
+      "compileInParallel": true
+    }
   },
   "resources": {},
   "security": {},

--- a/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.RestAPI.json
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.RestAPI.json
@@ -19,7 +19,10 @@
         },
         "Inherit": true
       }
-    ]
+    ],
+    "ViewCompilation": {
+      "compileInParallel": true
+    }
   },
   "resources": {
     "DotVVM.Framework.ResourceManagement.InlineScriptResource": {

--- a/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -11,7 +11,10 @@
       {
         "namespace": "DotVVM.Framework.Binding.HelperNamespace"
       }
-    ]
+    ],
+    "ViewCompilation": {
+      "compileInParallel": true
+    }
   },
   "resources": {
     "DotVVM.Framework.ResourceManagement.InlineScriptResource": {

--- a/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.SerializeEmptyConfig.json
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.SerializeEmptyConfig.json
@@ -4,7 +4,10 @@
       {
         "namespace": "DotVVM.Framework.Binding.HelperNamespace"
       }
-    ]
+    ],
+    "ViewCompilation": {
+      "compileInParallel": true
+    }
   },
   "resources": {},
   "security": {},

--- a/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.SerializeResources.json
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.SerializeResources.json
@@ -4,7 +4,10 @@
       {
         "namespace": "DotVVM.Framework.Binding.HelperNamespace"
       }
-    ]
+    ],
+    "ViewCompilation": {
+      "compileInParallel": true
+    }
   },
   "resources": {
     "DotVVM.Framework.ResourceManagement.InlineScriptResource": {

--- a/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.SerializeRoutes.json
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.SerializeRoutes.json
@@ -4,7 +4,10 @@
       {
         "namespace": "DotVVM.Framework.Binding.HelperNamespace"
       }
-    ]
+    ],
+    "ViewCompilation": {
+      "compileInParallel": true
+    }
   },
   "routes": {
     "route1": {

--- a/src/DotVVM.Framework/Compilation/DotvvmViewCompilationServiceExtensions.cs
+++ b/src/DotVVM.Framework/Compilation/DotvvmViewCompilationServiceExtensions.cs
@@ -21,17 +21,13 @@ namespace DotVVM.Framework.Compilation
             });
         }
 
-        public static void HandleViewCompilation(this ViewCompilationConfiguration compilationConfiguration,
-            DotvvmConfiguration config)
+        public static void HandleViewCompilation(this ViewCompilationConfiguration compilationConfiguration, DotvvmConfiguration config)
         {
+            if (compilationConfiguration.Mode == ViewCompilationMode.Lazy)
+                return;
+
             var getCompilationTask = compilationConfiguration.Precompile(config);
-            if (compilationConfiguration.Mode == ViewCompilationMode.AfterStartup)
-            {
-#pragma warning disable 4014
-                getCompilationTask.ConfigureAwait(false);
-#pragma warning restore 4014
-            }
-            else if (compilationConfiguration.Mode == ViewCompilationMode.DuringStartup)
+            if (compilationConfiguration.Mode == ViewCompilationMode.DuringApplicationStart)
             {
                 getCompilationTask.Wait();
             }

--- a/src/DotVVM.Framework/Compilation/DotvvmViewCompilationServiceExtensions.cs
+++ b/src/DotVVM.Framework/Compilation/DotvvmViewCompilationServiceExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading.Tasks;
+using DotVVM.Framework.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DotVVM.Framework.Compilation
+{
+    public static class DotvvmViewCompilationServiceExtensions
+    {
+        public static void Precompile(this ViewCompilationConfiguration compilationConfiguration, DotvvmConfiguration config)
+        {
+            var compilationTask = new Task(async () => {
+                var compilationService = config.ServiceProvider.GetService<IDotvvmViewCompilationService>();
+                if (compilationConfiguration.BackgroundCompilationDelay != null)
+                {
+                    await Task.Delay(compilationConfiguration.BackgroundCompilationDelay.Value);
+                }
+
+                await compilationService.CompileAll(
+                    compilationConfiguration.Mode == ViewCompilationMode.ParallelPrecompilation, false);
+            }, TaskCreationOptions.LongRunning);
+
+            compilationTask.ConfigureAwait(false);
+            compilationTask.Start();
+        }
+    }
+}

--- a/src/DotVVM.Framework/Compilation/ViewCompilationMode.cs
+++ b/src/DotVVM.Framework/Compilation/ViewCompilationMode.cs
@@ -2,8 +2,17 @@ namespace DotVVM.Framework.Compilation
 {
     public enum ViewCompilationMode
     {
+        /// <summary>
+        /// Compilation will be done when do markup is first needed.
+        /// </summary>
         Lazy,
+        /// <summary>
+        /// Compilation will run during application startup. 
+        /// </summary>
         Precompilation,
+        /// <summary> 
+        /// Compilation will run during application startup. Markup will be compiled in parallel. 
+        /// </summary>
         ParallelPrecompilation,
     }
 }

--- a/src/DotVVM.Framework/Compilation/ViewCompilationMode.cs
+++ b/src/DotVVM.Framework/Compilation/ViewCompilationMode.cs
@@ -11,11 +11,11 @@ namespace DotVVM.Framework.Compilation
         /// Compilation will run during application startup.
         /// Application will start after compilation is done.
         /// </summary>
-        DuringStartup,
+        DuringApplicationStart,
         
         /// <summary>
-        /// Compilation will run after application startup.
+        /// Compilation will run after application started.
         /// </summary>
-        AfterStartup
+        AfterApplicationStart
     }
 }

--- a/src/DotVVM.Framework/Compilation/ViewCompilationMode.cs
+++ b/src/DotVVM.Framework/Compilation/ViewCompilationMode.cs
@@ -1,0 +1,9 @@
+namespace DotVVM.Framework.Compilation
+{
+    public enum ViewCompilationMode
+    {
+        Lazy,
+        Precompilation,
+        ParallelPrecompilation,
+    }
+}

--- a/src/DotVVM.Framework/Compilation/ViewCompilationMode.cs
+++ b/src/DotVVM.Framework/Compilation/ViewCompilationMode.cs
@@ -6,13 +6,16 @@ namespace DotVVM.Framework.Compilation
         /// Compilation will be done when do markup is first needed.
         /// </summary>
         Lazy,
+
         /// <summary>
-        /// Compilation will run during application startup. 
+        /// Compilation will run during application startup.
+        /// Application will start after compilation is done.
         /// </summary>
-        Precompilation,
-        /// <summary> 
-        /// Compilation will run during application startup. Markup will be compiled in parallel. 
+        DuringStartup,
+        
+        /// <summary>
+        /// Compilation will run after application startup.
         /// </summary>
-        ParallelPrecompilation,
+        AfterStartup
     }
 }

--- a/src/DotVVM.Framework/Configuration/DotvvmMarkupConfiguration.cs
+++ b/src/DotVVM.Framework/Configuration/DotvvmMarkupConfiguration.cs
@@ -176,7 +176,10 @@ namespace DotVVM.Framework.Configuration
         public void Freeze()
         {
             this.isFrozen = true;
+
+            ViewCompilation.Freeze();
             _controls.Freeze();
+            
             foreach (var c in this.Controls)
                 c.Freeze();
             _assemblies.Freeze();
@@ -184,11 +187,6 @@ namespace DotVVM.Framework.Configuration
             foreach (var t in this.HtmlAttributeTransforms)
                 t.Value.Freeze();
             _defaultDirectives.Freeze();
-        }
-
-        public void Validate()
-        {
-            ViewCompilation.Validate();
         }
     }
 }

--- a/src/DotVVM.Framework/Configuration/DotvvmMarkupConfiguration.cs
+++ b/src/DotVVM.Framework/Configuration/DotvvmMarkupConfiguration.cs
@@ -69,6 +69,9 @@ namespace DotVVM.Framework.Configuration
         }
         private IList<BindingExtensionParameter> _defaultExtensionParameters = new FreezableList<BindingExtensionParameter>();
 
+        public ViewCompilationConfiguration ViewCompilation { get; private set; } = new ViewCompilationConfiguration();
+
+
         public void AddServiceImport(string identifier, Type type)
         {
             ThrowIfFrozen();
@@ -181,6 +184,11 @@ namespace DotVVM.Framework.Configuration
             foreach (var t in this.HtmlAttributeTransforms)
                 t.Value.Freeze();
             _defaultDirectives.Freeze();
+        }
+
+        public void Validate()
+        {
+            ViewCompilation.Validate();
         }
     }
 }

--- a/src/DotVVM.Framework/Configuration/ViewCompilationConfiguration.cs
+++ b/src/DotVVM.Framework/Configuration/ViewCompilationConfiguration.cs
@@ -52,7 +52,7 @@ namespace DotVVM.Framework.Configuration
 
         public void Validate()
         {
-            if (BackgroundCompilationDelay.HasValue && (Mode == ViewCompilationMode.Lazy || Mode==ViewCompilationMode.DuringStartup))
+            if (BackgroundCompilationDelay.HasValue && (Mode == ViewCompilationMode.Lazy || Mode==ViewCompilationMode.DuringApplicationStart))
             {
                 throw new Exception($"{nameof(BackgroundCompilationDelay)} must be null in {nameof(ViewCompilationMode.Lazy)} {nameof(Mode)}.");
             }

--- a/src/DotVVM.Framework/Configuration/ViewCompilationConfiguration.cs
+++ b/src/DotVVM.Framework/Configuration/ViewCompilationConfiguration.cs
@@ -7,6 +7,9 @@ namespace DotVVM.Framework.Configuration
     {
         private bool isFrozen = false;
         private ViewCompilationMode mode;
+        /// <summary>
+        /// Gets or sets the mode under which the view compilation (pages, controls, ... ) is done.
+        /// </summary>
         public ViewCompilationMode Mode
         {
             get => mode;
@@ -17,6 +20,9 @@ namespace DotVVM.Framework.Configuration
         }
 
         private TimeSpan? backgroundCompilationDelay;
+        /// <summary>
+        /// Gets or sets the delay before view compilation will be done. This compilation delay can be set only in precompilation modes.
+        /// </summary>
         public TimeSpan? BackgroundCompilationDelay
         {
             get => backgroundCompilationDelay;

--- a/src/DotVVM.Framework/Configuration/ViewCompilationConfiguration.cs
+++ b/src/DotVVM.Framework/Configuration/ViewCompilationConfiguration.cs
@@ -1,5 +1,6 @@
 using System;
 using DotVVM.Framework.Compilation;
+using Newtonsoft.Json;
 
 namespace DotVVM.Framework.Configuration
 {
@@ -10,6 +11,7 @@ namespace DotVVM.Framework.Configuration
         /// <summary>
         /// Gets or sets the mode under which the view compilation (pages, controls, ... ) is done.
         /// </summary>
+        [JsonProperty("mode")]
         public ViewCompilationMode Mode
         {
             get => mode;
@@ -23,6 +25,7 @@ namespace DotVVM.Framework.Configuration
         /// <summary>
         /// Gets or sets the delay before view compilation will be done. This compilation delay can be set only in precompilation modes.
         /// </summary>
+        [JsonProperty("backgroundCompilationDelay")]
         public TimeSpan? BackgroundCompilationDelay
         {
             get => backgroundCompilationDelay;
@@ -36,6 +39,7 @@ namespace DotVVM.Framework.Configuration
         /// <summary>
         /// Gets or sets whether the view compilation will be performed in parallel or in series.
         /// </summary>
+        [JsonProperty("compileInParallel")]
         public bool CompileInParallel
         {
             get => compileInParallel;

--- a/src/DotVVM.Framework/Configuration/ViewCompilationConfiguration.cs
+++ b/src/DotVVM.Framework/Configuration/ViewCompilationConfiguration.cs
@@ -32,6 +32,19 @@ namespace DotVVM.Framework.Configuration
                 backgroundCompilationDelay = value;
             }
         }
+        private bool compileInParallel = true;
+        /// <summary>
+        /// Gets or sets whether the view compilation will be performed in parallel or in series.
+        /// </summary>
+        public bool CompileInParallel
+        {
+            get => compileInParallel;
+            set
+            {
+                ThrowIfFrozen();
+                compileInParallel = value;
+            }
+        }
 
         public void Validate()
         {
@@ -40,6 +53,13 @@ namespace DotVVM.Framework.Configuration
                 throw new Exception($"{nameof(BackgroundCompilationDelay)} is not supported in {nameof(ViewCompilationMode.Lazy)} {nameof(Mode)}.");
             }
         }
+        
+        public void Freeze()
+        {
+            Validate();
+            this.isFrozen = true;
+        }
+
         private void ThrowIfFrozen()
         {
             if (isFrozen)

--- a/src/DotVVM.Framework/Configuration/ViewCompilationConfiguration.cs
+++ b/src/DotVVM.Framework/Configuration/ViewCompilationConfiguration.cs
@@ -1,0 +1,43 @@
+using System;
+using DotVVM.Framework.Compilation;
+
+namespace DotVVM.Framework.Configuration
+{
+    public sealed class ViewCompilationConfiguration
+    {
+        private bool isFrozen = false;
+        private ViewCompilationMode mode;
+        public ViewCompilationMode Mode
+        {
+            get => mode;
+            set {
+                ThrowIfFrozen();
+                mode = value;
+            }
+        }
+
+        private TimeSpan? backgroundCompilationDelay;
+        public TimeSpan? BackgroundCompilationDelay
+        {
+            get => backgroundCompilationDelay;
+            set
+            {
+                ThrowIfFrozen();
+                backgroundCompilationDelay = value;
+            }
+        }
+
+        public void Validate()
+        {
+            if (BackgroundCompilationDelay.HasValue && Mode == ViewCompilationMode.Lazy)
+            {
+                throw new Exception($"{nameof(BackgroundCompilationDelay)} is not supported in {nameof(ViewCompilationMode.Lazy)} {nameof(Mode)}.");
+            }
+        }
+        private void ThrowIfFrozen()
+        {
+            if (isFrozen)
+                throw FreezableUtils.Error(nameof(DotvvmMarkupConfiguration));
+        }
+    }
+}

--- a/src/DotVVM.Framework/Configuration/ViewCompilationConfiguration.cs
+++ b/src/DotVVM.Framework/Configuration/ViewCompilationConfiguration.cs
@@ -52,9 +52,9 @@ namespace DotVVM.Framework.Configuration
 
         public void Validate()
         {
-            if (BackgroundCompilationDelay.HasValue && Mode == ViewCompilationMode.Lazy)
+            if (BackgroundCompilationDelay.HasValue && (Mode == ViewCompilationMode.Lazy || Mode==ViewCompilationMode.DuringStartup))
             {
-                throw new Exception($"{nameof(BackgroundCompilationDelay)} is not supported in {nameof(ViewCompilationMode.Lazy)} {nameof(Mode)}.");
+                throw new Exception($"{nameof(BackgroundCompilationDelay)} must be null in {nameof(ViewCompilationMode.Lazy)} {nameof(Mode)}.");
             }
         }
         

--- a/src/DotVVM.Framework/Controls/UpdateProgress.cs
+++ b/src/DotVVM.Framework/Controls/UpdateProgress.cs
@@ -93,7 +93,7 @@ namespace DotVVM.Framework.Controls
             {
                 if ((int)delayProperty.Value < 0)
                 {
-                    yield return new ControlUsageError("Delay cannot be set to negative number.");
+                    yield return new ControlUsageError("BackgroundCompilationDelay cannot be set to negative number.");
                 }
             }
 

--- a/src/DotVVM.Framework/Controls/UpdateProgress.cs
+++ b/src/DotVVM.Framework/Controls/UpdateProgress.cs
@@ -93,7 +93,7 @@ namespace DotVVM.Framework.Controls
             {
                 if ((int)delayProperty.Value < 0)
                 {
-                    yield return new ControlUsageError("BackgroundCompilationDelay cannot be set to negative number.");
+                    yield return new ControlUsageError($"{nameof(Delay)} cannot be set to negative number.");
                 }
             }
 
@@ -102,15 +102,15 @@ namespace DotVVM.Framework.Controls
             var excludedQueues = (control.GetValue(ExcludedQueuesProperty) as ResolvedPropertyValue)?.Value as string[];
             if (includedQueues != null && excludedQueues != null)
             {
-                yield return new ControlUsageError("The IncludedQueues and ExcludedQueues cannot be used together!");
+                yield return new ControlUsageError($"The {nameof(IncludedQueues)} and {nameof(ExcludedQueues)} cannot be used together!");
             }
             if (includedQueues != null && !ValidateQueueNames(includedQueues))
             {
-                yield return new ControlUsageError("The IncludedQueues must contain comma-separated list of queue names (which can contain alphanumeric characters, underscore or dash)!");
+                yield return new ControlUsageError($"The {nameof(IncludedQueues)} must contain comma-separated list of queue names (which can contain alphanumeric characters, underscore or dash)!");
             }
             if (excludedQueues != null && !ValidateQueueNames(excludedQueues))
             {
-                yield return new ControlUsageError("The ExcludedQueues must contain comma-separated list of queue names (which can contain alphanumeric characters, underscore or dash)!");
+                yield return new ControlUsageError($"The {nameof(ExcludedQueues)} must contain comma-separated list of queue names (which can contain alphanumeric characters, underscore or dash)!");
             }
         }
 


### PR DESCRIPTION
This PR adds configuration for view compilation modes.
```
/// Gets or sets the mode under which the view compilation (pages, controls, ... ) is done.
configuration.Markup.ViewCompilation.Mode = ViewCompilationMode.AfterStartup;

/// Gets or sets the delay before view compilation will be done. This compilation delay can be set only in precompilation modes.
configuration.Markup.ViewCompilation.BackgroundCompilationDelay = TimeSpan.FromMinutes(1);
```

Compilation modes are:
- Lazy 
Current mode of compilation.
- DuringApplicationStart
Compilation will run during application startup. Application will start after compilation is done.
- AfterApplicationStart
Compilation will run after application startup.