### PR TITLE
Issue with async command execution

### DIFF
--- a/src/DotVVM.Framework/Hosting/DotvvmPresenter.cs
+++ b/src/DotVVM.Framework/Hosting/DotvvmPresenter.cs
@@ -392,23 +392,21 @@ namespace DotVVM.Framework.Hosting
                 await filter.OnCommandExecutingAsync(context, action);
             }
 
-            object? result = null;
             try
             {
-                Task? resultTask = null;
+                var commandResultOrNotYetComputedTask = action.Action();
 
-                result = action.Action();
-
-                resultTask = result as Task;
-                if (resultTask != null)
+                var notYetComputedTask = commandResultOrNotYetComputedTask as Task;
+                if (notYetComputedTask != null)
                 {
-                    await resultTask;
+                    await notYetComputedTask;
                 }
 
-                if (resultTask != null)
+                if (notYetComputedTask != null)
                 {
-                    result = TaskUtils.GetResult(resultTask);
+                    return TaskUtils.GetResult(notYetComputedTask);
                 }
+                return commandResultOrNotYetComputedTask;
             }
             catch (Exception ex)
             {
@@ -433,7 +431,7 @@ namespace DotVVM.Framework.Hosting
             {
                 throw new Exception("Unhandled exception occurred in the command!", context.CommandException);
             }
-            return result;
+            return null;
         }
 
         public static bool DetermineIsPostBack(IHttpContext context)

--- a/src/DotVVM.Framework/Hosting/DotvvmPresenter.cs
+++ b/src/DotVVM.Framework/Hosting/DotvvmPresenter.cs
@@ -404,7 +404,7 @@ namespace DotVVM.Framework.Hosting
                 }
 
                 var resultType = commandResultOrNotYetComputedAwaitable?.GetType();
-                var possibleResultAwaiter = resultType?.GetMethod(nameof(Task.GetAwaiter));
+                var possibleResultAwaiter = resultType?.GetMethod(nameof(Task.GetAwaiter), new Type[] { });
 
                 if(resultType != null && possibleResultAwaiter != null)
                 {

--- a/src/DotVVM.Framework/Hosting/DotvvmPresenter.cs
+++ b/src/DotVVM.Framework/Hosting/DotvvmPresenter.cs
@@ -403,10 +403,10 @@ namespace DotVVM.Framework.Hosting
                     return TaskUtils.GetResult(commandTask);
                 }
 
-                var resultType = commandResultOrNotYetComputedAwaitable.GetType();
-                var possibleResultAwaiter = resultType.GetMethod(nameof(Task.GetAwaiter));
+                var resultType = commandResultOrNotYetComputedAwaitable?.GetType();
+                var possibleResultAwaiter = resultType?.GetMethod(nameof(Task.GetAwaiter));
 
-                if(possibleResultAwaiter != null)
+                if(resultType != null && possibleResultAwaiter != null)
                 {
                     throw new NotSupportedException($"The command uses unsupported awaitable type {resultType.FullName}, please use System.Task instead.");
                 }

--- a/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
+++ b/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
@@ -61,6 +61,7 @@
     <None Remove="Views\FeatureSamples\Resources\RequiredOnPostback.dothtml" />
     <None Remove="Views\FeatureSamples\Serialization\DeserializationVirtualElements.dothtml" />
     <None Remove="Views\FeatureSamples\CustomResponseProperties\SimpleExceptionFilter.dothtml" />
+    <None Remove="Views\FeatureSamples\StaticCommand\CustomAwaitable.dothtml" />
     <None Remove="Views\FeatureSamples\StaticCommand\StaticCommand_ArrayAssigment.dothtml" />
     <None Remove="Views\FeatureSamples\StaticCommand\StaticCommand_LoadComplexDataFromService.dothtml" />
     <None Remove="Views\FeatureSamples\StaticCommand\StaticCommand_NullAssignment.dothtml" />

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/CustomResponseProperties/SimpleExceptionFilterViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/CustomResponseProperties/SimpleExceptionFilterViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -37,6 +38,8 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.CustomResponseProperti
     }
     public class SimpleExceptionFilterViewModel : DotvvmViewModelBase
     {
+        public string TestProperty { get; set; }
+
         [AllowStaticCommand]
         [ClientExceptionFilter]
         public static void StaticCommand()
@@ -47,6 +50,49 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.CustomResponseProperti
         [ClientExceptionFilter]
         public void Command()
         {
+            throw new UIException("Problem!");
+        }
+
+        [AllowStaticCommand]
+        [ClientExceptionFilter]
+        public static async Task AsyncStaticCommand()
+        {
+            await Task.Delay(500);
+            throw new UIException("Problem!");
+        }
+
+        [ClientExceptionFilter]
+        public async Task AsyncCommand()
+        {
+            await Task.Delay(500);
+            throw new UIException("Problem!");
+        }
+
+        [AllowStaticCommand]
+        [ClientExceptionFilter]
+        public static string StaticCommandResult()
+        {
+            throw new UIException("Problem!");
+        }
+
+        [ClientExceptionFilter]
+        public string CommandResult()
+        {
+            throw new UIException("Problem!");
+        }
+
+        [AllowStaticCommand]
+        [ClientExceptionFilter]
+        public static async Task<string> AsyncStaticCommandResult()
+        {
+            await Task.Delay(500);
+            throw new UIException("Problem!");
+        }
+
+        [ClientExceptionFilter]
+        public async Task<string> AsyncCommandResult()
+        {
+            await Task.Delay(500);
             throw new UIException("Problem!");
         }
     }

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/CustomResponseProperties/SimpleExceptionFilterViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/CustomResponseProperties/SimpleExceptionFilterViewModel.cs
@@ -20,14 +20,23 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.CustomResponseProperti
         {
             if (exception is UIException clientError)
             {
-                context.CustomResponseProperties.Add("validation-errors",new PageErrorModel {
-                    Message = clientError.Message
-                });
-                context.CustomResponseProperties.Add("Message", "Hello there");
-
-                context.IsCommandExceptionHandled = true;
+                HandleUiException(context, clientError);
+            }
+            else if(exception is AggregateException aggregate && aggregate.InnerException is UIException uiException)
+            {
+                HandleUiException(context, uiException);
             }
             return Task.FromResult(0);
+        }
+
+        private void HandleUiException(IDotvvmRequestContext context, UIException clientError)
+        {
+            context.CustomResponseProperties.Add("validation-errors", new PageErrorModel {
+                Message = clientError.Message
+            });
+            context.CustomResponseProperties.Add("Message", "Hello there");
+
+            context.IsCommandExceptionHandled = true;
         }
     }
     public class UIException : Exception
@@ -92,7 +101,7 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.CustomResponseProperti
         [ClientExceptionFilter]
         public async Task<string> AsyncCommandResult()
         {
-            await Task.Delay(500);
+            await Task.Delay(500).ConfigureAwait(false);
             throw new UIException("Problem!");
         }
     }

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/StaticCommand/CustomAwaitableViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/StaticCommand/CustomAwaitableViewModel.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Hosting;
+using DotVVM.Framework.Runtime.Filters;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.StaticCommand
+{
+    public class Filtr: ExceptionFilterAttribute
+    {
+        protected override Task OnCommandExceptionAsync(IDotvvmRequestContext context, ActionInfo actionInfo, Exception ex)
+        {
+            if(ex is NotSupportedException)
+            {
+                context.CustomResponseProperties.Add("test","Test ok");
+                context.IsCommandExceptionHandled = true;
+            }
+            return Task.FromResult(0);
+        }
+    }
+
+    public class TaskBag
+    {
+        public ConcurrentBag<Task> Bag { get; } = new ConcurrentBag<Task>();
+
+        public void Add(Task task) => Bag.Add(task);
+
+        public TaskAwaiter GetAwaiter()
+        {
+            return Task.WhenAll(Bag.ToArray()).GetAwaiter();
+        }
+    }
+
+    public class CustomAwaitableViewModel : DotvvmViewModelBase
+    {
+        [Filtr]
+        [AllowStaticCommand]
+        public TaskBag Test()
+        {
+            var bag = new TaskBag();
+            bag.Add(Task.FromResult(0));
+            return bag;
+        }
+    }
+}
+

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/CustomResponseProperties/SimpleExceptionFilter.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/CustomResponseProperties/SimpleExceptionFilter.dothtml
@@ -8,16 +8,16 @@
     <div>
         <ul>
             <li><dot:Button Click="{staticCommand: model.StaticCommand()}" data-ui="staticCommand" Text="Static Command Test" /></li>
-            <li><dot:Button Click="{command: Command()}"  data-ui="command" Text="Command Test"/></li>
+            <li><dot:Button Click="{command: Command()}" data-ui="command" Text="Command Test" /></li>
 
             <li><dot:Button Click="{staticCommand: model.AsyncStaticCommand()}" data-ui="asyncStaticCommand" Text="Async Static Command Test" /></li>
             <li><dot:Button Click="{command: AsyncCommand()}" data-ui="asyncCommand" Text="Async Command Test" /></li>
 
-            <li><dot:Button Click="{staticCommand: TestProperty = model.StaticCommandResult()}" data-ui="staticCommand" Text="Static Command Result Test" /></li>
-            <li><dot:Button Click="{command: TestProperty = CommandResult()}" data-ui="command" Text="Command Result Test"/></li>
+            <li><dot:Button Click="{staticCommand: TestProperty = model.StaticCommandResult()}" data-ui="staticCommandResult" Text="Static Command Result Test" /></li>
+            <li><dot:Button Click="{command: TestProperty = CommandResult()}" data-ui="commandResult" Text="Command Result Test" /></li>
 
-            <li><dot:Button Click="{staticCommand: TestProperty = model.AsyncStaticCommandResult().Result}" data-ui="asyncStaticCommand" Text="Async Static Command Result Test" /></li>
-            <li><dot:Button Click="{command: TestProperty = AsyncCommandResult().Result}" data-ui="asyncCommand" Text="Async Command Result Test" /></li>
+            <li><dot:Button Click="{staticCommand: TestProperty = model.AsyncStaticCommandResult().Result}" data-ui="asyncStaticCommandResult" Text="Async Static Command Result Test" /></li>
+            <li><dot:Button Click="{command: TestProperty = AsyncCommandResult().Result}" data-ui="asyncCommandResult" Text="Async Command Result Test" /></li>
         </ul>
 
         <dot:Button onclick="javascript: clearTexts()" Text="Clear" data-ui="clear"></dot:Button>

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/CustomResponseProperties/SimpleExceptionFilter.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/CustomResponseProperties/SimpleExceptionFilter.dothtml
@@ -6,8 +6,20 @@
 </head>
 <body>
     <div>
-        <dot:Button Click="{staticCommand: model.StaticCommand()}" data-ui="staticCommand" Text="Static Command Test" />
-        <dot:Button Click="{command: Command()}" Text="Command Test"  data-ui="command" />
+        <ul>
+            <li><dot:Button Click="{staticCommand: model.StaticCommand()}" data-ui="staticCommand" Text="Static Command Test" /></li>
+            <li><dot:Button Click="{command: Command()}"  data-ui="command" Text="Command Test"/></li>
+
+            <li><dot:Button Click="{staticCommand: model.AsyncStaticCommand()}" data-ui="asyncStaticCommand" Text="Async Static Command Test" /></li>
+            <li><dot:Button Click="{command: AsyncCommand()}" data-ui="asyncCommand" Text="Async Command Test" /></li>
+
+            <li><dot:Button Click="{staticCommand: TestProperty = model.StaticCommandResult()}" data-ui="staticCommand" Text="Static Command Result Test" /></li>
+            <li><dot:Button Click="{command: TestProperty = CommandResult()}" data-ui="command" Text="Command Result Test"/></li>
+
+            <li><dot:Button Click="{staticCommand: TestProperty = model.AsyncStaticCommandResult().Result}" data-ui="asyncStaticCommand" Text="Async Static Command Result Test" /></li>
+            <li><dot:Button Click="{command: TestProperty = AsyncCommandResult().Result}" data-ui="asyncCommand" Text="Async Command Result Test" /></li>
+        </ul>
+
         <dot:Button onclick="javascript: clearTexts()" Text="Clear" data-ui="clear"></dot:Button>
     </div>
     <p>

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/StaticCommand/CustomAwaitable.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/StaticCommand/CustomAwaitable.dothtml
@@ -1,0 +1,27 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.StaticCommand.CustomAwaitableViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+    <dot:Button data-ui="test" Click="{staticCommand: Test()}" Text="Test"/>
+    <dot:Button data-ui="clear" onclick="javascript: clearTexts()" Text="Clear"/>
+    <span data-ui="result"></span>
+    <dot:InlineScript Dependencies="dotvvm">
+        function clearTexts() {
+            var customProperties = document.querySelector('[data-ui="result"]');
+            customProperties.innerText = "";
+        }
+        dotvvm.events.staticCommandMethodInvoked.subscribe(e => {
+            var customPropertiesInput = document.querySelector('[data-ui="result"]');
+            customPropertiesInput.innerText = e.serverResponseObject.customProperties.test;
+        });
+    </dot:InlineScript>
+</body>
+</html>
+
+

--- a/src/DotVVM.Samples.Tests/Feature/CommandResultTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/CommandResultTests.cs
@@ -39,16 +39,22 @@ namespace DotVVM.Samples.Tests.Feature
 
         private void TestResponse(IBrowserWrapper browser, string uiId)
         {
+            var customDataSpan = browser.First("customProperties", SelectByDataUi);
+
             var staticCommandButton = browser.First(uiId, SelectByDataUi);
             staticCommandButton.Click();
 
             browser.WaitFor(() => {
-                var customDataSpan = browser.First("customProperties", SelectByDataUi);
                 AssertUI.TextEquals(customDataSpan, "Hello there");
-            }, 8000);
+            }, 1000);
 
             var clearButton = browser.First("clear", SelectByDataUi);
             clearButton.Click();
+
+            browser.WaitFor(() => {
+                AssertUI.TextEmpty(customDataSpan);
+            }, 1000);
+
         }
     }
 }

--- a/src/DotVVM.Samples.Tests/Feature/CommandResultTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/CommandResultTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 using Xunit.Abstractions;
 using Riganti.Selenium.DotVVM;
 using Riganti.Selenium.Core;
+using Riganti.Selenium.Core.Abstractions;
 
 namespace DotVVM.Samples.Tests.Feature
 {
@@ -18,31 +19,36 @@ namespace DotVVM.Samples.Tests.Feature
         [Fact]
         public void SimpleExceptionFilterTest()
         {
-            RunInAllBrowsers(browser => {
+            base.RunInAllBrowsers(browser => {
                 browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_CustomResponseProperties_SimpleExceptionFilter);
                 browser.WaitUntilDotvvmInited();
 
-                var staticCommandButton = browser.First("staticCommand", SelectByDataUi);
-                staticCommandButton.Click();
+                TestResponse(browser, "staticCommand");
+                TestResponse(browser, "command");
 
-                browser.WaitFor(() => {
-                    var customDataSpan = browser.First("customProperties", SelectByDataUi);
-                    AssertUI.TextEquals(customDataSpan, "Hello there");
-                }, 8000);
+                TestResponse(browser, "asyncStaticCommand");
+                TestResponse(browser, "asyncCommand");
 
-                var clearButton = browser.First("clear", SelectByDataUi);
-                clearButton.Click();
+                TestResponse(browser, "staticCommandResult");
+                TestResponse(browser, "commandResult");
 
-                var commandButton = browser.First("command", SelectByDataUi);
-                commandButton.Click();
-                browser.WaitFor(() => {
-                    var customDataSpan = browser.First("customProperties", SelectByDataUi);
-                    AssertUI.TextEquals(customDataSpan, "Hello there");
-                }, 8000);
-
-
+                TestResponse(browser, "asyncStaticCommandResult");
+                TestResponse(browser, "asyncCommandResult");
             });
         }
 
+        private void TestResponse(IBrowserWrapper browser, string uiId)
+        {
+            var staticCommandButton = browser.First(uiId, SelectByDataUi);
+            staticCommandButton.Click();
+
+            browser.WaitFor(() => {
+                var customDataSpan = browser.First("customProperties", SelectByDataUi);
+                AssertUI.TextEquals(customDataSpan, "Hello there");
+            }, 8000);
+
+            var clearButton = browser.First("clear", SelectByDataUi);
+            clearButton.Click();
+        }
     }
 }

--- a/src/DotVVM.Samples.Tests/Feature/StaticCommandTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/StaticCommandTests.cs
@@ -283,5 +283,24 @@ namespace DotVVM.Samples.Tests.Feature
                 AssertUI.InnerTextEquals(browser.ElementAt(".food", 2), "Vindaloo");
             });
         }
+
+        [Fact]
+        public void Feature_StaticCommand_CustomAwaiter()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_StaticCommand_CustomAwaitable);
+
+                var testButton = browser.First("[data-ui=test]");
+                var clearButton = browser.First("[data-ui=clear]");
+
+                clearButton.Click();
+                testButton.Click();
+
+                browser.WaitFor(() => {
+                    var testElement = browser.First("[data-ui=result]");
+                    Assert.Equal("Test ok", testElement.GetInnerText());
+                }, 1000);
+            });
+        }
     }
 }

--- a/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
@@ -312,5 +312,6 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_ViewModelProtection_SignedNestedInServerToClient = "FeatureSamples/ViewModelProtection/SignedNestedInServerToClient";
         public const string FeatureSamples_ViewModelProtection_ViewModelProtection = "FeatureSamples/ViewModelProtection/ViewModelProtection";
         public const string FeatureSamples_Warnings_SelfClosingTags = "FeatureSamples/Warnings/SelfClosingTags";
-        }
+        public const string FeatureSamples_StaticCommand_CustomAwaitable = "FeatureSamples/StaticCommand/CustomAwaitable";
+    }
 }


### PR DESCRIPTION
There was en issue with executing async commands. In case en exception was thrown, the command result was set to the executing `Task` instead of null. This caused a seriqalization error.
Also now, if user tries to return custom awaitable, they will be warned that this is not supported. Before it would just fail quietly.