### PR TITLE
Fixed bug in generating invalid hash for type=nomodule resources

### DIFF
--- a/src/DotVVM.Framework/ResourceManagement/ScriptModuleResource.cs
+++ b/src/DotVVM.Framework/ResourceManagement/ScriptModuleResource.cs
@@ -38,7 +38,7 @@ namespace DotVVM.Framework.ResourceManagement
             if (NomoduleLocation is object)
             {
                 writer.AddAttribute("nomodule", null);
-                writer.AddAttribute("src", location.GetUrl(context, resourceName) + "?type=nomodule");
+                writer.AddAttribute("src", NomoduleLocation.GetUrl(context, resourceName) + "?type=nomodule");
                 if (Defer)
                     writer.AddAttribute("defer", null);
                 writer.RenderBeginTag("script");


### PR DESCRIPTION
I noticed that DotVVM uses incorrect hashes in URLs for `type=nomodule` resources in the production mode (`Debug=false`), so the resource is not found (hash doesn't match) and returns 404.

We must release this as a fix into 3.0 - right now DotVVM 3.0 apps won't work in IE11.
