### PR TITLE
Enum coercion was too strict

### DIFF
--- a/src/DotVVM.Framework/Resources/Scripts/metadata/coercer.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/metadata/coercer.ts
@@ -72,12 +72,26 @@ function tryCoerceNullable(value: any, innerType: TypeDefinition, originalValue:
 }    
 
 function tryCoerceEnum(value: any, type: EnumTypeMetadata): CoerceResult {
-    if (typeof value === "string" && value in type.values) {
-        return { value };
-    } else if (typeof value === "number") {
+    let wasCoerced = false;
+    if (typeof value === "string") {
+        if (value in type.values) {
+          return { value };
+        } else if (value !== "") {
+            // number value as string
+            const numberValue = Number(value);
+            if (!isNaN(numberValue)) {
+                value = numberValue; 
+                wasCoerced = true;
+            }
+        }
+    } 
+    if (typeof value === "number") {
         const matched = keys(type.values).filter(k => type.values[k] === value);
         if (matched.length) {
             return { value: matched[0], wasCoerced: true }
+        } else {
+            // number value not in enum
+            return { value: value | 0, wasCoerced }
         }
     }
     return new CoerceError(`Cannot cast '${value}' to type 'Enum(${keys(type.values).join(",")})'.`);

--- a/src/DotVVM.Framework/Resources/Scripts/tests/coercer.test.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/tests/coercer.test.ts
@@ -276,6 +276,41 @@ test("string - invalid, array", () => {
 })
 
 
+test("enum - valid, string", () => {
+    const result = tryCoerce("One", "e1");
+    expect(result.wasCoerced).toBeFalsy();
+    expect(result.value).toEqual("One");
+})
+
+test("enum - valid, number", () => {
+    const result = tryCoerce(1, "e1");
+    expect(result.wasCoerced).toBeTruthy();
+    expect(result.value).toEqual("One");
+})
+
+test("enum - valid, number in string", () => {
+    const result = tryCoerce("1", "e1");
+    expect(result.wasCoerced).toBeTruthy();
+    expect(result.value).toEqual("One");
+})
+
+test("enum - valid, number without string representation", () => {
+    const result = tryCoerce(3, "e1");
+    expect(result.wasCoerced).toBeFalsy();
+    expect(result.value).toEqual(3);
+})
+
+test("enum - invalid, undefined", () => {
+    const result = tryCoerce(void 0, "e1");
+    expect(result.isError).toBeTruthy();
+})
+
+test("enum - invalid, null", () => {
+    const result = tryCoerce(null, "e1");
+    expect(result.isError).toBeTruthy();
+})
+
+
 test("boolean - valid, true", () => {
     const result = tryCoerce(true, "Boolean");
     expect(result.wasCoerced).toBeFalsy();

--- a/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
+++ b/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
@@ -64,6 +64,7 @@
     <None Remove="Views\FeatureSamples\JsDirectives\BasicSample.dothtml" />
     <None Remove="Views\FeatureSamples\LambdaExpressions\LambdaExpressions.dothtml" />
     <None Remove="Views\FeatureSamples\Localization\Globalize.dothtml" />
+    <None Remove="Views\FeatureSamples\Serialization\EnumSerializationCoercion.dothtml" />
     <None Remove="Views\FeatureSamples\ViewModules\Incrementer.dotcontrol" />
     <None Remove="Views\FeatureSamples\ViewModules\IncrementerInRepeater.dothtml" />
     <None Remove="Views\FeatureSamples\ViewModules\ModuleControl.dotcontrol" />

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/Serialization/EnumSerializationCoercionViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/Serialization/EnumSerializationCoercionViewModel.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.Serialization
+{
+    public class EnumSerializationCoercionViewModel : DotvvmViewModelBase
+    {
+        public MyEnum EnumWithString { get; set; } = MyEnum.One;
+
+        public MyEnum EnumWithoutString { get; set; }
+
+        public void ChangeValues()
+        {
+            EnumWithString = (MyEnum)(-1);
+            EnumWithoutString = MyEnum.Two;
+        }
+    }
+
+    public enum MyEnum
+    {
+        One = 1,
+        Two = 2
+    }
+}
+

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/Serialization/EnumSerializationCoercion.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/Serialization/EnumSerializationCoercion.dothtml
@@ -1,0 +1,23 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.Serialization.EnumSerializationCoercionViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+
+    <h1>Enum serialization test</h1>
+
+    <p>Enum value with string equivalent: <span class="result-with-string">{{value: EnumWithString}}</span></p>
+
+    <p>Enum value without string equivalent: <span class="result-without-string">{{value: EnumWithoutString}}</span></p>
+
+    <dot:Button Text="Change values" Click="{command: ChangeValues()}" />
+
+</body>
+</html>
+
+

--- a/src/DotVVM.Samples.Tests/Feature/SerializationTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/SerializationTests.cs
@@ -131,6 +131,30 @@ namespace DotVVM.Samples.Tests.Feature
             });
         }
 
+        [Fact]
+        public void Feature_Serialization_EnumSerializationCoercion()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_Serialization_EnumSerializationCoercion);
+                browser.WaitUntilDotvvmInited();
+
+                var result = browser.Single(".result-with-string");
+                var result2 = browser.Single(".result-without-string");
+
+                browser.WaitFor(() => {
+                    AssertUI.TextEquals(result, "One");
+                    AssertUI.TextEquals(result2, "0");
+                }, 5000);
+
+                var changeButton = browser.First("input[type=button]");
+                changeButton.Click();
+
+                browser.WaitFor(() => {
+                    AssertUI.TextEquals(result, "-1");
+                    AssertUI.TextEquals(result2, "Two");
+                }, 5000);
+            });
+        }
 
         public SerializationTests(ITestOutputHelper output) : base(output)
         {

--- a/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
@@ -273,6 +273,7 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_ReturnedFile_ReturnedFileSample = "FeatureSamples/ReturnedFile/ReturnedFileSample";
         public const string FeatureSamples_Serialization_DeserializationVirtualElements = "FeatureSamples/Serialization/DeserializationVirtualElements";
         public const string FeatureSamples_Serialization_Dictionary = "FeatureSamples/Serialization/Dictionary";
+        public const string FeatureSamples_Serialization_EnumSerializationCoercion = "FeatureSamples/Serialization/EnumSerializationCoercion";
         public const string FeatureSamples_Serialization_EnumSerializationWithJsonConverter = "FeatureSamples/Serialization/EnumSerializationWithJsonConverter";
         public const string FeatureSamples_Serialization_ObservableCollectionShouldContainObservables = "FeatureSamples/Serialization/ObservableCollectionShouldContainObservables";
         public const string FeatureSamples_Serialization_Serialization = "FeatureSamples/Serialization/Serialization";


### PR DESCRIPTION
In .NET, you can assign any numeric value to an enum, even if there is no member assigned for the number value. 
For example, a property of type `public enum MyEnum { One = 1, Two = 2}` can still have `0` as a value.

The coercer was not allowing such values, which is now fixed by this PR. 
In order for the value to be serialized/deserialized correctly, the coercer uses `string` for members defined in the enum, and `number` for any other values. 