### PR TITLE
Parsing assembly qualified names and propagating errors

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Parser/Binding/BindingParserTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Parser/Binding/BindingParserTests.cs
@@ -725,6 +725,28 @@ namespace DotVVM.Framework.Tests.Parser.Binding
         }
 
         [TestMethod]
+        [DataRow("Domain.Company.Product.DotVVM.Feature.Type, Domain.Company.Product")]
+        [DataRow("Domain.Company.Product.DotVVM.Feature.Type, Product")]
+        public void BindingParser_AssemblyQualifiedName_ValidAssemblyName(string binding)
+        {
+            var parser = bindingParserNodeFactory.SetupParser(binding);
+            var node = parser.ReadDirectiveTypeName() as AssemblyQualifiedNameBindingParserNode;
+            Assert.IsFalse(node.AssemblyName.HasNodeErrors);
+        }
+
+        [TestMethod]
+        [DataRow("Domain.Company.Product.DotVVM.Feature.Type, Domain.Company.Product<int>")]
+        [DataRow("Domain.Company.Product.DotVVM.Feature.Type, Domain.Company<int>.Product")]
+        [DataRow("Domain.Company.Product.DotVVM.Feature.Type, Domain<int>.Company.Product")]
+        [DataRow("Domain.Company.Product.DotVVM.Feature.Type, Product<int>")]
+        public void BindingParser_AssemblyQualifiedName_InvalidAssemblyName(string binding)
+        {
+            var parser = bindingParserNodeFactory.SetupParser(binding);
+            var node = parser.ReadDirectiveTypeName() as AssemblyQualifiedNameBindingParserNode;
+            Assert.IsTrue(node.AssemblyName.HasNodeErrors);
+        }
+
+        [TestMethod]
         [DataRow("(arg) => Method(arg)", DisplayName = "Simple implicit single-parameter lambda expression with parentheses.")]
         [DataRow("arg => Method(arg)", DisplayName = "Simple implicit single-parameter lambda expression without parentheses.")]           
         [DataRow("  arg    =>   Method   (   arg  )", DisplayName = "Simple lambda with various whitespaces.")]

--- a/src/DotVVM.Framework/Compilation/Binding/ExpressionBuildingVisitor.cs
+++ b/src/DotVVM.Framework/Compilation/Binding/ExpressionBuildingVisitor.cs
@@ -227,6 +227,18 @@ namespace DotVVM.Framework.Compilation.Binding
             return GetMemberOrTypeExpression(node, null) ?? Expression.Default(typeof(void));
         }
 
+        protected override Expression VisitAssemblyQualifiedName(AssemblyQualifiedNameBindingParserNode node)
+        {
+            if (node.AssemblyName.HasNodeErrors)
+            {
+                var message = node.AssemblyName.NodeErrors.StringJoin(Environment.NewLine);
+                throw new BindingCompilationException(message, node.AssemblyName);
+            }
+
+            // Assembly was already added to TypeRegistry - we can just visit the type name
+            return Visit(node.TypeName);
+        }
+
         protected override Expression VisitConditionalExpression(ConditionalExpressionBindingParserNode node)
         {
             var condition = HandleErrors(node.ConditionExpression, n => TypeConversion.ImplicitConversion(Visit(n), typeof(bool), true));
@@ -389,7 +401,7 @@ namespace DotVVM.Framework.Compilation.Binding
 
         private void ThrowIfNotTypeNameRelevant(BindingParserNode node)
         {
-            if (ResolveOnlyTypeName && !(node is MemberAccessBindingParserNode) && !(node is IdentifierNameBindingParserNode))
+            if (ResolveOnlyTypeName && !(node is MemberAccessBindingParserNode) && !(node is IdentifierNameBindingParserNode) && !(node is AssemblyQualifiedNameBindingParserNode))
             {
                 throw new Exception("Only type name is supported.");
             }

--- a/src/DotVVM.Framework/Compilation/ControlTree/Resolved/ResolvedTreeBuilder.cs
+++ b/src/DotVVM.Framework/Compilation/ControlTree/Resolved/ResolvedTreeBuilder.cs
@@ -158,7 +158,6 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
             TypeRegistry registry;
             if (expressionSyntax is AssemblyQualifiedNameBindingParserNode assemblyQualifiedName)
             {
-                expressionSyntax = assemblyQualifiedName.TypeName;
                 registry = TypeRegistry.DirectivesDefault(compiledAssemblyCache, assemblyQualifiedName.AssemblyName.ToDisplayString());
             }
             else

--- a/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/BindingParser.cs
+++ b/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/BindingParser.cs
@@ -70,7 +70,7 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
                         var targetExprType = assemblyMemberBinding.TargetExpression.GetType();
                         if (memberExprType == typeof(GenericNameBindingParserNode) || targetExprType == typeof(GenericNameBindingParserNode))
                         {
-                            assemblyName.NodeErrors.Add($"Generic identifier name is not allowed in assembly name.");
+                            assemblyName.NodeErrors.Add($"Generic identifier name is not allowed in an assembly name.");
                             break;
                         }
 


### PR DESCRIPTION
This PR fixes small issues with parsing and subsequent validation of assembly qualified names.

### Current behaviour
DotVVM incorrectly interprets assembly name as generic, unless it is a `SimpleNameBindingParserNode`. Therefore, all instances of `MemberAccessBindingParserNode` are considered to be generics. Moreover, assigned node errors are later ignored completely.

* `@viewModel DotVVM.TestApp.ViewModels.DefaultViewModel, DotVVM.TestApp`
   * DotVVM creates a node error indicating that the `DotVVM.TestApp` is a generic identifier
* `@viewModel DotVVM.TestApp.ViewModels.DefaultViewModel, DotVVM.TestApp<int>`
   * Fails with an error: Unable to resolve type ...


### New behaviour
DotVVM interprets assembly names as generic iff `MemberAccessBindingParserNode` contains a `GenericNameBindingParserNode`. Furthermore, all errors (not only regarding generic names) are now propagated as a `BindingCompilationException` and as such user gets more concrete information about their error.

* `@viewModel DotVVM.TestApp.ViewModels.DefaultViewModel, DotVVM.TestApp`
   * No errors are generated
* `@viewModel DotVVM.TestApp.ViewModels.DefaultViewModel, DotVVM.TestApp<int>`
   * Fails with an error: Unable to resolve type ... Generic identifier name is not allowed in an assembly name.