### PR TITLE
Adjusted MemberExpressionFactory and uncommenting unit tests

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Binding/ExpressionHelperTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/ExpressionHelperTests.cs
@@ -249,8 +249,8 @@ namespace DotVVM.Framework.Tests.Common.Binding
 
         [TestMethod]
         [DataRow(typeof(GenericTestResult1), new Type[] { typeof(int), typeof(int), typeof(int), typeof(int) }, new Type[] { typeof(int) })]
-      //  [DataRow(typeof(GenericTestResult2), new Type[] { typeof(string), typeof(int), typeof(int), typeof(int) }, new Type[] { typeof(int) })]
-    //    [DataRow(typeof(GenericTestResult2), new Type[] { typeof(double), typeof(bool), typeof(bool) }, new Type[] { typeof(double) })]
+        [DataRow(typeof(GenericTestResult2), new Type[] { typeof(string), typeof(int), typeof(int), typeof(int) }, new Type[] { typeof(int) })]
+        [DataRow(typeof(GenericTestResult2), new Type[] { typeof(double), typeof(bool), typeof(bool) }, new Type[] { typeof(double) })]
         public void Call_FindOverload_Params_Generic_Array_Invalid(Type resultIdentifierType, Type[] argTypes, Type[] expectedArgsTypes)
         {
             Call_FindOverload_Generic(typeof(MethodsParamsArgumentsGenericResolvingSampleObject),

--- a/src/DotVVM.Framework/Compilation/Binding/MemberExpressionFactory.cs
+++ b/src/DotVVM.Framework/Compilation/Binding/MemberExpressionFactory.cs
@@ -165,17 +165,10 @@ namespace DotVVM.Framework.Compilation.Binding
             if (method.IsExtension)
             {
                 // Change to a static call
-                var newArguments = CreateArgumentsForExtensionMethod(target, arguments);
+                var newArguments = new[] { target }.Concat(arguments);
                 return Expression.Call(method.Method, newArguments);
             }
             return Expression.Call(target, method.Method, method.Arguments);
-        }
-        private static Expression[] CreateArgumentsForExtensionMethod(Expression target, Expression[] arguments)
-        {
-            var newArguments = new Expression[arguments.Length + 1];
-            Array.Copy(arguments, 0, newArguments, 1, arguments.Length);
-            newArguments[0] = target;
-            return newArguments;
         }
 
         public Expression CallMethod(Type target, BindingFlags flags, string name, Type[] typeArguments, Expression[] arguments, IDictionary<string, Expression> namedArgs = null)
@@ -196,7 +189,7 @@ namespace DotVVM.Framework.Compilation.Binding
                 if (target != null)
                 {
                     // Change to a static call
-                    var newArguments = CreateArgumentsForExtensionMethod(target, arguments);
+                    var newArguments = new[] { target }.Concat(arguments).ToArray();
                     var extensions = FindValidMethodOveloads(extensionsProvider.GetExtensionMethods().OfType<MethodInfo>().Where(m => m.Name == name), typeArguments, newArguments, namedArgs)
                         .Select(method => { method.IsExtension = true; return method; }).ToList();
 


### PR DESCRIPTION
While fixing a merge-conflict I noticed some issues introduced by a merge commit that is already in the `main` branch. This PR fixes the issues