### PR TITLE
Upgraded RIGANTI Selenium testing framework for UI tests 

### DIFF
--- a/src/DotVVM.Samples.Tests/Control/AuthenticatedViewTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/AuthenticatedViewTests.cs
@@ -1,6 +1,4 @@
-﻿
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Riganti.Selenium.Core;
+﻿using Riganti.Selenium.Core;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/DotVVM.Samples.Tests/Control/ContentPlaceHolderTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/ContentPlaceHolderTests.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Threading.Tasks;
 using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Riganti.Selenium.Core;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/DotVVM.Samples.Tests/Control/DataPagerTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/DataPagerTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium;
 using Riganti.Selenium.Core;
 using Riganti.Selenium.Core.Abstractions;

--- a/src/DotVVM.Samples.Tests/Control/EnabledPropertyTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/EnabledPropertyTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Configuration;
 using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium;
 using Riganti.Selenium.Core;
 using Xunit;

--- a/src/DotVVM.Samples.Tests/Control/EnvironmentViewTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/EnvironmentViewTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Linq;
 using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Riganti.Selenium.Core;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/DotVVM.Samples.Tests/Control/HtmlLiteralTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/HtmlLiteralTests.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Threading.Tasks;
 using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Riganti.Selenium.Core;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/DotVVM.Samples.Tests/Control/IncludeInPagePropertyTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/IncludeInPagePropertyTests.cs
@@ -5,7 +5,6 @@ using DotVVM.Testing.Abstractions;
 using Riganti.Selenium.Core.Abstractions;
 using Xunit;
 using Xunit.Abstractions;
-using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 namespace DotVVM.Samples.Tests.Control
 {
@@ -21,7 +20,7 @@ namespace DotVVM.Samples.Tests.Control
                 AssertUI.ContainsElement(gridView, "thead");
                 AssertUI.ContainsElement(gridView, "tbody");
             }, browser => {
-                Assert.AreEqual(0, browser.FindElements("gridView", this.SelectByDataUi).Count);
+                Assert.Equal(0, browser.FindElements("gridView", this.SelectByDataUi).Count);
             });
         }
 
@@ -38,8 +37,8 @@ namespace DotVVM.Samples.Tests.Control
                 AssertUI.IsDisplayed(message);
                 AssertUI.TextEquals(message, "There are no Customers to display");
             }, browser => {
-                Assert.AreEqual(0, browser.FindElements(gridViewDataUi).Count);
-                Assert.AreEqual(0, browser.FindElements(messageDataUi).Count);
+                Assert.Equal(0, browser.FindElements(gridViewDataUi).Count);
+                Assert.Equal(0, browser.FindElements(messageDataUi).Count);
             });
         }
 
@@ -52,7 +51,7 @@ namespace DotVVM.Samples.Tests.Control
                 AssertUI.IsDisplayed(literal);
                 AssertUI.TextEquals(literal, "Test 1");
             }, browser => {
-                Assert.AreEqual(0, browser.FindElements("literal", this.SelectByDataUi).Count);
+                Assert.Equal(0, browser.FindElements("literal", this.SelectByDataUi).Count);
             });
         }
 
@@ -62,13 +61,13 @@ namespace DotVVM.Samples.Tests.Control
         {
             CheckIncludeInPage(browser => {
                 var literals = browser.FindElements("literal-repeater", this.SelectByDataUi);
-                Assert.AreEqual(3, literals.Count);
+                Assert.Equal(3, literals.Count);
                 foreach (var literal in literals)
                 {
                     AssertUI.IsDisplayed(literal);
                 }
             }, browser => {
-                Assert.AreEqual(0, browser.FindElements("literal-repeater", this.SelectByDataUi).Count);
+                Assert.Equal(0, browser.FindElements("literal-repeater", this.SelectByDataUi).Count);
             });
         }
 
@@ -108,9 +107,9 @@ namespace DotVVM.Samples.Tests.Control
             CheckIncludeInPage(browser => {
                 var repeater = browser.First(dataUi, this.SelectByDataUi);
                 AssertUI.IsDisplayed(repeater);
-                Assert.AreEqual(childrenCount, repeater.Children.Count);
+                repeater.Children.ThrowIfDifferentCountThan(childrenCount);
             }, browser => {
-                Assert.AreEqual(0, browser.FindElements(dataUi, this.SelectByDataUi).Count);
+                browser.FindElements(dataUi, this.SelectByDataUi).ThrowIfDifferentCountThan(0);
             });
         }
 
@@ -129,7 +128,7 @@ namespace DotVVM.Samples.Tests.Control
                     AssertUI.IsDisplayed(textBox);
                 }
             }, browser => {
-                Assert.AreEqual(0, browser.FindElements(dataUi, this.SelectByDataUi).Count);
+                browser.FindElements(dataUi, this.SelectByDataUi).ThrowIfDifferentCountThan(0);
             });
         }
 

--- a/src/DotVVM.Samples.Tests/Control/LinkButtonTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/LinkButtonTests.cs
@@ -1,6 +1,5 @@
 ﻿using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Riganti.Selenium.Core;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/DotVVM.Samples.Tests/Control/RadioButtonTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/RadioButtonTests.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Threading.Tasks;
 using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Xunit;
 using Xunit.Abstractions;
 using Riganti.Selenium.DotVVM;

--- a/src/DotVVM.Samples.Tests/Control/RouteLinkTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/RouteLinkTests.cs
@@ -5,7 +5,6 @@ using Riganti.Selenium.Core;
 using Riganti.Selenium.Core.Abstractions;
 using Xunit;
 using Xunit.Abstractions;
-using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 namespace DotVVM.Samples.Tests.Control
 {
@@ -55,7 +54,7 @@ namespace DotVVM.Samples.Tests.Control
             {
                 var href = browser.Single(selector).GetAttribute("href");
 
-                Assert.AreEqual(relativeUrl, new Uri(href).AbsolutePath);
+                Assert.Equal(relativeUrl, new Uri(href).AbsolutePath);
             }
 
             checkNavigatedUrl("a[data-ui='optional-parameter-client']", "/ControlSamples/Repeater/RouteLink");

--- a/src/DotVVM.Samples.Tests/Control/SpaContentPlaceHolderTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/SpaContentPlaceHolderTests.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Threading.Tasks;
 using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Riganti.Selenium.Core;
 using Riganti.Selenium.Core.Abstractions;
 using Xunit;

--- a/src/DotVVM.Samples.Tests/Control/TextBoxTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/TextBoxTests.cs
@@ -9,7 +9,6 @@ using Riganti.Selenium.Core;
 using Riganti.Selenium.Core.Abstractions;
 using Xunit;
 using Xunit.Abstractions;
-using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 namespace DotVVM.Samples.Tests.Control
 {
@@ -56,10 +55,10 @@ namespace DotVVM.Samples.Tests.Control
 
                 var typeText = browser.Single("[data-ui='type-text']").GetText();
                 var typeTextDateTime = DateTime.Parse(typeText, DateTimeFormatInfo.InvariantInfo);
-                Assert.AreEqual(now.ToShortDateString(), typeTextDateTime.ToShortDateString());
+                Assert.Equal(now.ToShortDateString(), typeTextDateTime.ToShortDateString());
 
                 var customFormat = browser.Single("[data-ui='custom-format']").GetText();
-                Assert.AreEqual(customFormat, now.ToString("dd-MM-yy"));
+                Assert.Equal(customFormat, now.ToString("dd-MM-yy"));
 
                 browser.Single("[data-ui='fill-name-button']").Click();
                 AssertUI.TextEquals(browser.Single("[data-ui='name-of-day']"), now.DayOfWeek.ToString());
@@ -117,7 +116,7 @@ window.getSelectionText = function (dataui) {
             textBox.Click();
             var selectedText = (string)browser.GetJavaScriptExecutor().ExecuteScript($"return window.getSelectionText('{textBoxDataUi}');");
             var expectedText = isSelectAllOnFocusTrue ? "Testing text" : "";
-            Assert.AreEqual(expectedText, selectedText);
+            Assert.Equal(expectedText, selectedText);
         }
 
         public static IEnumerable<object[]> TextBoxStringFormatChangedCommandData =>

--- a/src/DotVVM.Samples.Tests/Control/UpdateProgressTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/UpdateProgressTests.cs
@@ -255,8 +255,7 @@ namespace DotVVM.Samples.Tests.Control
                 browser.Single("long", SelectByDataUi).Click();
                 AssertUI.IsDisplayed(progress);
                 Thread.Sleep(1000);
-                progress.WaitFor(AssertUI.IsNotDisplayed, 500,
-                    "Update progress did not hide after action finished");
+                AssertUI.IsNotDisplayed(progress); //"Update progress did not hide after action finished"
             });
         }
 

--- a/src/DotVVM.Samples.Tests/Control/ValidationSummaryTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/ValidationSummaryTests.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Threading.Tasks;
 using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Riganti.Selenium.Core;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/DotVVM.Samples.Tests/DotVVM.Samples.Tests.csproj
+++ b/src/DotVVM.Samples.Tests/DotVVM.Samples.Tests.csproj
@@ -7,17 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Riganti.Selenium.Coordinator.Client" Version="2.0.6.2" />
-    <PackageReference Include="Riganti.Selenium.Core" Version="2.0.6.2" />
-    <PackageReference Include="Riganti.Selenium.Core.Abstractions" Version="2.0.6.2" />
-    <PackageReference Include="Riganti.Selenium.DotVVM" Version="2.0.6.2" />
-    <PackageReference Include="Riganti.Selenium.AssertApi" Version="2.0.6.2" />
-    <PackageReference Include="Riganti.Selenium.xUnitIntegration" Version="2.0.6.2" />
-    <PackageReference Include="Riganti.Selenium.Validators" Version="2.0.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Riganti.Selenium.Coordinator.Client" Version="3.0.0-preview01-final" />
+    <PackageReference Include="Riganti.Selenium.Core" Version="3.0.0-preview01-final" />
+    <PackageReference Include="Riganti.Selenium.Core.Abstractions" Version="3.0.0-preview01-final" />
+    <PackageReference Include="Riganti.Selenium.DotVVM" Version="3.0.0-preview01-final" />
+    <PackageReference Include="Riganti.Selenium.AssertApi" Version="3.0.0-preview01-final" />
+    <PackageReference Include="Riganti.Selenium.xUnitIntegration" Version="3.0.0-preview01-final" />
+    <PackageReference Include="Riganti.Selenium.Validators" Version="3.0.0-preview01-final" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotVVM.Samples.Tests/ErrorsTests.cs
+++ b/src/DotVVM.Samples.Tests/ErrorsTests.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-using System;
+﻿using System;
 using System.Linq;
 using System.Net;
 using DotVVM.Samples.Tests.Base;

--- a/src/DotVVM.Samples.Tests/Feature/DependencyInjectionTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/DependencyInjectionTests.cs
@@ -3,7 +3,6 @@ using DotVVM.Testing.Abstractions;
 using Riganti.Selenium.Core;
 using Xunit;
 using Xunit.Abstractions;
-using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 namespace DotVVM.Samples.Tests.Feature
 {
@@ -24,7 +23,7 @@ namespace DotVVM.Samples.Tests.Feature
                     var value2 = browser.First(".result").GetInnerText();
                     AssertUI.InnerTextEquals(browser.First(".result2"), value2);
 
-                    Assert.AreNotEqual(value, value2);
+                    Assert.NotEqual(value, value2);
                 }
             });
         }

--- a/src/DotVVM.Samples.Tests/Feature/LocalizationTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/LocalizationTests.cs
@@ -8,7 +8,6 @@ using Riganti.Selenium.Core.Abstractions;
 using Riganti.Selenium.DotVVM;
 using Xunit;
 using Xunit.Abstractions;
-using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 namespace DotVVM.Samples.Tests.Feature
 {
@@ -78,9 +77,9 @@ namespace DotVVM.Samples.Tests.Feature
             RunInAllBrowsers(browser => {
                 browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_Localization_Localization_Control_Page);
 
-                Assert.AreEqual("Localized label for checkbox inside control",
+                Assert.Equal("Localized label for checkbox inside control",
                     browser.Driver.FindElement(By.XPath("//div[@data-ui='localization-control-bare']/label/span")).Text);
-                Assert.AreEqual("Localized literal inside control",
+                Assert.Equal("Localized literal inside control",
                     browser.Driver.FindElement(By.XPath("//div[@data-ui='localization-control-bare']/span")).Text);
             });
         }
@@ -92,9 +91,9 @@ namespace DotVVM.Samples.Tests.Feature
             RunInAllBrowsers(browser => {
                 browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_Localization_Localization_Control_Page);
 
-                Assert.AreEqual("Localized label for checkbox inside control",
+                Assert.Equal("Localized label for checkbox inside control",
                     browser.Driver.FindElement(By.XPath("//div[@data-ui='localization-control-import']/label/span")).Text);
-                Assert.AreEqual("Localized literal inside control",
+                Assert.Equal("Localized literal inside control",
                     browser.Driver.FindElement(By.XPath("//div[@data-ui='localization-control-import']/span")).Text);
             });
         }

--- a/src/DotVVM.Samples.Tests/Feature/PostBackTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/PostBackTests.cs
@@ -5,7 +5,6 @@ using Riganti.Selenium.Core;
 using Riganti.Selenium.Core.Abstractions;
 using Xunit;
 using Xunit.Abstractions;
-using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 namespace DotVVM.Samples.Tests.Feature
 {
@@ -128,7 +127,7 @@ namespace DotVVM.Samples.Tests.Feature
 
             // confirm third
             section.ElementAt("input[type=button]", 2).Click();
-            Assert.IsFalse(browser.HasAlert());
+            Assert.False(browser.HasAlert());
             browser.Wait();
             AssertUI.InnerTextEquals(index, "3");
 
@@ -148,7 +147,7 @@ namespace DotVVM.Samples.Tests.Feature
 
             // confirm conditional
             section.ElementAt("input[type=button]", 5).Click();
-            Assert.IsFalse(browser.HasAlert());
+            Assert.False(browser.HasAlert());
             browser.Wait();
             AssertUI.InnerTextEquals(index, "6");
 
@@ -163,7 +162,7 @@ namespace DotVVM.Samples.Tests.Feature
             browser.First("input[type=checkbox]").Click();
 
             section.ElementAt("input[type=button]", 5).Click();
-            Assert.IsFalse(browser.HasAlert());
+            Assert.False(browser.HasAlert());
             browser.Wait();
             AssertUI.InnerTextEquals(index, "6");
 

--- a/src/DotVVM.Samples.Tests/Feature/ReturnedFileTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/ReturnedFileTests.cs
@@ -6,7 +6,6 @@ using Riganti.Selenium.Core;
 using Riganti.Selenium.Core.Abstractions;
 using Xunit;
 using Xunit.Abstractions;
-using Assert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 namespace DotVVM.Samples.Tests.Feature
 {
@@ -56,14 +55,14 @@ namespace DotVVM.Samples.Tests.Feature
             browser.First("input").SendKeys(Keys.Enter);
             browser.Wait(5000);
             var downloadURL = (string)jsexec.ExecuteScript("return window.downloadURL;");
-            Assert.IsFalse(string.IsNullOrEmpty(downloadURL));
+            Assert.False(string.IsNullOrEmpty(downloadURL));
 
             string returnedFile;
             using (var client = new WebClient())
             {
                 returnedFile = client.DownloadString(browser.GetAbsoluteUrl(downloadURL));
             }
-            Assert.AreEqual(fileContent, returnedFile);
+            Assert.Equal(fileContent, returnedFile);
         }
 
         public ReturnedFileTests(ITestOutputHelper output) : base(output)

--- a/src/DotVVM.Samples.Tests/Feature/ValidationTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/ValidationTests.cs
@@ -580,7 +580,6 @@ namespace DotVVM.Samples.Tests.Feature
         /// Feature_s the validation rules load on postback.
         /// </summary>
         [Fact]
-        [Microsoft.VisualStudio.TestTools.UnitTesting.Timeout(120000)]
         public void Feature_Validation_ValidationRulesLoadOnPostback()
         {
             RunInAllBrowsers(browser => {

--- a/src/DotVVM.Samples.Tests/Feature/ViewModelProtectionTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/ViewModelProtectionTests.cs
@@ -99,7 +99,7 @@ namespace DotVVM.Samples.Tests.Feature
                 // try to do postback
                 browser.SendKeys("input[type=text]", "DotVVM rocks!");
                 browser.Click("input[type=button]");
-                
+
                 // verify that the original value was restored
                 browser.WaitFor(() => {
                     AssertUI.InnerTextEquals(browser.First("strong span"), originalValue);
@@ -140,7 +140,7 @@ namespace DotVVM.Samples.Tests.Feature
             int checkedRadioIndex = (int)selectedColor;
             AssertUI.IsChecked(radios[checkedRadioIndex]);
             radios.RemoveAt(checkedRadioIndex);
-            radios.ForEach(AssertUI.IsNotChecked);
+            radios.ForEach(s => AssertUI.IsNotChecked(s));
 
             AssertUI.TextEquals(selectedColorElement, selectedColor.ToString().ToLower());
         }


### PR DESCRIPTION
The new version of Riganti.Selenium has changed the behavior of all `AssertUI` functions. 
These functions have a `WaitFor` block inside of them now. So it's not required to write WaitFor block around every `AssertUI.Something()`.