### PR TITLE
Fixed issue with lambdas and System.Action

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Binding/BindingCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/BindingCompilationTests.cs
@@ -206,6 +206,19 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        [DataRow("(TestViewModel vm) => vm.IntProp = 11")]
+        [DataRow("(TestViewModel vm) => vm.GetEnum()")]
+        [DataRow("(TestViewModel vm) => ()")]
+        [DataRow("(TestViewModel vm) => ;")]
+        public void BindingCompiler_Valid_LambdaToAction(string expr)
+        {
+            var viewModel = new TestViewModel();
+            var binding = ExecuteBinding(expr, new[] { viewModel }, null, expectedType: typeof(Action<TestViewModel>)) as Action<TestViewModel>;
+            Assert.AreEqual(typeof(Action<TestViewModel>), binding.GetType());
+            binding.Invoke(viewModel);
+        }
+
+        [TestMethod]
         public void BindingCompiler_Valid_ExtensionMethods()
         {
             var viewModel = new TestViewModel();

--- a/src/DotVVM.Framework/Compilation/Binding/BindingExpressionBuilder.cs
+++ b/src/DotVVM.Framework/Compilation/Binding/BindingExpressionBuilder.cs
@@ -26,7 +26,7 @@ namespace DotVVM.Framework.Compilation.Binding
             this.extensionMethodsCache = extensionMethodsCache;
         }
 
-        public Expression Parse(string expression, DataContextStack dataContexts, BindingParserOptions options, params KeyValuePair<string, Expression>[] additionalSymbols)
+        public Expression Parse(string expression, DataContextStack dataContexts, BindingParserOptions options, Type expectedType = null, params KeyValuePair<string, Expression>[] additionalSymbols)
         {
             try
             {
@@ -54,7 +54,7 @@ namespace DotVVM.Framework.Compilation.Binding
                 symbols = symbols.AddSymbols(options.ExtensionParameters.Select(p => CreateParameter(dataContexts, p.Identifier, p)));
                 symbols = symbols.AddSymbols(additionalSymbols);
 
-                var visitor = new ExpressionBuildingVisitor(symbols, memberExpressionFactory);
+                var visitor = new ExpressionBuildingVisitor(symbols, memberExpressionFactory, expectedType);
                 visitor.Scope = symbols.Resolve(options.ScopeParameter);
                 return visitor.Visit(node);
             }
@@ -143,10 +143,10 @@ namespace DotVVM.Framework.Compilation.Binding
                                                   extensionParameter: new TypeConversion.MagicLambdaConversionExtensionParameter(index, p.Name, p.ParameterType)))
                                       ))
                                       .ToArray();
-                return builder.Parse(expression, dataContexts, options, additionalSymbols.Concat(delegateSymbols).ToArray());
+                return builder.Parse(expression, dataContexts, options, expectedType, additionalSymbols.Concat(delegateSymbols).ToArray());
             }
             else
-                return builder.Parse(expression, dataContexts, options, additionalSymbols);
+                return builder.Parse(expression, dataContexts, options, expectedType, additionalSymbols);
         }
     }
 }

--- a/src/DotVVM.Framework/Compilation/IBindingExpressionBuilder.cs
+++ b/src/DotVVM.Framework/Compilation/IBindingExpressionBuilder.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using DotVVM.Framework.Compilation.ControlTree;
@@ -8,6 +9,6 @@ namespace DotVVM.Framework.Compilation
 {
     public interface IBindingExpressionBuilder
     {
-        Expression Parse(string expression, DataContextStack dataContexts, BindingParserOptions options, params KeyValuePair<string, Expression>[] additionalSymbols);
+        Expression Parse(string expression, DataContextStack dataContexts, BindingParserOptions options, Type? expectedType = null, params KeyValuePair<string, Expression>[] additionalSymbols);
     }
 }


### PR DESCRIPTION
This PR fixes an issue when compiling lambda expressions that need to be assigned to `System.Action<...>`. It is also necessary for the type inference feature #936.

### Current state
If user defines a lambda in a binding whose expected type is `Action<...>`, current implementation fails for all non-`void` expressions. DotVVM throws compilation exception because it is unable to find an implicit conversion to convert from `Func<...>` to `Action<...>`. This is due to the fact that every expression that has non-`void` return type gets compiled into a `Func<...>`.

This is different from C#, where it is possible to have the following:
```csharp
Action<string> action = (strArg) => MyStringProperty = strArg;
```

The expression above would be compiled into `Func<string, string>` in DotVVM because the assignment gets evaluated to a string.

### Proposed solution
It is necessary to propagate information about expected types to the `BindingExpressionBuilder`. This type information can be then used inside `ExpressionBuildingVisitor` to validate that the body is a valid statement and if so, make sure to generate `Action<...>` if required.

### Breaking change
Interface `IBindingExpressionBuilder` was altered by adding an optional parameter to its `Parse` method. Regardless, I do not think that this change could actually break someone.