### PR TITLE
Postbacks were incorrectly disabled on redirects

### DIFF
--- a/src/DotVVM.Framework/Resources/Scripts/DotVVM.d.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/DotVVM.d.ts
@@ -100,15 +100,15 @@ declare class DotvvmAfterPostBackEventArgs implements PostbackEventArgs {
     xhr?: XMLHttpRequest | undefined;
     isHandled: boolean;
     wasInterrupted: boolean;
-    readonly postbackClientId: number;
-    readonly viewModelName: string;
-    readonly viewModel: any;
-    readonly sender: HTMLElement | undefined;
+    get postbackClientId(): number;
+    get viewModelName(): string;
+    get viewModel(): any;
+    get sender(): HTMLElement | undefined;
     constructor(postbackOptions: PostbackOptions, serverResponseObject: any, commandResult?: any, xhr?: XMLHttpRequest | undefined);
 }
 declare class DotvvmAfterPostBackWithRedirectEventArgs extends DotvvmAfterPostBackEventArgs {
     private _redirectPromise?;
-    readonly redirectPromise: Promise<DotvvmNavigationEventArgs> | undefined;
+    get redirectPromise(): Promise<DotvvmNavigationEventArgs> | undefined;
     constructor(postbackOptions: PostbackOptions, serverResponseObject: any, commandResult?: any, xhr?: XMLHttpRequest, _redirectPromise?: Promise<DotvvmNavigationEventArgs> | undefined);
 }
 declare class DotvvmSpaNavigatingEventArgs implements DotvvmEventArgs {
@@ -164,12 +164,12 @@ declare class DotvvmFileSize {
 declare class DotvvmGlobalize {
     private getGlobalize;
     format(format: string, ...values: any[]): string;
-    formatString(format: string, value: any): any;
+    formatString(format: string, value: any): string;
     parseDotvvmDate(value: string): Date | null;
     parseNumber(value: string): number;
-    parseDate(value: string, format: string, previousValue?: Date): any;
-    bindingDateToString(value: KnockoutObservable<string | Date> | string | Date, format?: string): "" | KnockoutComputed<any>;
-    bindingNumberToString(value: KnockoutObservable<string | number> | string | number, format?: string): "" | KnockoutComputed<any>;
+    parseDate(value: string, format: string, previousValue?: Date): Date | null;
+    bindingDateToString(value: KnockoutObservable<string | Date> | string | Date, format?: string): "" | KnockoutComputed<string>;
+    bindingNumberToString(value: KnockoutObservable<string | number> | string | number, format?: string): "" | KnockoutComputed<string>;
 }
 declare type DotvvmPostbackHandler = {
     execute(callback: () => Promise<PostbackCommitFunction>, options: PostbackOptions): Promise<PostbackCommitFunction>;
@@ -293,6 +293,7 @@ interface IDotvvmPostbackHandlerCollection {
 }
 declare class DotVVM {
     private postBackCounter;
+    private lastDisabledPostBack;
     private lastStartedPostack;
     private arePostbacksDisabled;
     private fakeRedirectAnchor;
@@ -339,10 +340,11 @@ declare class DotVVM {
     private handleHashChange;
     private persistViewModel;
     private backUpPostBackConter;
+    private setLastDisabledPostBack;
     private isPostBackStillActive;
     private fetchCsrfToken;
     staticCommandPostback(viewModelName: string, sender: HTMLElement, command: string, args: any[], callback?: (_: any) => void, errorCallback?: (errorInfo: {
-        xhr?: XMLHttpRequest | undefined;
+        xhr?: XMLHttpRequest;
         error?: any;
     }) => void): void;
     private processPassedId;
@@ -361,7 +363,6 @@ declare class DotVVM {
     private getSpaPlaceHolder;
     private navigateCore;
     private handleRedirect;
-    private disablePostbacks;
     private performRedirect;
     private fixSpaUrlPrefix;
     private removeVirtualDirectoryFromUrl;

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackSpaNavigation/DenyPostbacksOnSpaNavigationService.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackSpaNavigation/DenyPostbacksOnSpaNavigationService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using DotVVM.Framework.ViewModel;
 
 namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.PostBackSpaNavigation
@@ -10,6 +11,13 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.PostBackSpaNavigation
         [AllowStaticCommand]
         public int StaticCommand(int result)
         {
+            return result + 1;
+        }
+
+        [AllowStaticCommand]
+        public int LongStaticCommand(int result)
+        {
+            Thread.Sleep(5000);
             return result + 1;
         }
 

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackSpaNavigation/PageAViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackSpaNavigation/PageAViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.PostBackSpaNavigation
 {
@@ -14,5 +15,10 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.PostBackSpaNavigation
             Result++;
         }
 
+        public void LongCommand()
+        {
+            Thread.Sleep(5000);
+            Result++;
+        }
     }
 }

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackSpaNavigation/PageBViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/PostbackSpaNavigation/PageBViewModel.cs
@@ -9,6 +9,9 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.PostBackSpaNavigation
 {
     public class PageBViewModel : DenyPostbacksOnSpaNavigationViewModel
     {
+
+        public int Result { get; set; }
+
         public override Task Init()
         {
             Thread.Sleep(2000);

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackConcurrency/RedirectPostbackQueue.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackConcurrency/RedirectPostbackQueue.dothtml
@@ -9,11 +9,11 @@
 </head>
 <body>
 
-    <h1>Redirect should cancel waiting postbacks</h1>
+    <h1>Redirect should not cancel waiting postbacks</h1>
 
     <h2>Value: <span class="result">{{value: Value}}</span></h2>
 
-    <p>Click the first button and the second button immediately - the value should not be incremented to 1 when the page is reloading.</p>
+    <p>Click the first button and the second button immediately - the value will incremented to 1 while the new page is loading.</p>
 
     <div PostBack.Concurrency="Queue">
         <dot:Button Text="Redirect (blocks for 2 + 5 seconds)" Click="{command: Redirect()}" />

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackConcurrency/RedirectPostbackQueueSpa.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackConcurrency/RedirectPostbackQueueSpa.dothtml
@@ -4,7 +4,7 @@
 <dot:Content ContentPlaceHolderID="MainContent">
 
     <h1>Redirect should cancel waiting postbacks in SPA</h1>
-    
+
     <h2>Value: <span class="result">{{value: Value}}</span></h2>
 
     <p>Click the first button and the second button immediately - the value should not be incremented to 1 when the page is reloading.</p>

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackSpaNavigation/PageA.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackSpaNavigation/PageA.dothtml
@@ -16,4 +16,7 @@
     <dot:Button Click="{command: Command()}" Text="Command" />
     <dot:Button Click="{staticCommand: Result = _vm.StaticCommand(Result)}" Text="Static Command" />
 
+    <dot:Button Click="{command: LongCommand()}" Text="Long Running Command" />
+    <dot:Button Click="{staticCommand: Result = _vm.LongStaticCommand(Result)}" Text="Long Running Static Command" />
+
 </dot:Content>

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackSpaNavigation/PageB.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/PostbackSpaNavigation/PageB.dothtml
@@ -5,4 +5,6 @@
 
     <p>Navigation success</p>
 
+    <p class="result">{{value: Result}}</p>
+
 </dot:Content>

--- a/src/DotVVM.Samples.Tests/Feature/PostbackConcurrencyTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/PostbackConcurrencyTests.cs
@@ -187,7 +187,7 @@ namespace DotVVM.Samples.Tests.Feature
             });
         }
 
-        [Fact]
+        [Fact(Skip = "Cannot read element contents when the browser is already navigating away - getting element stale exception.")]
         public void Feature_PostbackConcurrency_RedirectPostbackQueue()
         {
             RunInAllBrowsers(browser => {

--- a/src/DotVVM.Samples.Tests/Feature/PostbackSpaNavigationTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/PostbackSpaNavigationTests.cs
@@ -117,7 +117,7 @@ namespace DotVVM.Samples.Tests.Feature
 
         [SampleReference(SamplesRouteUrls.FeatureSamples_PostbackSpaNavigation_PageA)]
         [SampleReference(SamplesRouteUrls.FeatureSamples_PostbackSpaNavigation_PageB)]
-        [Fact]
+        [Fact(Skip = "Won't fix in 2.5 - we don't know what else could break because of this.")]
         public void PostbackSpaNavigationTest_SuccessfulNavigation_SurvivingStaticCommand()
         {
             RunInAllBrowsers(browser => {

--- a/src/DotVVM.Samples.Tests/Feature/PostbackSpaNavigationTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/PostbackSpaNavigationTests.cs
@@ -86,6 +86,63 @@ namespace DotVVM.Samples.Tests.Feature
             });
         }
 
+        [SampleReference(SamplesRouteUrls.FeatureSamples_PostbackSpaNavigation_PageA)]
+        [SampleReference(SamplesRouteUrls.FeatureSamples_PostbackSpaNavigation_PageB)]
+        [Fact]
+        public void PostbackSpaNavigationTest_SuccessfulNavigation_SurvivingCommand()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_PostbackSpaNavigation_PageA);
+
+                var links = browser.FindElements("a");
+                var buttons = browser.FindElements("input[type=button]");
+                var result = browser.Single(".result");
+
+                // click the button to start a long postback
+                AssertUI.TextEquals(result, "0");
+                buttons[2].Click().Wait();
+
+                // click the first link to trigger the navigation
+                links[0].Click();
+
+                // wait for the navigation and postback to finish
+                browser.Wait(6000);
+                AssertUI.UrlEquals(browser, browser.BaseUrl + SamplesRouteUrls.FeatureSamples_PostbackSpaNavigation_PageB);
+
+                // check that the new field was not incremented
+                result = browser.Single(".result");
+                AssertUI.TextEquals(result, "0");
+            });
+        }
+
+        [SampleReference(SamplesRouteUrls.FeatureSamples_PostbackSpaNavigation_PageA)]
+        [SampleReference(SamplesRouteUrls.FeatureSamples_PostbackSpaNavigation_PageB)]
+        [Fact]
+        public void PostbackSpaNavigationTest_SuccessfulNavigation_SurvivingStaticCommand()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_PostbackSpaNavigation_PageA);
+
+                var links = browser.FindElements("a");
+                var buttons = browser.FindElements("input[type=button]");
+                var result = browser.Single(".result");
+
+                // click the button to start a long postback
+                AssertUI.TextEquals(result, "0");
+                buttons[3].Click().Wait();
+
+                // click the first link to trigger the navigation
+                links[0].Click();
+
+                // wait for the navigation and postback to finish
+                browser.Wait(6000);
+                AssertUI.UrlEquals(browser, browser.BaseUrl + SamplesRouteUrls.FeatureSamples_PostbackSpaNavigation_PageB);
+
+                // check that the new field was not incremented
+                result = browser.Single(".result");
+                AssertUI.TextEquals(result, "0");
+            });
+        }
 
         public PostbackSpaNavigationTests(ITestOutputHelper output) : base(output)
         {

--- a/src/DotVVM.Samples.Tests/Feature/ReturnedFileTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/ReturnedFileTests.cs
@@ -18,6 +18,7 @@ namespace DotVVM.Samples.Tests.Feature
         {
             RunInAllBrowsers(browser => {
                 ReturnedFileDownload(browser, "Hello DotVVM returned file sample!");
+                ReturnedFileDownload(browser, "XXX");
             });
         }
 
@@ -38,7 +39,7 @@ namespace DotVVM.Samples.Tests.Feature
                 browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_ReturnedFile_ReturnedFileSample);
 
                 browser.First("textarea").SendKeys("hello world");
-                browser.Last("input[type=button]").Click();
+                browser.Last("input[type=button]").Click().Wait();
 
                 AssertUI.TextEquals(browser.First("pre"), "hello world");
             });


### PR DESCRIPTION
We didn't realize that returning files is commonly done via redirects, and we were disabling postbacks on redirects. 
This PR returns to the previous behavior. 

Also, I've found an issue that we should fix in 3.x branch - long running static commands can modify a viewmodel of another page if SPA navigation is triggered during the time static command is running. 