### PR TITLE
Postbacks were not disabled on classic non-SPA redirects

### DIFF
--- a/src/DotVVM.Framework/Resources/Scripts/postback/redirect.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/postback/redirect.ts
@@ -1,11 +1,8 @@
 import * as events from '../events';
 import * as magicNavigator from '../utils/magic-navigator'
 import { handleSpaNavigationCore } from "../spa/spa";
-import { disablePostbacks } from './gate';
 
 export function performRedirect(url: string, replace: boolean, allowSpa: boolean): Promise<any> {
-    disablePostbacks();
-
     if (replace) {
         location.replace(url);
         return Promise.resolve();


### PR DESCRIPTION
This was fixed in 2.5, but we haven't merged it correctly into `main`.