### PR TITLE
Added alias parseDotvvmDate to preserve back-compatibility

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Binding/JavascriptCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/JavascriptCompilationTests.cs
@@ -231,7 +231,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JavascriptCompilation_Api_DateParameter()
         {
             var result = CompileBinding("_testApi.PostDateToString(DateFrom.Value)", typeof(TestViewModel));
-            Assert.IsTrue(result.StartsWith("dotvvm.api.invoke(dotvvm.api._testApi,\"postDateToString\",function(){return [dotvvm.globalize.parseDotvvmDate(DateFrom())];},function(args){return [];},function(args){return [\"DotVVM.Framework.Tests.Binding.TestApiClient/\"];},$element,function(args){return \""));
+            Assert.IsTrue(result.StartsWith("dotvvm.api.invoke(dotvvm.api._testApi,\"postDateToString\",function(){return [dotvvm.globalize.parseDate(DateFrom())];},function(args){return [];},function(args){return [\"DotVVM.Framework.Tests.Binding.TestApiClient/\"];},$element,function(args){return \""));
             Assert.IsTrue(result.EndsWith("\";})"));
         }
 

--- a/src/DotVVM.Framework/Configuration/RestApiRegistrationHelpers.cs
+++ b/src/DotVVM.Framework/Configuration/RestApiRegistrationHelpers.cs
@@ -76,7 +76,7 @@ namespace DotVVM.Framework.Configuration
             new JsIdentifierExpression("dotvvm").Member("serialization").Member("serialize").Invoke(expr.WithAnnotation(ShouldBeObservableAnnotation.Instance));
         
         private static JsExpression SerializeDate(JsExpression expr) =>
-            new JsIdentifierExpression("dotvvm").Member("globalize").Member("parseDotvvmDate").Invoke(expr);
+            new JsIdentifierExpression("dotvvm").Member("globalize").Member("parseDate").Invoke(expr);
 
         private static JsExpression[] ReplaceDefaultWithUndefined(IEnumerable<JsExpression> arguments, ParameterInfo[] parameters)
         {

--- a/src/DotVVM.Framework/Resources/Scripts/DotVVM.Globalize.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/DotVVM.Globalize.ts
@@ -1,4 +1,4 @@
-﻿import { parseDate as parseDotvvmDate, serializeDate as serializeDotvvmDate } from './serialization/date'
+﻿import { parseDate as serializationParseDate, serializeDate } from './serialization/date'
 import { getCulture } from './dotvvm-base';
 
 function getGlobalize(): GlobalizeStatic {
@@ -30,7 +30,7 @@ export function formatString(format: string | null | undefined, value: Globalize
 
     if (typeof value === "string") {
         // JSON date in string
-        value = parseDotvvmDate(value);
+        value = serializationParseDate(value);
         if (value == null) {
             throw new Error(`Could not parse ${value} as a date`);
         }
@@ -51,6 +51,8 @@ export function parseDate(value: string, format: string, previousValue?: Date) {
     return getGlobalize().parseDate(value, format, getCulture(), previousValue);
 }
 
+export const parseDotvvmDate = parseDate;
+
 export function bindingDateToString(value: KnockoutObservable<string | Date> | string | Date, format: string = "G") {
     if (!value) {
         return "";
@@ -58,7 +60,7 @@ export function bindingDateToString(value: KnockoutObservable<string | Date> | s
 
     const unwrapDate = () => {
         const unwrappedVal = ko.unwrap(value);
-        return typeof unwrappedVal == "string" ? parseDotvvmDate(unwrappedVal) : unwrappedVal;
+        return typeof unwrappedVal == "string" ? serializationParseDate(unwrappedVal) : unwrappedVal;
     };
 
     const formatDate = () => formatString(format, value);
@@ -66,7 +68,7 @@ export function bindingDateToString(value: KnockoutObservable<string | Date> | s
     if (ko.isWriteableObservable(value)) {
         const unwrappedVal = unwrapDate();
         const setter = typeof unwrappedVal == "string" ? (v: Date | null) => {
-            return value(v && serializeDotvvmDate(v, false));
+            return value(v && serializeDate(v, false));
         } : value;
         return ko.pureComputed({
             read: formatDate,

--- a/src/DotVVM.Framework/Resources/Scripts/binding-handlers/textbox-text.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/binding-handlers/textbox-text.ts
@@ -1,4 +1,4 @@
-import { parseDate as parseDotvvmDate, serializeDate } from '../serialization/date'
+import { parseDate, serializeDate } from '../serialization/date'
 import * as globalize from '../DotVVM.Globalize'
 import { DotvvmValidationElementMetadata, DotvvmValidationObservableMetadata, getValidationMetadata } from '../validation/common';
 import { lastSetErrorSymbol } from '../state-manager';
@@ -55,7 +55,7 @@ export default {
                     // parse date
                     let currentValue = obs();
                     if (currentValue != null) {
-                        currentValue = parseDotvvmDate(currentValue);
+                        currentValue = parseDate(currentValue);
                     }
                     result = globalize.parseDate(element.value, elmMetadata.format, currentValue) || globalize.parseDate(element.value, "", currentValue);
                     isEmpty = result == null;


### PR DESCRIPTION
We renamed `dotvvm.globalization.parseDotvvmDate` in the public API, and forgot to add an alias. 
Since it has probably broken several libraries, so this PR adds the alias back (and changes references to the new name in the code).