### PR TITLE
Use forward slashes for paths

### DIFF
--- a/src/DotVVM.Compiler/Resolving/DotNetCliInfoResolver.cs
+++ b/src/DotVVM.Compiler/Resolving/DotNetCliInfoResolver.cs
@@ -88,8 +88,8 @@ namespace DotVVM.Compiler.Resolving
                 tmpDir = tmpDir.Parent;
             }
 
-            var x64 = Path.Combine(dotnetRootPath, "store\\x64");
-            var x86 = Path.Combine(dotnetRootPath, "store\\x64");
+            var x64 = Path.Combine(dotnetRootPath, "store/x64");
+            var x86 = Path.Combine(dotnetRootPath, "store/x64");
             if (Directory.Exists(x64))
             {
                 info.Store = x64;

--- a/src/DotVVM.Samples.Common/CommonConfiguration.cs
+++ b/src/DotVVM.Samples.Common/CommonConfiguration.cs
@@ -90,7 +90,7 @@ namespace DotVVM.Samples.Common
             };
             resources.Register("Errors_ResourceCircularDependency2", circular2);
             circular.Dependencies = new[] { "Errors_ResourceCircularDependency" };
-            
+
 
             resources.Register("extenders", new ScriptResource {
                 Location = new FileResourceLocation("Scripts/ClientExtenders.js")
@@ -110,11 +110,6 @@ namespace DotVVM.Samples.Common
             resources.SetEmbeddedResourceDebugFile("dotvvm.internal", "../DotVVM.Framework/Resources/Scripts/DotVVM.js");
             resources.SetEmbeddedResourceDebugFile("dotvvm.debug", "../DotVVM.Framework/Resources/Scripts/DotVVM.Debug.js");
             resources.SetEmbeddedResourceDebugFile("dotvvm.fileupload-css", "../DotVVM.Framework/Resources/Scripts/DotVVM.FileUploads.css");
-
-            // test debug version of knockout
-            //((ScriptResource)config.Resources.FindResource("knockout"))
-            //    .Location = new FileResourceLocation("..\\DotVVM.Framework\\Resources\\Scripts\\knockout-latest.debug.js");
-
         }
     }
 }

--- a/src/DotVVM.Samples.Common/ViewModels/ControlSamples/FileUpload/FileUploadViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/ControlSamples/FileUpload/FileUploadViewModel.cs
@@ -62,7 +62,7 @@ namespace DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.FileUpload
 
         private string GetUploadPath()
         {
-            var uploadPath = Path.Combine(Context.Configuration.ApplicationPhysicalPath, "Temp\\Upload");
+            var uploadPath = Path.Combine(Context.Configuration.ApplicationPhysicalPath, "Temp/Upload");
             if (!Directory.Exists(uploadPath))
             {
                 Directory.CreateDirectory(uploadPath);


### PR DESCRIPTION
Both Windows and Linux accepts forward slashes in path which backslashes are only accepted on Windows.
It is thus easier to use forward slashes everywhere.