### PR TITLE
ScriptResource is `defer`ed by default

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.SerializeResources.json
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.SerializeResources.json
@@ -38,6 +38,7 @@
     },
     "scripts": {
       "r1": {
+        "Defer": true,
         "Location": {
           "$type": "DotVVM.Framework.ResourceManagement.UrlResourceLocation, DotVVM.Framework",
           "Url": "x"
@@ -47,6 +48,7 @@
         "IntegrityHash": "hash, maybe"
       },
       "r2": {
+        "Defer": true,
         "Location": {
           "$type": "DotVVM.Framework.ResourceManagement.UrlResourceLocation, DotVVM.Framework",
           "Url": "x"
@@ -72,7 +74,7 @@
         "Dependencies": [
           "r1"
         ],
-        "RenderPosition": "Body"
+        "RenderPosition": "Anywhere"
       }
     },
     "stylesheets": {

--- a/src/DotVVM.Framework/Configuration/DotvvmConfiguration.cs
+++ b/src/DotVVM.Framework/Configuration/DotvvmConfiguration.cs
@@ -326,19 +326,19 @@ namespace DotVVM.Framework.Configuration
         private static void RegisterResources(DotvvmConfiguration configuration)
         {
             configuration.Resources.Register(ResourceConstants.PolyfillBundleResourceName,
-                new ScriptModuleResource(defer: true, location: null,
+                new ScriptModuleResource(location: null,
                     nomoduleLocation: new EmbeddedResourceLocation(
                         typeof(DotvvmConfiguration).GetTypeInfo().Assembly,
                             "DotVVM.Framework.obj.javascript.polyfill.bundle.js")
                     ));
 
             configuration.Resources.Register(ResourceConstants.KnockoutJSResourceName,
-                new ScriptResource(defer: true, location: new EmbeddedResourceLocation(
+                new ScriptResource(location: new EmbeddedResourceLocation(
                     typeof(DotvvmConfiguration).GetTypeInfo().Assembly,
                     "DotVVM.Framework.Resources.Scripts.knockout-latest.js")));
 
             configuration.Resources.Register(ResourceConstants.DotvvmResourceName + ".internal",
-                new ScriptModuleResource(defer: true,
+                new ScriptModuleResource(
                     location: new EmbeddedResourceLocation(
                         typeof(DotvvmConfiguration).GetTypeInfo().Assembly,
                         "DotVVM.Framework.obj.javascript.root_only.dotvvm-root.js"),
@@ -349,7 +349,7 @@ namespace DotVVM.Framework.Configuration
                     Dependencies = new[] { ResourceConstants.KnockoutJSResourceName, ResourceConstants.PolyfillBundleResourceName }
                 });
             configuration.Resources.Register(ResourceConstants.DotvvmResourceName + ".internal-spa",
-                new ScriptModuleResource(defer: true,
+                new ScriptModuleResource(
                     location: new EmbeddedResourceLocation(
                         typeof(DotvvmConfiguration).GetTypeInfo().Assembly,
                         "DotVVM.Framework.obj.javascript.root_spa.dotvvm-root.js"),
@@ -365,7 +365,7 @@ namespace DotVVM.Framework.Configuration
                 });
 
             configuration.Resources.Register(ResourceConstants.DotvvmDebugResourceName,
-                new ScriptResource(defer: true, location: new EmbeddedResourceLocation(
+                new ScriptResource(location: new EmbeddedResourceLocation(
                     typeof(DotvvmConfiguration).GetTypeInfo().Assembly,
                     "DotVVM.Framework.Resources.Scripts.DotVVM.Debug.js")) {
                     Dependencies = new[] { ResourceConstants.DotvvmResourceName }
@@ -382,7 +382,7 @@ namespace DotVVM.Framework.Configuration
         private static void RegisterGlobalizeResources(DotvvmConfiguration configuration)
         {
             configuration.Resources.Register(ResourceConstants.GlobalizeResourceName,
-                new ScriptResource(defer: true, location: new EmbeddedResourceLocation(
+                new ScriptResource(location: new EmbeddedResourceLocation(
                     typeof(DotvvmConfiguration).GetTypeInfo().Assembly,
                     "DotVVM.Framework.Resources.Scripts.Globalize.globalize.min.js")));
 

--- a/src/DotVVM.Framework/Configuration/RestApiRegistrationHelpers.cs
+++ b/src/DotVVM.Framework/Configuration/RestApiRegistrationHelpers.cs
@@ -224,7 +224,7 @@ namespace DotVVM.Framework.Configuration
 
         private static void RegisterApiDependencies(DotvvmConfiguration configuration, string identifier, string jsApiClientFile, JsNode jsinitializer, ApiGroupDescriptor descriptor)
         {
-            configuration.Resources.Register("apiClient" + identifier, new ScriptResource(defer: true, location: new FileResourceLocation(jsApiClientFile)));
+            configuration.Resources.Register("apiClient" + identifier, new ScriptResource(location: new FileResourceLocation(jsApiClientFile)));
             configuration.Resources.Register("apiInit" + identifier, new InlineScriptResource(defer: true, code: jsinitializer.FormatScript(niceMode: configuration.Debug)) { Dependencies = new[] { "dotvvm", "apiClient" + identifier } });
 
             configuration.Markup.DefaultExtensionParameters.Add(new ApiExtensionParameter(identifier, descriptor));

--- a/src/DotVVM.Framework/ResourceManagement/ClientGlobalize/JQueryGlobalizeResourceRepository.cs
+++ b/src/DotVVM.Framework/ResourceManagement/ClientGlobalize/JQueryGlobalizeResourceRepository.cs
@@ -12,7 +12,7 @@ namespace DotVVM.Framework.ResourceManagement.ClientGlobalize
     public class JQueryGlobalizeResourceRepository : CachingResourceRepository
     {
         protected override IResource FindResource(string name) =>
-            new ScriptResource(defer: true, location: new JQueryGlobalizeResourceLocation(new CultureInfo(name)))
+            new ScriptResource(location: new JQueryGlobalizeResourceLocation(new CultureInfo(name)))
             {
                 Dependencies = new[] { ResourceConstants.GlobalizeResourceName },
             };

--- a/src/DotVVM.Framework/ResourceManagement/ResourcesRenderer.cs
+++ b/src/DotVVM.Framework/ResourceManagement/ResourcesRenderer.cs
@@ -65,7 +65,7 @@ namespace DotVVM.Framework.ResourceManagement
                     resourceManager.MarkRendered(resource);
                     resource.RenderResourceCached(writer, context);
                 }
-                else if (position == ResourceRenderPosition.Head && resourcePosition != ResourceRenderPosition.Head && resource.Resource is IPreloadResource preloadResource)
+                else if (position == ResourceRenderPosition.Head && resourcePosition == ResourceRenderPosition.Body && resource.Resource is IPreloadResource preloadResource)
                 {
                     if (resourceManager.IsRendered(resource.Name)) continue;
 

--- a/src/DotVVM.Framework/ResourceManagement/ScriptResource.cs
+++ b/src/DotVVM.Framework/ResourceManagement/ScriptResource.cs
@@ -21,7 +21,7 @@ namespace DotVVM.Framework.ResourceManagement
 
         /// <summary>Location property is required!</summary>
         public ScriptResource()
-            : base(ResourceRenderPosition.Body, "text/javascript")
+            : this(location: null!) // hack: people assign the Location property late, but it should non-nullable...
         { }
 
         public override void RenderLink(IResourceLocation location, IHtmlWriter writer, IDotvvmRequestContext context, string resourceName)

--- a/src/DotVVM.Framework/ResourceManagement/ScriptResource.cs
+++ b/src/DotVVM.Framework/ResourceManagement/ScriptResource.cs
@@ -13,7 +13,7 @@ namespace DotVVM.Framework.ResourceManagement
     public class ScriptResource : LinkResourceBase, IPreloadResource, IDeferableResource
     {
         public bool Defer { get; }
-        public ScriptResource(IResourceLocation location, bool defer = false)
+        public ScriptResource(IResourceLocation location, bool defer = true)
             : base(defer ? ResourceRenderPosition.Anywhere : ResourceRenderPosition.Body, "text/javascript", location)
         {
             this.Defer = defer;

--- a/src/DotVVM.Samples.Common/CommonConfiguration.cs
+++ b/src/DotVVM.Samples.Common/CommonConfiguration.cs
@@ -94,23 +94,19 @@ namespace DotVVM.Samples.Common
 
 
             resources.Register("extenders", new ScriptResource(
-                defer: true,
                 location: new FileResourceLocation("Scripts/ClientExtenders.js")
             ));
 
             resources.Register(nameof(StopwatchPostbackHandler), new ScriptResource(
-                defer: true,
                 location: new FileResourceLocation($"~/Scripts/{nameof(StopwatchPostbackHandler)}.js")) {
                 Dependencies = new[] { "dotvvm" }
             });
             resources.Register(nameof(ErrorCountPostbackHandler), new ScriptResource(
-                defer: true,
                 location: new FileResourceLocation($"~/Scripts/{nameof(ErrorCountPostbackHandler)}.js")) {
                 Dependencies = new[] { "dotvvm" }
             });
 
             resources.Register(nameof(PostBackHandlerCommandTypes), new ScriptResource(
-                defer: true,
                 location: new FileResourceLocation($"~/Scripts/{nameof(PostBackHandlerCommandTypes)}.js")) {
                     Dependencies = new [] { "dotvvm"}
             });


### PR DESCRIPTION
This is technically a breaking change, but it should have a lower impact than without this change.
Before this change, the dotvvm resource was defered (as it was a module), which caused a lot of issues.