### PR TITLE
Allow markups from different projects

### DIFF
--- a/src/DotVVM.Framework/Hosting/DefaultMarkupFileLoader.cs
+++ b/src/DotVVM.Framework/Hosting/DefaultMarkupFileLoader.cs
@@ -25,11 +25,6 @@ namespace DotVVM.Framework.Hosting
                 return null;
             }
 
-            if (!fullPath.Replace('\\', '/').StartsWith(configuration.ApplicationPhysicalPath.Replace('\\', '/'), StringComparison.CurrentCultureIgnoreCase))
-            {
-                return null;
-            }
-
             if (File.Exists(fullPath))
             {
                 // load the file

--- a/src/DotVVM.Framework/Routing/DefaultRouteStrategy.cs
+++ b/src/DotVVM.Framework/Routing/DefaultRouteStrategy.cs
@@ -60,7 +60,7 @@ namespace DotVVM.Framework.Routing
                     // Get relative path from applicationPhysicalPath to markup file
                     AppRelativePath = GetRelativePathBetween(applicationPhysicalPath, file.FullName),
                     // Get relative path from viewsFolderDirectory to markup file
-                    ViewsFolderRelativePath = GetRelativePathBetween(viewsFolderDirectoryInfo.FullName, file.FullName)
+                    ViewsFolderRelativePath = GetRelativePathBetween(viewsFolderDirectoryInfo.FullName, file.FullName).TrimStart('/')
                 });
         }
 
@@ -85,7 +85,7 @@ namespace DotVVM.Framework.Routing
             var goBack = Enumerable.Repeat("..", fromPathSegments.Length - index) ?? Enumerable.Empty<string>();
             var goForward = Enumerable.Skip(toPathSegments, index) ?? Enumerable.Empty<string>();
             var resultPathSegments = goBack.Concat(goForward).ToArray();
-            return Path.Combine(resultPathSegments);
+            return Path.Combine(resultPathSegments).Replace('\\', '/');
         }
 
         /// <summary>

--- a/src/DotVVM.Framework/Routing/DefaultRouteStrategy.cs
+++ b/src/DotVVM.Framework/Routing/DefaultRouteStrategy.cs
@@ -57,9 +57,35 @@ namespace DotVVM.Framework.Routing
                 .Select(file => new RouteStrategyMarkupFileInfo()
                 {
                     AbsolutePath = file.FullName,
-                    AppRelativePath = file.FullName.Substring(applicationPhysicalPath.Length).Replace('\\', '/').TrimStart('/'),
-                    ViewsFolderRelativePath = file.FullName.Substring(viewsFolderDirectoryInfo.FullName.Length).Replace('\\', '/').TrimStart('/')
+                    // Get relative path from applicationPhysicalPath to markup file
+                    AppRelativePath = GetRelativePathBetween(applicationPhysicalPath, file.FullName),
+                    // Get relative path from viewsFolderDirectory to markup file
+                    ViewsFolderRelativePath = GetRelativePathBetween(viewsFolderDirectoryInfo.FullName, file.FullName)
                 });
+        }
+
+        private string GetRelativePathBetween(string from, string to)
+        {
+            var fromPath = from.Replace('\\', '/');
+            var toPath = to.Replace('\\', '/');
+            var fromPathSegments = fromPath.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            var toPathSegments = toPath.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+
+            // Find index of the first path segments where they differ
+            var index = 0;
+            for (index = 0; index < Math.Min(fromPathSegments.Length, toPathSegments.Length); index++)
+            {
+                if (fromPathSegments[index] == toPathSegments[index])
+                    continue;
+
+                break;
+            }
+
+            // Construct path
+            var goBack = Enumerable.Repeat("..", fromPathSegments.Length - index) ?? Enumerable.Empty<string>();
+            var goForward = Enumerable.Skip(toPathSegments, index) ?? Enumerable.Empty<string>();
+            var resultPathSegments = goBack.Concat(goForward).ToArray();
+            return Path.Combine(resultPathSegments);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes a bug found by @martindybal regarding the inability to load markups from different directories. 

Current implementation depends on the `ApplicationPhysicalPath`. More specifically, every markup needs to be within one of the subfolders as determined by the "root" directory `ApplicationPhysicalPath`. Changes within this PR lifts the restriction and makes it possible to load markups also from different directories.

**Note**: I added a simple implementation of a method that generates relative paths between source directories and target files. While this method is already implemented in .NET (https://docs.microsoft.com/en-us/dotnet/api/system.io.path.getrelativepath?view=net-5.0), it is not supported by all frameworks usable with DotVVM. In future, once DotVVM drops support of older frameworks, we should switch to the standard implementation.