### PR TITLE
Fixed DotVVM.Framework to not rely on the default Newtonsoft.Json settings

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Binding/NullPropagationTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/NullPropagationTests.cs
@@ -10,6 +10,7 @@ using DotVVM.Framework.Utils;
 using DotVVM.Framework.Compilation.Binding;
 using System.Diagnostics;
 using Newtonsoft.Json;
+using DotVVM.Framework.Configuration;
 
 namespace DotVVM.Framework.Tests.Common.Binding
 {
@@ -125,7 +126,8 @@ namespace DotVVM.Framework.Tests.Common.Binding
             var withoutNullChecks = compile(expr);
 
             var args = Enumerable.Repeat(new TestViewModel { StringProp = "ll", StringProp2 = "pp", TestViewModel2 = new TestViewModel2() }, count).ToArray();
-            Assert.AreEqual(JsonConvert.SerializeObject(withNullCheks(args)), JsonConvert.SerializeObject(withoutNullChecks(args)));
+            var settings = DefaultSerializerSettingsProvider.Instance.Settings;
+            Assert.AreEqual(JsonConvert.SerializeObject(withNullCheks(args), settings), JsonConvert.SerializeObject(withoutNullChecks(args), settings));
 
             foreach (var i in Enumerable.Range(0, args.Length).Shuffle(rnd))
             {

--- a/src/DotVVM.Framework.Tests.Common/Routing/RouteSerializationTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Routing/RouteSerializationTests.cs
@@ -29,7 +29,8 @@ namespace DotVVM.Framework.Tests.Common.Routing
             typeof(RouteBase).GetProperty("Url").SetMethod.Invoke(r, new[] { "url3/{a:unsuppotedConstraint}" });
             config1.RouteTable.Add("route3", r);
 
-            var settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto };
+            var settings = DefaultSerializerSettingsProvider.Instance.GetSettingsCopy();
+            settings.TypeNameHandling = TypeNameHandling.Auto;
             var config2 = JsonConvert.DeserializeObject<DotvvmConfiguration>(JsonConvert.SerializeObject(config1, settings), settings);
 
             Assert.AreEqual(config2.RouteTable["route1"].Url, "url1");

--- a/src/DotVVM.Framework.Tests.Common/Runtime/DotvvmCompilationExceptionSerializationTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/DotvvmCompilationExceptionSerializationTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using DotVVM.Framework.Compilation;
+using DotVVM.Framework.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 
@@ -16,9 +17,10 @@ namespace DotVVM.Framework.Tests.Common.Runtime
             var compilationException =
                 new DotvvmCompilationException("Compilation error", new Exception("inner exception"));
 
-            var serializedObject = JsonConvert.SerializeObject(compilationException);
+            var settings = DefaultSerializerSettingsProvider.Instance.Settings;
+            var serializedObject = JsonConvert.SerializeObject(compilationException, settings);
 
-            var deserializedObject = JsonConvert.DeserializeObject<DotvvmCompilationException>(serializedObject);
+            var deserializedObject = JsonConvert.DeserializeObject<DotvvmCompilationException>(serializedObject, settings);
         }
     }
 }

--- a/src/DotVVM.Framework.Tests.Common/Runtime/ResourceManagerTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/ResourceManagerTests.cs
@@ -72,8 +72,9 @@ namespace DotVVM.Framework.Tests.Runtime
             config1.Resources.Register("rs7", new PolyfillResource(){ RenderPosition =  ResourceRenderPosition.Head});
             config1.Resources.Register("rs8", new ScriptResource(new JQueryGlobalizeResourceLocation(CultureInfo.GetCultureInfo("en-US"))));
 
-            // serialize & deserialize
-            JsonSerializerSettings settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto };
+            // serialize & 
+            var settings = DefaultSerializerSettingsProvider.Instance.Settings;
+            settings.TypeNameHandling = TypeNameHandling.Auto;
             var config2 = JsonConvert.DeserializeObject<DotvvmConfiguration>(JsonConvert.SerializeObject(config1, settings), settings);
 
             //test 

--- a/src/DotVVM.Framework.Tests.Common/Runtime/ResourceManagerTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/ResourceManagerTests.cs
@@ -72,7 +72,6 @@ namespace DotVVM.Framework.Tests.Runtime
             config1.Resources.Register("rs7", new PolyfillResource(){ RenderPosition =  ResourceRenderPosition.Head});
             config1.Resources.Register("rs8", new ScriptResource(new JQueryGlobalizeResourceLocation(CultureInfo.GetCultureInfo("en-US"))));
 
-            // serialize & 
             var settings = DefaultSerializerSettingsProvider.Instance.GetSettingsCopy();
             settings.TypeNameHandling = TypeNameHandling.Auto;
             var config2 = JsonConvert.DeserializeObject<DotvvmConfiguration>(JsonConvert.SerializeObject(config1, settings), settings);

--- a/src/DotVVM.Framework.Tests.Common/Runtime/ResourceManagerTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/ResourceManagerTests.cs
@@ -73,7 +73,7 @@ namespace DotVVM.Framework.Tests.Runtime
             config1.Resources.Register("rs8", new ScriptResource(new JQueryGlobalizeResourceLocation(CultureInfo.GetCultureInfo("en-US"))));
 
             // serialize & 
-            var settings = DefaultSerializerSettingsProvider.Instance.Settings;
+            var settings = DefaultSerializerSettingsProvider.Instance.GetSettingsCopy();
             settings.TypeNameHandling = TypeNameHandling.Auto;
             var config2 = JsonConvert.DeserializeObject<DotvvmConfiguration>(JsonConvert.SerializeObject(config1, settings), settings);
 

--- a/src/DotVVM.Framework.Tests.Common/ViewModel/SerializerTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/ViewModel/SerializerTests.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using DotVVM.Framework.ViewModel;
 using DotVVM.Framework.Compilation.Parser;
+using DotVVM.Framework.Configuration;
 
 namespace DotVVM.Framework.Tests.Common.ViewModel
 {
@@ -28,10 +29,11 @@ namespace DotVVM.Framework.Tests.Common.ViewModel
             };
         }
 
-        static string Serialize<T>(T viewModel, out JObject encryptedValues, bool isPostback = false)
+        string Serialize<T>(T viewModel, out JObject encryptedValues, bool isPostback = false)
         {
             encryptedValues = new JObject();
-            var serializer = JsonSerializer.Create(DefaultViewModelSerializer.CreateDefaultSettings());
+            var settings = DefaultSerializerSettingsProvider.Instance.Settings;
+            var serializer = JsonSerializer.Create(settings);
             serializer.Converters.Add(CreateConverter(isPostback, encryptedValues));
 
             var output = new StringWriter();
@@ -39,9 +41,10 @@ namespace DotVVM.Framework.Tests.Common.ViewModel
             return output.ToString();
         }
 
-        static T Populate<T>(string json, JObject encryptedValues = null)
+        T Populate<T>(string json, JObject encryptedValues = null)
         {
-            var serializer = JsonSerializer.Create(DefaultViewModelSerializer.CreateDefaultSettings());
+            var settings = DefaultSerializerSettingsProvider.Instance.Settings;
+            var serializer = JsonSerializer.Create(settings);
             serializer.Converters.Add(CreateConverter(true, encryptedValues));
 
             //serializer.Populate(new StringReader(json), viewModel);

--- a/src/DotVVM.Framework.Tests.Common/ViewModel/SerializerTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/ViewModel/SerializerTests.cs
@@ -29,7 +29,7 @@ namespace DotVVM.Framework.Tests.Common.ViewModel
             };
         }
 
-        string Serialize<T>(T viewModel, out JObject encryptedValues, bool isPostback = false)
+        static string Serialize<T>(T viewModel, out JObject encryptedValues, bool isPostback = false)
         {
             encryptedValues = new JObject();
             var settings = DefaultSerializerSettingsProvider.Instance.Settings;
@@ -41,7 +41,7 @@ namespace DotVVM.Framework.Tests.Common.ViewModel
             return output.ToString();
         }
 
-        T Populate<T>(string json, JObject encryptedValues = null)
+        static T Populate<T>(string json, JObject encryptedValues = null)
         {
             var settings = DefaultSerializerSettingsProvider.Instance.Settings;
             var serializer = JsonSerializer.Create(settings);

--- a/src/DotVVM.Framework/Compilation/Javascript/Ast/JsLiteral.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/Ast/JsLiteral.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using DotVVM.Framework.Configuration;
 using Newtonsoft.Json;
 
 namespace DotVVM.Framework.Compilation.Javascript.Ast
@@ -21,7 +22,7 @@ namespace DotVVM.Framework.Compilation.Javascript.Ast
         public string LiteralValue
         {
             get => JavascriptCompilationHelper.CompileConstant(Value);
-            set => Value = JsonConvert.DeserializeObject(value);
+            set => Value = JsonConvert.DeserializeObject(value, DefaultSerializerSettingsProvider.Instance.Settings);
         }
 
         public JsLiteral() { }

--- a/src/DotVVM.Framework/Compilation/Javascript/JavascriptCompilationHelper.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/JavascriptCompilationHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using DotVVM.Framework.Compilation.Javascript.Ast;
+using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Utils;
 using DotVVM.Framework.ViewModel.Serialization;
 using Newtonsoft.Json;
@@ -9,7 +10,7 @@ namespace DotVVM.Framework.Compilation.Javascript
 {
     public static class JavascriptCompilationHelper
     {
-        public static string CompileConstant(object obj) => JsonConvert.SerializeObject(obj, new StringEnumConverter());
+        public static string CompileConstant(object obj) => JsonConvert.SerializeObject(obj, DefaultSerializerSettingsProvider.Instance.Settings);
 
         private static readonly CodeSymbolicParameter indexerTargetParameter = new CodeSymbolicParameter("JavascriptCompilationHelper.indexerTargetParameter");
         private static readonly CodeSymbolicParameter indexerExpressionParameter = new CodeSymbolicParameter("JavascriptCompilationHelper.indexerExpressionParameter");

--- a/src/DotVVM.Framework/Configuration/DefaultSerializerSettingsProvider.cs
+++ b/src/DotVVM.Framework/Configuration/DefaultSerializerSettingsProvider.cs
@@ -11,15 +11,28 @@ namespace DotVVM.Framework.Configuration
 {
     public sealed class DefaultSerializerSettingsProvider
     {
-        public JsonSerializerSettings Settings { get; private set; }
+        public readonly JsonSerializerSettings Settings;
 
         public JsonSerializerSettings GetSettingsCopy()
         {
-            var clone = JsonConvert.SerializeObject(Settings, Settings);
-            return JsonConvert.DeserializeObject<JsonSerializerSettings>(clone, Settings);
+            return CreateSettings();
         }
 
-        public static DefaultSerializerSettingsProvider Instance {
+        private JsonSerializerSettings CreateSettings()
+        {
+            return new JsonSerializerSettings()
+            {
+                DateTimeZoneHandling = DateTimeZoneHandling.Unspecified,
+                Converters = new List<JsonConverter>
+                {
+                    new DotvvmDateTimeConverter(),
+                    new StringEnumConverter()
+                }
+            };
+        }
+
+        public static DefaultSerializerSettingsProvider Instance
+        {
             get
             {
                 if (instance == null)
@@ -31,12 +44,7 @@ namespace DotVVM.Framework.Configuration
 
         private DefaultSerializerSettingsProvider()
         {
-            Settings = new JsonSerializerSettings()
-            {
-                DateTimeZoneHandling = DateTimeZoneHandling.Unspecified
-            };
-            Settings.Converters.Add(new DotvvmDateTimeConverter());
-            Settings.Converters.Add(new StringEnumConverter());
+            Settings = CreateSettings();
         }
     }
 }

--- a/src/DotVVM.Framework/Configuration/DefaultSerializerSettingsProvider.cs
+++ b/src/DotVVM.Framework/Configuration/DefaultSerializerSettingsProvider.cs
@@ -11,7 +11,7 @@ namespace DotVVM.Framework.Configuration
 {
     public sealed class DefaultSerializerSettingsProvider
     {
-        public readonly JsonSerializerSettings Settings;
+        internal readonly JsonSerializerSettings Settings;
 
         public JsonSerializerSettings GetSettingsCopy()
         {

--- a/src/DotVVM.Framework/Configuration/DefaultSerializerSettingsProvider.cs
+++ b/src/DotVVM.Framework/Configuration/DefaultSerializerSettingsProvider.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace DotVVM.Framework.Configuration
+{
+    public sealed class DefaultSerializerSettingsProvider
+    {
+        public JsonSerializerSettings Settings { get; private set; }
+
+        public JsonSerializerSettings GetSettingsCopy()
+        {
+            var clone = JsonConvert.SerializeObject(Settings, Settings);
+            return JsonConvert.DeserializeObject<JsonSerializerSettings>(clone, Settings);
+        }
+
+        public static DefaultSerializerSettingsProvider Instance {
+            get
+            {
+                if (instance == null)
+                    instance = new DefaultSerializerSettingsProvider();
+                return instance;
+            }
+        }
+        private static DefaultSerializerSettingsProvider instance;
+
+        private DefaultSerializerSettingsProvider()
+        {
+            Settings = new JsonSerializerSettings()
+            {
+                DateTimeZoneHandling = DateTimeZoneHandling.Unspecified
+            };
+            Settings.Converters.Add(new DotvvmDateTimeConverter());
+            Settings.Converters.Add(new StringEnumConverter());
+        }
+    }
+}

--- a/src/DotVVM.Framework/Configuration/DotvvmConfigurationException.cs
+++ b/src/DotVVM.Framework/Configuration/DotvvmConfigurationException.cs
@@ -69,13 +69,14 @@ namespace DotVVM.Framework.Configuration
         {
             if (controls != null && controls.Any())
             {
+                var settings = DefaultSerializerSettingsProvider.Instance.Settings;
                 sb.AppendLine("Invalid control registrations: ");
                 foreach (var control in controls)
                 {
                     if (control.Reason == DotvvmConfigurationAssertReason.InvalidCombination)
                     {
                         sb.Append("Control '");
-                        sb.Append(JsonConvert.SerializeObject(control.Value));
+                        sb.Append(JsonConvert.SerializeObject(control.Value, settings));
                         sb.Append("' has set invalid combination of properties.");
                     }
 

--- a/src/DotVVM.Framework/Controls/DotvvmMarkupControl.cs
+++ b/src/DotVVM.Framework/Controls/DotvvmMarkupControl.cs
@@ -82,7 +82,7 @@ namespace DotVVM.Framework.Controls
         {
             if (ContainsPropertyStaticValue(property))
             {
-                var settings = DefaultSerializerSettingsProvider.Instance.Settings;
+                var settings = DefaultSerializerSettingsProvider.Instance.GetSettingsCopy();
                 settings.StringEscapeHandling = StringEscapeHandling.EscapeHtml;
 
                 return new PropertySerializeInfo(

--- a/src/DotVVM.Framework/Controls/DotvvmMarkupControl.cs
+++ b/src/DotVVM.Framework/Controls/DotvvmMarkupControl.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using DotVVM.Framework.Binding;
 using DotVVM.Framework.Binding.Expressions;
 using DotVVM.Framework.Compilation.Parser;
+using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Hosting;
 using DotVVM.Framework.ViewModel.Serialization;
 using Newtonsoft.Json;
@@ -81,7 +82,7 @@ namespace DotVVM.Framework.Controls
         {
             if (ContainsPropertyStaticValue(property))
             {
-                JsonSerializerSettings settings = DefaultViewModelSerializer.CreateDefaultSettings();
+                var settings = DefaultSerializerSettingsProvider.Instance.Settings;
                 settings.StringEscapeHandling = StringEscapeHandling.EscapeHtml;
 
                 return new PropertySerializeInfo(

--- a/src/DotVVM.Framework/Controls/FileUpload.cs
+++ b/src/DotVVM.Framework/Controls/FileUpload.cs
@@ -176,7 +176,7 @@ namespace DotVVM.Framework.Controls
         {
             // render result
             writer.AddAttribute("class", "dotvvm-upload-result");
-            writer.AddKnockoutDataBind("html", $"Error() ? {JsonConvert.SerializeObject(UploadErrorMessageText)} : {JsonConvert.SerializeObject(SuccessMessageText)}");
+            writer.AddKnockoutDataBind("html", $"Error() ? {KnockoutHelper.MakeStringLiteral(UploadErrorMessageText!)} : {KnockoutHelper.MakeStringLiteral(SuccessMessageText!)}");
             writer.AddKnockoutDataBind("attr", "{ title: Error }");
             writer.AddKnockoutDataBind("css", "{ 'dotvvm-upload-result-success': !Error(), 'dotvvm-upload-result-error': Error }");
             writer.AddKnockoutDataBind("visible", "!IsBusy() && Files().length > 0");
@@ -201,7 +201,7 @@ namespace DotVVM.Framework.Controls
         {
             // render upload files
             writer.AddAttribute("class", "dotvvm-upload-files");
-            writer.AddKnockoutDataBind("html", $"dotvvm.globalize.format({JsonConvert.SerializeObject(NumberOfFilesIndicatorText)}, Files().length)");
+            writer.AddKnockoutDataBind("html", $"dotvvm.globalize.format({KnockoutHelper.MakeStringLiteral(NumberOfFilesIndicatorText!)}, Files().length)");
             writer.RenderBeginTag("span");
             writer.RenderEndTag();
         }

--- a/src/DotVVM.Framework/Controls/KnockoutBindingGroup.cs
+++ b/src/DotVVM.Framework/Controls/KnockoutBindingGroup.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using DotVVM.Framework.Binding;
 using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Configuration;
 using DotVVM.Framework.ViewModel.Serialization;
 using Newtonsoft.Json;
 
@@ -22,7 +23,7 @@ namespace DotVVM.Framework.Controls
             if (binding == null)
             {
                 if (nullBindingAction != null) nullBindingAction();
-                else Add(name, JsonConvert.SerializeObject(control.GetValue(property), DefaultViewModelSerializer.CreateDefaultSettings()));
+                else Add(name, JsonConvert.SerializeObject(control.GetValue(property), DefaultSerializerSettingsProvider.Instance.Settings));
             }
             else
             {
@@ -34,7 +35,7 @@ namespace DotVVM.Framework.Controls
         {
             if (surroundWithDoubleQuotes)
             {
-                expression = JsonConvert.SerializeObject(expression);
+                expression = JsonConvert.SerializeObject(expression, DefaultSerializerSettingsProvider.Instance.Settings);
             }
 
             entries.Add(new KnockoutBindingInfo(name, expression));

--- a/src/DotVVM.Framework/Controls/KnockoutHelper.cs
+++ b/src/DotVVM.Framework/Controls/KnockoutHelper.cs
@@ -12,6 +12,7 @@ using DotVVM.Framework.Compilation.Javascript;
 using DotVVM.Framework.Compilation.Javascript.Ast;
 using DotVVM.Framework.ViewModel.Serialization;
 using DotVVM.Framework.Utils;
+using DotVVM.Framework.Configuration;
 
 namespace DotVVM.Framework.Controls
 {
@@ -374,7 +375,7 @@ namespace DotVVM.Framework.Controls
         {
             var binding = obj.GetValueBinding(property);
             if (binding != null) return binding.GetKnockoutBindingExpression(obj);
-            return JsonConvert.SerializeObject(obj.GetValue(property), DefaultViewModelSerializer.CreateDefaultSettings());
+            return JsonConvert.SerializeObject(obj.GetValue(property), DefaultSerializerSettingsProvider.Instance.Settings);
         }
 
         /// <summary>

--- a/src/DotVVM.Framework/Controls/RouteLinkHelpers.cs
+++ b/src/DotVVM.Framework/Controls/RouteLinkHelpers.cs
@@ -11,6 +11,7 @@ using DotVVM.Framework.Runtime;
 using DotVVM.Framework.Hosting;
 using DotVVM.Framework.ViewModel.Serialization;
 using DotVVM.Framework.Utils;
+using DotVVM.Framework.Configuration;
 
 namespace DotVVM.Framework.Controls
 {
@@ -99,7 +100,7 @@ namespace DotVVM.Framework.Controls
             var urlSuffixBase =
                 control.GetValueBinding(RouteLink.UrlSuffixProperty)
                 ?.Apply(binding => binding.GetKnockoutBindingExpression(control))
-                ?? JsonConvert.SerializeObject(control.UrlSuffix ?? "");
+                ?? KnockoutHelper.MakeStringLiteral(control.UrlSuffix ?? "");
             var queryParams =
                 control.QueryParameters.RawValues.Select(p => TranslateRouteParameter(control, p, true)).StringJoin(",");
 
@@ -132,13 +133,13 @@ namespace DotVVM.Framework.Controls
                 EnsureValidBindingType(binding);
 
                 expression = (param.Value as IValueBinding)?.GetKnockoutBindingExpression(control)
-                    ?? JsonConvert.SerializeObject((param.Value as IStaticValueBinding)?.Evaluate(control), DefaultViewModelSerializer.CreateDefaultSettings());
+                    ?? JsonConvert.SerializeObject((param.Value as IStaticValueBinding)?.Evaluate(control), DefaultSerializerSettingsProvider.Instance.Settings);
             }
             else
             {
-                expression = JsonConvert.SerializeObject(param.Value, DefaultViewModelSerializer.CreateDefaultSettings());
+                expression = JsonConvert.SerializeObject(param.Value, DefaultSerializerSettingsProvider.Instance.Settings);
             }
-            return JsonConvert.SerializeObject(caseSensitive ? param.Key : param.Key.ToLower()) + ": " + expression;
+            return KnockoutHelper.MakeStringLiteral(caseSensitive ? param.Key : param.Key.ToLower()) + ": " + expression;
         }
 
         private static void EnsureValidBindingType(IBinding binding)

--- a/src/DotVVM.Framework/Controls/Validator.cs
+++ b/src/DotVVM.Framework/Controls/Validator.cs
@@ -8,6 +8,8 @@ using Newtonsoft.Json;
 using DotVVM.Framework.Hosting;
 using DotVVM.Framework.ViewModel.Serialization;
 using DotVVM.Framework.Binding.Expressions;
+using Microsoft.Extensions.DependencyInjection;
+using DotVVM.Framework.Configuration;
 
 namespace DotVVM.Framework.Controls
 {
@@ -92,7 +94,8 @@ namespace DotVVM.Framework.Controls
                 var optionValue = control.GetValue(property);
                 if (!object.Equals(optionValue, property.DefaultValue))
                 {
-                    bindingGroup.Add(javascriptName, JsonConvert.SerializeObject(optionValue, DefaultViewModelSerializer.CreateDefaultSettings()));
+                    var settings = DefaultSerializerSettingsProvider.Instance.Settings;
+                    bindingGroup.Add(javascriptName, JsonConvert.SerializeObject(optionValue, settings));
                 }
             }
             writer.AddKnockoutDataBind("dotvvmValidationOptions", bindingGroup);

--- a/src/DotVVM.Framework/Diagnostics/DiagnosticsInformationSender.cs
+++ b/src/DotVVM.Framework/Diagnostics/DiagnosticsInformationSender.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
+using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Diagnostics.Models;
 using Newtonsoft.Json;
 
@@ -32,7 +33,8 @@ namespace DotVVM.Framework.Diagnostics
                         await client.ConnectAsync(hostname, port.Value);
                         using (var stream = new StreamWriter(client.GetStream()))
                         {
-                            await stream.WriteAsync(JsonConvert.SerializeObject(information));
+                            var settings = DefaultSerializerSettingsProvider.Instance.Settings;
+                            await stream.WriteAsync(JsonConvert.SerializeObject(information, settings));
                             await stream.FlushAsync();
                         }
                     }

--- a/src/DotVVM.Framework/Diagnostics/DotvvmDiagnosticsConfiguration.cs
+++ b/src/DotVVM.Framework/Diagnostics/DotvvmDiagnosticsConfiguration.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using DotVVM.Framework.Configuration;
 using Newtonsoft.Json;
 
 namespace DotVVM.Framework.Diagnostics
@@ -35,7 +36,8 @@ namespace DotVVM.Framework.Diagnostics
                     configurationLastWriteTimeUtc = info.LastWriteTimeUtc;
 
                     var diagnosticsJson = File.ReadAllText(path);
-                    configuration = JsonConvert.DeserializeObject<DiagnosticsServerConfiguration>(diagnosticsJson);
+                    var settings = DefaultSerializerSettingsProvider.Instance.Settings;
+                    configuration = JsonConvert.DeserializeObject<DiagnosticsServerConfiguration>(diagnosticsJson, settings);
                 }
             }
             catch

--- a/src/DotVVM.Framework/Hosting/DotvvmPresenter.cs
+++ b/src/DotVVM.Framework/Hosting/DotvvmPresenter.cs
@@ -92,7 +92,8 @@ namespace DotVVM.Framework.Hosting
                 // TODO this should be done by IOutputRender or something like that. IOutputRenderer does not support that, so should we make another IJsonErrorOutputWriter?
                 context.HttpContext.Response.StatusCode = 400;
                 context.HttpContext.Response.ContentType = "application/json; charset=utf-8";
-                await context.HttpContext.Response.WriteAsync(JsonConvert.SerializeObject(new { action = "invalidCsrfToken", message = ex.Message }));
+                var settings = DefaultSerializerSettingsProvider.Instance.Settings;
+                await context.HttpContext.Response.WriteAsync(JsonConvert.SerializeObject(new { action = "invalidCsrfToken", message = ex.Message }, settings));
             }
             catch (DotvvmControlException ex)
             {

--- a/src/DotVVM.Framework/Hosting/Middlewares/DotvvmFileUploadMiddleware.cs
+++ b/src/DotVVM.Framework/Hosting/Middlewares/DotvvmFileUploadMiddleware.cs
@@ -97,6 +97,7 @@ namespace DotVVM.Framework.Hosting.Middlewares
 
         private async Task RenderResponse(IHttpContext context, bool isPost, string errorMessage, List<UploadedFile> uploadedFiles)
         {
+            var settings = DefaultSerializerSettingsProvider.Instance.Settings;
             if (isPost && ShouldReturnJsonResponse(context))
             {
                 // modern browser - return JSON
@@ -105,7 +106,7 @@ namespace DotVVM.Framework.Hosting.Middlewares
                     if (context.Request.Query["iframe"] == "true")
                     {
                         // IE will otherwise try to download the response as JSON file
-                        await outputRenderer.RenderPlainTextResponse(context, JsonConvert.SerializeObject(uploadedFiles));
+                        await outputRenderer.RenderPlainTextResponse(context, JsonConvert.SerializeObject(uploadedFiles, settings));
                     }
                     else
                     {
@@ -132,12 +133,12 @@ namespace DotVVM.Framework.Hosting.Middlewares
                     if (string.IsNullOrEmpty(errorMessage))
                     {
                         template.StartupScript = string.Format("reportProgress(false, 100, {0})",
-                            JsonConvert.SerializeObject(uploadedFiles));
+                            JsonConvert.SerializeObject(uploadedFiles, settings));
                     }
                     else
                     {
                         template.StartupScript = string.Format("reportProgress(false, 100, {0})",
-                            JsonConvert.SerializeObject(errorMessage));
+                            JsonConvert.SerializeObject(errorMessage, settings));
                     }
                 }
 

--- a/src/DotVVM.Framework/Runtime/DefaultOutputRenderer.cs
+++ b/src/DotVVM.Framework/Runtime/DefaultOutputRenderer.cs
@@ -11,6 +11,7 @@ using DotVVM.Framework.Controls.Infrastructure;
 using DotVVM.Framework.Hosting;
 using DotVVM.Framework.Binding;
 using System.Text;
+using DotVVM.Framework.Configuration;
 
 namespace DotVVM.Framework.Runtime
 {
@@ -103,7 +104,8 @@ namespace DotVVM.Framework.Runtime
             context.Response.StatusCode = (int)HttpStatusCode.OK;
             context.Response.ContentType = "application/json; charset=utf-8";
             SetCacheHeaders(context);
-            await context.Response.WriteAsync(JsonConvert.SerializeObject(data));
+            var settings = DefaultSerializerSettingsProvider.Instance.Settings;
+            await context.Response.WriteAsync(JsonConvert.SerializeObject(data, settings));
         }
 
         public virtual async Task RenderHtmlResponse(IHttpContext context, string html)

--- a/src/DotVVM.Framework/Storage/FileSystemReturnedFileStorage.cs
+++ b/src/DotVVM.Framework/Storage/FileSystemReturnedFileStorage.cs
@@ -7,6 +7,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Utils;
 using Newtonsoft.Json;
 
@@ -35,7 +36,8 @@ namespace DotVVM.Framework.Storage
         /// Initializes new instance of <see cref="FileSystemReturnedFileStorage"/> class with default interval for deleting old files.
         /// </summary>
         /// <param name="directory">Temp directory for storing files.</param>
-        public FileSystemReturnedFileStorage(string directory) : this(directory, new TimeSpan(0, 5, 0))
+        public FileSystemReturnedFileStorage(string directory)
+            : this(directory, new TimeSpan(0, 5, 0))
         {
         }
 
@@ -83,7 +85,8 @@ namespace DotVVM.Framework.Storage
         private void StoreMetadata(Guid id, ReturnedFileMetadata metadata)
         {
             var metadataFilePath = GetMetadataFilePath(id);
-            File.WriteAllText(metadataFilePath, JsonConvert.SerializeObject(metadata), Encoding.UTF8);
+            var settings = DefaultSerializerSettingsProvider.Instance.Settings;
+            File.WriteAllText(metadataFilePath, JsonConvert.SerializeObject(metadata, settings), Encoding.UTF8);
         }
 
         private string GetDataFilePath(Guid id)

--- a/src/DotVVM.Framework/Storage/FileSystemReturnedFileStorage.cs
+++ b/src/DotVVM.Framework/Storage/FileSystemReturnedFileStorage.cs
@@ -102,7 +102,8 @@ namespace DotVVM.Framework.Storage
         public Stream GetFile(Guid id, out ReturnedFileMetadata metadata)
         {
             var metadataJson = File.ReadAllText(GetMetadataFilePath(id), Encoding.UTF8);
-            metadata = JsonConvert.DeserializeObject<ReturnedFileMetadata>(metadataJson);
+            var settings = DefaultSerializerSettingsProvider.Instance.Settings;
+            metadata = JsonConvert.DeserializeObject<ReturnedFileMetadata>(metadataJson, settings);
 
             return new FileStream(GetDataFilePath(id), FileMode.Open);
         }

--- a/src/DotVVM.Framework/ViewModel/Serialization/DefaultViewModelSerializer.cs
+++ b/src/DotVVM.Framework/ViewModel/Serialization/DefaultViewModelSerializer.cs
@@ -152,17 +152,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
             return response.ToString(JsonFormatting);
         }
 
-        public static JsonSerializerSettings CreateDefaultSettings()
-        {
-            var s = new JsonSerializerSettings() {
-                DateTimeZoneHandling = DateTimeZoneHandling.Unspecified
-            };
-            s.Converters.Add(new DotvvmDateTimeConverter());
-            s.Converters.Add(new StringEnumConverter());
-            return s;
-        }
-
-        protected virtual JsonSerializer CreateJsonSerializer() => CreateDefaultSettings().Apply(JsonSerializer.Create);
+        protected virtual JsonSerializer CreateJsonSerializer() => DefaultSerializerSettingsProvider.Instance.Settings.Apply(JsonSerializer.Create);
 
         public JObject BuildResourcesJson(IDotvvmRequestContext context, Func<string, bool> predicate)
         {


### PR DESCRIPTION
Resolves #875.

The issue, however, still remains in generated REST API Bindings. This is tracked as a new issue #889 and will be addressed in future releases. In the meantime, users will be notified to not change these settings when working with generated bindings.