### PR TITLE
Improved error reporting for corrupted master page

### DIFF
--- a/src/DotVVM.Framework/Compilation/ControlTree/ControlTreeResolverBase.cs
+++ b/src/DotVVM.Framework/Compilation/ControlTree/ControlTreeResolverBase.cs
@@ -208,7 +208,14 @@ namespace DotVVM.Framework.Compilation.ControlTree
             if (masterPage == null)
                 return;
             var viewModel = root.DataContextTypeStack.DataContextType;
-            if (!masterPage.DataContextType.IsAssignableFrom(viewModel))
+
+            if (masterPage.DataContextType is ResolvedTypeDescriptor typeDescriptor && typeDescriptor.Type == typeof(UnknownTypeSentinel))
+            {
+                masterPageDirective!.DothtmlNode!.AddError("Could not resolve the type of viewmodel for the specified master page. " +
+                    $"This usually means that there is an error with the @viewModel directive in the master page file: \"{masterPage.FileName}\". " +
+                    $"Make sure that the provided viewModel type is correct and visible for DotVVM.");
+            }
+            else if (!masterPage.DataContextType.IsAssignableFrom(viewModel))
             {
                 masterPageDirective!.DothtmlNode!.AddError($"The viewmodel {viewModel.Name} is not assignable to the viewmodel of the master page {masterPage.DataContextType.Name}.");
             }


### PR DESCRIPTION
This PR fixes weird DotVVM error reported by @martindybal. If user makes a mistake while specifying viewmodel (by referencing a non-existing class) for their master page, they receive a somewhat confusing error message.

![image](https://user-images.githubusercontent.com/12575176/111318545-73598e80-8665-11eb-94ea-18e27aba877c.png)

The problem:
- DotVVM finds out that the specified viewmodel could not be found https://github.com/riganti/dotvvm/blob/7dc7e9d0cda757f953545f1f47e85ce0fb883662/src/DotVVM.Framework/Compilation/ControlTree/Resolved/ResolvedTreeBuilder.cs#L149
- However this information gets stripped and is not propagated further https://github.com/riganti/dotvvm/blob/7dc7e9d0cda757f953545f1f47e85ce0fb883662/src/DotVVM.Framework/Compilation/ControlTree/Resolved/ResolvedTreeRoot.cs#L29

If we were to add those errors there, I am not sure whether it could break something. In the meantime, I created a simple fix that should not break anything and provides users with a more specific error message.