### PR TITLE
Fix generics resolving in method overloads search

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Binding/ExpressionHelperTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/ExpressionHelperTests.cs
@@ -116,10 +116,16 @@ namespace DotVVM.Framework.Tests.Common.Binding
             Call_FindOverload_Generic(typeof(MethodsGenericArgumentsResolvingSampleObject3), MethodsGenericArgumentsResolvingSampleObject3.MethodName, argTypes, resultIdentifierType, expectedGenericArgs);
         }
         [TestMethod]
-        [DataRow(typeof(int[]), new Type[] { typeof(int[]) }, new Type[] { typeof(int) })]
+        [DataRow(typeof(int[]), new Type[] { typeof(int[]) }, new Type[] { typeof(int) })]      
         public void Call_FindOverload_Generic_Array(Type resultIdentifierType, Type[] argTypes, Type[] expectedGenericArgs)
         {
             Call_FindOverload_Generic(typeof(MethodsGenericArgumentsResolvingSampleObject4), MethodsGenericArgumentsResolvingSampleObject4.MethodName, argTypes, resultIdentifierType, expectedGenericArgs);
+        }
+        [TestMethod]
+        [DataRow(typeof(int), new Type[] { typeof(int[]) }, new Type[] { typeof(int) })]
+        public void Call_FindOverload_Generic_Enumerable_Array(Type resultIdentifierType, Type[] argTypes, Type[] expectedGenericArgs)
+        {
+            Call_FindOverload_Generic(typeof(MethodsGenericArgumentsResolvingSampleObject6), MethodsGenericArgumentsResolvingSampleObject6.MethodName, argTypes, resultIdentifierType, expectedGenericArgs);
         }
         [TestMethod]
         [DataRow(typeof(GenericTestResult1), new Type[] { typeof(GenericModelSampleObject<int[]>) }, new Type[] { typeof(int) })]
@@ -130,6 +136,11 @@ namespace DotVVM.Framework.Tests.Common.Binding
         }
     }
 
+    public static class MethodsGenericArgumentsResolvingSampleObject6
+    {
+        public const string MethodName = nameof(TestMethod);
+        public static T2 TestMethod<T2>(IEnumerable<T2> a) => default;
+    }
     public static class MethodsGenericArgumentsResolvingSampleObject5
     {
         public const string MethodName = nameof(TestMethod);

--- a/src/DotVVM.Framework.Tests.Common/Binding/ExpressionHelperTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/ExpressionHelperTests.cs
@@ -116,7 +116,7 @@ namespace DotVVM.Framework.Tests.Common.Binding
             Call_FindOverload_Generic(typeof(MethodsGenericArgumentsResolvingSampleObject3), MethodsGenericArgumentsResolvingSampleObject3.MethodName, argTypes, resultIdentifierType, expectedGenericArgs);
         }
         [TestMethod]
-        [DataRow(typeof(int[]), new Type[] { typeof(int[]) }, new Type[] { typeof(int) })]      
+        [DataRow(typeof(int[]), new Type[] { typeof(int[]) }, new Type[] { typeof(int) })]
         public void Call_FindOverload_Generic_Array(Type resultIdentifierType, Type[] argTypes, Type[] expectedGenericArgs)
         {
             Call_FindOverload_Generic(typeof(MethodsGenericArgumentsResolvingSampleObject4), MethodsGenericArgumentsResolvingSampleObject4.MethodName, argTypes, resultIdentifierType, expectedGenericArgs);

--- a/src/DotVVM.Framework/Compilation/Binding/ExpressionHelper.cs
+++ b/src/DotVVM.Framework/Compilation/Binding/ExpressionHelper.cs
@@ -289,7 +289,16 @@ namespace DotVVM.Framework.Compilation.Binding
                 }
                 else if (sgt.IsGenericType)
                 {
-                    var value = GetGenericParameterType(genericArg, sgt.GetGenericArguments(), expressionTypes[i].GetGenericArguments());
+                    Type[] genericArguments;
+                    var expression = expressionTypes[i];  
+
+                    // Arrays need to be handled in a special way to obtain instantiation
+                    if (expression.IsArray)
+                        genericArguments = new[] { expression.GetElementType() };
+                    else
+                        genericArguments = expression.GetGenericArguments();
+
+                    var value = GetGenericParameterType(genericArg, sgt.GetGenericArguments(), genericArguments);
                     if (value is Type) return value;
                 }
             }


### PR DESCRIPTION
This PR fixes a bug that failed method overloads search, for example in the following case:

- Suppose user created a method with given signature: `T Method<T>(Enumerable<T> arg)`
- User called the method by passing an array `T[]` as the first and the only argument
- DotVVM tries to resolve generic argument `T` based on `typeof(T[]).GetGenericArguments()` which fails for arrays