### PR TITLE
Static Commands in MarkupControl

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Binding/StaticCommandCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/StaticCommandCompilationTests.cs
@@ -392,13 +392,13 @@ namespace DotVVM.Framework.Tests.Binding
         public static readonly DotvvmProperty LoadProperty
             = DotvvmProperty.Register<Func<string>, TestMarkupControl>(c => c.Load, null);
 
-        public Func<string, string> Chanege
+        public Func<string, string> Change
         {
-            get { return (Func<string, string>)GetValue(ChanegeProperty); }
-            set { SetValue(ChanegeProperty, value); }
+            get { return (Func<string, string>)GetValue(ChangeProperty); }
+            set { SetValue(ChangeProperty, value); }
         }
-        public static readonly DotvvmProperty ChanegeProperty
-            = DotvvmProperty.Register<Func<string, string>, TestMarkupControl>(c => c.Chanege, null);
+        public static readonly DotvvmProperty ChangeProperty
+            = DotvvmProperty.Register<Func<string, string>, TestMarkupControl>(c => c.Change, null);
 
 
         public static TestMarkupControl CreateInitialized()
@@ -406,7 +406,7 @@ namespace DotVVM.Framework.Tests.Binding
             var control = new TestMarkupControl();
             control.SetBinding(SaveProperty, new FakeCommandBinding(new ParametrizedCode("test"), null));
             control.SetBinding(LoadProperty, new FakeCommandBinding(new ParametrizedCode("test2"), null));
-            control.SetBinding(ChanegeProperty, new FakeCommandBinding(new ParametrizedCode("test3"), null));
+            control.SetBinding(ChangeProperty, new FakeCommandBinding(new ParametrizedCode("test3"), null));
             return control;
         }
 

--- a/src/DotVVM.Framework.Tests.Common/Binding/StaticCommandCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/StaticCommandCompilationTests.cs
@@ -307,9 +307,9 @@ namespace DotVVM.Framework.Tests.Binding
             var control = new TestMarkupControl();
             control.SetBinding(TestMarkupControl.SaveProperty, new FakeCommandBinding(new ParametrizedCode("test"), null));
 
-
             var result = CompileBinding("_control.Save()", niceMode: true, new[] { typeof(object) }, typeof(Command), typeof(TestMarkupControl));
 
+            Assert.Fail("TODO: implement changes and create expected result.");
         }
 
 

--- a/src/DotVVM.Framework.Tests.Common/Binding/StaticCommandCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/StaticCommandCompilationTests.cs
@@ -311,7 +311,7 @@ namespace DotVVM.Framework.Tests.Binding
             var expectedReslt = @"
 (function(a) {
 	return new Promise(function(resolve, reject) {
-		Promise.resolve(a.$control.Save()).then(function(r_0) {
+		Promise.resolve(a.$control.Save()()).then(function(r_0) {
 			resolve(r_0);
 		}, reject);
 	});
@@ -331,7 +331,7 @@ namespace DotVVM.Framework.Tests.Binding
             var expectedReslt = @"
 (function(a, b) {
 	return new Promise(function(resolve, reject) {
-		Promise.resolve(a.$control.Load()).then(function(r_0) {
+		Promise.resolve(a.$control.Load()()).then(function(r_0) {
 			dotvvm.staticCommandPostback(b, ""WARNING/NOT/ENCRYPTED+++WyJEb3RWVk0uRnJhbWV3b3JrLlRlc3RzLkJpbmRpbmcuVGVzdFNlcnZpY2UsIERvdFZWTS5GcmFtZXdvcmsuVGVzdHMuQ29tbW9uIiwiTG9hZCIsW10sIkFRQT0iXQ=="", [r_0], options).then(function(r_1) {
 				resolve(r_1);
 			}, reject);
@@ -355,7 +355,7 @@ namespace DotVVM.Framework.Tests.Binding
 	return new Promise(function(resolve, reject) {
 		(
 			b = dotvvm.staticCommandPostback(a, ""WARNING/NOT/ENCRYPTED+++WyJEb3RWVk0uRnJhbWV3b3JrLlRlc3RzLkJpbmRpbmcuVGVzdFNlcnZpY2UsIERvdFZWTS5GcmFtZXdvcmsuVGVzdHMuQ29tbW9uIiwiTG9hZCIsW10sIkFRQT0iXQ=="", [c.$data.StringProp()], options) ,
-			Promise.resolve(c.$control.Chanege(c.$data.StringProp())).then(function(r_0) {
+			Promise.resolve(c.$control.Chanege()(c.$data.StringProp())).then(function(r_0) {
 				b.then(function(r_1) {
 					resolve(c.$data.StringProp(r_0 + r_1).StringProp());
 				}, reject);

--- a/src/DotVVM.Framework.Tests.Common/ControlTests/ControlTestHelper.cs
+++ b/src/DotVVM.Framework.Tests.Common/ControlTests/ControlTestHelper.cs
@@ -57,6 +57,12 @@ namespace DotVVM.Framework.Tests.Common.ControlTests
             if (!fileLoader.MarkupFiles.TryAdd(fileName, markup))
                 throw new Exception($"File {fileName} already exists");
 
+            if (markupFiles is object) foreach (var markupFile in markupFiles)
+            {
+                if (!fileLoader.MarkupFiles.TryAdd(markupFile.Key, markupFile.Value))
+                    throw new Exception($"File {markupFile.Value} already exists");
+            }
+
             return controlBuilderFactory.GetControlBuilder(fileName);
         }
 
@@ -108,6 +114,7 @@ namespace DotVVM.Framework.Tests.Common.ControlTests
             Type viewModel,
             string markup,
             Dictionary<string, string> markupFiles = null,
+            string directives = "",
             bool renderResources = false,
             [CallerMemberName] string fileName = null)
         {
@@ -127,7 +134,7 @@ namespace DotVVM.Framework.Tests.Common.ControlTests
             {
                 markup = "<tc:FakeHeadResourceLink />" + markup;
             }
-            markup = $"@viewModel {viewModel.ToString().Replace("+", ".")}\n\n{markup}";
+            markup = $"@viewModel {viewModel.ToString().Replace("+", ".")}\n{directives}\n\n{markup}";
             var request = PreparePage(markup, markupFiles, fileName);
             await presenter.ProcessRequest(request);
             return CreatePageResult(request);

--- a/src/DotVVM.Framework.Tests.Common/ControlTests/MarkupControlTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/ControlTests/MarkupControlTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading.Tasks;
+using CheckTestOutput;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Tests.Binding;
+using DotVVM.Framework.ViewModel;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotVVM.Framework.Tests.Common.ControlTests
+{
+    [TestClass]
+    public class MarkupControlTests
+    {
+        ControlTestHelper cth = new ControlTestHelper(config: config => {
+            config.Markup.AddMarkupControl("cc", "CustomControlWithCommand", "CustomControlWithCommand.dotcontrol");
+        }, services: s => {
+            s.AddSingleton<TestService>();
+        });
+        OutputChecker check = new OutputChecker("testoutputs");
+
+        [TestMethod]
+        public async Task MarkupControl_PassingStaticCommand()
+        {
+
+            var r = await cth.RunPage(typeof(BasicTestViewModel), @"
+
+                <cc:CustomControlWithCommand DataContext={value: Integer} Click={staticCommand: s.Save(_parent.Integer)} />
+                <dot:Repeater DataSource={value: Collection}>
+                    <cc:CustomControlWithCommand Click={staticCommand: s.Save(_this)} />
+                </dot:Repeater>
+                ",
+                directives: $"@service s = {typeof(TestService)}",
+                markupFiles: new Dictionary<string, string> {
+                    ["CustomControlWithCommand.dotcontrol"] = @"
+                        @viewModel int
+                        @baseType DotVVM.Framework.Tests.Common.ControlTests.CustomControlWithCommand
+                        @wrapperTag div
+                        <dot:Button Click={staticCommand: _control.Click()} />"
+                }
+            );
+            check.CheckString(r.FormattedHtml, fileExtension: "html");
+        }
+
+        public class BasicTestViewModel: DotvvmViewModelBase
+        {
+            [Bind(Name = "int")]
+            public int Integer { get; set; } = 10000000;
+
+            public List<int> Collection { get; set; } = new List<int> { 10, -20 };
+        }
+    }
+
+    public class CustomControlWithCommand: DotvvmMarkupControl
+    {
+        public static readonly DotvvmProperty ClickProperty =
+            DotvvmProperty.Register<Command, CustomControlWithCommand>("Click");
+    }
+}

--- a/src/DotVVM.Framework.Tests.Common/ControlTests/MarkupControlTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/ControlTests/MarkupControlTests.cs
@@ -21,12 +21,12 @@ namespace DotVVM.Framework.Tests.Common.ControlTests
         }, services: s => {
             s.AddSingleton<TestService>();
         });
-        OutputChecker check = new OutputChecker("testoutputs");
+        OutputChecker check = new OutputChecker(
+            "testoutputs");
 
         [TestMethod]
         public async Task MarkupControl_PassingStaticCommand()
         {
-
             var r = await cth.RunPage(typeof(BasicTestViewModel), @"
 
                 <cc:CustomControlWithCommand DataContext={value: Integer} Click={staticCommand: s.Save(_parent.Integer)} />
@@ -43,10 +43,11 @@ namespace DotVVM.Framework.Tests.Common.ControlTests
                         <dot:Button Click={staticCommand: _control.Click()} />"
                 }
             );
+
             check.CheckString(r.FormattedHtml, fileExtension: "html");
         }
 
-        public class BasicTestViewModel: DotvvmViewModelBase
+        public class BasicTestViewModel : DotvvmViewModelBase
         {
             [Bind(Name = "int")]
             public int Integer { get; set; } = 10000000;
@@ -55,7 +56,7 @@ namespace DotVVM.Framework.Tests.Common.ControlTests
         }
     }
 
-    public class CustomControlWithCommand: DotvvmMarkupControl
+    public class CustomControlWithCommand : DotvvmMarkupControl
     {
         public static readonly DotvvmProperty ClickProperty =
             DotvvmProperty.Register<Command, CustomControlWithCommand>("Click");

--- a/src/DotVVM.Framework.Tests.Common/ControlTests/testoutputs/MarkupControlTests.MarkupControl_PassingStaticCommand.html
+++ b/src/DotVVM.Framework.Tests.Common/ControlTests/testoutputs/MarkupControlTests.MarkupControl_PassingStaticCommand.html
@@ -11,9 +11,9 @@
 		}, reject);
 	});
 }($element, ko.contextFor($element)))}.bind(this),$element,[])} } -->
-			<input type="button" value="" onclick="dotvvm.applyPostbackHandlers(function(options){return (function(a) {
+			<input type="button" value="" onclick="dotvvm.applyPostbackHandlers(function(options){return (function(a, b) {
 	return new Promise(function(resolve, reject) {
-		Promise.resolve(a.$control.Click &amp;&amp; a.$control.Click()).then(function(r_0) {
+		Promise.resolve((b = a.$control.Click()) &amp;&amp; b()).then(function(r_0) {
 			resolve(r_0);
 		}, reject);
 	});
@@ -30,9 +30,9 @@
 		}, reject);
 	});
 }($element, ko.contextFor($element)))}.bind(this),$element,[])} } -->
-				<input type="button" value="" onclick="dotvvm.applyPostbackHandlers(function(options){return (function(a) {
+				<input type="button" value="" onclick="dotvvm.applyPostbackHandlers(function(options){return (function(a, b) {
 	return new Promise(function(resolve, reject) {
-		Promise.resolve(a.$control.Click &amp;&amp; a.$control.Click()).then(function(r_0) {
+		Promise.resolve((b = a.$control.Click()) &amp;&amp; b()).then(function(r_0) {
 			resolve(r_0);
 		}, reject);
 	});

--- a/src/DotVVM.Framework.Tests.Common/ControlTests/testoutputs/MarkupControlTests.MarkupControl_PassingStaticCommand.html
+++ b/src/DotVVM.Framework.Tests.Common/ControlTests/testoutputs/MarkupControlTests.MarkupControl_PassingStaticCommand.html
@@ -1,0 +1,36 @@
+<html>
+	<head></head>
+	<body>
+		
+		<!-- ko with: int -->
+		<div>
+			<!-- ko dotvvm-with-control-properties: { "Click": function(){return dotvvm.applyPostbackHandlers(function(options){return (function(a, b) {
+	return new Promise(function(resolve, reject) {
+		dotvvm.staticCommandPostback(a, "WARNING/NOT/ENCRYPTED+++WyJEb3RWVk0uRnJhbWV3b3JrLlRlc3RzLkJpbmRpbmcuVGVzdFNlcnZpY2UsIERvdFZWTS5GcmFtZXdvcmsuVGVzdHMuQ29tbW9uIiwiU2F2ZSIsW10sIkFRQT0iXQ==", [b.$parent.int()], options).then(function(r_0) {
+			resolve(r_0);
+		}, reject);
+	});
+}($element, ko.contextFor($element)))}.bind(this),$element,[])} } -->
+			<input type="button" value="" onclick="dotvvm.applyPostbackHandlers(function(options){return (function(a) {
+	return Promise.resolve(a.$control.Click &amp;&amp; a.$control.Click());
+}(ko.contextFor(this)))}.bind(this),this,[]).catch(function(){});event.stopPropagation();return false;">
+			<!-- /ko -->
+		</div>
+		<!-- /ko -->
+		<div data-bind="foreach: { &quot;data&quot;: Collection }">
+			<div>
+				<!-- ko dotvvm-with-control-properties: { "Click": function(){return dotvvm.applyPostbackHandlers(function(options){return (function(a, b) {
+	return new Promise(function(resolve, reject) {
+		dotvvm.staticCommandPostback(a, "WARNING/NOT/ENCRYPTED+++WyJEb3RWVk0uRnJhbWV3b3JrLlRlc3RzLkJpbmRpbmcuVGVzdFNlcnZpY2UsIERvdFZWTS5GcmFtZXdvcmsuVGVzdHMuQ29tbW9uIiwiU2F2ZSIsW10sIkFRQT0iXQ==", [b.$data], options).then(function(r_0) {
+			resolve(r_0);
+		}, reject);
+	});
+}($element, ko.contextFor($element)))}.bind(this),$element,[])} } -->
+				<input type="button" value="" onclick="dotvvm.applyPostbackHandlers(function(options){return (function(a) {
+	return Promise.resolve(a.$control.Click &amp;&amp; a.$control.Click());
+}(ko.contextFor(this)))}.bind(this),this,[]).catch(function(){});event.stopPropagation();return false;">
+				<!-- /ko -->
+			</div>
+		</div>
+	</body>
+</html>

--- a/src/DotVVM.Framework.Tests.Common/ControlTests/testoutputs/MarkupControlTests.MarkupControl_PassingStaticCommand.html
+++ b/src/DotVVM.Framework.Tests.Common/ControlTests/testoutputs/MarkupControlTests.MarkupControl_PassingStaticCommand.html
@@ -12,7 +12,11 @@
 	});
 }($element, ko.contextFor($element)))}.bind(this),$element,[])} } -->
 			<input type="button" value="" onclick="dotvvm.applyPostbackHandlers(function(options){return (function(a) {
-	return Promise.resolve(a.$control.Click &amp;&amp; a.$control.Click());
+	return new Promise(function(resolve, reject) {
+		Promise.resolve(a.$control.Click &amp;&amp; a.$control.Click()).then(function(r_0) {
+			resolve(r_0);
+		}, reject);
+	});
 }(ko.contextFor(this)))}.bind(this),this,[]).catch(function(){});event.stopPropagation();return false;">
 			<!-- /ko -->
 		</div>
@@ -27,7 +31,11 @@
 	});
 }($element, ko.contextFor($element)))}.bind(this),$element,[])} } -->
 				<input type="button" value="" onclick="dotvvm.applyPostbackHandlers(function(options){return (function(a) {
-	return Promise.resolve(a.$control.Click &amp;&amp; a.$control.Click());
+	return new Promise(function(resolve, reject) {
+		Promise.resolve(a.$control.Click &amp;&amp; a.$control.Click()).then(function(r_0) {
+			resolve(r_0);
+		}, reject);
+	});
 }(ko.contextFor(this)))}.bind(this),this,[]).catch(function(){});event.stopPropagation();return false;">
 				<!-- /ko -->
 			</div>

--- a/src/DotVVM.Framework/Compilation/Binding/StaticCommandBindingCompiler.cs
+++ b/src/DotVVM.Framework/Compilation/Binding/StaticCommandBindingCompiler.cs
@@ -60,6 +60,9 @@ namespace DotVVM.Framework.Compilation.Binding
             // var resultPromiseVariable = new JsNewExpression("DotvvmPromise"));
             var senderVariable = new JsTemporaryVariableParameter(new JsSymbolicParameter(CommandBindingExpression.SenderElementParameter));
 
+            var invocationRewriter = new InvocationRewriterExpressionVisitor();
+            expression = invocationRewriter.Visit(expression);
+
             var rewriter = new TaskSequenceRewriterExpressionVisitor();
             expression = rewriter.Visit(expression);
 

--- a/src/DotVVM.Framework/Compilation/Javascript/InvocationRewriterExpressionVisitor.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/InvocationRewriterExpressionVisitor.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Linq.Expressions;
+
+namespace DotVVM.Framework.Compilation.Javascript
+{
+    public class InvocationRewriterExpressionVisitor : ExpressionVisitor
+    {
+        protected override Expression VisitInvocation(InvocationExpression node)
+        {
+            var invokeMethod = node.Expression.Type.GetMethod("Invoke");
+
+            return Expression.Call(node.Expression, invokeMethod, node.Arguments); ;
+        }
+    }
+}

--- a/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -27,8 +27,8 @@ namespace DotVVM.Framework.Compilation.Javascript
             if (method.Name == "Invoke" && typeof(Delegate).IsAssignableFrom(method.DeclaringType))
             {
                 var invocationTargetExpresionCall = context.JsExpression().Invoke(arguments.Select(a => a.JsExpression()));
-                return new JsIdentifierExpression("Promise").Member("resolve").Invoke(invocationTargetExpresionCall)
-                    .WithAnnotation(new ResultIsPromiseAnnotation(a=> a));
+                return invocationTargetExpresionCall
+                    .WithAnnotation(new ResultIsPromiseAnnotation(a=> new JsIdentifierExpression("Promise").Member("resolve").Invoke(a)));
             }
             return null;
         }

--- a/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -15,6 +15,25 @@ using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Compilation.Javascript
 {
+    public class DelegateInvokeMethodTranslator : IJavascriptMethodTranslator
+    {
+        public JsExpression TryTranslateCall(LazyTranslatedExpression context, LazyTranslatedExpression[] arguments, MethodInfo method)
+        {
+            if (method == null)
+            {
+                return null;
+            }
+
+            if (method.Name == "Invoke" && typeof(Delegate).IsAssignableFrom(method.DeclaringType))
+            {
+                var invocationTargetExpresionCall = context.JsExpression().Invoke(arguments.Select(a => a.JsExpression()));
+                return new JsIdentifierExpression("Promise").Member("resolve").Invoke(invocationTargetExpresionCall)
+                    .WithAnnotation(new ResultIsPromiseAnnotation(a=> a));
+            }
+            return null;
+        }
+    }
+
     public class JavascriptTranslatableMethodCollection : IJavascriptMethodTranslator
     {
         public readonly Dictionary<MethodInfo, IJavascriptMethodTranslator> MethodTranslators = new Dictionary<MethodInfo, IJavascriptMethodTranslator>();
@@ -180,11 +199,18 @@ namespace DotVVM.Framework.Compilation.Javascript
 
         public JsExpression TryTranslateCall(LazyTranslatedExpression context, LazyTranslatedExpression[] args, MethodInfo method)
         {
-            if (method == null) return null;
+            if (method == null)
+            {
+                return null;
+            }
+
             {
                 if (MethodTranslators.TryGetValue(method, out var translator) && translator.TryTranslateCall(context, args, method) is JsExpression result)
+                {
                     return result;
+                }
             }
+
             if (method.IsGenericMethod)
             {
                 var genericMethod = method.GetGenericMethodDefinition();

--- a/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslator.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslator.cs
@@ -182,6 +182,7 @@ namespace DotVVM.Framework.Compilation.Javascript
         {
             Translators.Add(MethodCollection = new JavascriptTranslatableMethodCollection());
             Translators.Add(new EnumToStringMethodTranslator());
+            Translators.Add(new DelegateInvokeMethodTranslator());
         }
 
         public JsExpression TryTranslateCall(LazyTranslatedExpression context, LazyTranslatedExpression[] arguments, MethodInfo method) =>

--- a/src/DotVVM.Framework/Compilation/Javascript/JsViewModelPropertyAdjuster.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/JsViewModelPropertyAdjuster.cs
@@ -49,12 +49,6 @@ namespace DotVVM.Framework.Compilation.Javascript
                 else if (propAnnotation.MemberInfo is FieldInfo)
                     throw new NotSupportedException($"Can not translate field '{propAnnotation.MemberInfo}' to Javascript");
 
-                //When command is assigned into a property of marcup control, we should not treat the result of the call as observable
-                if(typeof(Delegate).IsAssignableFrom(propertyType))
-                {
-                    containsObservables = false;
-                }
-
                 if (containsObservables)
                 {
                     node.AddAnnotation(ResultIsObservableAnnotation.Instance);

--- a/src/DotVVM.Framework/Compilation/Javascript/JsViewModelPropertyAdjuster.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/JsViewModelPropertyAdjuster.cs
@@ -49,6 +49,12 @@ namespace DotVVM.Framework.Compilation.Javascript
                 else if (propAnnotation.MemberInfo is FieldInfo)
                     throw new NotSupportedException($"Can not translate field '{propAnnotation.MemberInfo}' to Javascript");
 
+                //When command is assigned into a property of marcup control, we should not treat the result of the call as observable
+                if(typeof(Delegate).IsAssignableFrom(propertyType))
+                {
+                    containsObservables = false;
+                }
+
                 if (containsObservables)
                 {
                     node.AddAnnotation(ResultIsObservableAnnotation.Instance);

--- a/src/DotVVM.Framework/Controls/DotvvmMarkupControl.cs
+++ b/src/DotVVM.Framework/Controls/DotvvmMarkupControl.cs
@@ -97,6 +97,19 @@ namespace DotVVM.Framework.Controls
                     valueBinding.GetKnockoutBindingExpression(this)
                 );
             }
+            else if (GetBinding(property) is StaticCommandBindingExpression staticCommand)
+            {
+                var call = KnockoutHelper.GenerateClientPostBackExpression(
+                    property.Name,
+                    staticCommand,
+                    this,
+                    new PostbackScriptOptions(false, true, false, "$element"));
+
+                return new PropertySerializeInfo(
+                    property,
+                    $"function(){{return {call}}}"
+                );
+            }
             else
             {
                 return new PropertySerializeInfo(property, null);

--- a/src/DotVVM.Framework/Controls/DotvvmMarkupControl.cs
+++ b/src/DotVVM.Framework/Controls/DotvvmMarkupControl.cs
@@ -97,11 +97,11 @@ namespace DotVVM.Framework.Controls
                     valueBinding.GetKnockoutBindingExpression(this)
                 );
             }
-            else if (GetBinding(property) is StaticCommandBindingExpression staticCommand)
+            else if (GetBinding(property) is ICommandBinding command)
             {
                 var call = KnockoutHelper.GenerateClientPostBackExpression(
                     property.Name,
-                    staticCommand,
+                    command,
                     this,
                     new PostbackScriptOptions(false, true, false, "$element"));
 
@@ -109,7 +109,7 @@ namespace DotVVM.Framework.Controls
                     property,
                     $"function(){{return {call}}}"
                 );
-            }
+            }          
             else
             {
                 return new PropertySerializeInfo(property, null);

--- a/src/DotVVM.Framework/Controls/DotvvmMarkupControl.cs
+++ b/src/DotVVM.Framework/Controls/DotvvmMarkupControl.cs
@@ -103,7 +103,7 @@ namespace DotVVM.Framework.Controls
                     property.Name,
                     command,
                     this,
-                    new PostbackScriptOptions(false, true, false, "$element"));
+                    new PostbackScriptOptions(elementAccessor: "$element"));
 
                 return new PropertySerializeInfo(
                     property,

--- a/src/DotVVM.Framework/Resources/Scripts/binding-handlers/introduce-alias.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/binding-handlers/introduce-alias.ts
@@ -29,6 +29,9 @@ export default {
 
             const value = valueAccessor();
             for (const prop of keys(value)) {
+                if (!ko.isObservable(value[prop]) && typeof value[prop] == 'function') {
+                    continue;
+                }
 
                 value[prop] = createWrapperComputed(
                     () => {

--- a/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
+++ b/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
@@ -51,6 +51,8 @@
     <None Remove="Views\FeatureSamples\Caching\CachedValues.dothtml" />
     <None Remove="Views\FeatureSamples\JavascriptTranslation\GenericMethodTranslation.dothtml" />
     <None Remove="Views\FeatureSamples\Localization\Globalize.dothtml" />
+    <None Remove="Views\FeatureSamples\MarkupControl\Device.dotcontrol" />
+    <None Remove="Views\FeatureSamples\MarkupControl\StaticCommandInMarkupControl.dothtml" />
     <None Remove="Views\FeatureSamples\PostbackConcurrency\RedirectPostbackQueue.dothtml" />
     <None Remove="Views\FeatureSamples\PostbackConcurrency\StressTest.dothtml" />
     <None Remove="Views\FeatureSamples\PostBack\RecursiveTextRepeater.dotcontrol" />
@@ -101,6 +103,9 @@
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resource.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Views\FeatureSamples\NewFolder\" />
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <OutputPath>bin\Debug</OutputPath>

--- a/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
+++ b/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
@@ -53,6 +53,7 @@
     <None Remove="Views\FeatureSamples\Localization\Globalize.dothtml" />
     <None Remove="Views\FeatureSamples\MarkupControl\Device.dotcontrol" />
     <None Remove="Views\FeatureSamples\MarkupControl\StaticCommandInMarkupControl.dothtml" />
+    <None Remove="Views\FeatureSamples\MarkupControl\StaticCommandInMarkupControlCallingRegularCommand.dothtml" />
     <None Remove="Views\FeatureSamples\PostbackConcurrency\RedirectPostbackQueue.dothtml" />
     <None Remove="Views\FeatureSamples\PostbackConcurrency\StressTest.dothtml" />
     <None Remove="Views\FeatureSamples\PostBack\RecursiveTextRepeater.dotcontrol" />

--- a/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
+++ b/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
@@ -51,7 +51,9 @@
     <None Remove="Views\FeatureSamples\Caching\CachedValues.dothtml" />
     <None Remove="Views\FeatureSamples\JavascriptTranslation\GenericMethodTranslation.dothtml" />
     <None Remove="Views\FeatureSamples\Localization\Globalize.dothtml" />
+    <None Remove="Views\FeatureSamples\MarkupControl\CommandPropertiesInMarkupControl.dothtml" />
     <None Remove="Views\FeatureSamples\MarkupControl\Device.dotcontrol" />
+    <None Remove="Views\FeatureSamples\MarkupControl\Dialog.dotcontrol" />
     <None Remove="Views\FeatureSamples\MarkupControl\StaticCommandInMarkupControl.dothtml" />
     <None Remove="Views\FeatureSamples\MarkupControl\StaticCommandInMarkupControlCallingRegularCommand.dothtml" />
     <None Remove="Views\FeatureSamples\PostbackConcurrency\RedirectPostbackQueue.dothtml" />

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/MarkupControl/CommadPropertiesInMarkupControlViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/MarkupControl/CommadPropertiesInMarkupControlViewModel.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.MarkupControl
+{
+    public static class TestService
+    {
+        [AllowStaticCommand]
+        public static Task<string> Ok()
+        {
+            return Task.FromResult("Command result.");
+        }
+    }
+
+    public class CommandPropertiesInMarkupControlViewModel : DotvvmViewModelBase
+    {
+        public string Property { get; set; }
+    }
+}
+

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/MarkupControl/FakeDb.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/MarkupControl/FakeDb.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.MarkupControl
+{
+    public static class FakeDb
+    {
+        public static DeviceModel Insert(DeviceModel model)
+        {
+            model.Id = Guid.NewGuid();
+            devices.Add(model);
+            return model;
+        }
+        public static DeviceModel Update(DeviceModel model)
+        {
+            var d = Get(model.Id);
+            d.Name = model.Name;
+            d.Groups = model.Groups;
+            return d;
+        }
+
+        public static void Remove(Guid id) => devices = devices.Where(d => d.Id != id).ToList();
+        public static DeviceModel Get(Guid id) => devices.FirstOrDefault(d=>d.Id == id);
+        public static IQueryable<DeviceModel> GetQueriable() => devices.AsQueryable();
+
+        private static IList<DeviceModel> devices = new List<DeviceModel> {
+            new DeviceModel {
+                Name = "Washing machine",
+                Id = Guid.NewGuid(),
+                Groups = new List<string> { "Laundry room" }
+            },
+            new DeviceModel {
+                Name = "Stove",
+                Id = Guid.NewGuid(),
+                Groups = new List<string> { "Kitchen" }
+            },
+            new DeviceModel {
+                Name = "Dryer",
+                Id = Guid.NewGuid(),
+                Groups = new List<string> { "Laundry room" }
+            },
+        };
+    }
+}
+

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/MarkupControl/FakeDb.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/MarkupControl/FakeDb.cs
@@ -4,15 +4,15 @@ using System.Linq;
 
 namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.MarkupControl
 {
-    public static class FakeDb
+    public class FakeDb
     {
-        public static DeviceModel Insert(DeviceModel model)
+        public DeviceModel Insert(DeviceModel model)
         {
             model.Id = Guid.NewGuid();
             devices.Add(model);
             return model;
         }
-        public static DeviceModel Update(DeviceModel model)
+        public DeviceModel Update(DeviceModel model)
         {
             var d = Get(model.Id);
             d.Name = model.Name;
@@ -20,11 +20,11 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.MarkupControl
             return d;
         }
 
-        public static void Remove(Guid id) => devices = devices.Where(d => d.Id != id).ToList();
-        public static DeviceModel Get(Guid id) => devices.FirstOrDefault(d=>d.Id == id);
-        public static IQueryable<DeviceModel> GetQueriable() => devices.AsQueryable();
+        public void Remove(Guid id) => devices = devices.Where(d => d.Id != id).ToList();
+        public DeviceModel Get(Guid id) => devices.FirstOrDefault(d=>d.Id == id);
+        public IQueryable<DeviceModel> GetQueriable() => devices.AsQueryable();
 
-        private static IList<DeviceModel> devices = new List<DeviceModel> {
+        private IList<DeviceModel> devices = new List<DeviceModel> {
             new DeviceModel {
                 Name = "Washing machine",
                 Id = Guid.NewGuid(),

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/MarkupControl/StaticCommandInMarkupControlCallingRegularCommandViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/MarkupControl/StaticCommandInMarkupControlCallingRegularCommandViewModel.cs
@@ -19,7 +19,7 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.MarkupControl
         public DeviceModel Detail { get; set; } = new DeviceModel { };
         public bool IsDetailOpen { get; set; }
 
-        public string MyProperty { get; set; }
+        private static FakeDb FakeDb { get; } = new FakeDb();
 
         public override Task PreRender()
         {

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/MarkupControl/StaticCommandInMarkupControlCallingRegularCommandViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/MarkupControl/StaticCommandInMarkupControlCallingRegularCommandViewModel.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.MarkupControl
+{
+    public class StaticCommandInMarkupControlCallingRegularCommandViewModel : DotvvmViewModelBase
+    {
+        public GridViewDataSet<DeviceModel> Devices { get; set; } = new GridViewDataSet<DeviceModel> {
+            PagingOptions = new PagingOptions {
+                PageSize = 10
+            }
+        };
+
+        public DeviceModel Detail { get; set; } = new DeviceModel { };
+        public bool IsDetailOpen { get; set; }
+
+        public string MyProperty { get; set; }
+
+        public override Task PreRender()
+        {
+            Devices.LoadFromQueryable(FakeDb.GetQueriable());
+            return base.PreRender();
+        }
+
+        public void Save()
+        {
+            if (Detail.Id == null || Detail.Id == Guid.Empty)
+            {
+                Detail = FakeDb.Insert(Detail);
+            }
+            Detail = FakeDb.Update(Detail);
+        }
+
+        public void Edit(Guid id)
+        {
+            Detail = FakeDb.Get(id);
+        }
+
+        public void Remove(Guid id)
+        {
+            FakeDb.Remove(id);
+        }
+
+        public void Blank()
+        {
+            Detail= new DeviceModel { };
+        }
+    }
+}
+

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/MarkupControl/StaticCommandInMarkupControlViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/MarkupControl/StaticCommandInMarkupControlViewModel.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.MarkupControl
+{
+    public static class FakeDb
+    {
+        public static DeviceModel Insert(DeviceModel model)
+        {
+            model.Id = Guid.NewGuid();
+            devices.Add(model);
+            return model;
+        }
+        public static DeviceModel Update(DeviceModel model)
+        {
+            var d = Get(model.Id);
+            d.Name = model.Name;
+            d.Groups = model.Groups;
+            return d;
+        }
+
+        public static void Remove(Guid id) => devices = devices.Where(d => d.Id != id).ToList();
+        public static DeviceModel Get(Guid id) => devices.FirstOrDefault(d=>d.Id == id);
+        public static IQueryable<DeviceModel> GetQueriable() => devices.AsQueryable();
+
+        private static IList<DeviceModel> devices = new List<DeviceModel> {
+            new DeviceModel {
+                Name = "Washing machine",
+                Id = Guid.NewGuid(),
+                Groups = new List<string> { "Laundry room" }
+            },
+            new DeviceModel {
+                Name = "Stove",
+                Id = Guid.NewGuid(),
+                Groups = new List<string> { "Kitchen" }
+            },
+            new DeviceModel {
+                Name = "Dryer",
+                Id = Guid.NewGuid(),
+                Groups = new List<string> { "Laundry room" }
+            },
+        };
+    }
+
+    public class DeviceModel
+    {
+        public string Name { get; set; }
+        public Guid Id { get; set; }
+        public List<string> Groups { get; set; }
+    }
+
+    public class StaticCommandInMarkupControlViewModel : DotVVM.Samples.BasicSamples.ViewModels.ComplexSamples.SPA.SiteViewModel
+    {
+        public GridViewDataSet<DeviceModel> Devices { get; set; } = new GridViewDataSet<DeviceModel> {
+            PagingOptions = new PagingOptions {
+                PageSize = 10
+            }
+        };
+
+        public DeviceModel Detail { get; set; } = new DeviceModel { };
+        public bool IsDetailOpen { get; set; }
+
+        public override Task PreRender()
+        {
+            Devices.LoadFromQueryable(FakeDb.GetQueriable());
+            return base.PreRender();
+        }
+
+        [AllowStaticCommand]
+        public static DeviceModel Save(DeviceModel model)
+        {
+            if(model.Id == null || model.Id == Guid.Empty)
+            {
+                return FakeDb.Insert(model);
+            }
+            return FakeDb.Update(model);
+        }
+
+        [AllowStaticCommand]
+        public static DeviceModel Blank() => new DeviceModel { };
+
+        [AllowStaticCommand]
+        public static IList<DeviceModel> List() => FakeDb.GetQueriable().ToList();
+
+        [AllowStaticCommand]
+        public static Task<DeviceModel> Get(Guid id) => Task.FromResult(FakeDb.Get(id));
+
+        [AllowStaticCommand]
+        public static void Remove(Guid id) => FakeDb.Remove(id);
+    }
+}
+

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/MarkupControl/StaticCommandInMarkupControlViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/MarkupControl/StaticCommandInMarkupControlViewModel.cs
@@ -65,6 +65,8 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.MarkupControl
         public DeviceModel Detail { get; set; } = new DeviceModel { };
         public bool IsDetailOpen { get; set; }
 
+        public string MyProperty { get; set; }
+
         public override Task PreRender()
         {
             Devices.LoadFromQueryable(FakeDb.GetQueriable());

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/MarkupControl/StaticCommandInMarkupControlViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/MarkupControl/StaticCommandInMarkupControlViewModel.cs
@@ -23,6 +23,8 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.MarkupControl
             }
         };
 
+        private static FakeDb FakeDb { get; } = new FakeDb();
+
         public DeviceModel Detail { get; set; } = new DeviceModel { };
         public bool IsDetailOpen { get; set; }
 

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/MarkupControl/StaticCommandInMarkupControlViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/MarkupControl/StaticCommandInMarkupControlViewModel.cs
@@ -8,45 +8,6 @@ using DotVVM.Framework.ViewModel;
 
 namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.MarkupControl
 {
-    public static class FakeDb
-    {
-        public static DeviceModel Insert(DeviceModel model)
-        {
-            model.Id = Guid.NewGuid();
-            devices.Add(model);
-            return model;
-        }
-        public static DeviceModel Update(DeviceModel model)
-        {
-            var d = Get(model.Id);
-            d.Name = model.Name;
-            d.Groups = model.Groups;
-            return d;
-        }
-
-        public static void Remove(Guid id) => devices = devices.Where(d => d.Id != id).ToList();
-        public static DeviceModel Get(Guid id) => devices.FirstOrDefault(d=>d.Id == id);
-        public static IQueryable<DeviceModel> GetQueriable() => devices.AsQueryable();
-
-        private static IList<DeviceModel> devices = new List<DeviceModel> {
-            new DeviceModel {
-                Name = "Washing machine",
-                Id = Guid.NewGuid(),
-                Groups = new List<string> { "Laundry room" }
-            },
-            new DeviceModel {
-                Name = "Stove",
-                Id = Guid.NewGuid(),
-                Groups = new List<string> { "Kitchen" }
-            },
-            new DeviceModel {
-                Name = "Dryer",
-                Id = Guid.NewGuid(),
-                Groups = new List<string> { "Laundry room" }
-            },
-        };
-    }
-
     public class DeviceModel
     {
         public string Name { get; set; }

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/MarkupControl/CommandPropertiesInMarkupControl.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/MarkupControl/CommandPropertiesInMarkupControl.dothtml
@@ -1,0 +1,17 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.MarkupControl.CommandPropertiesInMarkupControlViewModel, DotVVM.Samples.Common
+@import DotVVM.Samples.Common.ViewModels.FeatureSamples.MarkupControl
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+    <sample:Dialog Ok="{staticCommand: Property = TestService.Ok().Result}"/>
+    <span data-ui="result" InnerText="{value: Property}"/>
+</body>
+</html>
+
+

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/MarkupControl/Device.cs
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/MarkupControl/Device.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Controls;
+
+namespace DotVVM.Samples.Common.Views.FeatureSamples.MarkupControl
+{
+    public class Device : DotvvmMarkupControl
+    {
+        public Command Edit
+        {
+            get => (Command)GetValue(EditProperty);
+            set => SetValue(EditProperty, value);
+        }
+        public static readonly DotvvmProperty EditProperty
+            = DotvvmProperty.Register<Command, Device>(c => c.Edit, null);
+
+        public Command Remove
+        {
+            get => (Command)GetValue(RemoveProperty);
+            set => SetValue(RemoveProperty, value);
+        }
+        public static readonly DotvvmProperty RemoveProperty
+            = DotvvmProperty.Register<Command, Device>(c => c.Remove, null);
+
+        public string MyProperty
+        {
+            get { return (string)GetValue(MyPropertyProperty); }
+            set { SetValue(MyPropertyProperty, value); }
+        }
+        public static readonly DotvvmProperty MyPropertyProperty
+            = DotvvmProperty.Register<string, Device>(c => c.MyProperty, null);
+
+
+    }
+}

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/MarkupControl/Device.dotcontrol
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/MarkupControl/Device.dotcontrol
@@ -6,8 +6,8 @@
     <dot:Repeater DataSource="{value: Groups}" WrapperTagName="ul">
         <li InnerText="{value: _this}" />
     </dot:Repeater>
-    <dot:Button Click="{staticCommand: _control.Edit()}" Text="Edit" />
-    <dot:Button Click="{staticCommand: _control.Remove()}" Text="Remove" />
+    <dot:Button UITests.Name="edit" Click="{staticCommand: _control.Edit()}" Text="Edit" />
+    <dot:Button UITests.Name="remove" Click="{staticCommand: _control.Remove()}" Text="Remove" />
 
 </article>
 

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/MarkupControl/Device.dotcontrol
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/MarkupControl/Device.dotcontrol
@@ -1,0 +1,14 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.MarkupControl.DeviceModel, DotVVM.Samples.Common
+@baseType DotVVM.Samples.Common.Views.FeatureSamples.MarkupControl.Device, DotVVM.Samples.Common
+
+<article>
+    {{value: Name}}
+    <dot:Repeater DataSource="{value: Groups}" WrapperTagName="ul">
+        <li InnerText="{value: _this}" />
+    </dot:Repeater>
+    <dot:Button Click="{staticCommand: _control.Edit()}" Text="Edit" />
+    <dot:Button Click="{staticCommand: _control.Remove()}" Text="Remove" />
+
+</article>
+
+

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/MarkupControl/Dialog.cs
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/MarkupControl/Dialog.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Controls;
+
+namespace DotVVM.Samples.Common.Views.FeatureSamples.MarkupControl
+{
+    public class Dialog : DotvvmMarkupControl
+    {
+        public Command Ok
+        {
+            get { return (Command)GetValue(OkProperty); }
+            set { SetValue(OkProperty, value); }
+        }
+        public static readonly DotvvmProperty OkProperty
+            = DotvvmProperty.Register<Command, Dialog>(c => c.Ok, null);
+
+        public Command Cancel
+        {
+            get { return (Command)GetValue(CancelProperty); }
+            set { SetValue(CancelProperty, value); }
+        }
+        public static readonly DotvvmProperty CancelProperty
+            = DotvvmProperty.Register<Command, Dialog>(c => c.Cancel, null);
+    }
+}
+

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/MarkupControl/Dialog.dotcontrol
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/MarkupControl/Dialog.dotcontrol
@@ -1,0 +1,8 @@
+﻿@viewModel object
+@baseType DotVVM.Samples.Common.Views.FeatureSamples.MarkupControl.Dialog, DotVVM.Samples.Common
+
+<div>
+    <h1>Hello</h1>
+    <dot:Button data-ui="ok" IncludeInPage="{value: _control.Ok != null}" Text="Ok" Click="{staticCommand: _control.Ok() }" />
+    <dot:Button data-ui="cancel" IncludeInPage="{value: _control.Cancel != null}" Text="Cancel" Click="{staticCommand: _control.Cancel() }" />
+</div>

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/MarkupControl/StaticCommandInMarkupControl.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/MarkupControl/StaticCommandInMarkupControl.dothtml
@@ -9,8 +9,8 @@
 <body>
     <p DataContext="{value: Detail}">
         <dot:TextBox Text="{value: Name}" />
-        <dot:Button Click="{staticCommand: vm.Save(_this); _root.Devices.Items = vm.List()}" Text="Save" />
-        <dot:Button Click="{staticCommand: _root.Detail = vm.Blank()}" Text="Cancel" />
+        <dot:Button data-ui="save" Click="{staticCommand: vm.Save(_this); _root.Devices.Items = vm.List()}" Text="Save" />
+        <dot:Button data-ui="blank" Click="{staticCommand: _root.Detail = vm.Blank()}" Text="Cancel" />
     </p>
     <dot:Repeater WrapperTagName="section" DataSource="{value: Devices}">
         <sample:Device

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/MarkupControl/StaticCommandInMarkupControl.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/MarkupControl/StaticCommandInMarkupControl.dothtml
@@ -1,0 +1,24 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.MarkupControl.StaticCommandInMarkupControlViewModel, DotVVM.Samples.Common
+@import vm = DotVVM.Samples.Common.ViewModels.FeatureSamples.MarkupControl.StaticCommandInMarkupControlViewModel
+
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>Hello from DotVVM!</title>
+</head>
+<body>
+    <p DataContext="{value: Detail}">
+        <dot:TextBox Text="{value: Name}" />
+        <dot:Button Click="{staticCommand: vm.Save(_this); _root.Devices.Items = vm.List()}" Text="Save" />
+        <dot:Button Click="{staticCommand: _root.Detail = vm.Blank()}" Text="Cancel" />
+    </p>
+    <dot:Repeater WrapperTagName="section" DataSource="{value: Devices}">
+        <sample:Device
+                       Edit="{staticCommand: _root.Detail = vm.Get(_this.Id).Result}"
+                       Remove="{staticCommand: vm.Remove(_this.Id); _root.Devices.Items = vm.List()}"
+                       MyProperty="{value: Name + "- test"}"/>
+    </dot:Repeater>
+
+</body>
+</html>
+

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/MarkupControl/StaticCommandInMarkupControlCallingRegularCommand.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/MarkupControl/StaticCommandInMarkupControlCallingRegularCommand.dothtml
@@ -1,0 +1,21 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.MarkupControl.StaticCommandInMarkupControlCallingRegularCommandViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>Hello from DotVVM!</title>
+</head>
+<body>
+    <p DataContext="{value: Detail}">
+        <dot:TextBox Text="{value: Name}" />
+        <dot:Button Click="{command: _root.Save()}" Text="Save" />
+        <dot:Button Click="{command: _root.Blank()}" Text="Cancel" />
+    </p>
+    <dot:Repeater WrapperTagName="section" DataSource="{value: Devices}">
+        <sample:Device Edit="{command: _root.Edit(Id)}"
+                       Remove="{command: _root.Remove(Id)}"
+                       MyProperty="{value: Name + "- test"}" />
+    </dot:Repeater>
+
+</body>
+</html>

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/MarkupControl/StaticCommandInMarkupControlCallingRegularCommand.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/MarkupControl/StaticCommandInMarkupControlCallingRegularCommand.dothtml
@@ -7,9 +7,9 @@
 </head>
 <body>
     <p DataContext="{value: Detail}">
-        <dot:TextBox Text="{value: Name}" />
-        <dot:Button Click="{command: _root.Save()}" Text="Save" />
-        <dot:Button Click="{command: _root.Blank()}" Text="Cancel" />
+        <dot:TextBox data-ui="device-name" Text="{value: Name}" />
+        <dot:Button data-ui="save" Click="{command: _root.Save()}" Text="Save" />
+        <dot:Button data-ui="blank" Click="{command: _root.Blank()}" Text="Cancel" />
     </p>
     <dot:Repeater WrapperTagName="section" DataSource="{value: Devices}">
         <sample:Device Edit="{command: _root.Edit(Id)}"

--- a/src/DotVVM.Samples.Tests/Feature/MarkupControlTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/MarkupControlTests.cs
@@ -298,5 +298,43 @@ namespace DotVVM.Samples.Tests.Feature
                 AssertUI.InnerTextEquals(combobox.ElementAt("option", 2), "Number 2");
             });
         }
+
+        [Fact]
+        public void Feature_MarkupControl_CommandPropertiesInMarkupControl()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_MarkupControl_CommandPropertiesInMarkupControl);
+
+                var ok = browser.First("[data-ui=ok]");
+                var body = browser.First("body");
+                var span = browser.First("[data-ui=result]");
+
+                AssertUI.NotContainsElement(body,"[data-ui=cancel]");
+                ok.Click();
+
+                browser.WaitFor(() => {
+                    AssertUI.InnerTextEquals(span, "Command result.");
+                },1000);
+            });
+        }
+
+        [Fact]
+        public void Feature_MarkupControl_StaticCommandInMarkupControl()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_MarkupControl_StaticCommandInMarkupControl);
+
+                var ok = browser.First("[data-ui=ok]");
+                var body = browser.First("body");
+                var span = browser.First("[data-ui=result]");
+
+                AssertUI.NotContainsElement(body, "[data-ui=cancel]");
+                ok.Click();
+
+                browser.WaitFor(() => {
+                    AssertUI.InnerTextEquals(span, "Command result.");
+                }, 1000);
+            });
+        }
     }
 }

--- a/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
@@ -312,5 +312,8 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_ViewModelProtection_SignedNestedInServerToClient = "FeatureSamples/ViewModelProtection/SignedNestedInServerToClient";
         public const string FeatureSamples_ViewModelProtection_ViewModelProtection = "FeatureSamples/ViewModelProtection/ViewModelProtection";
         public const string FeatureSamples_Warnings_SelfClosingTags = "FeatureSamples/Warnings/SelfClosingTags";
-        }
+        public const string FeatureSamples_MarkupControl_StaticCommandInMarkupControl = "/FeatureSamples/MarkupControl/StaticCommandInMarkupControl";
+        public const string FeatureSamples_MarkupControl_StaticCommandInMarkupControlCallingRegularCommand = "/FeatureSamples/MarkupControl/StaticCommandInMarkupControlCallingRegularCommand";
+        public const string FeatureSamples_MarkupControl_CommandPropertiesInMarkupControl = "/FeatureSamples/MarkupControl/CommandPropertiesInMarkupControl";
+    }
 }

--- a/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
@@ -313,7 +313,6 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_ViewModelProtection_ViewModelProtection = "FeatureSamples/ViewModelProtection/ViewModelProtection";
         public const string FeatureSamples_Warnings_SelfClosingTags = "FeatureSamples/Warnings/SelfClosingTags";
         public const string FeatureSamples_StaticCommand_CustomAwaitable = "FeatureSamples/StaticCommand/CustomAwaitable";
-    }
         public const string FeatureSamples_MarkupControl_StaticCommandInMarkupControl = "/FeatureSamples/MarkupControl/StaticCommandInMarkupControl";
         public const string FeatureSamples_MarkupControl_StaticCommandInMarkupControlCallingRegularCommand = "/FeatureSamples/MarkupControl/StaticCommandInMarkupControlCallingRegularCommand";
         public const string FeatureSamples_MarkupControl_CommandPropertiesInMarkupControl = "/FeatureSamples/MarkupControl/CommandPropertiesInMarkupControl";


### PR DESCRIPTION
I try to use static command as much as possible to make my pages faster. However I ren into a severe limitation. It is impossible to bind `Command` property to static command binding in the markup control.
Example:
Let's assume I have `DeviceDetail` markup control used in the page like so:
```html
<cc:DeviceDetail Save={staticCommand: _root.Detail = service.Save(Detail); _alert.Show('Item saved')} />
``` 
I wanted to implement the `DeviceDetail` control as follows:
```html
@viewModel MyProject.DeviceViewModel
@baseType MyProject.Device 
<div>
<!-- ... --/>
    <dot:Button Click={staticCommand: _control.Save()} Text="Save"/>
</div>
```
Code behind:
```csharp
public class Device : DotvvmMarkupControl {
public Command Save
        {
            get { return (Command)GetValue(SaveProperty); }
            set { SetValue(SaveProperty, value); }
        }
        public static readonly DotvvmProperty SaveProperty
            = DotvvmProperty.Register<Command, Device>(c => c.Save, null);
}
```
This use case does not work as it generates client side JavaScript `contetext.$control.Save()` for the save button in the markup control. The `Save` property is not present in the `$control` context and attempt to press the "Save" button fails silently. 

Since markup control properties of type `Command` generate no corresponding property into the `$control` client context no control commands can be called from staticCommand binding. 

We need to correct this. 
