### PR TITLE
Support nested ProtectAttribute

### DIFF
--- a/src/DotVVM.Framework/Hosting/ErrorPages/ErrorFormatter.cs
+++ b/src/DotVVM.Framework/Hosting/ErrorPages/ErrorFormatter.cs
@@ -272,7 +272,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
                 ErrorLength = errorLength
             };
 
-            if (fileName != null)
+            if (!string.IsNullOrEmpty(fileName))
             {
                 try
                 {

--- a/src/DotVVM.Framework/ViewModel/Serialization/EncryptedValuesReader.cs
+++ b/src/DotVVM.Framework/ViewModel/Serialization/EncryptedValuesReader.cs
@@ -14,6 +14,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
         Stack<(int prop, JObject obj)> stack = new Stack<(int prop, JObject obj)>();
         int virtualNests = 0;
         int lastPropertyIndex = -1;
+        public bool Suppressed { get; private set; } = false;
 
         public EncryptedValuesReader(JObject json)
         {
@@ -62,8 +63,22 @@ namespace DotVVM.Framework.ViewModel.Serialization
             lastPropertyIndex = stack.Pop().prop;
         }
 
+        public void Suppress()
+        {
+            if (Suppressed) throw SecurityError();
+            Suppressed = true;
+        }
+
+        public void EndSuppress()
+        {
+            if (!Suppressed) throw SecurityError();
+            Suppressed = false;
+        }
+
         public JToken ReadValue(int property)
         {
+            if (Suppressed) throw SecurityError();
+
             var prop = Property(property);
             if (prop == null) throw SecurityError();
             prop.Remove();

--- a/src/DotVVM.Framework/ViewModel/Serialization/EncryptedValuesReader.cs
+++ b/src/DotVVM.Framework/ViewModel/Serialization/EncryptedValuesReader.cs
@@ -34,6 +34,9 @@ namespace DotVVM.Framework.ViewModel.Serialization
 
         public void Nest(int property)
         {
+            if (Suppressed)
+                return;
+
             var prop = Property(property);
             if (prop != null)
             {
@@ -51,6 +54,9 @@ namespace DotVVM.Framework.ViewModel.Serialization
 
         public void AssertEnd()
         {
+            if (Suppressed)
+                return;
+
             if (virtualNests > 0)
             {
                 virtualNests--;

--- a/src/DotVVM.Framework/ViewModel/Serialization/EncryptedValuesWriter.cs
+++ b/src/DotVVM.Framework/ViewModel/Serialization/EncryptedValuesWriter.cs
@@ -13,6 +13,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
         int virtualNests = 0;
         int lastPropertyIndex = -1;
         int suppress = 0;
+        public int SuppressedLevel => suppress;
 
         public EncryptedValuesWriter(JsonWriter jsonWriter)
         {

--- a/src/DotVVM.Framework/ViewModel/Serialization/EncryptedValuesWriter.cs
+++ b/src/DotVVM.Framework/ViewModel/Serialization/EncryptedValuesWriter.cs
@@ -12,6 +12,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
         Stack<int> propertyIndices = new Stack<int>();
         int virtualNests = 0;
         int lastPropertyIndex = -1;
+        int suppress = 0;
 
         public EncryptedValuesWriter(JsonWriter jsonWriter)
         {
@@ -27,9 +28,21 @@ namespace DotVVM.Framework.ViewModel.Serialization
         /// </summary>
         public void Nest(int property)
         {
+            if (suppress > 0) return;
+
             propertyIndices.Push(property);
             lastPropertyIndex = -1;
             virtualNests++;
+        }
+
+        public void Suppress()
+        {
+            suppress++;
+        }
+
+        public void EndSuppress()
+        {
+            suppress--;
         }
 
         /// <summary>
@@ -38,6 +51,8 @@ namespace DotVVM.Framework.ViewModel.Serialization
         /// </summary>
         public void End()
         {
+            if (suppress > 0) return;
+
             if (virtualNests > 0)
             {
                 virtualNests--;
@@ -54,6 +69,8 @@ namespace DotVVM.Framework.ViewModel.Serialization
         /// </summary>
         public void ClearEmptyNest()
         {
+            if (suppress > 0) return;
+
             if (virtualNests <= 0) throw new NotSupportedException("There is no empty (virtual) nest to be cleared.");
             virtualNests--;
             lastPropertyIndex = propertyIndices.Pop();
@@ -84,6 +101,8 @@ namespace DotVVM.Framework.ViewModel.Serialization
         /// </summary>
         public void WriteValue(int propertyIndex, object value)
         {
+            if (suppress > 0) return;
+
             EnsureObjectStarted();
             WritePropertyName(propertyIndex);
             lastPropertyIndex = propertyIndex;

--- a/src/DotVVM.Framework/ViewModel/Serialization/ViewModelJsonConverter.cs
+++ b/src/DotVVM.Framework/ViewModel/Serialization/ViewModelJsonConverter.cs
@@ -91,7 +91,11 @@ namespace DotVVM.Framework.ViewModel.Serialization
             {
                 // safety check: we are not leaking suppressed reader accidentally
                 if (evSuppressed != evReader.Value.Suppressed)
+                {
+                    // Newtonsoft.Json may catch and consume the exception - kill the reader to be sure that deserialization can not continue
+                    reader.Close();
                     throw new SecurityException("encrypted values state corrupted.");
+                }
             }
         }
 
@@ -111,7 +115,11 @@ namespace DotVVM.Framework.ViewModel.Serialization
             {
                 // safety check: we are not leaking suppressed reader accidentally
                 if (evSuppressLevel != evWriter.Value.SuppressedLevel)
+                {
+                    // Newtonsoft.Json may catch and consume the exception - kill the writer to be sure that serialization can not continue
+                    writer.Close();
                     throw new SecurityException("encrypted values state corrupted.");
+                }
             }
         }
 
@@ -131,7 +139,11 @@ namespace DotVVM.Framework.ViewModel.Serialization
             {
                 // safety check: we are not leaking suppressed reader accidentally
                 if (evSuppressed != evReader.Value.Suppressed)
+                {
+                    // Newtonsoft.Json may catch and consume the exception - kill the reader to be sure that deserialization can not continue
+                    reader.Close();
                     throw new SecurityException("encrypted values state corrupted.");
+                }
             }
         }
     }

--- a/src/DotVVM.Framework/ViewModel/Serialization/ViewModelJsonConverter.cs
+++ b/src/DotVVM.Framework/ViewModel/Serialization/ViewModelJsonConverter.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json.Linq;
 using DotVVM.Framework.Configuration;
 using System.Reflection;
 using DotVVM.Framework.Utils;
+using System.Security;
 
 namespace DotVVM.Framework.ViewModel.Serialization
 {
@@ -76,11 +77,22 @@ namespace DotVVM.Framework.ViewModel.Serialization
                 return null;
             }
 
-            // deserialize
-            var serializationMap = GetSerializationMapForType(objectType);
-            var instance = serializationMap.ConstructorFactory(Services);
-            serializationMap.ReaderFactory(reader, serializer, instance, evReader.Value);
-            return instance;
+            var evSuppressed = evReader.Value.Suppressed;
+
+            try
+            {
+                // deserialize
+                var serializationMap = GetSerializationMapForType(objectType);
+                var instance = serializationMap.ConstructorFactory(Services);
+                serializationMap.ReaderFactory(reader, serializer, instance, evReader.Value);
+                return instance;
+            }
+            finally
+            {
+                // safety check: we are not leaking suppressed reader accidentally
+                if (evSuppressed != evReader.Value.Suppressed)
+                    throw new SecurityException("encrypted values state corrupted.");
+            }
         }
 
         /// <summary>
@@ -88,9 +100,19 @@ namespace DotVVM.Framework.ViewModel.Serialization
         /// </summary>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            var serializationMap = GetSerializationMapForType(value.GetType());
-            UsedSerializationMaps.Add(serializationMap);
-            serializationMap.WriterFactory(writer, value, serializer, evWriter.Value, IsPostback);
+            var evSuppressLevel = evWriter.Value.SuppressedLevel;
+            try
+            {
+                var serializationMap = GetSerializationMapForType(value.GetType());
+                UsedSerializationMaps.Add(serializationMap);
+                serializationMap.WriterFactory(writer, value, serializer, evWriter.Value, IsPostback);
+            }
+            finally
+            {
+                // safety check: we are not leaking suppressed reader accidentally
+                if (evSuppressLevel != evWriter.Value.SuppressedLevel)
+                    throw new SecurityException("encrypted values state corrupted.");
+            }
         }
 
         /// <summary>
@@ -98,10 +120,19 @@ namespace DotVVM.Framework.ViewModel.Serialization
         /// </summary>
         public virtual void Populate(JsonReader reader, JsonSerializer serializer, object value)
         {
-            if (reader.TokenType == JsonToken.None) reader.Read();
-            var serializationMap = GetSerializationMapForType(value.GetType());
-            serializationMap.ReaderFactory(reader, serializer, value, evReader.Value);
+            var evSuppressed = evReader.Value.Suppressed;
+            try
+            {
+                if (reader.TokenType == JsonToken.None) reader.Read();
+                var serializationMap = GetSerializationMapForType(value.GetType());
+                serializationMap.ReaderFactory(reader, serializer, value, evReader.Value);
+            }
+            finally
+            {
+                // safety check: we are not leaking suppressed reader accidentally
+                if (evSuppressed != evReader.Value.Suppressed)
+                    throw new SecurityException("encrypted values state corrupted.");
+            }
         }
-
     }
 }

--- a/src/DotVVM.Framework/ViewModel/Serialization/ViewModelSerializationMap.cs
+++ b/src/DotVVM.Framework/ViewModel/Serialization/ViewModelSerializationMap.cs
@@ -189,7 +189,11 @@ namespace DotVVM.Framework.ViewModel.Serialization
                     body = Expression.IfThenElse(
                         isEVSuppressed,
                         body,
-                        Expression.Default(typeof(void))
+                        Expression.Block(
+                            Expression.IfThen(
+                                ExpressionUtils.Replace((JsonReader rdr) => rdr.TokenType == JsonToken.StartArray || rdr.TokenType == JsonToken.StartConstructor || rdr.TokenType == JsonToken.StartObject, reader),
+                                Expression.Call(reader, "Skip", Type.EmptyTypes)),
+                            Expression.Call(reader, "Read", Type.EmptyTypes))
                     );
                 }
 


### PR DESCRIPTION
This PR supports nesting `ProtectMode.None`, `ProtectMode.Signed` and `ProtectMode.Encrypted`. Whenever a property is affected by multiple `ProtectMode`s, the most strict one is used. Resolves #866, #854