### PR TITLE
Added support for multiple SpaContentPlaceHolders per page

### DIFF
--- a/src/DotVVM.Framework/Resources/Scripts/spa/navigation.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/spa/navigation.ts
@@ -7,7 +7,7 @@ import { loadResourceList } from '../postback/resourceLoader';
 import * as updater from '../postback/updater';
 import * as counter from '../postback/counter';
 import * as events from './events';
-import { getSpaPlaceHolderUniqueId, isSpaReady } from './spa';
+import { getSpaPlaceHoldersUniqueId, isSpaReady } from './spa';
 import { handleRedirect } from '../postback/redirect';
 import * as gate from '../postback/gate';
 
@@ -35,7 +35,7 @@ export async function navigateCore(url: string, handlePageNavigating?: (url: str
         const displayUrl = uri.addVirtualDirectoryToUrl(url);
 
         // send the request
-        const resultObject = await http.getJSON<any>(spaFullUrl, getSpaPlaceHolderUniqueId());
+        const resultObject = await http.getJSON<any>(spaFullUrl, getSpaPlaceHoldersUniqueId());
 
         // if another postback has already been passed, don't do anything
         if (!counter.isPostBackStillActive(currentPostBackCounter)) {

--- a/src/DotVVM.Framework/Resources/Scripts/spa/spa.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/spa/spa.ts
@@ -13,12 +13,10 @@ export function init(): void {
         throw new Error("No SpaContentPlaceHolder control was found!");
     }
 
-    spaPlaceHolders.forEach(function (spa) {
-        window.addEventListener("hashchange", event => handleHashChangeWithHistory(spa, false));
-        handleHashChangeWithHistory(spa, true);
+    window.addEventListener("hashchange", event => handleHashChangeWithHistory(spaPlaceHolders, false));
+    handleHashChangeWithHistory(spaPlaceHolders, true);
 
-        window.addEventListener('popstate', event => handlePopState(event, spa != null));
-    });
+    window.addEventListener('popstate', event => handlePopState(event, spaPlaceHolders[0] != null));
 }
 
 function getSpaPlaceHolders(): NodeListOf<HTMLElement> | null {
@@ -47,7 +45,7 @@ function handlePopState(event: PopStateEvent, inSpaPage: boolean) {
     }
 }
 
-function handleHashChangeWithHistory(spaPlaceHolder: HTMLElement, isInitialPageLoad: boolean) {
+function handleHashChangeWithHistory(spaPlaceHolders: NodeListOf<HTMLElement>, isInitialPageLoad: boolean) {
     if (document.location.hash.indexOf("#!/") === 0) {
         // the user requested navigation to another SPA page
         navigateCore(
@@ -56,7 +54,9 @@ function handleHashChangeWithHistory(spaPlaceHolder: HTMLElement, isInitialPageL
         );
     } else {
         isSpaReady(true);
-        spaPlaceHolder.style.display = "";
+        spaPlaceHolders.forEach(function (element) {
+            element.style.display = "";
+        });
 
         const currentRelativeUrl = location.pathname + location.search + location.hash
         replacePage(currentRelativeUrl);

--- a/src/DotVVM.Framework/Resources/Scripts/spa/spa.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/spa/spa.ts
@@ -9,7 +9,7 @@ export const isSpaReady = ko.observable(false);
 
 export function init(): void {
     const spaPlaceHolders = getSpaPlaceHolders();
-    if (spaPlaceHolders == null || spaPlaceHolders.length == 0) {
+    if (spaPlaceHolders.length == 0) {
         throw new Error("No SpaContentPlaceHolder control was found!");
     }
 
@@ -19,12 +19,12 @@ export function init(): void {
     window.addEventListener('popstate', event => handlePopState(event, true));
 }
 
-function getSpaPlaceHolders(): NodeListOf<HTMLElement> | null {
+function getSpaPlaceHolders(): NodeListOf<HTMLElement> {
     return document.getElementsByName("__dot_SpaContentPlaceHolder");
 }
 
 export function getSpaPlaceHoldersUniqueId(): string {
-    const spas = Array.from(getSpaPlaceHolders()!);
+    const spas = Array.from(getSpaPlaceHolders());
     const identifiers = spas.map((element) =>
     {
         return element.getAttribute("data-dotvvm-spacontentplaceholder")?.valueOf()

--- a/src/DotVVM.Framework/Resources/Scripts/spa/spa.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/spa/spa.ts
@@ -8,27 +8,30 @@ import { DotvvmPostbackError } from '../shared-classes';
 export const isSpaReady = ko.observable(false);
 
 export function init(): void {
-    const spaPlaceHolder = getSpaPlaceHolder();
-    if (spaPlaceHolder == null) {
-        throw new Error("The SpaContentPlaceHolder control was not found!");
+    const spaPlaceHolders = getSpaPlaceHolders();
+    if (!spaPlaceHolders) {
+        throw new Error("No SpaContentPlaceHolder control was found!");
     }
 
-    window.addEventListener("hashchange", event => handleHashChangeWithHistory(spaPlaceHolder, false));
-    handleHashChangeWithHistory(spaPlaceHolder, true);
+    spaPlaceHolders.forEach(function (spa) {
+        window.addEventListener("hashchange", event => handleHashChangeWithHistory(spa, false));
+        handleHashChangeWithHistory(spa, true);
 
-    window.addEventListener('popstate', event => handlePopState(event, spaPlaceHolder != null));
+        window.addEventListener('popstate', event => handlePopState(event, spa != null));
+    });
 }
 
-function getSpaPlaceHolder(): HTMLElement | null {
-    const elements = document.getElementsByName("__dot_SpaContentPlaceHolder");
-    if (elements.length == 1) {
-        return <HTMLElement> elements[0];
-    }
-    return null;
+function getSpaPlaceHolders(): NodeListOf<HTMLElement> | null {
+    return document.getElementsByName("__dot_SpaContentPlaceHolder");
 }
 
-export function getSpaPlaceHolderUniqueId(): string {
-    return getSpaPlaceHolder()!.getAttribute("data-dotvvm-spacontentplaceholder")!;
+export function getSpaPlaceHoldersUniqueId(): string {  
+    let identifier = "";
+    getSpaPlaceHolders()!.forEach(function (element) {
+        identifier += element.getAttribute("data-dotvvm-spacontentplaceholder")?.valueOf();
+    });
+
+    return identifier;
 }
 
 function handlePopState(event: PopStateEvent, inSpaPage: boolean) {

--- a/src/DotVVM.Framework/Resources/Scripts/spa/spa.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/spa/spa.ts
@@ -9,27 +9,28 @@ export const isSpaReady = ko.observable(false);
 
 export function init(): void {
     const spaPlaceHolders = getSpaPlaceHolders();
-    if (!spaPlaceHolders) {
+    if (spaPlaceHolders == null || spaPlaceHolders.length == 0) {
         throw new Error("No SpaContentPlaceHolder control was found!");
     }
 
     window.addEventListener("hashchange", event => handleHashChangeWithHistory(spaPlaceHolders, false));
     handleHashChangeWithHistory(spaPlaceHolders, true);
 
-    window.addEventListener('popstate', event => handlePopState(event, spaPlaceHolders[0] != null));
+    window.addEventListener('popstate', event => handlePopState(event, true));
 }
 
 function getSpaPlaceHolders(): NodeListOf<HTMLElement> | null {
     return document.getElementsByName("__dot_SpaContentPlaceHolder");
 }
 
-export function getSpaPlaceHoldersUniqueId(): string {  
-    let identifier = "";
-    getSpaPlaceHolders()!.forEach(function (element) {
-        identifier += element.getAttribute("data-dotvvm-spacontentplaceholder")?.valueOf();
+export function getSpaPlaceHoldersUniqueId(): string {
+    const spas = Array.from(getSpaPlaceHolders()!);
+    const identifiers = spas.map((element) =>
+    {
+        return element.getAttribute("data-dotvvm-spacontentplaceholder")?.valueOf()
     });
 
-    return identifier;
+    return identifiers.join(';');
 }
 
 function handlePopState(event: PopStateEvent, inSpaPage: boolean) {

--- a/src/DotVVM.Framework/Runtime/DefaultDotvvmViewBuilder.cs
+++ b/src/DotVVM.Framework/Runtime/DefaultDotvvmViewBuilder.cs
@@ -70,11 +70,8 @@ namespace DotVVM.Framework.Runtime
             if (context.IsSpaRequest)
             {
                 var spaContentPlaceHolders = page.GetAllDescendants().OfType<SpaContentPlaceHolder>().ToList();
-                if (spaContentPlaceHolders.Count > 1)
-                {
-                    throw new Exception("Multiple controls of type <dot:SpaContentPlaceHolder /> found on the page! This control can be used only once!");   // TODO: exception handling
-                }
-                if (spaContentPlaceHolders.Count == 0 || spaContentPlaceHolders[0].GetSpaContentPlaceHolderUniqueId() != context.GetSpaContentPlaceHolderUniqueId())
+
+                if (spaContentPlaceHolders.Count == 0 || !context.GetSpaContentPlaceHolderUniqueId().Contains(spaContentPlaceHolders[0].GetSpaContentPlaceHolderUniqueId()))
                 {
                     // the client has loaded different page which does not contain current SpaContentPlaceHolder - he needs to be redirected
                     context.RedirectToUrl(context.HttpContext.Request.Url.AbsoluteUri.Replace("/" + HostingConstants.SpaUrlIdentifier, ""));

--- a/src/DotVVM.Framework/Runtime/DefaultDotvvmViewBuilder.cs
+++ b/src/DotVVM.Framework/Runtime/DefaultDotvvmViewBuilder.cs
@@ -70,8 +70,9 @@ namespace DotVVM.Framework.Runtime
             if (context.IsSpaRequest)
             {
                 var spaContentPlaceHolders = page.GetAllDescendants().OfType<SpaContentPlaceHolder>().ToList();
+                var spaContentPlaceHolderIds = context.GetSpaContentPlaceHolderUniqueId().Split(';');
 
-                if (spaContentPlaceHolders.Count == 0 || !context.GetSpaContentPlaceHolderUniqueId().Contains(spaContentPlaceHolders[0].GetSpaContentPlaceHolderUniqueId()))
+                if (spaContentPlaceHolders.Count == 0 || !spaContentPlaceHolderIds.Contains(spaContentPlaceHolders[0].GetSpaContentPlaceHolderUniqueId()))
                 {
                     // the client has loaded different page which does not contain current SpaContentPlaceHolder - he needs to be redirected
                     context.RedirectToUrl(context.HttpContext.Request.Url.AbsoluteUri.Replace("/" + HostingConstants.SpaUrlIdentifier, ""));

--- a/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/MultiSpaDefaultViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/MultiSpaDefaultViewModel.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.SpaContentPlaceHolder_HistoryApi
+{
+    public class MultiSpaDefaultViewModel : MultiSpaMasterViewModel
+    {
+    }
+}

--- a/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/MultiSpaMasterViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/MultiSpaMasterViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.SpaContentPlaceHolder_HistoryApi
+{
+    public class MultiSpaMasterViewModel : DotvvmViewModelBase
+    {
+    }
+}

--- a/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa1PageAViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa1PageAViewModel.cs
@@ -6,6 +6,5 @@ namespace DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.SpaContentPlaceH
 {
     public class Spa1PageAViewModel : MultiSpaMasterViewModel
     {
-        public string Text { get; set; } = "Text from SPA1 PageA";
     }
 }

--- a/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa1PageAViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa1PageAViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.SpaContentPlaceHolder_HistoryApi
+{
+    public class Spa1PageAViewModel : MultiSpaMasterViewModel
+    {
+        public string Text { get; set; } = "Text from SPA1 PageA";
+    }
+}

--- a/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa1PageBViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa1PageBViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.SpaContentPlaceHolder_HistoryApi
+{
+    public class Spa1PageBViewModel : MultiSpaMasterViewModel
+    {
+        public string Text { get; set; } = "Text from SPA1 PageB";
+    }
+}

--- a/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa1PageBViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa1PageBViewModel.cs
@@ -6,6 +6,5 @@ namespace DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.SpaContentPlaceH
 {
     public class Spa1PageBViewModel : MultiSpaMasterViewModel
     {
-        public string Text { get; set; } = "Text from SPA1 PageB";
     }
 }

--- a/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa1Spa2ViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa1Spa2ViewModel.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.SpaContentPlaceHolder_HistoryApi
+{
+    public class Spa1Spa2ViewModel : MultiSpaMasterViewModel
+    {
+    }
+}

--- a/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa2PageAViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa2PageAViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.SpaContentPlaceHolder_HistoryApi
+{
+    public class Spa2PageAViewModel : MultiSpaMasterViewModel
+    {
+        public DateTime Date { get; set; }
+    }
+}

--- a/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa2PageAViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa2PageAViewModel.cs
@@ -6,6 +6,5 @@ namespace DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.SpaContentPlaceH
 {
     public class Spa2PageAViewModel : MultiSpaMasterViewModel
     {
-        public DateTime Date { get; set; }
     }
 }

--- a/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa2PageBViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa2PageBViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.SpaContentPlaceHolder_HistoryApi
+{
+    public class Spa2PageBViewModel : MultiSpaMasterViewModel
+    {
+        public DateTime Date { get; set; }
+    }
+}

--- a/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa2PageBViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa2PageBViewModel.cs
@@ -6,6 +6,5 @@ namespace DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.SpaContentPlaceH
 {
     public class Spa2PageBViewModel : MultiSpaMasterViewModel
     {
-        public DateTime Date { get; set; }
     }
 }

--- a/src/DotVVM.Samples.Common/Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/MultiSpaDefault.dothtml
+++ b/src/DotVVM.Samples.Common/Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/MultiSpaDefault.dothtml
@@ -1,0 +1,12 @@
+@viewModel DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.SpaContentPlaceHolder_HistoryApi.MultiSpaDefaultViewModel, DotVVM.Samples.Common
+@masterPage Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/MultiSpaMaster.dotmaster
+
+<dot:Content ContentPlaceHolderID="FirstSpa">
+
+
+</dot:Content>
+
+<dot:Content ContentPlaceHolderID="SecondSpa">
+
+
+</dot:Content>

--- a/src/DotVVM.Samples.Common/Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/MultiSpaMaster.dotmaster
+++ b/src/DotVVM.Samples.Common/Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/MultiSpaMaster.dotmaster
@@ -1,0 +1,53 @@
+@viewModel DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.SpaContentPlaceHolder_HistoryApi.MultiSpaMasterViewModel, DotVVM.Samples.Common
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title>SPA test application</title>
+    <style>
+        .completed {
+            color: maroon;
+            text-decoration: line-through;
+        }
+        form 
+		{
+			border: solid 3px red;
+		}
+    </style>
+</head>
+<body>
+    <div class="container">
+
+        <menu>
+            <li>
+                <dot:RouteLink RouteName="ControlSamples_SpaContentPlaceHolder_HistoryApi_Spa1PageA" Text="SPA1: Page A" />
+            </li>
+            <li>
+                <dot:RouteLink RouteName="ControlSamples_SpaContentPlaceHolder_HistoryApi_Spa1PageB" Text="SPA1: Page B" />
+            </li>
+            <li>
+                <dot:RouteLink RouteName="ControlSamples_SpaContentPlaceHolder_HistoryApi_Spa2PageA" Text="SPA2: Page A" />
+            </li>
+            <li>
+                <dot:RouteLink RouteName="ControlSamples_SpaContentPlaceHolder_HistoryApi_Spa2PageB" Text="SPA2: Page B" />
+            </li>
+        </menu>
+
+        <form>
+            <h3>First SPA</h3>
+            <dot:SpaContentPlaceHolder ID="FirstSpa" />
+            <h3>First SPA</h3>
+        </form>
+
+        </br>
+
+        <form>
+            <h3>Second SPA</h3>
+            <dot:SpaContentPlaceHolder ID="SecondSpa" />
+            <h3>Second SPA</h3>
+        </form>
+
+    </div>
+</body>
+</html>

--- a/src/DotVVM.Samples.Common/Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/MultiSpaMaster.dotmaster
+++ b/src/DotVVM.Samples.Common/Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/MultiSpaMaster.dotmaster
@@ -32,11 +32,16 @@
             <li>
                 <dot:RouteLink RouteName="ControlSamples_SpaContentPlaceHolder_HistoryApi_Spa2PageB" Text="SPA2: Page B" />
             </li>
+            <li>
+                <dot:RouteLink RouteName="ControlSamples_SpaContentPlaceHolder_HistoryApi_Spa1Spa2Page" Text="Spa1 + Spa2" />
+            </li>
         </menu>
 
         <form>
             <h3>First SPA</h3>
-            <dot:SpaContentPlaceHolder ID="FirstSpa" />
+            <dot:SpaContentPlaceHolder ID="FirstSpa">
+                Default SPA1 content
+            </dot:SpaContentPlaceHolder>
             <h3>First SPA</h3>
         </form>
 
@@ -44,7 +49,9 @@
 
         <form>
             <h3>Second SPA</h3>
-            <dot:SpaContentPlaceHolder ID="SecondSpa" />
+            <dot:SpaContentPlaceHolder ID="SecondSpa">
+                Default SPA2 content
+            </dot:SpaContentPlaceHolder>
             <h3>Second SPA</h3>
         </form>
 

--- a/src/DotVVM.Samples.Common/Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa1PageA.dothtml
+++ b/src/DotVVM.Samples.Common/Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa1PageA.dothtml
@@ -1,0 +1,8 @@
+@viewModel DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.SpaContentPlaceHolder_HistoryApi.Spa1PageAViewModel, DotVVM.Samples.Common
+@masterPage Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/MultiSpaMaster.dotmaster
+
+<dot:Content ContentPlaceHolderID="FirstSpa">
+    
+    <dot:RouteLink RouteName="ControlSamples_SpaContentPlaceHolder_HistoryApi_Spa1PageB" Text="SPA1: Go to Second Page" />
+
+</dot:Content>

--- a/src/DotVVM.Samples.Common/Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa1PageB.dothtml
+++ b/src/DotVVM.Samples.Common/Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa1PageB.dothtml
@@ -1,0 +1,8 @@
+@viewModel DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.SpaContentPlaceHolder_HistoryApi.Spa1PageBViewModel, DotVVM.Samples.Common
+@masterPage Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/MultiSpaMaster.dotmaster
+
+<dot:Content ContentPlaceHolderID="FirstSpa">
+    
+    <dot:RouteLink RouteName="ControlSamples_SpaContentPlaceHolder_HistoryApi_Spa1PageA" Text="SPA1: Go to First Page" />
+
+</dot:Content>

--- a/src/DotVVM.Samples.Common/Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa1Spa2Page.dothtml
+++ b/src/DotVVM.Samples.Common/Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa1Spa2Page.dothtml
@@ -1,0 +1,14 @@
+@viewModel DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.SpaContentPlaceHolder_HistoryApi.Spa1Spa2ViewModel, DotVVM.Samples.Common
+@masterPage Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/MultiSpaMaster.dotmaster
+
+<dot:Content ContentPlaceHolderID="FirstSpa">
+    
+    <dot:Literal Text="SPA1: Hello World!" />
+
+</dot:Content>
+
+<dot:Content ContentPlaceHolderID="SecondSpa">
+    
+    <dot:Literal Text="SPA2: Hello World!" />
+
+</dot:Content>

--- a/src/DotVVM.Samples.Common/Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa2PageA.dothtml
+++ b/src/DotVVM.Samples.Common/Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa2PageA.dothtml
@@ -1,0 +1,8 @@
+@viewModel DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.SpaContentPlaceHolder_HistoryApi.Spa2PageAViewModel, DotVVM.Samples.Common
+@masterPage Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/MultiSpaMaster.dotmaster
+
+<dot:Content ContentPlaceHolderID="SecondSpa">
+    
+    <dot:RouteLink RouteName="ControlSamples_SpaContentPlaceHolder_HistoryApi_Spa2PageB" Text="SPA2: Go to Second Page" />
+
+</dot:Content>

--- a/src/DotVVM.Samples.Common/Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa2PageB.dothtml
+++ b/src/DotVVM.Samples.Common/Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa2PageB.dothtml
@@ -1,0 +1,8 @@
+@viewModel DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.SpaContentPlaceHolder_HistoryApi.Spa2PageBViewModel, DotVVM.Samples.Common
+@masterPage Views/ControlSamples/SpaContentPlaceHolder_HistoryApi/MultiSpaMaster.dotmaster
+
+<dot:Content ContentPlaceHolderID="SecondSpa">
+    
+    <dot:RouteLink RouteName="ControlSamples_SpaContentPlaceHolder_HistoryApi_Spa2PageA" Text="SPA2: Go to First Page" />
+
+</dot:Content>

--- a/src/DotVVM.Samples.Tests/Control/SpaContentPlaceHolderTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/SpaContentPlaceHolderTests.cs
@@ -231,6 +231,37 @@ namespace DotVVM.Samples.Tests.Control
             });
         }
 
+        [Fact]
+        public void Control_SpaContentPlaceHolder_SpaContentPlaceHolder_HistoryApi_MultipleSpas()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.ControlSamples_SpaContentPlaceHolder_HistoryApi_MultiSpaDefault);
+                browser.Wait();
+
+                var defaultUrl = browser.CurrentUrl;
+                var baseUrl = browser.CurrentUrl.Substring(0, browser.CurrentUrlPath.LastIndexOf('/'));
+                var routeLinks = browser.FindElements("a");
+
+                routeLinks.First().Click().Wait();
+                AssertUI.UrlEquals(browser, $"{baseUrl}/Spa1PageA");
+                routeLinks.Skip(1).First().Click().Wait();
+                AssertUI.UrlEquals(browser, $"{baseUrl}/Spa1PageB");
+                routeLinks.Skip(2).First().Click().Wait();
+                AssertUI.UrlEquals(browser, $"{baseUrl}/Spa2PageA");
+                routeLinks.Skip(3).First().Click().Wait();
+                AssertUI.UrlEquals(browser, $"{baseUrl}/Spa2PageB");
+
+                browser.NavigateBack();
+                AssertUI.UrlEquals(browser, $"{baseUrl}/Spa2PageA");
+                browser.NavigateBack();
+                AssertUI.UrlEquals(browser, $"{baseUrl}/Spa1PageB");
+                browser.NavigateBack();
+                AssertUI.UrlEquals(browser, $"{baseUrl}/Spa1PageA");
+                browser.NavigateBack();
+                AssertUI.UrlEquals(browser, defaultUrl);
+            });
+        }
+
         public SpaContentPlaceHolderTests(ITestOutputHelper output) : base(output)
         {
         }

--- a/src/DotVVM.Samples.Tests/Control/SpaContentPlaceHolderTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/SpaContentPlaceHolderTests.cs
@@ -7,6 +7,7 @@ using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Riganti.Selenium.Core;
+using Riganti.Selenium.Core.Abstractions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -234,6 +235,9 @@ namespace DotVVM.Samples.Tests.Control
         [Fact]
         public void Control_SpaContentPlaceHolder_SpaContentPlaceHolder_HistoryApi_MultipleSpas()
         {
+            void CheckOnlyOneSpaRouteLink(IBrowserWrapper browser)
+                => Xunit.Assert.StrictEqual(1, browser.FindElements("a").Where(elem => elem.GetText().Contains(": Go to ")).Count());
+
             RunInAllBrowsers(browser => {
                 browser.NavigateToUrl(SamplesRouteUrls.ControlSamples_SpaContentPlaceHolder_HistoryApi_MultiSpaDefault);
                 browser.Wait();
@@ -244,13 +248,31 @@ namespace DotVVM.Samples.Tests.Control
 
                 routeLinks.First().Click().Wait();
                 AssertUI.UrlEquals(browser, $"{baseUrl}/Spa1PageA");
+                CheckOnlyOneSpaRouteLink(browser);
+                browser.FindElements("a").Single(elem => elem.GetText() == "SPA1: Go to Second Page");
+
                 routeLinks.Skip(1).First().Click().Wait();
                 AssertUI.UrlEquals(browser, $"{baseUrl}/Spa1PageB");
+                CheckOnlyOneSpaRouteLink(browser);
+                browser.FindElements("a").Single(elem => elem.GetText() == "SPA1: Go to First Page");
+
                 routeLinks.Skip(2).First().Click().Wait();
                 AssertUI.UrlEquals(browser, $"{baseUrl}/Spa2PageA");
+                CheckOnlyOneSpaRouteLink(browser);
+                browser.FindElements("a").Single(elem => elem.GetText() == "SPA2: Go to Second Page");
+
                 routeLinks.Skip(3).First().Click().Wait();
                 AssertUI.UrlEquals(browser, $"{baseUrl}/Spa2PageB");
+                CheckOnlyOneSpaRouteLink(browser);
+                browser.FindElements("a").Single(elem => elem.GetText().Contains("SPA2: Go to First Page"));
 
+                routeLinks.Skip(4).First().Click().Wait();
+                AssertUI.UrlEquals(browser, $"{baseUrl}/Spa1Spa2Page");
+                browser.FindElements("span").Single(elem => elem.GetText() == "SPA1: Hello World!");
+                browser.FindElements("span").Single(elem => elem.GetText() == "SPA2: Hello World!");
+
+                browser.NavigateBack();
+                AssertUI.UrlEquals(browser, $"{baseUrl}/Spa2PageB");
                 browser.NavigateBack();
                 AssertUI.UrlEquals(browser, $"{baseUrl}/Spa2PageA");
                 browser.NavigateBack();

--- a/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
@@ -123,8 +123,13 @@ namespace DotVVM.Testing.Abstractions
         public const string ControlSamples_RouteLink_RouteLinkUrlGen = "ControlSamples/RouteLink/RouteLinkUrlGen";
         public const string ControlSamples_RouteLink_TestRoute = "ControlSamples/RouteLink/TestRoute";
         public const string ControlSamples_SpaContentPlaceHolder_HistoryApi_Default = "ControlSamples/SpaContentPlaceHolder_HistoryApi/Default";
+        public const string ControlSamples_SpaContentPlaceHolder_HistoryApi_MultiSpaDefault = "ControlSamples/SpaContentPlaceHolder_HistoryApi/MultiSpaDefault";
         public const string ControlSamples_SpaContentPlaceHolder_HistoryApi_PageA = "ControlSamples/SpaContentPlaceHolder_HistoryApi/PageA";
         public const string ControlSamples_SpaContentPlaceHolder_HistoryApi_PageB = "ControlSamples/SpaContentPlaceHolder_HistoryApi/PageB";
+        public const string ControlSamples_SpaContentPlaceHolder_HistoryApi_Spa1PageA = "ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa1PageA";
+        public const string ControlSamples_SpaContentPlaceHolder_HistoryApi_Spa1PageB = "ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa1PageB";
+        public const string ControlSamples_SpaContentPlaceHolder_HistoryApi_Spa2PageA = "ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa2PageA";
+        public const string ControlSamples_SpaContentPlaceHolder_HistoryApi_Spa2PageB = "ControlSamples/SpaContentPlaceHolder_HistoryApi/Spa2PageB";
         public const string ControlSamples_TextBox_IntBoundTextBox = "ControlSamples/TextBox/IntBoundTextBox";
         public const string ControlSamples_TextBox_SelectAllOnFocus = "ControlSamples/TextBox/SelectAllOnFocus";
         public const string ControlSamples_TextBox_SimpleDateBox = "ControlSamples/TextBox/SimpleDateBox";


### PR DESCRIPTION
This PR lifts the restriction on having only a single `SpaContentPlaceHolder` per page. Resolves #719 