### PR TITLE
Verbose logging on the client

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/ControlTests/testoutputs/MarkupControlTests.MarkupControl_PassingStaticCommand.html
+++ b/src/DotVVM.Framework.Tests.Common/ControlTests/testoutputs/MarkupControlTests.MarkupControl_PassingStaticCommand.html
@@ -17,7 +17,7 @@
 			resolve(r_0);
 		}, reject);
 	});
-}(ko.contextFor(this)))}.bind(this),this,[],[]).catch(console.error);event.stopPropagation();return false;">
+}(ko.contextFor(this)))}.bind(this),this,[],[]).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;">
 			<!-- /ko -->
 		</div>
 		<!-- /ko -->
@@ -36,7 +36,7 @@
 			resolve(r_0);
 		}, reject);
 	});
-}(ko.contextFor(this)))}.bind(this),this,[],[]).catch(console.error);event.stopPropagation();return false;">
+}(ko.contextFor(this)))}.bind(this),this,[],[]).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;">
 				<!-- /ko -->
 			</div>
 		</div>

--- a/src/DotVVM.Framework.Tests.Common/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModuleInControl.html
+++ b/src/DotVVM.Framework.Tests.Common/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModuleInControl.html
@@ -30,7 +30,7 @@
 			<!-- ko dotvvm-with-view-modules: { viewIdOrElement: $element, modules: ["controlModule"] } -->
 			<input type="button" value="" onclick="dotvvm.applyPostbackHandlers(function(options){return (function(a) {
 	return Promise.resolve(dotvvm.viewModules.call(a, &quot;name&quot;, [1]));
-}(this))}.bind(this),this,[],[]).catch(console.error);event.stopPropagation();return false;">
+}(this))}.bind(this),this,[],[]).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;">
 			<!-- /ko -->
 			<!-- /ko -->
 		</div>
@@ -40,7 +40,7 @@
 				<!-- ko dotvvm-with-view-modules: { viewIdOrElement: $element, modules: ["controlModule"] } -->
 				<input type="button" value="" onclick="dotvvm.applyPostbackHandlers(function(options){return (function(a) {
 	return Promise.resolve(dotvvm.viewModules.call(a, &quot;name&quot;, [1]));
-}(this))}.bind(this),this,[],[]).catch(console.error);event.stopPropagation();return false;">
+}(this))}.bind(this),this,[],[]).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;">
 				<!-- /ko -->
 				<!-- /ko -->
 			</div>

--- a/src/DotVVM.Framework/Controls/Infrastructure/BodyResourceLinks.cs
+++ b/src/DotVVM.Framework/Controls/Infrastructure/BodyResourceLinks.cs
@@ -56,7 +56,7 @@ namespace DotVVM.Framework.Controls
             foreach (var w in collector.GetWarnings())
             {
                 var msg = JsonConvert.ToString(w.ToString(), '"', StringEscapeHandling.EscapeHtml);
-                result += $"console.warn({msg});\n";
+                result += $"dotvvm.log.logWarning({msg});\n";
             }
             return result;
         }

--- a/src/DotVVM.Framework/Controls/KnockoutHelper.cs
+++ b/src/DotVVM.Framework/Controls/KnockoutHelper.cs
@@ -97,7 +97,7 @@ namespace DotVVM.Framework.Controls
         public static string GenerateClientPostBackScript(string propertyName, ICommandBinding expression, DotvvmBindableObject control, PostbackScriptOptions options)
         {
             var expr = GenerateClientPostBackExpression(propertyName, expression, control, options);
-            expr += ".catch(console.error)";
+            expr += ".catch(dotvvm.log.logPostBackScriptError)";
             if (options.ReturnValue == false)
                 return expr + ";event.stopPropagation();return false;";
             else

--- a/src/DotVVM.Framework/Resources/Scripts/DotVVM.Debug.js
+++ b/src/DotVVM.Framework/Resources/Scripts/DotVVM.Debug.js
@@ -53,9 +53,9 @@
     iframe.style.width = "100%";
 
     dotvvm.events.error.subscribe(function (e) {
-        console.error("DotVVM: An " + (e.handled ? "" : "un") + "handled exception returned from the server command.");
-        console.log("Response: ", e.response);
-        console.log("ViewModel: ", e.viewModel);
+        dotvvm.log.logError("debug", "DotVVM: An " + (e.handled ? "" : "un") + "handled exception returned from the server command.");
+        dotvvm.log.logInfoVerbose("debug", "Response: ", e.response);
+        dotvvm.log.logInfoVerbose("debug", "ViewModel: ", e.viewModel);
         if (e.handled) return;
         debugWindow.querySelector("h1").textContent = "DotVVM Debugger: Error " +
            (e.response && e.response.status ? e.response.status + ": " + e.response.statusText + "" :
@@ -125,7 +125,7 @@
         if ("subscribe" in dotvvm.events[event]) {
             (function (event) {
                 dotvvm.events[event].subscribe(function (e) {
-                    console.log("Event " + event, e);
+                    dotvvm.log.logInfoVerbose("debug", "Event " + event, e);
                 });
             })(event);
         }

--- a/src/DotVVM.Framework/Resources/Scripts/api/api.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/api/api.ts
@@ -1,5 +1,6 @@
 import * as eventHub from './eventHub';
 import { deserialize } from '../serialization/deserialize';
+import { logError, logWarning } from '../utils/logging';
 
 type ApiComputed<T> =
     KnockoutObservable<T | null> & {
@@ -45,9 +46,9 @@ export function invoke<T>(
                     eventHub.notify(t);
                 }
                 return val;
-            }, console.warn) };
+            }, e => logWarning("rest-api", e)) };
         } catch (e) {
-            console.warn(e);
+            logWarning("rest-api", e);
             return { type: 'error', error: e };
         }
     };
@@ -85,11 +86,11 @@ export function refreshOn<T>(
     watch: KnockoutObservable<any>
 ): ApiComputed<T> {
     if (typeof value.refreshValue != "function") {
-        console.error(`The object is not refreshable.`);
+        logError("rest-api", `The object is not refreshable.`);
     }
     watch.subscribe(() => {
         if (typeof value.refreshValue != "function") {
-            console.error(`The object is not refreshable.`);
+            logError("rest-api", `The object is not refreshable.`);
         }
         value.refreshValue();
     });

--- a/src/DotVVM.Framework/Resources/Scripts/binding-handlers/SSR-foreach.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/binding-handlers/SSR-foreach.ts
@@ -1,3 +1,5 @@
+import { logError } from "../utils/logging";
+
 const foreachCollectionSymbol = "$foreachCollectionSymbol" // knockout does not support symbols ;(
 
 ko.virtualElements.allowedBindings["dotvvm-SSR-foreach"] = true;
@@ -56,7 +58,7 @@ export default {
         },
         update(element: SeenUpdateElement) {
             if (element.seenUpdate) {
-                console.error(`dotvvm-SSR-item binding did not expect to see an update`);
+                logError("binding-handler", `The dotvvm-SSR-item binding did not expect to see an update.`);
             }
             element.seenUpdate = 1;
         }

--- a/src/DotVVM.Framework/Resources/Scripts/binding-handlers/introduce-alias.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/binding-handlers/introduce-alias.ts
@@ -1,4 +1,5 @@
 import { deserialize } from '../serialization/deserialize'
+import { logWarning } from '../utils/logging';
 import { keys } from '../utils/objects';
 
 function isCommand(value: any, prop: string) {
@@ -15,7 +16,7 @@ function createWrapperComputed<T>(accessor: () => KnockoutObservable<T> | T, pro
             if (ko.isObservable(val)) {
                 val(value);
             } else {
-                console.warn(`Attempted to write to readonly property` + (!propertyDebugInfo ? `` : ` ` + propertyDebugInfo) + `.`);
+                logWarning("binding-handler", `Attempted to write to readonly property` + (!propertyDebugInfo ? `` : ` ` + propertyDebugInfo) + `.`);
             }
         }
     });

--- a/src/DotVVM.Framework/Resources/Scripts/dotvvm-root.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/dotvvm-root.ts
@@ -23,6 +23,7 @@ import * as api from './api/api'
 import * as eventHub from './api/eventHub'
 import * as viewModuleManager from './viewModules/viewModuleManager'
 import { notifyModuleLoaded } from './postback/resourceLoader'
+import { logError, logWarning, logInfo, logInfoVerbose, level, logPostBackScriptError } from "./utils/logging"
 
 if (compileConstants.nomodules) {
     addPolyfills()
@@ -103,6 +104,14 @@ const dotvvmExports = {
     },
     resourceLoader: {
         notifyModuleLoaded
+    },
+    log: {
+        logError,
+        logWarning,
+        logInfo,
+        logInfoVerbose,
+        logPostBackScriptError,
+        level
     }
 }
 

--- a/src/DotVVM.Framework/Resources/Scripts/postback/http.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/postback/http.ts
@@ -1,5 +1,6 @@
 import { getVirtualDirectory, getViewModel, getState, getStateManager } from '../dotvvm-base';
 import { DotvvmPostbackError } from '../shared-classes';
+import { logInfoVerbose, logWarning } from '../utils/logging';
 import { keys } from '../utils/objects';
 import { addLeadingSlash, concatUrl } from '../utils/uri';
 
@@ -57,12 +58,12 @@ export async function fetchCsrfToken(): Promise<string> {
             response = await fetch(url);
         }
         catch (err) {
-            console.warn(`CSRF token fetch failed.`);
+            logWarning("postback", `CSRF token fetch failed.`);
             throw new DotvvmPostbackError({ type: "network", err });
         }
 
         if (response.status != 200) {
-            console.warn(`CSRF token fetch failed. HTTP status: ${response.statusText}`);
+            logWarning("postback", `CSRF token fetch failed. HTTP status: ${response.statusText}`);
             throw new DotvvmPostbackError({ type: "csrfToken" });
         }
 
@@ -82,7 +83,7 @@ export async function retryOnInvalidCsrfToken<TResult>(postbackFunction: () => P
         if (err instanceof DotvvmPostbackError) {
             if (err.reason.type === "serverError") {
                 if (err.reason.responseObject?.action === "invalidCsrfToken") {
-                    console.log("Resending postback due to invalid CSRF token.");
+                    logInfoVerbose("postback", "Resending postback due to invalid CSRF token.");
                     getStateManager().update(u => ({ ...u, $csrfToken: undefined }))
 
                     if (iteration < 3) {

--- a/src/DotVVM.Framework/Resources/Scripts/postback/postback.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/postback/postback.ts
@@ -6,6 +6,7 @@ import * as internalHandlers from './internal-handlers';
 import * as events from '../events';
 import * as gate from './gate';
 import { DotvvmPostbackError } from '../shared-classes';
+import { logError } from '../utils/logging';
 
 const globalPostbackHandlers: (ClientFriendlyPostbackHandlerConfiguration)[] = [
     internalHandlers.suppressOnDisabledElementHandler,
@@ -84,7 +85,7 @@ export async function postBack(
                 }
                 events.error.trigger(errorEventArgs);
                 if (!errorEventArgs.handled) {
-                    console.error("Postback failed", errorEventArgs);                    
+                    logError("postback", "Postback failed", errorEventArgs);                    
                 } else {
                     return {
                         ...options,
@@ -95,7 +96,7 @@ export async function postBack(
                 }
             }
         } else {
-            console.error("Unexpected exception during postback.", err);
+            logError("postback", "Unexpected exception during postback.", err);
         }
         throw err;
     }
@@ -162,7 +163,7 @@ export async function applyPostbackHandlers(
                 events.error.trigger(errorEventArgs);
 
                 if (!errorEventArgs.handled) {
-                    console.error("StaticCommand failed", errorEventArgs);
+                    logError("static-command", "StaticCommand failed", errorEventArgs);
                 } else {
                     return {
                         ...options,
@@ -173,7 +174,7 @@ export async function applyPostbackHandlers(
                 }
             }
         } else {
-            console.error("Unexpected exception during static command.", err);
+            logError("static-command", "Unexpected exception during static command.", err);
         }
         throw err
     }

--- a/src/DotVVM.Framework/Resources/Scripts/postback/resourceLoader.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/postback/resourceLoader.ts
@@ -1,3 +1,4 @@
+import { logWarning } from "../utils/logging";
 import { createArray, keys } from "../utils/objects";
 
 export type RenderedResourceList = {
@@ -106,7 +107,7 @@ function waitForElementLoaded(element: HTMLElement) {
     return new Promise<void>(resolve => {
         element.addEventListener("load", () => resolve());
         element.addEventListener("error", () => {
-            console.warn(`Error loading resource`, element);
+            logWarning("resource-loader", `Error loading resource`, element);
             resolve();
         });
     });

--- a/src/DotVVM.Framework/Resources/Scripts/postback/updater.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/postback/updater.ts
@@ -1,6 +1,7 @@
 import { getElementByDotvvmId } from '../utils/dom'
 import { replaceViewModel, updateViewModelCache, clearViewModelCache, getStateManager } from '../dotvvm-base'
 import { keys } from '../utils/objects';
+import { logInfoVerbose } from '../utils/logging';
 
 const diffEqual = {}
 
@@ -32,7 +33,7 @@ export function restoreUpdatedControls(resultObject: any, updatedControls: any) 
                 throw new Error("Postback.Update control always has to render id attribute.");
             }
             if (element.id !== updatedControls[id].control.id) {
-                console.log(`Postback.Update control changed id from '${updatedControls[id].control.id}' to '${element.id}'`);
+                logInfoVerbose("postback", `Postback.Update control changed id from '${updatedControls[id].control.id}' to '${element.id}'`);
             }
             wrapper.removeChild(element);
             if (updatedControl.nextSibling) {

--- a/src/DotVVM.Framework/Resources/Scripts/serialization/date.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/serialization/date.ts
@@ -1,3 +1,5 @@
+import { logWarning } from "../utils/logging";
+
 export function parseDate(value: string): Date | null {
     const match = value.match("^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})(\\.[0-9]{3,7})$");
     if (match) {
@@ -21,7 +23,7 @@ export function serializeDate(date: string | Date | null, convertToUtc: boolean 
     } else if (typeof date == "string") {
         // just print in the console if it's invalid
         if (parseDate(date) == null) {
-            console.error(new Error(`Date ${date} is invalid.`));
+            logWarning("coercer", `Date ${date} is invalid.`);
         }
         return date;
     }
@@ -48,7 +50,7 @@ export function serializeTime(date: string | Date | null, convertToUtc: boolean 
     } else if (typeof date == "string") {
         // just print in the console if it's invalid
         if (parseDate(date) == null) {
-            console.error(new Error(`Date ${date} is invalid.`));
+            logWarning("coercer", `Date ${date} is invalid.`);
         }
         return date;
     }

--- a/src/DotVVM.Framework/Resources/Scripts/spa/spa.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/spa/spa.ts
@@ -7,6 +7,7 @@ import { navigateCore } from './navigation';
 import * as counter from '../postback/counter';
 import { options } from 'knockout';
 import { DotvvmPostbackError } from '../shared-classes';
+import { logError } from '../utils/logging';
 
 export const isSpaReady = ko.observable(false);
 
@@ -121,7 +122,7 @@ export async function handleSpaNavigationCore(url: string | null, sender?: HTMLE
             };
             events.error.trigger(errArgs);
             if (!errArgs.handled) {
-                console.error("Unexpected exception during SPA navigation", errArgs);
+                logError("spa", "Unexpected exception during SPA navigation", errArgs);
             } else {
                 return {
                     ...options,
@@ -129,7 +130,7 @@ export async function handleSpaNavigationCore(url: string | null, sender?: HTMLE
                 }
             }
         } else {
-            console.error("Unexpected exception during SPA navigation", err)
+            logError("spa", "Unexpected exception during SPA navigation", err)
         }
 
         throw err;

--- a/src/DotVVM.Framework/Resources/Scripts/state-manager.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/state-manager.ts
@@ -6,6 +6,7 @@ import { extendToObservableArrayIfRequired } from "./serialization/deserialize"
 import { getObjectTypeInfo } from "./metadata/typeMap";
 import { coerce } from "./metadata/coercer";
 import { patchViewModel } from "./postback/updater";
+import { logWarning } from "./utils/logging";
 
 export const currentStateSymbol = Symbol("currentState")
 const notifySymbol = Symbol("notify")
@@ -107,7 +108,7 @@ export class StateManager<TViewModel extends { $type?: TypeDefinition }> {
             isViewModelUpdating = false
             ko.delaySync.resume()
         }
-        // console.log("New state dispatched, t = ", performance.now() - time, "; t_cpu = ", performance.now() - realStart)
+        //logInfoVerbose("New state dispatched, t = ", performance.now() - time, "; t_cpu = ", performance.now() - realStart);
     }
 
     public setState(newState: TViewModel): TViewModel {
@@ -181,7 +182,7 @@ class FakeObservableObject<T extends object> implements UpdatableObjectExtension
                             }
                         }
                     } else if (p.indexOf("$") !== 0) {
-                        console.warn(`Unknown property '${p}' set on an object of type ${typeId}.`);
+                        logWarning("state-manager", `Unknown property '${p}' set on an object of type ${typeId}.`);
                     }
 
                     this[internalPropCache][p] = newObs
@@ -256,7 +257,7 @@ function createWrappedObservable<T>(initialValue: T, typeHint: TypeDefinition | 
             return coerceResult;
         } catch (err) {
             (this as any)[lastSetErrorSymbol] = err;
-            console.debug(`Can not update observable to ${newValue}:`, err)
+            logWarning("state-manager", `Can not update observable to ${newValue}:`, err)
             throw err
         }
     }
@@ -317,8 +318,7 @@ function createWrappedObservable<T>(initialValue: T, typeHint: TypeDefinition | 
                         continue
                     }
                     if (newContents[index]) {
-                        // TODO: remove eventually
-                        console.warn(`Replacing old knockout observable with a new one, just because it is not created by DotVVM. Please do not assign objects into the knockout tree directly. The object is `, unmapKnockoutObservables(newContents[index]))
+                        logWarning("state-manager", `Replacing old knockout observable with a new one, just because it is not created by DotVVM. Please do not assign objects into the knockout tree directly. The object is `, unmapKnockoutObservables(newContents[index]))
                     }
                     const indexForClosure = index
                     newContents[index] = createWrappedObservable(newVal[index], Array.isArray(typeHint) ? typeHint[0] : void 0, update => updater((viewModelArray: any) => {
@@ -351,8 +351,6 @@ function createWrappedObservable<T>(initialValue: T, typeHint: TypeDefinition | 
         }
         else {
             // create new object and replace
-
-            // console.debug("Creating new KO object for", newVal)
             newContents = createObservableObject(newVal, typeHint, updater)
         }
 

--- a/src/DotVVM.Framework/Resources/Scripts/tests/helper.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/tests/helper.ts
@@ -3,6 +3,7 @@ import { keys } from '../utils/objects'
 import { events as validationEvents } from '../validation/validation'
 import fc_types from '../../../node_modules/fast-check/lib/types/fast-check'
 import { replaceTypeInfo, updateTypeInfo } from '../metadata/typeMap';
+import { logInfoVerbose } from '../utils/logging';
 
 export const fc: typeof fc_types = require('fast-check');
 
@@ -64,7 +65,7 @@ export function watchEvents(consoleOutput: boolean = true) {
         if ("subscribe" in (allEvents as any)[event]) {
             const h = function (args: any): void {
                 if (consoleOutput) {
-                    console.debug("Event " + event, args.postbackId ?? "")
+                    logInfoVerbose("events", "Event " + event, args.postbackId ?? "")
                 }
                 eventHistory.push({ event, args })
             };

--- a/src/DotVVM.Framework/Resources/Scripts/utils/evaluator.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/utils/evaluator.ts
@@ -1,4 +1,5 @@
 import { isObservableArray } from "./knockout";
+import { logError } from "./logging";
 
 export function evaluateOnViewModel(context: any, expression: string): any {
     // todo: reimplement
@@ -42,7 +43,7 @@ function updateObservable(getObservable: () => KnockoutObservable<any>, value: a
     const result = getExpressionResult(getObservable);
 
     if (!ko.isWriteableObservable(result)) {
-        console.error(`Cannot write a value to ko.computed because the expression '${getObservable}' does not return a writable observable.`);
+        logError("evaluator", `Cannot write a value to ko.computed because the expression '${getObservable}' does not return a writable observable.`);
     } else {
         result(value);
     }
@@ -52,7 +53,7 @@ function updateObservableArray(getObservableArray: () => KnockoutObservableArray
     const result = getExpressionResult(getObservableArray);
 
     if (!isObservableArray(result)) {
-        console.error(`Cannot execute '${fnName}' function on ko.computed because the expression '${getObservableArray}' does not return an observable array.`);
+        logError("evaluator", `Cannot execute '${fnName}' function on ko.computed because the expression '${getObservableArray}' does not return an observable array.`);
     } else {
         result[fnName].apply(result, args);
     }

--- a/src/DotVVM.Framework/Resources/Scripts/utils/logging.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/utils/logging.ts
@@ -1,0 +1,39 @@
+import { DotvvmPostbackError } from "../shared-classes";
+
+type LogLevel = "normal" | "verbose";
+
+export const level = getLogLevel();
+
+export function logInfoVerbose(area: string, ...args: any[]) {
+    if (level === "verbose") {
+        console.log(`%c${area}`, "background-color: #7fdbff", ...args);
+    }
+}
+
+export function logInfo(area: string, ...args: any[]) {
+    console.log(`%c${area}`, "background-color: #f0f0f0", ...args);
+}
+
+export function logWarning(area: string, ...args: any[]) {
+    console.warn(`%c${area}`, "background-color: #ff851b", ...args);
+}
+
+export function logError(area: string, ...args: any[]) {
+    console.error(`%c${area}`, "background-color: #ff4136; color: white", ...args);
+}
+
+export function logPostBackScriptError(err: any) {
+    if (err instanceof DotvvmPostbackError) {
+        return;     // this was logged or handled in the postback pipeline
+    }
+    logError("postback", "Uncaught error returned from promise!", err);
+}
+
+function getLogLevel() : LogLevel {
+    var logLevel = window.localStorage.getItem("dotvvm-loglevel");
+    if (!logLevel) return "normal";
+    if (logLevel === "normal" || logLevel === "verbose") return logLevel;
+    
+    logWarning("log", "Invalid value of 'dotvvm-loglevel' config value! Supported values: 'normal', 'verbose'");
+    return "normal";
+}

--- a/src/DotVVM.Framework/Resources/Scripts/validation/validation.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/validation/validation.ts
@@ -12,6 +12,7 @@ import { getObjectTypeInfo } from "../metadata/typeMap"
 import { tryCoerce } from "../metadata/coercer"
 import { primitiveTypes } from "../metadata/primitiveTypes"
 import { lastSetErrorSymbol } from "../state-manager"
+import { logError } from "../utils/logging"
 
 type ValidationSummaryBinding = {
     target: KnockoutObservable<any>,
@@ -51,7 +52,7 @@ const createValidationHandler = (path: string) => ({
             });
 
             if (allErrors.length > 0) {
-                console.log("Validation failed: postback aborted; errors: ", allErrors);
+                logError("validation", "Validation failed: postback aborted; errors: ", allErrors);
                 return Promise.reject(new DotvvmPostbackError({ type: "handler", handlerName: "validation", message: "Validation failed" }))
             }
         }


### PR DESCRIPTION
This PR adds allows to turn on verbose logging on the client (by setting the `dotvvm-loglevel=verbose` in local storage).

I've changed all calls to `console.log/warn/error...` in the TypeScript code to call our custom logging functions (exposed publicly in `dotvvm.log...`).
We can make some extensibility points in the future if we want to send the errors to some other external service.

I've also added the "area" flag to these functions - it should help in understanding from which part of DotVVM the error message comes from. Also, in the future, I can imagine that it may be used to filter out unwanted messages.