### PR TITLE
Added support for string interpolation in bindings

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Binding/BindingCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/BindingCompilationTests.cs
@@ -173,10 +173,19 @@ namespace DotVVM.Framework.Tests.Binding
         [DataRow(@"$""Interpolated {StringProp} {StringProp}""", "Interpolated abc abc")]
         [DataRow(@"$'Interpolated {StringProp} {StringProp}'", "Interpolated abc abc")]
         [DataRow(@"$'Interpolated {StringProp.Length}'", "Interpolated 3")]
-        [DataRow(@"$'{string.Join(', ', IntArray)}'", "1, 2, 3")]
         public void BindingCompiler_Valid_InterpolatedString_WithSimpleExpressions(string expression, string evaluated)
         {
-            var viewModel = new TestViewModel() { StringProp = "abc", IntArray = new[] { 1, 2, 3 } };
+            var viewModel = new TestViewModel() { StringProp = "abc" };
+            var binding = ExecuteBinding(expression, viewModel);
+            Assert.AreEqual(evaluated, binding);
+        }
+
+        [TestMethod]
+        [DataRow(@"$'{string.Join(', ', IntArray)}'", "1, 2, 3")]
+        [DataRow(@"$'{string.Join(', ', 'abc', 'def', $'{string.Join(', ', IntArray)}')}'", "abc, def, 1, 2, 3")]
+        public void BindingCompiler_Valid_InterpolatedString_NestedExpressions(string expression, string evaluated)
+        {
+            var viewModel = new TestViewModel { IntArray = new[] { 1, 2, 3 } };
             var binding = ExecuteBinding(expression, viewModel);
             Assert.AreEqual(evaluated, binding);
         }
@@ -195,9 +204,10 @@ namespace DotVVM.Framework.Tests.Binding
         [TestMethod]
         [DataRow(@"$'Interpolated {DateFrom:R}'", "Interpolated Fri, 11 Nov 2011 12:11:11 GMT")]
         [DataRow(@"$'Interpolated {$'{DateFrom:R}'}'", "Interpolated Fri, 11 Nov 2011 12:11:11 GMT")]
+        [DataRow(@"$'Interpolated {$'{IntProp:0000}'}'", "Interpolated 0006")]
         public void BindingCompiler_Valid_InterpolatedString_WithFormattingComponent(string expression, string evaluated)
         {
-            var viewModel = new TestViewModel() { DateFrom = DateTime.Parse("2011-11-11T11:11:11+00:00") };
+            var viewModel = new TestViewModel() { DateFrom = DateTime.Parse("2011-11-11T11:11:11+00:00"), IntProp = 6 };
             var binding = ExecuteBinding(expression, viewModel);
             Assert.AreEqual(evaluated, binding);
         }

--- a/src/DotVVM.Framework.Tests.Common/Binding/BindingCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/BindingCompilationTests.cs
@@ -131,6 +131,16 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        [DataRow(@"$""Interpolated {StringProp} {StringProp}""", "Interpolated abc abc")]
+        [DataRow(@"$'Interpolated {StringProp} {StringProp}'", "Interpolated abc abc")]
+        public void BindingCompiler_Valid_InterpolatedString(string expression, string evaluated)
+        {
+            var viewModel = new TestViewModel() { StringProp = "abc" };
+            var binding = ExecuteBinding(expression, viewModel);
+            Assert.AreEqual(evaluated, binding);
+        }
+
+        [TestMethod]
         public void BindingCompiler_Valid_PropertyProperty()
         {
             var viewModel = new TestViewModel() { StringProp = "abc", TestViewModel2 = new TestViewModel2 { MyProperty = 42 } };

--- a/src/DotVVM.Framework.Tests.Common/Binding/BindingCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/BindingCompilationTests.cs
@@ -148,7 +148,10 @@ namespace DotVVM.Framework.Tests.Binding
         [DataRow(@"$'Malformed {'", "Could not find matching closing character '}' for an interpolated expression")]
         [DataRow(@"$'Malformed }'", "Unexpected token '$'Malformed  ---->}<----")]
         [DataRow(@"$'Malformed {}'", "Expected expression, but instead found empty")]
-        public void BindingCompiler_Valid_InterpolatedString_Malformed(string expression, string errorMessage)
+        [DataRow(@"$'Malformed {StringProp; IntProp}'", "Expected end of interpolated expression, but instead found Semicolon")]
+        [DataRow(@"$'Malformed {(string arg) => arg.Length}'", "Expected end of interpolated expression, but instead found Identifier")]
+        [DataRow(@"$'Malformed {(StringProp == null) ? 'StringPropWasNull' : 'StringPropWasNotNull'}'", "Conditional expression needs to be enclosed in parentheses")]
+        public void BindingCompiler_Invalid_InterpolatedString_MalformedExpression(string expression, string errorMessage)
         {
             try
             {
@@ -181,7 +184,7 @@ namespace DotVVM.Framework.Tests.Binding
         [TestMethod]
         [DataRow(@"$'Interpolated {IntProp < LongProperty}'", "Interpolated True")]
         [DataRow(@"$'Interpolated {StringProp ?? 'StringPropWasNull'}'", "Interpolated StringPropWasNull")]
-        [DataRow(@"$'Interpolated {(StringProp == null) ? 'StringPropWasNull' : 'StringPropWasNotNull'}'", "Interpolated StringPropWasNull")]
+        [DataRow(@"$'Interpolated {((StringProp == null) ? 'StringPropWasNull' : 'StringPropWasNotNull')}'", "Interpolated StringPropWasNull")]
         public void BindingCompiler_Valid_InterpolatedString_WithComplexExpressions(string expression, string evaluated)
         {
             var viewModel = new TestViewModel() { IntProp = 1, LongProperty = 2 };

--- a/src/DotVVM.Framework.Tests.Common/Binding/BindingCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/BindingCompilationTests.cs
@@ -190,6 +190,16 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        [DataRow(@"$'Interpolated {DateFrom:R}'", "Interpolated Fri, 11 Nov 2011 12:11:11 GMT")]
+        [DataRow(@"$'Interpolated {$'{DateFrom:R}'}'", "Interpolated Fri, 11 Nov 2011 12:11:11 GMT")]
+        public void BindingCompiler_Valid_InterpolatedString_WithFormattingComponent(string expression, string evaluated)
+        {
+            var viewModel = new TestViewModel() { DateFrom = DateTime.Parse("2011-11-11T11:11:11+00:00") };
+            var binding = ExecuteBinding(expression, viewModel);
+            Assert.AreEqual(evaluated, binding);
+        }
+
+        [TestMethod]
         public void BindingCompiler_Valid_PropertyProperty()
         {
             var viewModel = new TestViewModel() { StringProp = "abc", TestViewModel2 = new TestViewModel2 { MyProperty = 42 } };

--- a/src/DotVVM.Framework.Tests.Common/Binding/BindingCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/BindingCompilationTests.cs
@@ -141,12 +141,12 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
-        [DataRow(@"$'} Malformed'", "Could not find matching opening character '{' for an interpolated expression")]
+        [DataRow(@"$'} Malformed'", "Unexpected token '$' ---->}<----")]
         [DataRow(@"$'{ Malformed'", "Could not find matching closing character '}' for an interpolated expression")]
         [DataRow(@"$'Malformed {expr'", "Could not find matching closing character '}' for an interpolated expression")]
-        [DataRow(@"$'Malformed expr}'", "Could not find matching opening character '{' for an interpolated expression")]
+        [DataRow(@"$'Malformed expr}'", "Unexpected token '$'Malformed expr ---->}<---- ")]
         [DataRow(@"$'Malformed {'", "Could not find matching closing character '}' for an interpolated expression")]
-        [DataRow(@"$'Malformed }'", "Could not find matching opening character '{' for an interpolated expression")]
+        [DataRow(@"$'Malformed }'", "Unexpected token '$'Malformed  ---->}<----")]
         [DataRow(@"$'Malformed {}'", "Expected expression, but instead found empty")]
         public void BindingCompiler_Valid_InterpolatedString_Malformed(string expression, string errorMessage)
         {
@@ -170,17 +170,18 @@ namespace DotVVM.Framework.Tests.Binding
         [DataRow(@"$""Interpolated {StringProp} {StringProp}""", "Interpolated abc abc")]
         [DataRow(@"$'Interpolated {StringProp} {StringProp}'", "Interpolated abc abc")]
         [DataRow(@"$'Interpolated {StringProp.Length}'", "Interpolated 3")]
+        [DataRow(@"$'{string.Join(', ', IntArray)}'", "1, 2, 3")]
         public void BindingCompiler_Valid_InterpolatedString_WithSimpleExpressions(string expression, string evaluated)
         {
-            var viewModel = new TestViewModel() { StringProp = "abc" };
+            var viewModel = new TestViewModel() { StringProp = "abc", IntArray = new[] { 1, 2, 3 } };
             var binding = ExecuteBinding(expression, viewModel);
             Assert.AreEqual(evaluated, binding);
         }
 
         [TestMethod]
         [DataRow(@"$'Interpolated {IntProp < LongProperty}'", "Interpolated True")]
-        [DataRow(@"$'Interpolated {StringProp ?? \'StringPropWasNull\'}'", "Interpolated StringPropWasNull")]
-        [DataRow(@"$'Interpolated {(StringProp == null) ? \'StringPropWasNull\' : \'StringPropWasNotNull\'}'", "Interpolated StringPropWasNull")]
+        [DataRow(@"$'Interpolated {StringProp ?? 'StringPropWasNull'}'", "Interpolated StringPropWasNull")]
+        [DataRow(@"$'Interpolated {(StringProp == null) ? 'StringPropWasNull' : 'StringPropWasNotNull'}'", "Interpolated StringPropWasNull")]
         public void BindingCompiler_Valid_InterpolatedString_WithComplexExpressions(string expression, string evaluated)
         {
             var viewModel = new TestViewModel() { IntProp = 1, LongProperty = 2 };

--- a/src/DotVVM.Framework.Tests.Common/Binding/JavascriptCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/JavascriptCompilationTests.cs
@@ -126,6 +126,22 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        [DataRow(@"$""Interpolated {StringProp} {StringProp}""")]
+        [DataRow(@"$'Interpolated {StringProp} {StringProp}'")]
+        public void JavascriptCompilation_InterpolatedString(string expression)
+        {
+            var js = CompileBinding(expression, new[] { typeof(TestViewModel) }, typeof(string));
+            Assert.AreEqual("dotvvm.globalize.format(\"Interpolated {0} {1}\",[StringProp(),StringProp()])", js);
+        }
+
+        [TestMethod]
+        public void JavascriptCompilation_InterpolatedString_NoExpressions()
+        {
+            var js = CompileBinding("$'Non-Interpolated {{ no-expr }}'", new[] { typeof(TestViewModel) });
+            Assert.AreEqual("\"Non-Interpolated { no-expr }\"", js);
+        }
+
+        [TestMethod]
         public void JavascriptCompilation_UnwrappedObservables()
         {
             var js = CompileBinding("TestViewModel2.Collection[0].StringValue.Length + TestViewModel2.Collection[8].StringValue", new[] { typeof(TestViewModel) });

--- a/src/DotVVM.Framework.Tests.Common/Parser/Binding/BindingParserTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Parser/Binding/BindingParserTests.cs
@@ -178,6 +178,17 @@ namespace DotVVM.Framework.Tests.Parser.Binding
         }
 
         [TestMethod]
+        public void BindingParser_InterpolatedString_Valid()
+        {
+            var result = bindingParserNodeFactory.Parse("$\"Hello {Argument1} with {Argument2}!\"") as InterpolatedStringBindingParserNode;
+            Assert.AreEqual("Hello {0} with {1}!", result.Format);
+            Assert.IsFalse(result.HasNodeErrors);
+            Assert.AreEqual(2, result.Arguments.Count);
+            Assert.AreEqual("Argument1", ((SimpleNameBindingParserNode)result.Arguments[0]).Name);
+            Assert.AreEqual("Argument2", ((SimpleNameBindingParserNode)result.Arguments[1]).Name);
+        }
+
+        [TestMethod]
         public void BindingParser_StringLiteral_SingleQuotes_Valid()
         {
             var result = bindingParserNodeFactory.Parse("'help\\nhelp'");

--- a/src/DotVVM.Framework.Tests.Common/Parser/Binding/BindingParserTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Parser/Binding/BindingParserTests.cs
@@ -189,6 +189,18 @@ namespace DotVVM.Framework.Tests.Parser.Binding
         }
 
         [TestMethod]
+        [DataRow("$'{DateProperty:dd/MM/yyyy}'", "{0:dd/MM/yyyy}")]
+        [DataRow("$'{IntProperty:####}'", "{0:####}")]
+        public void BindingParser_InterpolatedString_WithFormattingComponenet_Valid(string expression, string formatOptions)
+        {
+            var result = bindingParserNodeFactory.Parse(expression) as InterpolatedStringBindingParserNode;
+            Assert.IsFalse(result.HasNodeErrors);
+            Assert.AreEqual(1, result.Arguments.Count);
+            Assert.AreEqual(typeof(FormattedBindingParserNode), result.Arguments.First().GetType());
+            Assert.AreEqual(formatOptions, ((FormattedBindingParserNode)result.Arguments.First()).Format);
+        }
+
+        [TestMethod]
         public void BindingParser_StringLiteral_SingleQuotes_Valid()
         {
             var result = bindingParserNodeFactory.Parse("'help\\nhelp'");

--- a/src/DotVVM.Framework.Tests.Common/Parser/Binding/BindingTokenizerTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Parser/Binding/BindingTokenizerTests.cs
@@ -240,6 +240,16 @@ namespace DotVVM.Framework.Tests.Parser.Binding
         }
 
         [TestMethod]
+        [DataRow("$\"String {Arg}\"")]
+        [DataRow("$'String {Arg}'")]
+        public void BindingTokenizer_InterpolatedString_Valid(string expression)
+        {
+            var tokens = Tokenize(expression);
+            Assert.AreEqual(1, tokens.Count);
+            Assert.AreEqual(BindingTokenType.InterpolatedStringToken, tokens[0].Type);
+        }
+
+        [TestMethod]
         public void BindingTokenizer_UnaryOperator_BunchingOperators_Valid()
         {
             var tokens = Tokenize("A(!IsDisplayed)");

--- a/src/DotVVM.Framework.Tests.Common/Parser/Binding/BindingTokenizerTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Parser/Binding/BindingTokenizerTests.cs
@@ -250,6 +250,16 @@ namespace DotVVM.Framework.Tests.Parser.Binding
         }
 
         [TestMethod]
+        [DataRow("$'String {'InnerString'}'")]
+        [DataRow("$'String {$'Inner {'InnerInnerString'}'}'")]
+        public void BindingTokenizer_InterpolatedString_InnerString(string expression)
+        {
+            var tokens = Tokenize(expression);
+            Assert.AreEqual(1, tokens.Count);
+            Assert.AreEqual(BindingTokenType.InterpolatedStringToken, tokens[0].Type);
+        }
+
+        [TestMethod]
         public void BindingTokenizer_UnaryOperator_BunchingOperators_Valid()
         {
             var tokens = Tokenize("A(!IsDisplayed)");

--- a/src/DotVVM.Framework/Compilation/Binding/ExpressionBuildingVisitor.cs
+++ b/src/DotVVM.Framework/Compilation/Binding/ExpressionBuildingVisitor.cs
@@ -112,13 +112,22 @@ namespace DotVVM.Framework.Compilation.Binding
                 Target = Registry.Resolve(nameof(String))
             };
 
-            var arguments = new Expression[node.Arguments.Count];
-            for (var index = 0; index < node.Arguments.Count; index++)
+            if (node.Arguments.Any())
             {
-                arguments[index] = HandleErrors(node.Arguments[index], Visit)!;
-            }
+                // Translate to a String.Format(...) call
+                var arguments = new Expression[node.Arguments.Count];
+                for (var index = 0; index < node.Arguments.Count; index++)
+                {
+                    arguments[index] = HandleErrors(node.Arguments[index], Visit)!;
+                }
 
-            return memberExpressionFactory.Call(target, new[] { Expression.Constant(node.Format) }.Concat(arguments).ToArray());
+                return memberExpressionFactory.Call(target, new[] { Expression.Constant(node.Format) }.Concat(arguments).ToArray());
+            }
+            else
+            {
+                // There are no interpolation expressions - we can just return string
+                return Expression.Constant(node.Format);
+            }
         }
 
         protected override Expression VisitParenthesizedExpression(ParenthesizedExpressionBindingParserNode node)

--- a/src/DotVVM.Framework/Compilation/Binding/ExpressionBuildingVisitor.cs
+++ b/src/DotVVM.Framework/Compilation/Binding/ExpressionBuildingVisitor.cs
@@ -105,6 +105,22 @@ namespace DotVVM.Framework.Compilation.Binding
             return Expression.Constant(node.Value);
         }
 
+        protected override Expression VisitInterpolatedStringExpression(InterpolatedStringBindingParserNode node)
+        {
+            var target = new MethodGroupExpression() {
+                MethodName = nameof(String.Format),
+                Target = Registry.Resolve(nameof(String))
+            };
+
+            var arguments = new Expression[node.Arguments.Count];
+            for (var index = 0; index < node.Arguments.Count; index++)
+            {
+                arguments[index] = HandleErrors(node.Arguments[index], Visit)!;
+            }
+
+            return memberExpressionFactory.Call(target, new[] { Expression.Constant(node.Format) }.Concat(arguments).ToArray());
+        }
+
         protected override Expression VisitParenthesizedExpression(ParenthesizedExpressionBindingParserNode node)
         {
             // just visit content

--- a/src/DotVVM.Framework/Compilation/Binding/ExpressionBuildingVisitor.cs
+++ b/src/DotVVM.Framework/Compilation/Binding/ExpressionBuildingVisitor.cs
@@ -115,11 +115,7 @@ namespace DotVVM.Framework.Compilation.Binding
             if (node.Arguments.Any())
             {
                 // Translate to a String.Format(...) call
-                var arguments = new Expression[node.Arguments.Count];
-                for (var index = 0; index < node.Arguments.Count; index++)
-                {
-                    arguments[index] = HandleErrors(node.Arguments[index], Visit)!;
-                }
+                var arguments = node.Arguments.Select(arg => HandleErrors(node.Arguments[index], Visit))[.ToArray()];
 
                 return memberExpressionFactory.Call(target, new[] { Expression.Constant(node.Format) }.Concat(arguments).ToArray());
             }

--- a/src/DotVVM.Framework/Compilation/Binding/ExpressionBuildingVisitor.cs
+++ b/src/DotVVM.Framework/Compilation/Binding/ExpressionBuildingVisitor.cs
@@ -109,7 +109,7 @@ namespace DotVVM.Framework.Compilation.Binding
         {
             var target = new MethodGroupExpression() {
                 MethodName = nameof(String.Format),
-                Target = Registry.Resolve(nameof(String))
+                Target = typeof(string)
             };
 
             if (node.Arguments.Any())

--- a/src/DotVVM.Framework/Compilation/Binding/ExpressionBuildingVisitor.cs
+++ b/src/DotVVM.Framework/Compilation/Binding/ExpressionBuildingVisitor.cs
@@ -109,14 +109,13 @@ namespace DotVVM.Framework.Compilation.Binding
         {
             var target = new MethodGroupExpression() {
                 MethodName = nameof(String.Format),
-                Target = typeof(string)
+                Target = new StaticClassIdentifierExpression(typeof(string))
             };
 
             if (node.Arguments.Any())
             {
                 // Translate to a String.Format(...) call
-                var arguments = node.Arguments.Select(arg => HandleErrors(node.Arguments[index], Visit))[.ToArray()];
-
+                var arguments = node.Arguments.Select((arg, index) => HandleErrors(node.Arguments[index], Visit)).ToArray();
                 return memberExpressionFactory.Call(target, new[] { Expression.Constant(node.Format) }.Concat(arguments).ToArray());
             }
             else
@@ -371,6 +370,17 @@ namespace DotVVM.Framework.Compilation.Binding
                 return Expression.Block(variables.Concat(rightBlock.Variables), new Expression[] { left }.Concat(rightBlock.Expressions));
             }
             else return Expression.Block(variables, left, right);
+        }
+
+        protected override Expression VisitFormattedExpression(FormattedBindingParserNode node)
+        {
+            var target = new MethodGroupExpression() {
+                MethodName = nameof(String.Format),
+                Target = new StaticClassIdentifierExpression(typeof(string))
+            };
+
+            var nodeObj = HandleErrors(node.Node, Visit);
+            return memberExpressionFactory.Call(target, new[] { Expression.Constant(node.Format), nodeObj });
         }
 
         protected override Expression VisitVoid(VoidBindingParserNode node) => Expression.Default(typeof(void));

--- a/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/BindingParserNodeVisitor.cs
+++ b/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/BindingParserNodeVisitor.cs
@@ -36,6 +36,10 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
             {
                 return VisitLiteralExpression((LiteralExpressionBindingParserNode)node);
             }
+            else if (node is InterpolatedStringBindingParserNode)
+            {
+                return VisitInterpolatedStringExpression((InterpolatedStringBindingParserNode)node);
+            }
             else if (node is MemberAccessBindingParserNode)
             {
                 return VisitMemberAccess((MemberAccessBindingParserNode)node);
@@ -123,6 +127,11 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
         }
 
         protected virtual T VisitLiteralExpression(LiteralExpressionBindingParserNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        protected virtual T VisitInterpolatedStringExpression(InterpolatedStringBindingParserNode node)
         {
             return DefaultVisit(node);
         }

--- a/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/BindingParserNodeVisitor.cs
+++ b/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/BindingParserNodeVisitor.cs
@@ -68,6 +68,10 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
             {
                 return VisitAssemblyQualifiedName((AssemblyQualifiedNameBindingParserNode)node);
             }
+            else if (node is FormattedBindingParserNode)
+            {
+                return VisitFormattedExpression((FormattedBindingParserNode)node);
+            }
             else if (node is BlockBindingParserNode blockNode)
             {
                 return VisitBlock(blockNode);
@@ -157,6 +161,11 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
         }
 
         protected virtual T VisitAssemblyQualifiedName(AssemblyQualifiedNameBindingParserNode node)
+        {
+            return DefaultVisit(node);
+        }
+
+        protected virtual T VisitFormattedExpression(FormattedBindingParserNode node)
         {
             return DefaultVisit(node);
         }

--- a/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/FormattedBindingParserNode.cs
+++ b/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/FormattedBindingParserNode.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
+{
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class FormattedBindingParserNode : BindingParserNode
+    {
+        public BindingParserNode Node { get; private set; }
+        public string Format { get; private set; }
+
+        public FormattedBindingParserNode(BindingParserNode node, string format)
+        {
+            this.Node = node;
+            this.Format = format;
+        }
+
+        public override IEnumerable<BindingParserNode> EnumerateChildNodes()
+            => base.EnumerateNodes().Concat(new[] { Node });
+
+        public override string ToDisplayString()
+            => $"{Node.ToDisplayString()}:{Format}";
+    }
+}

--- a/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/InterpolatedStringBindingParserNode.cs
+++ b/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/InterpolatedStringBindingParserNode.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.Utils;
+
+namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
+{
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class InterpolatedStringBindingParserNode : BindingParserNode
+    {
+        public string Format { get; set; }
+        public List<BindingParserNode> Arguments { get; set; }
+
+        public InterpolatedStringBindingParserNode(string format, List<BindingParserNode> arguments)
+        {
+            this.Format = format;
+            this.Arguments = arguments;
+        }
+
+        public override IEnumerable<BindingParserNode> EnumerateChildNodes()
+            => base.EnumerateNodes().Concat(Arguments);
+
+        public override string ToDisplayString()
+            => $"String.Format(\"{Format}\", {Arguments.Select(arg => arg.ToDisplayString()).StringJoin(", ")})";
+    }
+}

--- a/src/DotVVM.Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenType.cs
+++ b/src/DotVVM.Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenType.cs
@@ -30,6 +30,7 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Tokenizer
         NotOperator,
 
         StringLiteralToken,
+        InterpolatedStringToken,
 
         NullCoalescingOperator,
         QuestionMarkOperator,

--- a/src/DotVVM.Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenizer.cs
+++ b/src/DotVVM.Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenizer.cs
@@ -215,18 +215,20 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Tokenizer
                     case '\'':
                     case '"':
                         var bindingTokenType = default(BindingTokenType);
+                        var errorMessage = default(string);
+                        FinishIncompleteIdentifier();
+
                         if (ch == '$')
                         {
-                            Read();
                             bindingTokenType = BindingTokenType.InterpolatedStringToken;
+                            ReadInterpolatedString(out errorMessage);
                         }
                         else
                         {
-                            FinishIncompleteIdentifier();
                             bindingTokenType = BindingTokenType.StringLiteralToken;
+                            ReadStringLiteral(out errorMessage);
                         }
 
-                        ReadStringLiteral(out var errorMessage);
                         CreateToken(bindingTokenType, errorProvider: t => CreateTokenError(t, errorMessage ?? "unknown error"));
                         break;
 
@@ -303,6 +305,11 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Tokenizer
             ReadStringLiteral(Peek, Read, out errorMessage);
         }
 
+        internal void ReadInterpolatedString(out string? errorMessage)
+        {
+            ReadInterpolatedString(Peek, Read, out errorMessage);
+        }
+
         /// <summary>
         /// Reads the string literal.
         /// </summary>
@@ -334,6 +341,44 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Tokenizer
             }
             readFunction();
 
+            errorMessage = null;
+        }
+
+        internal static void ReadInterpolatedString(Func<char> peekFunction, Func<char> readFunction, out string? errorMessage)
+        {
+            readFunction();
+            var quoteChar = readFunction();
+            var exprDepth = 0;
+
+            while (peekFunction() != quoteChar || exprDepth != 0)
+            {
+                if (peekFunction() == NullChar)
+                {
+                    errorMessage = "Interpolated string was not closed!";
+                    return;
+                }
+
+                if (peekFunction() == '\\' && exprDepth == 0)
+                {
+                    readFunction();
+                }
+                else if (peekFunction() == '{')
+                {
+                    exprDepth++;
+                }
+                else if (peekFunction() == '}')
+                {
+                    if (--exprDepth <= -1)
+                    {
+                        errorMessage = "Could not find matching '{' character!";
+                        return;
+                    }
+                }
+
+                readFunction();
+            }
+
+            readFunction();
             errorMessage = null;
         }
     }

--- a/src/DotVVM.Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenizer.cs
+++ b/src/DotVVM.Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenizer.cs
@@ -211,11 +211,23 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Tokenizer
                         }
                         break;
 
+                    case '$':
                     case '\'':
                     case '"':
-                        FinishIncompleteIdentifier();
+                        var bindingTokenType = default(BindingTokenType);
+                        if (ch == '$')
+                        {
+                            Read();
+                            bindingTokenType = BindingTokenType.InterpolatedStringToken;
+                        }
+                        else
+                        {
+                            FinishIncompleteIdentifier();
+                            bindingTokenType = BindingTokenType.StringLiteralToken;
+                        }
+
                         ReadStringLiteral(out var errorMessage);
-                        CreateToken(BindingTokenType.StringLiteralToken, errorProvider: t => CreateTokenError(t, errorMessage ?? "unknown error"));
+                        CreateToken(bindingTokenType, errorProvider: t => CreateTokenError(t, errorMessage ?? "unknown error"));
                         break;
 
                     case '?':


### PR DESCRIPTION
Resolves #362. This PR adds support for string interpolation in bindings.

Interpolated strings are always translated into C# `String.Format(...)` calls, unless a constant string is provided with no interpolation expressions. When compiling `String.Format(...)` calls to JavaScript, the function `dotvvm.globalize.format(...)` is used.

Implementation progress:
- [x] Expression interpolation support
- [x] String formatting component
- [ ] ~~String alignment component~~ (we decided that this will not be supported)