### PR TITLE
Fix concurrency handler for staticCommands

### DIFF
--- a/src/DotVVM.Framework/Resources/Scripts/postback/internal-handlers.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/postback/internal-handlers.ts
@@ -95,8 +95,10 @@ export const suppressOnUpdating = (o: any) => ({
     }
 })
 
-export function isPostbackStillActive(id: number) {
-    return getLastStartedPostbackId() == id && !gate.isPostbackDisabled(id)
+export function isPostbackStillActive(options: PostbackOptions) {
+    const id = options.postbackId
+    // For postback and SPA navigation, we reject it if another postback has already started to prevent flashes of new data that will be soon overridden anyway.
+    return (options.commandType == "staticCommand" || getLastStartedPostbackId() == id) && !gate.isPostbackDisabled(id)
 }
 
 function commonConcurrencyHandler<T>(promise: Promise<PostbackCommitFunction>, options: PostbackOptions, queueName: string): Promise<PostbackCommitFunction> {
@@ -113,7 +115,7 @@ function commonConcurrencyHandler<T>(promise: Promise<PostbackCommitFunction>, o
     return promise.then(innerCommit => {
         return async () => {
             try {
-                if (isPostbackStillActive(options.postbackId)) {
+                if (isPostbackStillActive(options)) {
                     return await innerCommit();
                 } else {
                     throw new DotvvmPostbackError({ type: "commit" })


### PR DESCRIPTION
The problem was that the static command commit was always rejected,
because it was not started as postback