### PR TITLE
Routes: Parameters and queries are URL encoded + client-side fixes

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/ControlTests/SimpleControlTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/ControlTests/SimpleControlTests.cs
@@ -11,8 +11,52 @@ namespace DotVVM.Framework.Tests.Common.ControlTests
     [TestClass]
     public class SimpleControlTests
     {
-        ControlTestHelper cth = new ControlTestHelper();
+        ControlTestHelper cth = new ControlTestHelper(config: config => {
+            config.RouteTable.Add("WithParams", "WithParams/{A}-{B:int}/{C?}", "WithParams.dothtml", new { B = 1 });
+            config.RouteTable.Add("Simple", "Simple", "Simple.dothtml");
+        });
         OutputChecker check = new OutputChecker("testoutputs");
+
+        [TestMethod]
+        public async Task RouteLink()
+        {
+            var r = await cth.RunPage(typeof(BasicTestViewModel), @"
+                <!-- client rendering, no params -->
+                <dot:RouteLink RenderSettings.Mode=Client RouteName=Simple Text='Click me' />
+                <!-- client rendering, no params, query and suffix -->
+                <dot:RouteLink RenderSettings.Mode=Client RouteName=Simple Text='Click me' Query-Binding={value: Integer} Query-Constant='c/y' UrlSuffix='#mySuffix' />
+                <!-- client rendering, no params, text binding -->
+                <dot:RouteLink RenderSettings.Mode=Client RouteName=Simple Text={value: Label} />
+
+                <!-- server rendering, no params -->
+                <dot:RouteLink RenderSettings.Mode=Server RouteName=Simple Text='Click me' />
+                <!-- server rendering, no params, query and suffix -->
+                <dot:RouteLink RenderSettings.Mode=Server RouteName=Simple Text='Click me' Query-Binding={value: Integer} Query-Constant='c/y' UrlSuffix='#mySuffix' />
+                <!-- server rendering, no params, text binding -->
+                <dot:RouteLink RenderSettings.Mode=Server RouteName=Simple Text={value: Label} />
+
+                <!-- client rendering, static params -->
+                <dot:RouteLink RenderSettings.Mode=Client RouteName=WithParams Param-A=A Param-B=1 Text='Click me' />
+                <!-- client rendering, static params, query and suffix -->
+                <dot:RouteLink RenderSettings.Mode=Client RouteName=WithParams Param-A=A Param-B=1 Text='Click me' Query-Binding={value: Integer} Query-Constant='c/y' UrlSuffix='#mySuffix' />
+                <!-- client rendering, dynamic params, query and suffix -->
+                <dot:RouteLink RenderSettings.Mode=Client RouteName=WithParams Param-A={value: Label} Param-B={value: Integer} Text='Click me' Query-Binding={value: Integer} Query-Constant='c/y' UrlSuffix='#mySuffix' />
+                <!-- client rendering, static params, text binding -->
+                <dot:RouteLink RenderSettings.Mode=Client RouteName=WithParams Param-A=A Param-B=1 Text={value: Label} />
+
+                <!-- server rendering, static params -->
+                <dot:RouteLink RenderSettings.Mode=Server RouteName=WithParams Param-A=A Param-B=1 Text='Click me' />
+                <!-- server rendering, static params, query and suffix -->
+                <dot:RouteLink RenderSettings.Mode=Server RouteName=WithParams Param-A=A Param-B=1 Text='Click me' Query-Binding={value: Integer} Query-Constant='c/y' UrlSuffix='#mySuffix' />
+                <!-- server rendering, dynamic params, query and suffix -->
+                <dot:RouteLink RenderSettings.Mode=Server RouteName=WithParams Param-A={value: Label} Param-B={value: Integer} Text='Click me' Query-Binding={value: Integer} Query-Constant='c/y' UrlSuffix='#mySuffix' />
+                <!-- server rendering, static params, text binding -->
+                <dot:RouteLink RenderSettings.Mode=Server RouteName=WithParams Param-A=A Param-B=1 Text={value: Label} />
+                "
+            );
+
+            check.CheckString(r.FormattedHtml, fileExtension: "html");
+        }
 
         [TestMethod]
         public async Task Literal_ClientServerRendering()
@@ -88,6 +132,7 @@ namespace DotVVM.Framework.Tests.Common.ControlTests
             public double Float { get; set; } = 0.11111;
             [Bind(Name = "date")]
             public DateTime DateTime { get; set; } = DateTime.Parse("2020-08-11T16:01:44.5141480");
+            public string Label { get; } = "My Label";
         }
     }
 }

--- a/src/DotVVM.Framework.Tests.Common/ControlTests/SimpleControlTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/ControlTests/SimpleControlTests.cs
@@ -47,9 +47,9 @@ namespace DotVVM.Framework.Tests.Common.ControlTests
                 <!-- server rendering, static params -->
                 <dot:RouteLink RenderSettings.Mode=Server RouteName=WithParams Param-A=A Param-B=1 Text='Click me' />
                 <!-- server rendering, static params, query and suffix -->
-                <dot:RouteLink RenderSettings.Mode=Server RouteName=WithParams Param-A=A Param-B=1 Text='Click me' Query-Binding={value: Integer} Query-Constant='c/y' UrlSuffix='#mySuffix' />
+                <dot:RouteLink RenderSettings.Mode=Server RouteName=WithParams Param-a=A Param-B=1 Text='Click me' Query-Binding={value: Integer} Query-Constant='c/y' UrlSuffix='#mySuffix' />
                 <!-- server rendering, dynamic params, query and suffix -->
-                <dot:RouteLink RenderSettings.Mode=Server RouteName=WithParams Param-A={value: Label} Param-B={value: Integer} Text='Click me' Query-Binding={value: Integer} Query-Constant='c/y' UrlSuffix='#mySuffix' />
+                <dot:RouteLink RenderSettings.Mode=Server RouteName=WithParams Param-A={value: Label} Param-b={value: Integer} Text='Click me' Query-Binding={value: Integer} Query-Constant='c/y' UrlSuffix='#mySuffix' />
                 <!-- server rendering, static params, text binding -->
                 <dot:RouteLink RenderSettings.Mode=Server RouteName=WithParams Param-A=A Param-B=1 Text={value: Label} />
                 "

--- a/src/DotVVM.Framework.Tests.Common/ControlTests/testoutputs/SimpleControlTests.RouteLink.html
+++ b/src/DotVVM.Framework.Tests.Common/ControlTests/testoutputs/SimpleControlTests.RouteLink.html
@@ -1,0 +1,47 @@
+<html>
+	<head></head>
+	<body>
+		
+		<!-- client rendering, no params -->
+		<a href="/Simple" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="dotvvm-enable: true">Click me</a>
+		
+		<!-- client rendering, no params, query and suffix -->
+		<a onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="attr: { &quot;href&quot;: '/' + &quot;Simple&quot; + dotvvm.buildUrlSuffix('#mySuffix', {'Constant': &quot;c/y&quot;,'Binding': int}) }, dotvvm-enable: true">Click me</a>
+		
+		<!-- client rendering, no params, text binding -->
+		<a href="/Simple" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="text: Label, dotvvm-enable: true"></a>
+		
+		<!-- server rendering, no params -->
+		<a href="/Simple" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="dotvvm-enable: true">Click me</a>
+		
+		<!-- server rendering, no params, query and suffix -->
+		<a href="/Simple?Constant=c%2Fy&amp;Binding=10000000#mySuffix" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="attr: { &quot;href&quot;: '/' + &quot;Simple&quot; + dotvvm.buildUrlSuffix('#mySuffix', {'Constant': &quot;c/y&quot;,'Binding': int}) }, dotvvm-enable: true">Click me</a>
+		
+		<!-- server rendering, no params, text binding -->
+		<a href="/Simple" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="dotvvm-enable: true">My Label</a>
+		
+		<!-- client rendering, static params -->
+		<a href="/WithParams/A-1" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="dotvvm-enable: true">Click me</a>
+		
+		<!-- client rendering, static params, query and suffix -->
+		<a onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="attr: { &quot;href&quot;: '/' + dotvvm.buildRouteUrl(&quot;WithParams/{a}-{b}/{c}&quot;, {'b': &quot;1&quot;,'a': &quot;A&quot;}) + dotvvm.buildUrlSuffix('#mySuffix', {'Constant': &quot;c/y&quot;,'Binding': int}) }, dotvvm-enable: true">Click me</a>
+		
+		<!-- client rendering, dynamic params, query and suffix -->
+		<a onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="attr: { &quot;href&quot;: '/' + dotvvm.buildRouteUrl(&quot;WithParams/{a}-{b}/{c}&quot;, {'b': int,'a': Label}) + dotvvm.buildUrlSuffix('#mySuffix', {'Constant': &quot;c/y&quot;,'Binding': int}) }, dotvvm-enable: true">Click me</a>
+		
+		<!-- client rendering, static params, text binding -->
+		<a href="/WithParams/A-1" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="text: Label, dotvvm-enable: true"></a>
+		
+		<!-- server rendering, static params -->
+		<a href="/WithParams/A-1" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="dotvvm-enable: true">Click me</a>
+		
+		<!-- server rendering, static params, query and suffix -->
+		<a href="/WithParams/A-1?Constant=c%2Fy&amp;Binding=10000000#mySuffix" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="attr: { &quot;href&quot;: '/' + dotvvm.buildRouteUrl(&quot;WithParams/{a}-{b}/{c}&quot;, {'b': &quot;1&quot;,'a': &quot;A&quot;}) + dotvvm.buildUrlSuffix('#mySuffix', {'Constant': &quot;c/y&quot;,'Binding': int}) }, dotvvm-enable: true">Click me</a>
+		
+		<!-- server rendering, dynamic params, query and suffix -->
+		<a href="/WithParams/My%20Label-10000000?Constant=c%2Fy&amp;Binding=10000000#mySuffix" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="attr: { &quot;href&quot;: '/' + dotvvm.buildRouteUrl(&quot;WithParams/{a}-{b}/{c}&quot;, {'b': int,'a': Label}) + dotvvm.buildUrlSuffix('#mySuffix', {'Constant': &quot;c/y&quot;,'Binding': int}) }, dotvvm-enable: true">Click me</a>
+		
+		<!-- server rendering, static params, text binding -->
+		<a href="/WithParams/A-1" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="dotvvm-enable: true">My Label</a>
+	</body>
+</html>

--- a/src/DotVVM.Framework.Tests.Common/ControlTests/testoutputs/SimpleControlTests.RouteLink.html
+++ b/src/DotVVM.Framework.Tests.Common/ControlTests/testoutputs/SimpleControlTests.RouteLink.html
@@ -6,7 +6,7 @@
 		<a href="/Simple" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="dotvvm-enable: true">Click me</a>
 		
 		<!-- client rendering, no params, query and suffix -->
-		<a onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="attr: { &quot;href&quot;: '/' + &quot;Simple&quot; + dotvvm.buildUrlSuffix('#mySuffix', {'Constant': &quot;c/y&quot;,'Binding': int}) }, dotvvm-enable: true">Click me</a>
+		<a onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="attr: { &quot;href&quot;: '/' + &quot;Simple&quot; + dotvvm.buildUrlSuffix('#mySuffix', {'Binding': int,'Constant': &quot;c/y&quot;}) }, dotvvm-enable: true">Click me</a>
 		
 		<!-- client rendering, no params, text binding -->
 		<a href="/Simple" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="text: Label, dotvvm-enable: true"></a>
@@ -15,7 +15,7 @@
 		<a href="/Simple" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="dotvvm-enable: true">Click me</a>
 		
 		<!-- server rendering, no params, query and suffix -->
-		<a href="/Simple?Constant=c%2Fy&amp;Binding=10000000#mySuffix" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="attr: { &quot;href&quot;: '/' + &quot;Simple&quot; + dotvvm.buildUrlSuffix('#mySuffix', {'Constant': &quot;c/y&quot;,'Binding': int}) }, dotvvm-enable: true">Click me</a>
+		<a href="/Simple?Binding=10000000&amp;Constant=c%2Fy#mySuffix" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="attr: { &quot;href&quot;: '/' + &quot;Simple&quot; + dotvvm.buildUrlSuffix('#mySuffix', {'Binding': int,'Constant': &quot;c/y&quot;}) }, dotvvm-enable: true">Click me</a>
 		
 		<!-- server rendering, no params, text binding -->
 		<a href="/Simple" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="dotvvm-enable: true">My Label</a>
@@ -24,10 +24,10 @@
 		<a href="/WithParams/A-1" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="dotvvm-enable: true">Click me</a>
 		
 		<!-- client rendering, static params, query and suffix -->
-		<a onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="attr: { &quot;href&quot;: '/' + dotvvm.buildRouteUrl(&quot;WithParams/{a}-{b}/{c}&quot;, {'b': &quot;1&quot;,'a': &quot;A&quot;}) + dotvvm.buildUrlSuffix('#mySuffix', {'Constant': &quot;c/y&quot;,'Binding': int}) }, dotvvm-enable: true">Click me</a>
+		<a onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="attr: { &quot;href&quot;: '/' + dotvvm.buildRouteUrl(&quot;WithParams/{a}-{b}/{c}&quot;, {'b': &quot;1&quot;,'a': &quot;A&quot;}) + dotvvm.buildUrlSuffix('#mySuffix', {'Binding': int,'Constant': &quot;c/y&quot;}) }, dotvvm-enable: true">Click me</a>
 		
 		<!-- client rendering, dynamic params, query and suffix -->
-		<a onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="attr: { &quot;href&quot;: '/' + dotvvm.buildRouteUrl(&quot;WithParams/{a}-{b}/{c}&quot;, {'b': int,'a': Label}) + dotvvm.buildUrlSuffix('#mySuffix', {'Constant': &quot;c/y&quot;,'Binding': int}) }, dotvvm-enable: true">Click me</a>
+		<a onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="attr: { &quot;href&quot;: '/' + dotvvm.buildRouteUrl(&quot;WithParams/{a}-{b}/{c}&quot;, {'b': int,'a': Label}) + dotvvm.buildUrlSuffix('#mySuffix', {'Binding': int,'Constant': &quot;c/y&quot;}) }, dotvvm-enable: true">Click me</a>
 		
 		<!-- client rendering, static params, text binding -->
 		<a href="/WithParams/A-1" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="text: Label, dotvvm-enable: true"></a>
@@ -36,10 +36,10 @@
 		<a href="/WithParams/A-1" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="dotvvm-enable: true">Click me</a>
 		
 		<!-- server rendering, static params, query and suffix -->
-		<a href="/WithParams/A-1?Constant=c%2Fy&amp;Binding=10000000#mySuffix" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="attr: { &quot;href&quot;: '/' + dotvvm.buildRouteUrl(&quot;WithParams/{a}-{b}/{c}&quot;, {'b': &quot;1&quot;,'a': &quot;A&quot;}) + dotvvm.buildUrlSuffix('#mySuffix', {'Constant': &quot;c/y&quot;,'Binding': int}) }, dotvvm-enable: true">Click me</a>
+		<a href="/WithParams/A-1?Binding=10000000&amp;Constant=c%2Fy#mySuffix" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="attr: { &quot;href&quot;: '/' + dotvvm.buildRouteUrl(&quot;WithParams/{a}-{b}/{c}&quot;, {'b': &quot;1&quot;,'a': &quot;A&quot;}) + dotvvm.buildUrlSuffix('#mySuffix', {'Binding': int,'Constant': &quot;c/y&quot;}) }, dotvvm-enable: true">Click me</a>
 		
 		<!-- server rendering, dynamic params, query and suffix -->
-		<a href="/WithParams/My%20Label-10000000?Constant=c%2Fy&amp;Binding=10000000#mySuffix" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="attr: { &quot;href&quot;: '/' + dotvvm.buildRouteUrl(&quot;WithParams/{a}-{b}/{c}&quot;, {'b': int,'a': Label}) + dotvvm.buildUrlSuffix('#mySuffix', {'Constant': &quot;c/y&quot;,'Binding': int}) }, dotvvm-enable: true">Click me</a>
+		<a href="/WithParams/My%20Label-10000000?Binding=10000000&amp;Constant=c%2Fy#mySuffix" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="attr: { &quot;href&quot;: '/' + dotvvm.buildRouteUrl(&quot;WithParams/{a}-{b}/{c}&quot;, {'b': int,'a': Label}) + dotvvm.buildUrlSuffix('#mySuffix', {'Binding': int,'Constant': &quot;c/y&quot;}) }, dotvvm-enable: true">Click me</a>
 		
 		<!-- server rendering, static params, text binding -->
 		<a href="/WithParams/A-1" onclick="event.stopPropagation();return !this.hasAttribute('disabled');" data-bind="dotvvm-enable: true">My Label</a>

--- a/src/DotVVM.Framework.Tests.Common/Routing/DotvvmRouteTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Routing/DotvvmRouteTests.cs
@@ -8,6 +8,7 @@ using DotVVM.Framework.Hosting;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using System.Globalization;
 
 namespace DotVVM.Framework.Tests.Routing
 {
@@ -362,6 +363,27 @@ namespace DotVVM.Framework.Tests.Routing
             Assert.AreEqual("~/RR", result);
         }
 
+        [TestMethod]
+        public void DotvvmRoute_BuildUrl_InvariantCulture()
+        {
+            CultureInfo.CurrentCulture = CultureInfo.CurrentUICulture = new CultureInfo("cs-CZ");
+            var route = new DotvvmRoute("RR-{p}", null, null, null, configuration);
+
+            var result = route.BuildUrl(new { p = 1.1});
+
+            Assert.AreEqual("~/RR-1.1", result);
+        }
+
+        [TestMethod]
+        public void DotvvmRoute_BuildUrl_UrlEncode()
+        {
+            CultureInfo.CurrentCulture = CultureInfo.CurrentUICulture = new CultureInfo("cs-CZ");
+            var route = new DotvvmRoute("RR-{p}", null, null, null, configuration);
+
+            var result = route.BuildUrl(new { p = 1.1});
+
+            Assert.AreEqual("~/RR-1.1", result);
+        }
 
         [TestMethod]
         public void DotvvmRoute_BuildUrl_Invalid_UnclosedParameter()
@@ -387,6 +409,18 @@ namespace DotVVM.Framework.Tests.Routing
             });
         }
 
+        [TestMethod]
+        public void DotvvmRoute_BuildUrl_Parameter_UrlDecode()
+        {
+            var route = new DotvvmRoute("Article/{Title}", null, null, null, configuration);
+
+            IDictionary<string, object> parameters;
+            var result = route.IsMatch("Article/" + Uri.EscapeDataString("x a d # ? %%%%% | ://"), out parameters);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(1, parameters.Count);
+            Assert.AreEqual("x a d # ? %%%%% | ://", parameters["Title"]);
+        }
 
         [TestMethod]
         public void DotvvmRoute_BuildUrl_ParameterConstraint_Int()
@@ -547,6 +581,18 @@ namespace DotVVM.Framework.Tests.Routing
             Assert.IsTrue(route.IsMatch("test/bb", out parameters));
             Assert.IsTrue(route.IsMatch("test/cc", out parameters));
             Assert.IsFalse(route.IsMatch("test/aaaa", out parameters));
+        }
+
+        [TestMethod]
+        public void DotvvmRoute_UrlWithoutTypes()
+        {
+            string parse(string url) => new DotvvmRoute(url, null, null, null, configuration).UrlWithoutTypes;
+
+            Assert.AreEqual(parse("test/xx/12"), "/test/xx/12");
+            Assert.AreEqual(parse("test/{Param}-{PaRAM2}"), "/test/{param}-{param2}");
+            Assert.AreEqual(parse("test/{Param?}-{PaRAM2?}"), "/test/{param}-{param2}");
+            Assert.AreEqual(parse("test/{Param:int}-{PaRAM2?:regex(.*)}"), "/test/{param}-{param2}");
+            Assert.AreEqual(parse("test/{Param:int}-{PaRAM2?:regex((.){4,10})}"), "/test/{param}-{param2}");
         }
     }
 

--- a/src/DotVVM.Framework.Tests.Common/Routing/DotvvmRouteTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Routing/DotvvmRouteTests.cs
@@ -588,11 +588,11 @@ namespace DotVVM.Framework.Tests.Routing
         {
             string parse(string url) => new DotvvmRoute(url, null, null, null, configuration).UrlWithoutTypes;
 
-            Assert.AreEqual(parse("test/xx/12"), "/test/xx/12");
-            Assert.AreEqual(parse("test/{Param}-{PaRAM2}"), "/test/{param}-{param2}");
-            Assert.AreEqual(parse("test/{Param?}-{PaRAM2?}"), "/test/{param}-{param2}");
-            Assert.AreEqual(parse("test/{Param:int}-{PaRAM2?:regex(.*)}"), "/test/{param}-{param2}");
-            Assert.AreEqual(parse("test/{Param:int}-{PaRAM2?:regex((.){4,10})}"), "/test/{param}-{param2}");
+            Assert.AreEqual(parse("test/xx/12"), "test/xx/12");
+            Assert.AreEqual(parse("test/{Param}-{PaRAM2}"), "test/{param}-{param2}");
+            Assert.AreEqual(parse("test/{Param?}-{PaRAM2?}"), "test/{param}-{param2}");
+            Assert.AreEqual(parse("test/{Param:int}-{PaRAM2?:regex(.*)}"), "test/{param}-{param2}");
+            Assert.AreEqual(parse("test/{Param:int}-{PaRAM2?:regex((.){4,10})}"), "test/{param}-{param2}");
         }
     }
 

--- a/src/DotVVM.Framework/Controls/RouteLinkHelpers.cs
+++ b/src/DotVVM.Framework/Controls/RouteLinkHelpers.cs
@@ -138,7 +138,7 @@ namespace DotVVM.Framework.Controls
 
             return
                 route.ParameterNames.Any()
-                    ? $"dotvvm.buildRouteUrl({JsonConvert.ToString(route.Url)}, {{{parametersExpression}}})"
+                    ? $"dotvvm.buildRouteUrl({JsonConvert.ToString(route.UrlWithoutTypes)}, {{{parametersExpression}}})"
                     : JsonConvert.ToString(route.Url);
         }
 

--- a/src/DotVVM.Framework/Controls/RouteLinkHelpers.cs
+++ b/src/DotVVM.Framework/Controls/RouteLinkHelpers.cs
@@ -78,7 +78,7 @@ namespace DotVVM.Framework.Controls
             // evaluate bindings on server
             foreach (var param in parameters.Where(p => p.Value is IStaticValueBinding).ToList())
             {
-                EnsureValidBindingType((IBinding)param.Value);
+                EnsureValidBindingType((IBinding)param.Value!);
                 parameters[param.Key] = ((IValueBinding)param.Value).Evaluate(control);   // TODO: see below
             }
 
@@ -89,7 +89,9 @@ namespace DotVVM.Framework.Controls
         private static string GenerateUrlSuffixCore(string? urlSuffix, RouteLink control)
         {
             // generate the URL suffix
-            return UrlHelper.BuildUrlSuffix(urlSuffix, control.QueryParameters);
+            var queryParams = control.QueryParameters.ToArray();
+            Array.Sort(queryParams, (a, b) => a.Key.CompareTo(b.Key)); // deterministic order of query params
+            return UrlHelper.BuildUrlSuffix(urlSuffix, queryParams);
         }
 
         private static RouteBase GetRoute(IDotvvmRequestContext context, string routeName)
@@ -118,12 +120,13 @@ namespace DotVVM.Framework.Controls
                 control.GetValueBinding(RouteLink.UrlSuffixProperty)
                 ?.Apply(binding => binding.GetKnockoutBindingExpression(control))
                 ?? KnockoutHelper.MakeStringLiteral(control.UrlSuffix ?? "");
-            var queryParams =
-                control.QueryParameters.RawValues.Select(p => TranslateRouteParameter(control, p, true)).StringJoin(",");
+            var queryParamsArray = control.QueryParameters.RawValues.ToArray();
+            Array.Sort(queryParamsArray, (a, b) => a.Key.CompareTo(b.Key)); // deterministic order of query params
+            var queryParams = queryParamsArray.Select(p => TranslateRouteParameter(control, p, true)).StringJoin(",");
 
             // generate the function call
             return
-                queryParams.Length > 0 ? $"dotvvm.buildUrlSuffix({urlSuffixBase}, {{{queryParams}}})" :
+                queryParamsArray.Length > 0 ? $"dotvvm.buildUrlSuffix({urlSuffixBase}, {{{queryParams}}})" :
                 urlSuffixBase != "\"\"" ? urlSuffixBase :
                 null;
         }

--- a/src/DotVVM.Framework/Resources/Scripts/controls/routeLink.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/controls/routeLink.ts
@@ -3,13 +3,22 @@ import { keys } from "../utils/objects";
 export function buildRouteUrl(routePath: string, params: any): string {
     // prepend url with backslash to correctly handle optional parameters at start
     routePath = '/' + routePath;
+    const paramPattern =
+    /*
+         (         ) -- group 1 - prefix
+          \/?[^\/{]*  -- match prefix = optional slash plus any string without slashes
+                     \{        \} -- in curly braces
+                       (      )       -- group 2 - paramName
+                        [^\}]+        -- anything except }, more than one character
+    */
+        /(\/?[^\/{]*)\{([^\}]+)\}/g
 
-    const url = routePath.replace(/(\/[^\/]*?)\{([^\}]+?)\??(:(.+?))?\}/g, (s, prefix, paramName, _, type) => {
+    const url = routePath.replace(paramPattern, (s, prefix, paramName) => {
         if (!paramName) {
             return "";
         }
-        const x = ko.unwrap(params[paramName.toLowerCase()])
-        return x == null ? "" : prefix + x;
+        const x = ko.unwrap(params[paramName])
+        return x == null ? "" : prefix + encodeURIComponent(x);
     });
 
     if (url.indexOf('/') === 0) {
@@ -32,7 +41,7 @@ export function buildUrlSuffix(urlSuffix: string, query: any): string {
             continue;
         }
 
-        resultSuffix += (resultSuffix.indexOf("?") != -1 ? "&" : "?") + `${property}=${queryParamValue}`
+        resultSuffix += (resultSuffix.indexOf("?") != -1 ? "&" : "?") + `${encodeURIComponent(property)}=${encodeURIComponent(queryParamValue)}`
     }
     return resultSuffix + hashSuffix;
 }

--- a/src/DotVVM.Framework/Resources/Scripts/tests/route-url.test.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/tests/route-url.test.ts
@@ -1,0 +1,37 @@
+import { buildRouteUrl, buildUrlSuffix } from '../controls/routeLink'
+
+
+test("buildUrlSuffix encodes", () => {
+    expect(buildUrlSuffix("", { a: 1, b: "1 2" } )).toBe("?a=1&b=1%202")
+    expect(buildUrlSuffix("", { a: 1, "a/b/c": 10.123 } )).toBe("?a=1&a%2Fb%2Fc=10.123")
+})
+test("buildUrlSuffix joins query params", () => {
+    expect(buildUrlSuffix("path?q=X", { a: 1 } )).toBe("path?q=X&a=1")
+    expect(buildUrlSuffix("path", { a: 1 } )).toBe("path?a=1")
+    expect(buildUrlSuffix("path?q", { a: 1 } )).toBe("path?q&a=1")
+})
+test("buildUrlSuffix ignores null query", () => {
+    expect(buildUrlSuffix("path?q=X", { a: null } )).toBe("path?q=X")
+    expect(buildUrlSuffix("path?q=X", { a: "" } )).toBe("path?q=X&a=")
+    expect(buildUrlSuffix("path?q=X", { a: 0 } )).toBe("path?q=X&a=0")
+})
+test("buildUrlSuffix handles hash", () => {
+    expect(buildUrlSuffix("#myHash", { a: 1, b: 2 } )).toBe("?a=1&b=2#myHash")
+    expect(buildUrlSuffix("?myQuery=2#myHash", { a: 1 } )).toBe("?myQuery=2&a=1#myHash")
+})
+
+test("buildRouteUrl encodes", () => {
+    expect(buildRouteUrl("/P/{id}", { id: "1/2" })).toBe("/P/1%2F2")
+})
+test("buildRouteUrl handles multiple args", () => {
+    expect(buildRouteUrl("/P/{id}-{name}", { id: 1, name: "N" })).toBe("/P/1-N")
+    expect(buildRouteUrl("/P/a{id}b/xx-{name}", { id: 1, name: "N" })).toBe("/P/a1b/xx-N")
+    expect(buildRouteUrl("/P/{id}{name}", { id: 1, name: "N" })).toBe("/P/1N")
+})
+test("buildRouteUrl handles optional args", () => {
+    expect(buildRouteUrl("/P/{id}/{name}", { name: "N" })).toBe("/P/N")
+    expect(buildRouteUrl("/P/{id}/{name}", { id: 1 })).toBe("/P/1")
+    expect(buildRouteUrl("/P/a{id}/xx-{name}", { id: 1, name: null })).toBe("/P/a1")
+    expect(buildRouteUrl("/P/a{id}/xx-{name}", { id: null, name: "N" })).toBe("/P/xx-N")
+    expect(buildRouteUrl("/{id}", { id: null })).toBe("")
+})

--- a/src/DotVVM.Framework/Routing/DotvvmRoute.cs
+++ b/src/DotVVM.Framework/Routing/DotvvmRoute.cs
@@ -130,7 +130,8 @@ namespace DotVVM.Framework.Routing
                                      v.Value?.ToString();
 
                         return strVal == null ? null : Uri.EscapeDataString(strVal);
-                    }
+                    },
+                    StringComparer.InvariantCultureIgnoreCase
                 );
             try
             {

--- a/src/DotVVM.Framework/Routing/DotvvmRoute.cs
+++ b/src/DotVVM.Framework/Routing/DotvvmRoute.cs
@@ -8,6 +8,7 @@ using DotVVM.Framework.Hosting;
 using System.Text.RegularExpressions;
 using DotVVM.Framework.Configuration;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace DotVVM.Framework.Routing
 {
@@ -16,13 +17,16 @@ namespace DotVVM.Framework.Routing
         private Func<IServiceProvider,IDotvvmPresenter> presenterFactory;
 
         private Regex routeRegex;
-        private List<Func<Dictionary<string, object?>, string>> urlBuilders;
+        private List<Func<Dictionary<string, string?>, string>> urlBuilders;
         private List<KeyValuePair<string, Func<string, ParameterParseResult>?>> parameters;
+        private string urlWithoutTypes;
 
         /// <summary>
         /// Gets the names of the route parameters in the order in which they appear in the URL.
         /// </summary>
         public override IEnumerable<string> ParameterNames => parameters.Select(p => p.Key);
+
+        public override string UrlWithoutTypes => urlWithoutTypes;
 
 
         /// <summary>
@@ -73,6 +77,7 @@ namespace DotVVM.Framework.Routing
             routeRegex = result.RouteRegex;
             urlBuilders = result.UrlBuilders;
             parameters = result.Parameters;
+            urlWithoutTypes = result.UrlWithoutTypes;
         }
 
         /// <summary>
@@ -97,14 +102,15 @@ namespace DotVVM.Framework.Routing
                 var g = match.Groups["param" + parameter.Key];
                 if (g.Success)
                 {
+                    var decodedValue = Uri.UnescapeDataString(g.Value);
                     if (parameter.Value != null)
                     {
-                        var r = parameter.Value(g.Value);
+                        var r = parameter.Value(decodedValue);
                         if (!r.IsOK) return false;
                         values[parameter.Key] = r.Value;
                     }
                     else
-                        values[parameter.Key] = g.Value;
+                        values[parameter.Key] = decodedValue;
                 }
             }
             return true;
@@ -115,9 +121,20 @@ namespace DotVVM.Framework.Routing
         /// </summary>
         protected override string BuildUrlCore(Dictionary<string, object?> values)
         {
+            var convertedValues =
+                values.ToDictionary(
+                    v => v.Key,
+                    v => {
+                        var strVal = v.Value is IConvertible convertible ?
+                                     convertible.ToString(CultureInfo.InvariantCulture) :
+                                     v.Value?.ToString();
+
+                        return strVal == null ? null : Uri.EscapeDataString(strVal);
+                    }
+                );
             try
             {
-                var url = string.Concat(urlBuilders.Select(b => b(values)));
+                var url = string.Concat(urlBuilders.Select(b => b(convertedValues)));
 
                 if (url == "~")
                     return "~/";

--- a/src/DotVVM.Framework/Routing/RouteBase.cs
+++ b/src/DotVVM.Framework/Routing/RouteBase.cs
@@ -7,6 +7,7 @@ using DotVVM.Framework.Hosting;
 using System.Reflection;
 using System.Collections.ObjectModel;
 using DotVVM.Framework.Configuration;
+using System.Diagnostics.CodeAnalysis;
 
 namespace DotVVM.Framework.Routing
 {
@@ -18,12 +19,15 @@ namespace DotVVM.Framework.Routing
         /// </summary>
         public string Url { get; private set; }
 
+        /// <summary>
+        /// Gets the URL pattern for the route, but it must not contain type parameter types (i.e. should turn a/{id:int}/{name:regex(...)} into a/{id}/{name}
+        /// </summary>
+        public abstract string UrlWithoutTypes { get; }
 
         /// <summary>
         /// Gets key of route.
         /// </summary>
         public string RouteName { get; internal set; }
-
 
         /// <summary>
         /// Gets the default values of the optional parameters.
@@ -89,8 +93,7 @@ namespace DotVVM.Framework.Routing
         /// <summary>
         /// Determines whether the route matches to the specified URL and extracts the parameter values.
         /// </summary>
-        public abstract bool IsMatch(string url, out IDictionary<string, object?> values);
-
+        public abstract bool IsMatch(string url, [MaybeNullWhen(false)] out IDictionary<string, object?> values);
 
         /// <summary>
         /// Builds the URL with the specified parameters.

--- a/src/DotVVM.Framework/Routing/RouteTableJsonConverter.cs
+++ b/src/DotVVM.Framework/Routing/RouteTableJsonConverter.cs
@@ -61,6 +61,8 @@ namespace DotVVM.Framework.Routing
 
             public override IEnumerable<string> ParameterNames => new string[0];
 
+            public override string UrlWithoutTypes => base.Url;
+
             public override IDotvvmPresenter GetPresenter(IServiceProvider provider) => throw new InvalidOperationException($"Could not create route {RouteName}", error);
 
             public override bool IsMatch(string url, out IDictionary<string, object> values) => throw new InvalidOperationException($"Could not create route {RouteName}", error);


### PR DESCRIPTION
Route parameters are now automatically URL encoded and decoded, both client-side and server-side.

Fix client-side parameter placement - mutliple parameters in one path segment is now supported.
To fix this, I had to strip the template URL from parameters constraints, as they are hard to parse.

Also, now we use invariant culture to format parameters.

+ unit tests for server-side, client-side URL building and for RouteLink control