### PR TITLE
Deny postbacks during SPA navigation + fixed SPA navigation for default page

### DIFF
--- a/src/DotVVM.Framework/Resources/Scripts/DotVVM.SpaHistory.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/DotVVM.SpaHistory.ts
@@ -5,6 +5,9 @@
 class DotvvmSpaHistory {
 
     public pushPage(url: string) {
+        // pushState doesn't work when the url is empty
+        url = url || "/";
+
         history.pushState(new HistoryRecord('SPA', url), '', url);
     }
 

--- a/src/DotVVM.Framework/Resources/Scripts/DotVVM.d.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/DotVVM.d.ts
@@ -332,6 +332,7 @@ declare class DotVVM {
     extensions: IDotvvmExtensions;
     useHistoryApiSpaNavigation: boolean;
     isPostbackRunning: KnockoutObservable<boolean>;
+    isSpaNavigationRunning: KnockoutObservable<boolean>;
     updateProgressChangeCounter: KnockoutObservable<number>;
     init(viewModelName: string, culture: string): void;
     private handlePopState;

--- a/src/DotVVM.Framework/Resources/Scripts/DotVVM.js
+++ b/src/DotVVM.Framework/Resources/Scripts/DotVVM.js
@@ -1074,6 +1074,7 @@ var DotVVM = /** @class */ (function () {
         this.fileUpload = new DotvvmFileUpload();
         this.extensions = {};
         this.isPostbackRunning = ko.observable(false);
+        this.isSpaNavigationRunning = ko.observable(false);
         this.updateProgressChangeCounter = ko.observable(0);
         this.diffEqual = {};
     }
@@ -1425,6 +1426,8 @@ var DotVVM = /** @class */ (function () {
         if (args === void 0) { args = []; }
         if (context === void 0) { context = ko.contextFor(sender); }
         if (viewModel === void 0) { viewModel = context.$root; }
+        if (dotvvm.isSpaNavigationRunning())
+            return Promise.reject({ type: "handler" });
         var options = new PostbackOptions(this.backUpPostBackConter(), sender, args, viewModel, viewModelName);
         var promise = this.applyPostbackHandlersCore(callback, options, this.findPostbackHandlers(context, this.globalPostbackHandlers.concat(handlers || []).concat(this.globalLaterPostbackHandlers)))
             .then(function (r) { return r(); }, function (r) { return Promise.reject(r); });
@@ -1616,6 +1619,8 @@ var DotVVM = /** @class */ (function () {
     };
     DotVVM.prototype.postBack = function (viewModelName, sender, path, command, controlUniqueId, context, handlers, commandArgs) {
         var _this = this;
+        if (dotvvm.isSpaNavigationRunning())
+            return Promise.reject({ type: "handler" });
         context = context || ko.contextFor(sender);
         var preparedHandlers = this.findPostbackHandlers(context, this.globalPostbackHandlers.concat(handlers || []).concat(this.globalLaterPostbackHandlers));
         if (preparedHandlers.filter(function (h) { return h.name && h.name.indexOf("concurrency-") == 0; }).length == 0) {
@@ -1729,6 +1734,7 @@ var DotVVM = /** @class */ (function () {
             var viewModel = _this.viewModels[viewModelName].viewModel;
             // prevent double postbacks
             var currentPostBackCounter = _this.backUpPostBackConter();
+            _this.isSpaNavigationRunning(true);
             // trigger spaNavigating event
             var spaNavigatingArgs = new DotvvmSpaNavigatingEventArgs(viewModel, viewModelName, url);
             _this.events.spaNavigating.trigger(spaNavigatingArgs);
@@ -1790,17 +1796,19 @@ var DotVVM = /** @class */ (function () {
                         }
                     }
                     else if (resultObject.action === "redirect") {
+                        _this.isSpaNavigationRunning(false);
                         _this.handleRedirect(resultObject, viewModelName, true).then(resolve, reject);
                         return;
                     }
                     // trigger spaNavigated event
                     var spaNavigatedArgs = new DotvvmSpaNavigatedEventArgs(_this.viewModels[viewModelName].viewModel, viewModelName, resultObject, result);
                     _this.events.spaNavigated.trigger(spaNavigatedArgs);
-                    resolve(spaNavigatedArgs);
+                    _this.isSpaNavigationRunning(false);
                     if (!isSuccess && !spaNavigatedArgs.isHandled) {
                         reject();
                         throw "Invalid response from server!";
                     }
+                    resolve(spaNavigatedArgs);
                 });
             }, function (xhr) {
                 // if another postback has already been passed, don't do anything
@@ -1812,6 +1820,7 @@ var DotVVM = /** @class */ (function () {
                 if (!errArgs.handled) {
                     alert(xhr.responseText);
                 }
+                _this.isSpaNavigationRunning(false);
                 reject(errArgs);
             });
         });

--- a/src/DotVVM.Framework/Resources/Scripts/DotVVM.js
+++ b/src/DotVVM.Framework/Resources/Scripts/DotVVM.js
@@ -95,6 +95,8 @@ var DotvvmSpaHistory = /** @class */ (function () {
     function DotvvmSpaHistory() {
     }
     DotvvmSpaHistory.prototype.pushPage = function (url) {
+        // pushState doesn't work when the url is empty
+        url = url || "/";
         history.pushState(new HistoryRecord('SPA', url), '', url);
     };
     DotvvmSpaHistory.prototype.replacePage = function (url) {

--- a/src/DotVVM.Samples.Common/CommonConfiguration.cs
+++ b/src/DotVVM.Samples.Common/CommonConfiguration.cs
@@ -11,6 +11,7 @@ using DotVVM.Samples.Common.Api.AspNetCore;
 using DotVVM.Samples.Common.Api.Owin;
 using DotVVM.Samples.Common.Utilities;
 using DotVVM.Samples.Common.ViewModels.FeatureSamples.DependencyInjection;
+using DotVVM.Samples.Common.ViewModels.FeatureSamples.PostBackSpaNavigation;
 using DotVVM.Samples.Common.ViewModels.FeatureSamples.StaticCommand;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -48,6 +49,8 @@ namespace DotVVM.Samples.Common
             services.AddSingleton<CompaniesClient>();
             services.AddSingleton<TestWebApiClientOwin>();
             services.AddSingleton<TestWebApiClientAspNetCore>();
+
+            services.AddSingleton<DenyPostbacksOnSpaNavigationService>();
 
             services.AddSingleton<IDiagnosticsInformationSender, TextFileDiagnosticsInformationSender>();
         }

--- a/src/DotVVM.Samples.Common/ViewModels/DefaultViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/DefaultViewModel.cs
@@ -1,4 +1,3 @@
-using DotVVM.Framework.ViewModel;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,7 +9,7 @@ using DotVVM.Framework.Routing;
 
 namespace DotVVM.Samples.BasicSamples.ViewModels
 {
-    public class DefaultViewModel : DotvvmViewModelBase
+    public class DefaultViewModel : SamplesViewModel
     {
         public string Title { get; set; }
         public List<RouteData> Routes { get; set; }

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackSpaNavigation/DenyPostbacksOnSpaNavigationService.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackSpaNavigation/DenyPostbacksOnSpaNavigationService.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.PostBackSpaNavigation
+{
+    public class DenyPostbacksOnSpaNavigationService
+    {
+        [AllowStaticCommand]
+        public int StaticCommand(int result)
+        {
+            return result + 1;
+        }
+
+    }
+}

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackSpaNavigation/DenyPostbacksOnSpaNavigationViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackSpaNavigation/DenyPostbacksOnSpaNavigationViewModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.PostBackSpaNavigation
+{
+    public class DenyPostbacksOnSpaNavigationViewModel : DotvvmViewModelBase
+    {
+    }
+}

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackSpaNavigation/PageAViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackSpaNavigation/PageAViewModel.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.PostBackSpaNavigation
+{
+    public class PageAViewModel : DenyPostbacksOnSpaNavigationViewModel
+    {
+
+        public int Result { get; set; }
+
+        public void Command()
+        {
+            Result++;
+        }
+
+    }
+}

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackSpaNavigation/PageBViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackSpaNavigation/PageBViewModel.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DotVVM.Framework.Hosting;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.PostBackSpaNavigation
+{
+    public class PageBViewModel : DenyPostbacksOnSpaNavigationViewModel
+    {
+        public override Task Init()
+        {
+            Thread.Sleep(2000);
+
+            if (Context.Query.ContainsKey("fail"))
+            {
+                throw new DotvvmHttpException("Intentional error.");
+            }
+
+            return base.Init();
+        }
+    }
+}

--- a/src/DotVVM.Samples.Common/ViewModels/SamplesViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/SamplesViewModel.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.BasicSamples.ViewModels
+{
+    public class SamplesViewModel : DotvvmViewModelBase
+    {
+    }
+}

--- a/src/DotVVM.Samples.Common/ViewModels/SpaNavigationToEmptyUrlViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/SpaNavigationToEmptyUrlViewModel.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DotVVM.Samples.BasicSamples.ViewModels
+{
+    public class SpaNavigationToEmptyUrlViewModel : SamplesViewModel
+    {
+
+        public void Redirect()
+        {
+            Context.RedirectToRoute("Default");
+        }
+
+    }
+}

--- a/src/DotVVM.Samples.Common/Views/Default.dothtml
+++ b/src/DotVVM.Samples.Common/Views/Default.dothtml
@@ -1,24 +1,9 @@
 ﻿@viewModel DotVVM.Samples.BasicSamples.ViewModels.DefaultViewModel, DotVVM.Samples.Common
+@masterPage Views/Samples.dotmaster
 
-<!DOCTYPE html>
-
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
-<head>
-    <meta charset="utf-8" />
-    <style>
-        ul li {
-            padding:2px;
-        }
-        body{
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-        }
-    </style>
-</head>
-<body>
+<dot:Content ContentPlaceHolderID="Main">
     <dot:Repeater WrapperTagName="ul" DataSource={value: Routes }>
         <li><a href={value: Url}>{{value: RouteName}}</a></li>
     </dot:Repeater>
     <div>Number of Tests: {{value: Routes.Count}}</div>
-
-</body>
-</html>
+</dot:Content>

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackSpaNavigation/DenyPostbacksOnSpaNavigation.dotmaster
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackSpaNavigation/DenyPostbacksOnSpaNavigation.dotmaster
@@ -1,0 +1,15 @@
+@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.PostBackSpaNavigation.DenyPostbacksOnSpaNavigationViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title>Hello from DotVVM!</title>
+</head>
+<body>
+
+    <dot:SpaContentPlaceHolder ID="MainContent" />
+
+</body>
+</html>

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackSpaNavigation/PageA.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackSpaNavigation/PageA.dothtml
@@ -1,0 +1,19 @@
+@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.PostBackSpaNavigation.PageAViewModel, DotVVM.Samples.Common
+@masterPage Views/FeatureSamples/PostbackSpaNavigation/DenyPostbacksOnSpaNavigation.dotmaster
+@service _vm = DotVVM.Samples.Common.ViewModels.FeatureSamples.PostBackSpaNavigation.DenyPostbacksOnSpaNavigationService
+
+<dot:Content ContentPlaceHolderID="MainContent">
+
+    <p>
+        <dot:RouteLink RouteName="FeatureSamples_PostbackSpaNavigation_PageB" Text="Navigate with success" />
+    </p>
+    <p>
+        <dot:RouteLink RouteName="FeatureSamples_PostbackSpaNavigation_PageB" Query-fail="true" Text="Navigate with failure" />
+    </p>
+
+    <span class="result">{{value: Result}}</span>
+
+    <dot:Button Click="{command: Command()}" Text="Command" />
+    <dot:Button Click="{staticCommand: Result = _vm.StaticCommand(Result)}" Text="Static Command" />
+
+</dot:Content>

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackSpaNavigation/PageB.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackSpaNavigation/PageB.dothtml
@@ -1,0 +1,8 @@
+@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.PostBackSpaNavigation.PageBViewModel, DotVVM.Samples.Common
+@masterPage Views/FeatureSamples/PostbackSpaNavigation/DenyPostbacksOnSpaNavigation.dotmaster
+
+<dot:Content ContentPlaceHolderID="MainContent">
+
+    <p>Navigation success</p>
+
+</dot:Content>

--- a/src/DotVVM.Samples.Common/Views/Samples.dotmaster
+++ b/src/DotVVM.Samples.Common/Views/Samples.dotmaster
@@ -1,0 +1,20 @@
+﻿@viewModel DotVVM.Samples.BasicSamples.ViewModels.SamplesViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <style>
+        ul li {
+            padding:2px;
+        }
+        body{
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+        }
+    </style>
+</head>
+<body>
+    <dot:SpaContentPlaceHolder UseHistoryApi="true" ID="Main" />
+</body>
+</html>

--- a/src/DotVVM.Samples.Common/Views/SpaNavigationToEmptyUrl.dothtml
+++ b/src/DotVVM.Samples.Common/Views/SpaNavigationToEmptyUrl.dothtml
@@ -1,0 +1,7 @@
+﻿@viewModel DotVVM.Samples.BasicSamples.ViewModels.SpaNavigationToEmptyUrlViewModel, DotVVM.Samples.Common
+@masterPage Views/Samples.dotmaster
+
+<dot:Content ContentPlaceHolderID="Main">
+    <dot:RouteLink RouteName="Default" Text="Navigate to page with empty URL" />
+    <dot:Button Text="Redirect to page with empty URL" Click="{command: Redirect()}" />
+</dot:Content>

--- a/src/DotVVM.Samples.Tests/Feature/PostbackSpaNavigationTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/PostbackSpaNavigationTests.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DotVVM.Samples.Tests.Base;
+using DotVVM.Testing.Abstractions;
+using Riganti.Selenium.Core;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DotVVM.Samples.Tests.Feature
+{
+    public class PostbackSpaNavigationTests : AppSeleniumTest
+    {
+
+        [SampleReference(SamplesRouteUrls.FeatureSamples_PostbackSpaNavigation_PageA)]
+        [SampleReference(SamplesRouteUrls.FeatureSamples_PostbackSpaNavigation_PageB)]
+        [Fact]
+        public void PostbackSpaNavigationTest_SuccessfulNavigation()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_PostbackSpaNavigation_PageA);
+
+                var links = browser.FindElements("a");
+                var buttons = browser.FindElements("input[type=button]");
+                var result = browser.Single(".result");
+
+                // click the button and make sure the postback works
+                AssertUI.TextEquals(result, "0");
+                buttons[0].Click().Wait();
+                AssertUI.TextEquals(result, "1");
+                buttons[1].Click().Wait();
+                AssertUI.TextEquals(result, "2");
+
+                // click the first link to trigger the navigation
+                links[0].Click();
+
+                buttons[0].Click().Wait();
+                AssertUI.TextEquals(result, "2");
+                buttons[1].Click().Wait();
+                AssertUI.TextEquals(result, "2");
+
+                browser.Wait(3000);
+
+                AssertUI.UrlEquals(browser, browser.BaseUrl + SamplesRouteUrls.FeatureSamples_PostbackSpaNavigation_PageB);
+            });
+        }
+
+        [SampleReference(SamplesRouteUrls.FeatureSamples_PostbackSpaNavigation_PageA)]
+        [Fact]
+        public void PostbackSpaNavigationTest_FailedNavigation()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_PostbackSpaNavigation_PageA);
+
+                var links = browser.FindElements("a");
+                var buttons = browser.FindElements("input[type=button]");
+                var result = browser.Single(".result");
+
+                // click the button and make sure the postback works
+                AssertUI.TextEquals(result, "0");
+                buttons[0].Click().Wait();
+                AssertUI.TextEquals(result, "1");
+                buttons[1].Click().Wait();
+                AssertUI.TextEquals(result, "2");
+
+                // click the second link to trigger the navigation
+                links[1].Click();
+
+                // now the buttons shouldn't do anything
+                buttons[0].Click().Wait();
+                AssertUI.TextEquals(result, "2");
+                buttons[1].Click().Wait();
+                AssertUI.TextEquals(result, "2");
+
+                browser.Wait(3000);
+
+                // dismiss the error window
+                AssertUI.IsDisplayed(browser.Single("#debugWindow"));
+                browser.Single("#debugWindow button").Click();
+
+                // now the buttons should work
+                buttons[0].Click().Wait();
+                AssertUI.TextEquals(result, "3");
+                buttons[1].Click().Wait();
+                AssertUI.TextEquals(result, "4");
+            });
+        }
+
+
+        public PostbackSpaNavigationTests(ITestOutputHelper output) : base(output)
+        {
+        }
+    }
+}

--- a/src/DotVVM.Samples.Tests/SpaNavigationToEmptyUrlTests.cs
+++ b/src/DotVVM.Samples.Tests/SpaNavigationToEmptyUrlTests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DotVVM.Samples.Tests.Base;
+using DotVVM.Testing.Abstractions;
+using Riganti.Selenium.Core;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DotVVM.Samples.Tests
+{
+    public class SpaNavigationToEmptyUrlTests : AppSeleniumTest
+    {
+
+        [Fact]
+        [SampleReference(SamplesRouteUrls.SpaNavigationToEmptyUrl)]
+        public void SpaNavigationToEmptyUrlTest()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.SpaNavigationToEmptyUrl);
+                browser.Wait();
+
+                browser.Single("a").Click().Wait();
+
+                AssertUI.UrlEquals(browser, browser.BaseUrl);
+            });
+        }
+
+
+        [Fact]
+        [SampleReference(SamplesRouteUrls.SpaNavigationToEmptyUrl)]
+        public void SpaNavigationToEmptyUrlTest_Redirect()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.SpaNavigationToEmptyUrl);
+                browser.Wait();
+
+                browser.Single("input[type=button]").Click().Wait();
+
+                AssertUI.UrlEquals(browser, browser.BaseUrl);
+            });
+        }
+
+
+        public SpaNavigationToEmptyUrlTests(ITestOutputHelper output) : base(output)
+        {
+        }
+    }
+}

--- a/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
@@ -8,6 +8,7 @@ namespace DotVVM.Testing.Abstractions
     {
     
         public const string Default = "Default";
+        public const string SpaNavigationToEmptyUrl = "SpaNavigationToEmptyUrl";
         public const string ComplexSamples_Auth_Login = "ComplexSamples/Auth/Login";
         public const string ComplexSamples_Auth_SecuredPage = "ComplexSamples/Auth/SecuredPage";
         public const string ComplexSamples_ButtonInMarkupControl_Enabled = "ComplexSamples/ButtonInMarkupControl/Enabled";

--- a/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
@@ -17,6 +17,7 @@ namespace DotVVM.Testing.Abstractions
         public const string ComplexSamples_ChangedEvent_ChangedEvent = "ComplexSamples/ChangedEvent/ChangedEvent";
         public const string ComplexSamples_ClassBindings_ClassBindings = "ComplexSamples/ClassBindings/ClassBindings";
         public const string ComplexSamples_EmptyDataTemplate_RepeaterGridView = "ComplexSamples/EmptyDataTemplate/RepeaterGridView";
+        public const string ComplexSamples_EventPropagation_EventPropagation = "ComplexSamples/EventPropagation/EventPropagation";
         public const string ComplexSamples_FileUploadInRepeater_FileUploadInRepeater = "ComplexSamples/FileUploadInRepeater/FileUploadInRepeater";
         public const string ComplexSamples_GridViewDataSet_GridViewDataSet = "ComplexSamples/GridViewDataSet/GridViewDataSet";
         public const string ComplexSamples_InvoiceCalculator_InvoiceCalculator = "ComplexSamples/InvoiceCalculator/InvoiceCalculator";
@@ -237,6 +238,8 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_PostbackConcurrency_RedirectPostbackQueue = "FeatureSamples/PostbackConcurrency/RedirectPostbackQueue";
         public const string FeatureSamples_PostbackConcurrency_RedirectPostbackQueueSpa = "FeatureSamples/PostbackConcurrency/RedirectPostbackQueueSpa";
         public const string FeatureSamples_PostbackConcurrency_StressTest = "FeatureSamples/PostbackConcurrency/StressTest";
+        public const string FeatureSamples_PostbackSpaNavigation_PageA = "FeatureSamples/PostbackSpaNavigation/PageA";
+        public const string FeatureSamples_PostbackSpaNavigation_PageB = "FeatureSamples/PostbackSpaNavigation/PageB";
         public const string FeatureSamples_Redirect_Redirect = "FeatureSamples/Redirect/Redirect";
         public const string FeatureSamples_Redirect_RedirectionHelpers = "FeatureSamples/Redirect/RedirectionHelpers";
         public const string FeatureSamples_Redirect_RedirectionHelpers_PageA = "FeatureSamples/Redirect/RedirectionHelpers_PageA";


### PR DESCRIPTION
We've discovered that SPA navigation is cancelled when the user issues a postback or a static command (with server-side call) during the navigation because the same postback counter is used.
To fix the issue, the postback and static commands are now disabled when the SPA navigation is in progress (and restored when it fails). The solution is not very nice and I'd like to discuss it with @exyi.

Also, this PR fixes #873 which caused the old URL stay in the address bar when navigating back from some page to the default one (`/`). 