### PR TITLE
Fixed NullReferenceException on postback when Task is returned

### DIFF
--- a/src/DotVVM.Framework/Utils/TaskUtils.cs
+++ b/src/DotVVM.Framework/Utils/TaskUtils.cs
@@ -28,9 +28,10 @@ namespace DotVVM.Framework.Utils
         {
             var type = task.GetType();
 
-            if (type != typeof(Task))
+            var resultProperty = type.GetProperty("Result");
+            if (type != typeof(Task) && resultProperty != null)
             {
-                var taskResultPropertyName = type.GetProperty("Result")!.PropertyType.Name;
+                var taskResultPropertyName = resultProperty.PropertyType.Name;
                 return taskResultPropertyName == "VoidTaskResult" || taskResultPropertyName == "VoidResult";
             }
 


### PR DESCRIPTION
This PR implements a fix for `NullReferenceException` as described in #828.

Code was failing for all subclasses of `System.Threading.Task` that did not have the `Result` property. Resolves #828.