### PR TITLE
Non-minified version of DotVVM in debug mode

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.RestAPI.json
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.RestAPI.json
@@ -41,7 +41,8 @@
         "Defer": true,
         "Location": {
           "$type": "DotVVM.Framework.ResourceManagement.FileResourceLocation, DotVVM.Framework",
-          "FilePath": "./apiscript.js"
+          "FilePath": "./apiscript.js",
+          "DebugFilePath": "./apiscript.js"
         },
         "MimeType": "text/javascript",
         "RenderPosition": "Anywhere"

--- a/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -32,13 +32,15 @@
         "NomoduleLocation": {
           "$type": "DotVVM.Framework.ResourceManagement.EmbeddedResourceLocation, DotVVM.Framework",
           "Assembly": "DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da",
-          "Name": "DotVVM.Framework.obj.javascript.root_only_system.dotvvm-root.js"
+          "Name": "DotVVM.Framework.obj.javascript.root_only_system.dotvvm-root.js",
+          "DebugName": "DotVVM.Framework.obj.javascript.root_only_system_debug.dotvvm-root.js"
         },
         "Defer": true,
         "Location": {
           "$type": "DotVVM.Framework.ResourceManagement.EmbeddedResourceLocation, DotVVM.Framework",
           "Assembly": "DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da",
-          "Name": "DotVVM.Framework.obj.javascript.root_only.dotvvm-root.js"
+          "Name": "DotVVM.Framework.obj.javascript.root_only.dotvvm-root.js",
+          "DebugName": "DotVVM.Framework.obj.javascript.root_only_debug.dotvvm-root.js"
         },
         "MimeType": "text/javascript",
         "Dependencies": [
@@ -51,13 +53,15 @@
         "NomoduleLocation": {
           "$type": "DotVVM.Framework.ResourceManagement.EmbeddedResourceLocation, DotVVM.Framework",
           "Assembly": "DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da",
-          "Name": "DotVVM.Framework.obj.javascript.root_spa_system.dotvvm-root.js"
+          "Name": "DotVVM.Framework.obj.javascript.root_spa_system.dotvvm-root.js",
+          "DebugName": "DotVVM.Framework.obj.javascript.root_spa_system_debug.dotvvm-root.js"
         },
         "Defer": true,
         "Location": {
           "$type": "DotVVM.Framework.ResourceManagement.EmbeddedResourceLocation, DotVVM.Framework",
           "Assembly": "DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da",
-          "Name": "DotVVM.Framework.obj.javascript.root_spa.dotvvm-root.js"
+          "Name": "DotVVM.Framework.obj.javascript.root_spa.dotvvm-root.js",
+          "DebugName": "DotVVM.Framework.obj.javascript.root_spa_debug.dotvvm-root.js"
         },
         "MimeType": "text/javascript",
         "Dependencies": [
@@ -70,13 +74,15 @@
         "NomoduleLocation": {
           "$type": "DotVVM.Framework.ResourceManagement.EmbeddedResourceLocation, DotVVM.Framework",
           "Assembly": "DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da",
-          "Name": "DotVVM.Framework.obj.javascript.polyfill.bundle.js"
+          "Name": "DotVVM.Framework.obj.javascript.polyfill.bundle.js",
+          "DebugName": "DotVVM.Framework.obj.javascript.polyfill.bundle.js"
         },
         "Defer": true,
         "Location": {
           "$type": "DotVVM.Framework.ResourceManagement.EmbeddedResourceLocation, DotVVM.Framework",
           "Assembly": "DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da",
-          "Name": "DotVVM.Framework.obj.javascript.polyfill.bundle.js"
+          "Name": "DotVVM.Framework.obj.javascript.polyfill.bundle.js",
+          "DebugName": "DotVVM.Framework.obj.javascript.polyfill.bundle.js"
         },
         "MimeType": "text/javascript",
         "RenderPosition": "Anywhere"
@@ -88,7 +94,8 @@
         "Location": {
           "$type": "DotVVM.Framework.ResourceManagement.EmbeddedResourceLocation, DotVVM.Framework",
           "Assembly": "DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da",
-          "Name": "DotVVM.Framework.Resources.Scripts.DotVVM.Debug.js"
+          "Name": "DotVVM.Framework.Resources.Scripts.DotVVM.Debug.js",
+          "DebugName": "DotVVM.Framework.Resources.Scripts.DotVVM.Debug.js"
         },
         "MimeType": "text/javascript",
         "Dependencies": [
@@ -101,7 +108,8 @@
         "Location": {
           "$type": "DotVVM.Framework.ResourceManagement.EmbeddedResourceLocation, DotVVM.Framework",
           "Assembly": "DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da",
-          "Name": "DotVVM.Framework.Resources.Scripts.Globalize.globalize.min.js"
+          "Name": "DotVVM.Framework.Resources.Scripts.Globalize.globalize.min.js",
+          "DebugName": "DotVVM.Framework.Resources.Scripts.Globalize.globalize.min.js"
         },
         "MimeType": "text/javascript",
         "RenderPosition": "Anywhere"
@@ -111,7 +119,8 @@
         "Location": {
           "$type": "DotVVM.Framework.ResourceManagement.EmbeddedResourceLocation, DotVVM.Framework",
           "Assembly": "DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da",
-          "Name": "DotVVM.Framework.Resources.Scripts.knockout-latest.js"
+          "Name": "DotVVM.Framework.Resources.Scripts.knockout-latest.js",
+          "DebugName": "DotVVM.Framework.Resources.Scripts.knockout-latest.debug.js"
         },
         "MimeType": "text/javascript",
         "RenderPosition": "Anywhere"
@@ -122,7 +131,8 @@
         "Location": {
           "$type": "DotVVM.Framework.ResourceManagement.EmbeddedResourceLocation, DotVVM.Framework",
           "Assembly": "DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da",
-          "Name": "DotVVM.Framework.Resources.Scripts.DotVVM.FileUpload.css"
+          "Name": "DotVVM.Framework.Resources.Scripts.DotVVM.FileUpload.css",
+          "DebugName": "DotVVM.Framework.Resources.Scripts.DotVVM.FileUpload.css"
         },
         "MimeType": "text/css"
       }

--- a/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.SerializeResources.json
+++ b/src/DotVVM.Framework.Tests.Common/Runtime/config-tests/ConfigurationSerializationTests.SerializeResources.json
@@ -41,7 +41,8 @@
         "Defer": true,
         "Location": {
           "$type": "DotVVM.Framework.ResourceManagement.UrlResourceLocation, DotVVM.Framework",
-          "Url": "x"
+          "Url": "x",
+          "DebugUrl": "x"
         },
         "MimeType": "text/javascript",
         "VerifyResourceIntegrity": true,
@@ -51,22 +52,26 @@
         "Defer": true,
         "Location": {
           "$type": "DotVVM.Framework.ResourceManagement.UrlResourceLocation, DotVVM.Framework",
-          "Url": "x"
+          "Url": "x",
+          "DebugUrl": "x"
         },
         "LocationFallback": {
           "JavascriptCondition": "window.x",
           "AlternativeLocations": [
             {
               "$type": "DotVVM.Framework.ResourceManagement.UrlResourceLocation, DotVVM.Framework",
-              "Url": "y"
+              "Url": "y",
+              "DebugUrl": "y"
             },
             {
               "$type": "DotVVM.Framework.ResourceManagement.UrlResourceLocation, DotVVM.Framework",
-              "Url": "z"
+              "Url": "z",
+              "DebugUrl": "z"
             },
             {
               "$type": "DotVVM.Framework.ResourceManagement.FileResourceLocation, DotVVM.Framework",
-              "FilePath": "some-script.js"
+              "FilePath": "some-script.js",
+              "DebugFilePath": "some-script.js"
             }
           ]
         },
@@ -81,7 +86,8 @@
       "r3": {
         "Location": {
           "$type": "DotVVM.Framework.ResourceManagement.UrlResourceLocation, DotVVM.Framework",
-          "Url": "s"
+          "Url": "s",
+          "DebugUrl": "s"
         },
         "MimeType": "text/css",
         "VerifyResourceIntegrity": true,

--- a/src/DotVVM.Framework/Configuration/DotvvmConfiguration.cs
+++ b/src/DotVVM.Framework/Configuration/DotvvmConfiguration.cs
@@ -335,16 +335,19 @@ namespace DotVVM.Framework.Configuration
             configuration.Resources.Register(ResourceConstants.KnockoutJSResourceName,
                 new ScriptResource(location: new EmbeddedResourceLocation(
                     typeof(DotvvmConfiguration).GetTypeInfo().Assembly,
-                    "DotVVM.Framework.Resources.Scripts.knockout-latest.js")));
+                    "DotVVM.Framework.Resources.Scripts.knockout-latest.js",
+                    debugName: "DotVVM.Framework.Resources.Scripts.knockout-latest.debug.js")));
 
             configuration.Resources.Register(ResourceConstants.DotvvmResourceName + ".internal",
                 new ScriptModuleResource(
                     location: new EmbeddedResourceLocation(
                         typeof(DotvvmConfiguration).GetTypeInfo().Assembly,
-                        "DotVVM.Framework.obj.javascript.root_only.dotvvm-root.js"),
+                        "DotVVM.Framework.obj.javascript.root_only.dotvvm-root.js",
+                        debugName: "DotVVM.Framework.obj.javascript.root_only_debug.dotvvm-root.js"),
                     nomoduleLocation: new EmbeddedResourceLocation(
                         typeof(DotvvmConfiguration).GetTypeInfo().Assembly,
-                        "DotVVM.Framework.obj.javascript.root_only_system.dotvvm-root.js")
+                        "DotVVM.Framework.obj.javascript.root_only_system.dotvvm-root.js",
+                        debugName: "DotVVM.Framework.obj.javascript.root_only_system_debug.dotvvm-root.js")
                     ) {
                     Dependencies = new[] { ResourceConstants.KnockoutJSResourceName, ResourceConstants.PolyfillBundleResourceName }
                 });
@@ -352,10 +355,12 @@ namespace DotVVM.Framework.Configuration
                 new ScriptModuleResource(
                     location: new EmbeddedResourceLocation(
                         typeof(DotvvmConfiguration).GetTypeInfo().Assembly,
-                        "DotVVM.Framework.obj.javascript.root_spa.dotvvm-root.js"),
+                        "DotVVM.Framework.obj.javascript.root_spa.dotvvm-root.js",
+                        debugName: "DotVVM.Framework.obj.javascript.root_spa_debug.dotvvm-root.js"),
                     nomoduleLocation: new EmbeddedResourceLocation(
                         typeof(DotvvmConfiguration).GetTypeInfo().Assembly,
-                        "DotVVM.Framework.obj.javascript.root_spa_system.dotvvm-root.js")
+                        "DotVVM.Framework.obj.javascript.root_spa_system.dotvvm-root.js",
+                        debugName: "DotVVM.Framework.obj.javascript.root_spa_system_debug.dotvvm-root.js")
                     ) {
                     Dependencies = new[] { ResourceConstants.KnockoutJSResourceName, ResourceConstants.PolyfillBundleResourceName }
                 });

--- a/src/DotVVM.Framework/DotVVM.Framework.csproj
+++ b/src/DotVVM.Framework/DotVVM.Framework.csproj
@@ -72,24 +72,25 @@
     <None Remove="node_modules\**" />
   </ItemGroup>
   <ItemGroup>
-    <None Remove="Resources\Scripts\knockout-latest.debug.js" />
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="Resources\Scripts\DotVVM.FileUpload.css" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\Scripts\DotVVM.Debug.js" />
     <EmbeddedResource Include="obj/javascript/root-only/dotvvm-root.js" />
+    <EmbeddedResource Include="obj/javascript/root-only-debug/dotvvm-root.js" />
     <EmbeddedResource Include="obj/javascript/root-spa/dotvvm-root.js" />
+    <EmbeddedResource Include="obj/javascript/root-spa-debug/dotvvm-root.js" />
     <EmbeddedResource Include="obj/javascript/root-only-system/dotvvm-root.js" />
+    <EmbeddedResource Include="obj/javascript/root-only-system-debug/dotvvm-root.js" />
     <EmbeddedResource Include="obj/javascript/root-spa-system/dotvvm-root.js" />
+    <EmbeddedResource Include="obj/javascript/root-spa-system-debug/dotvvm-root.js" />
     <EmbeddedResource Include="obj/javascript/polyfill.bundle.js" />
     <EmbeddedResource Include="Resources\Scripts\Globalize\globalize.min.js" />
     <EmbeddedResource Include="Resources\Scripts\knockout-latest.js" />
+    <EmbeddedResource Include="Resources\Scripts\knockout-latest.debug.js" />
     <EmbeddedResource Include="Resources\Scripts\Globalize\globalize.js" />
     <None Include="Resources\Scripts\DotVVM.Globalize.ts" />
     <None Include="Resources\Scripts\typings\globalize\globalize.d.ts" />
-    <None Include="Resources\Scripts\typings\knockout.mapper\knockout.mapper.d.ts" />
     <None Include="Resources\Scripts\typings\knockout\knockout.d.ts" />
   </ItemGroup>
   <ItemGroup>
@@ -126,9 +127,6 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Resources\Scripts\knockout-latest.debug.js" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Controls\DelegateTemplate.d.ts">

--- a/src/DotVVM.Framework/ResourceManagement/EmbeddedResourceLocation.cs
+++ b/src/DotVVM.Framework/ResourceManagement/EmbeddedResourceLocation.cs
@@ -16,17 +16,29 @@ namespace DotVVM.Framework.ResourceManagement
         [JsonConverter(typeof(ReflectionAssemblyJsonConverter))]
         public Assembly Assembly { get; }
         public string Name { get; }
+        public string DebugName { get; }
         /// <summary>
         /// File where the resource is located for debug purposes
         /// </summary>
         public string? DebugFilePath { get; set; }
-        public EmbeddedResourceLocation(Assembly assembly, string name, string? debugFileName = null)
+        public EmbeddedResourceLocation(Assembly assembly, string name, string? debugFilePath = null, string? debugName = null)
         {
             if (assembly.GetManifestResourceInfo(name) == null) throw new ArgumentException($"Could not find resource '{name}' in assembly {assembly.GetName().Name}. Did you mean one of {string.Join(", ", assembly.GetManifestResourceNames())}?", nameof(name));
 
             this.Name = name;
             this.Assembly = assembly;
-            this.DebugFilePath = debugFileName;
+
+            if (debugName != null)
+            {
+                if (assembly.GetManifestResourceInfo(debugName) == null) throw new ArgumentException($"Could not find resource '{debugName}' in assembly {assembly.GetName().Name}. Did you mean one of {string.Join(", ", assembly.GetManifestResourceNames())}?", nameof(debugName));
+                this.DebugName = debugName;
+            }
+            else
+            {
+                this.DebugName = name;
+            }
+
+            this.DebugFilePath = debugFilePath;
         }
 
         public override Stream LoadResource(IDotvvmRequestContext context)
@@ -34,7 +46,7 @@ namespace DotVVM.Framework.ResourceManagement
             var debugPath = DebugFilePath == null ? null : Path.Combine(context.Configuration.ApplicationPhysicalPath, DebugFilePath);
             return context.Configuration.Debug && debugPath != null && File.Exists(debugPath) ?
                 File.OpenRead(debugPath) :
-                Assembly.GetManifestResourceStream(Name).NotNull();
+                Assembly.GetManifestResourceStream(context.Configuration.Debug ? DebugName : Name).NotNull();
         }
 
         public string? GetFilePath(IDotvvmRequestContext context) => DebugFilePath;

--- a/src/DotVVM.Framework/ResourceManagement/FileResourceLocation.cs
+++ b/src/DotVVM.Framework/ResourceManagement/FileResourceLocation.cs
@@ -11,14 +11,24 @@ namespace DotVVM.Framework.ResourceManagement
     public class FileResourceLocation: LocalResourceLocation, IDebugFileLocalLocation
     {
         public string FilePath { get; }
-        public FileResourceLocation(string filePath)
+        public string DebugFilePath { get; }
+        public FileResourceLocation(string filePath, string? debugFilePath = null)
         {
             if (filePath.StartsWith("~/", StringComparison.Ordinal)) filePath = filePath.Substring(2); // trim ~/ from the path
             this.FilePath = filePath;
+
+            if (debugFilePath != null)
+            {
+                if (debugFilePath.StartsWith("~/", StringComparison.Ordinal)) debugFilePath = debugFilePath.Substring(2); // trim ~/ from the path
+                this.DebugFilePath = debugFilePath;
+            } else
+            {
+                this.DebugFilePath = filePath;
+            }
         }
 
         public override Stream LoadResource(IDotvvmRequestContext context) => 
-            File.OpenRead(Path.Combine(context.Configuration.ApplicationPhysicalPath, FilePath));
+            File.OpenRead(Path.Combine(context.Configuration.ApplicationPhysicalPath, context.Configuration.Debug ? DebugFilePath : FilePath));
 
         public string GetFilePath(IDotvvmRequestContext context) => FilePath;
     }

--- a/src/DotVVM.Framework/ResourceManagement/UrlResourceLocation.cs
+++ b/src/DotVVM.Framework/ResourceManagement/UrlResourceLocation.cs
@@ -13,14 +13,16 @@ namespace DotVVM.Framework.ResourceManagement
     public class UrlResourceLocation: IResourceLocation
     {
         public string Url { get; }
-        public UrlResourceLocation(string url)
+        public string DebugUrl { get; set; }
+        public UrlResourceLocation(string url, string? debugUrl = null)
         {
             this.Url = url;
+            this.DebugUrl = debugUrl ?? url;
         }
 
         public string GetUrl(IDotvvmRequestContext context, string name)
         {
-            return context.TranslateVirtualPath(Url);
+            return context.TranslateVirtualPath(context.Configuration.Debug ? DebugUrl : Url);
         }
     }
 

--- a/src/DotVVM.Framework/package.json
+++ b/src/DotVVM.Framework/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build-development": "rollup -c",
-    "build": "npm run build-production && npm run build-polyfills",
+    "build": "npm run build-production && npm run build-development && npm run build-polyfills",
     "build-production": "rollup -c --environment BUILD:production",
     "tsc-build": "tsc -p .",
     "tsc-types": "tsc -d -p . --outFile ./obj/typescript-types/dotvvm.d.ts --emitDeclarationOnly --skipLibCheck",

--- a/src/DotVVM.Framework/rollup.config.js
+++ b/src/DotVVM.Framework/rollup.config.js
@@ -7,6 +7,7 @@ import replace from '@rollup/plugin-replace';
 
 const build = process.env.BUILD || "debug";
 const production = build == "production";
+const suffix = production ? "" : "-debug";
 
 const config = ({ minify, input, output, spa, legacy }) => ({
     input,
@@ -87,20 +88,20 @@ export default [
     config({
         minify: production,
         input: ['./Resources/Scripts/dotvvm-root.ts'],
-        output: "root-only",
+        output: "root-only" + suffix,
         spa: false
     }),
     config({
         minify: production,
         input: ['./Resources/Scripts/dotvvm-root.ts'],
-        output: "root-spa",
+        output: "root-spa" + suffix,
         spa: true,
     }),
     config({
         // this configuration is for IE (system.js)
         minify: production,
         input: ['./Resources/Scripts/dotvvm-root.ts'],
-        output: "root-only-system",
+        output: "root-only-system" + suffix,
         spa: false,
         legacy: true
     }),
@@ -108,7 +109,7 @@ export default [
         // this configuration is for IE (system.js)
         minify: production,
         input: ['./Resources/Scripts/dotvvm-root.ts'],
-        output: "root-spa-system",
+        output: "root-spa-system" + suffix,
         spa: true,
         legacy: true
     }),

--- a/src/DotVVM.Samples.Common/CommonConfiguration.cs
+++ b/src/DotVVM.Samples.Common/CommonConfiguration.cs
@@ -120,8 +120,8 @@ namespace DotVVM.Samples.Common
 
             // dev files
             resources.SetEmbeddedResourceDebugFile("knockout", "../DotVVM.Framework/Resources/Scripts/knockout-latest.debug.js");
-            resources.SetEmbeddedResourceDebugFile("dotvvm.internal", "../DotVVM.Framework/obj/javascript/root-only/dotvvm-root.js");
-            resources.SetEmbeddedResourceDebugFile("dotvvm.internal-spa", "../DotVVM.Framework/obj/javascript/root-spa/dotvvm-root.js");
+            resources.SetEmbeddedResourceDebugFile("dotvvm.internal", "../DotVVM.Framework/obj/javascript/root-only-debug/dotvvm-root.js");
+            resources.SetEmbeddedResourceDebugFile("dotvvm.internal-spa", "../DotVVM.Framework/obj/javascript/root-spa-debug/dotvvm-root.js");
             resources.SetEmbeddedResourceDebugFile("dotvvm.debug", "../DotVVM.Framework/Resources/Scripts/DotVVM.Debug.js");
             resources.SetEmbeddedResourceDebugFile("dotvvm.fileupload-css", "../DotVVM.Framework/Resources/Scripts/DotVVM.FileUploads.css");
             resources.SetEmbeddedResourceDebugFile("dotvvm.polyfill.bundle", "../DotVVM.Framework/obj/javascript/polyfill.bundle.js");


### PR DESCRIPTION
This PR uses non-minified versions of DotVVM and Knockout when `configuration.Debug` is `true`.