### PR TITLE
Fixed issues with OrderBy(Descending) and simplified their translations

### DIFF
--- a/src/DotVVM.Framework.Tests.Common/Binding/JavascriptCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests.Common/Binding/JavascriptCompilationTests.cs
@@ -18,6 +18,7 @@ using DotVVM.Framework.Configuration;
 using System.Linq.Expressions;
 using Microsoft.Extensions.DependencyInjection;
 using DotVVM.Framework.Binding.Properties;
+using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Tests.Binding
 {
@@ -568,18 +569,19 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
-        [DataRow("Enumerable.OrderBy(ObjectArray, (TestComparisonType item) => item.Int)", "Int", DisplayName = "Regular call of Enumerable.OrderBy")]
-        [DataRow("Enumerable.OrderBy(ObjectArray, (TestComparisonType item) => item.Bool)", "Bool", DisplayName = "Regular call of Enumerable.OrderBy")]
-        [DataRow("Enumerable.OrderBy(ObjectArray, (TestComparisonType item) => item.String)", "String", DisplayName = "Regular call of Enumerable.OrderBy")]
-        [DataRow("Enumerable.OrderBy(ObjectArray, (TestComparisonType item) => item.Enum)", "Enum", DisplayName = "Regular call of Enumerable.OrderBy")]
-        [DataRow("ObjectArray.OrderBy((TestComparisonType item) => item.Int)", "Int", DisplayName = "Syntax sugar - extension method")]
-        [DataRow("ObjectArray.OrderBy((TestComparisonType item) => item.Bool)", "Bool", DisplayName = "Syntax sugar - extension method")]
-        [DataRow("ObjectArray.OrderBy((TestComparisonType item) => item.String)", "String", DisplayName = "Syntax sugar - extension method")]
-        [DataRow("ObjectArray.OrderBy((TestComparisonType item) => item.Enum)", "Enum", DisplayName = "Syntax sugar - extension method")]
-        public void JsTranslator_EnumerableOrderBy(string binding, string key)
+        [DataRow("Enumerable.OrderBy(ObjectArray, (TestComparisonType item) => item.Int)", "Int", typeof(int), DisplayName = "Regular call of Enumerable.OrderBy")]
+        [DataRow("Enumerable.OrderBy(ObjectArray, (TestComparisonType item) => item.Bool)", "Bool", typeof(bool), DisplayName = "Regular call of Enumerable.OrderBy")]
+        [DataRow("Enumerable.OrderBy(ObjectArray, (TestComparisonType item) => item.String)", "String", typeof(string), DisplayName = "Regular call of Enumerable.OrderBy")]
+        [DataRow("Enumerable.OrderBy(ObjectArray, (TestComparisonType item) => item.Enum)", "Enum", typeof(TestComparisonType.TestEnum), DisplayName = "Regular call of Enumerable.OrderBy")]
+        [DataRow("ObjectArray.OrderBy((TestComparisonType item) => item.Int)", "Int", typeof(int), DisplayName = "Syntax sugar - extension method")]
+        [DataRow("ObjectArray.OrderBy((TestComparisonType item) => item.Bool)", "Bool", typeof(bool), DisplayName = "Syntax sugar - extension method")]
+        [DataRow("ObjectArray.OrderBy((TestComparisonType item) => item.String)", "String", typeof(string), DisplayName = "Syntax sugar - extension method")]
+        [DataRow("ObjectArray.OrderBy((TestComparisonType item) => item.Enum)", "Enum", typeof(TestComparisonType.TestEnum), DisplayName = "Syntax sugar - extension method")]
+        public void JsTranslator_EnumerableOrderBy(string binding, string key, Type comparedType)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestArraysViewModel) });
-            Assert.AreEqual($"dotvvm.arrayHelper.orderBy(ObjectArray(),function(item){{return ko.unwrap(item).{key}();}})", result);
+            var typeHash = (comparedType.IsEnum) ? $"\"{comparedType.GetTypeHash()}\"" : "null";
+            Assert.AreEqual($"dotvvm.arrayHelper.orderBy(ObjectArray(),function(item){{return ko.unwrap(item).{key}();}},{typeHash})", result);
         }
 
         [TestMethod]
@@ -592,18 +594,19 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
-        [DataRow("Enumerable.OrderByDescending(ObjectArray, (TestComparisonType item) => item.Int)", "Int", DisplayName = "Regular call of Enumerable.OrderByDescending")]
-        [DataRow("Enumerable.OrderByDescending(ObjectArray, (TestComparisonType item) => item.Bool)", "Bool", DisplayName = "Regular call of Enumerable.OrderByDescending")]
-        [DataRow("Enumerable.OrderByDescending(ObjectArray, (TestComparisonType item) => item.String)", "String", DisplayName = "Regular call of Enumerable.OrderByDescending")]
-        [DataRow("Enumerable.OrderByDescending(ObjectArray, (TestComparisonType item) => item.Enum)", "Enum", DisplayName = "Regular call of Enumerable.OrderByDescending")]
-        [DataRow("ObjectArray.OrderByDescending((TestComparisonType item) => item.Int)", "Int", DisplayName = "Syntax sugar - extension method")]
-        [DataRow("ObjectArray.OrderByDescending((TestComparisonType item) => item.Bool)", "Bool", DisplayName = "Syntax sugar - extension method")]
-        [DataRow("ObjectArray.OrderByDescending((TestComparisonType item) => item.String)", "String", DisplayName = "Syntax sugar - extension method")]
-        [DataRow("ObjectArray.OrderByDescending((TestComparisonType item) => item.Enum)", "Enum", DisplayName = "Syntax sugar - extension method")]
-        public void JsTranslator_EnumerableOrderByDescending(string binding, string key)
+        [DataRow("Enumerable.OrderByDescending(ObjectArray, (TestComparisonType item) => item.Int)", "Int", typeof(int), DisplayName = "Regular call of Enumerable.OrderByDescending")]
+        [DataRow("Enumerable.OrderByDescending(ObjectArray, (TestComparisonType item) => item.Bool)", "Bool", typeof(bool), DisplayName = "Regular call of Enumerable.OrderByDescending")]
+        [DataRow("Enumerable.OrderByDescending(ObjectArray, (TestComparisonType item) => item.String)", "String", typeof(string), DisplayName = "Regular call of Enumerable.OrderByDescending")]
+        [DataRow("Enumerable.OrderByDescending(ObjectArray, (TestComparisonType item) => item.Enum)", "Enum", typeof(TestComparisonType.TestEnum), DisplayName = "Regular call of Enumerable.OrderByDescending")]
+        [DataRow("ObjectArray.OrderByDescending((TestComparisonType item) => item.Int)", "Int", typeof(int), DisplayName = "Syntax sugar - extension method")]
+        [DataRow("ObjectArray.OrderByDescending((TestComparisonType item) => item.Bool)", "Bool", typeof(bool), DisplayName = "Syntax sugar - extension method")]
+        [DataRow("ObjectArray.OrderByDescending((TestComparisonType item) => item.String)", "String", typeof(string), DisplayName = "Syntax sugar - extension method")]
+        [DataRow("ObjectArray.OrderByDescending((TestComparisonType item) => item.Enum)", "Enum", typeof(TestComparisonType.TestEnum), DisplayName = "Syntax sugar - extension method")]
+        public void JsTranslator_EnumerableOrderByDescending(string binding, string key, Type comparedType)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestArraysViewModel) });
-            Assert.AreEqual($"dotvvm.arrayHelper.orderByDesc(ObjectArray(),function(item){{return ko.unwrap(item).{key}();}})", result);
+            var typeHash = (comparedType.IsEnum) ? $"\"{comparedType.GetTypeHash()}\"" : "null";
+            Assert.AreEqual($"dotvvm.arrayHelper.orderByDesc(ObjectArray(),function(item){{return ko.unwrap(item).{key}();}},{typeHash})", result);
         }
 
         [TestMethod]

--- a/src/DotVVM.Framework/Compilation/Javascript/GenericMethodCompiler.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/GenericMethodCompiler.cs
@@ -21,6 +21,14 @@ namespace DotVVM.Framework.Compilation.Javascript
                 : builder(new [] { t.JsExpression() }.Concat(arg.Select(a => a.JsExpression())).ToArray());
         }
 
+        public GenericMethodCompiler(Func<JsExpression[], Expression[], JsExpression> builder, Func<MethodInfo, Expression, Expression[], bool> check = null)
+        {
+            TryTranslateDelegate =
+                (t, arg, m) => check?.Invoke(m, t.OriginalExpression, arg.Select(a => a.OriginalExpression).ToArray()) == false
+                ? null
+                : builder(new[] { t.JsExpression() }.Concat(arg.Select(a => a.JsExpression())).ToArray(), arg.Select(a => a.OriginalExpression).ToArray());
+        }
+
         public GenericMethodCompiler(Func<JsExpression[], MethodInfo, JsExpression> builder, Func<MethodInfo, Expression, Expression[], bool> check = null)
         {
             TryTranslateDelegate =

--- a/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -121,7 +121,7 @@ namespace DotVVM.Framework.Compilation.Javascript
             AddMethodTranslator(typeof(IList), "get_Item", new GenericMethodCompiler(indexer));
             AddMethodTranslator(typeof(IList<>), "get_Item", new GenericMethodCompiler(indexer));
             AddMethodTranslator(typeof(List<>), "get_Item", new GenericMethodCompiler(indexer));
-            AddPropertyGetterTranslator(typeof(Nullable<>), "Value", new GenericMethodCompiler((args, method) => args[0]));
+            AddPropertyGetterTranslator(typeof(Nullable<>), "Value", new GenericMethodCompiler((JsExpression[] args, MethodInfo method) => args[0]));
             AddPropertyGetterTranslator(typeof(Nullable<>), "HasValue",
                 new GenericMethodCompiler(args => new JsBinaryExpression(args[0], BinaryOperatorType.NotEqual, new JsLiteral(null))));
             //AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.Count), lengthMethod, new[] { typeof(IEnumerable) });
@@ -345,6 +345,11 @@ namespace DotVVM.Framework.Compilation.Javascript
                 return true;
             }
 
+            Type GetDelegateReturnType(Type type)
+            {
+                return type.GetGenericArguments().Last();
+            }
+
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.All), parameterCount: 2, translator: new GenericMethodCompiler(args =>
                 new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("all").Invoke(args[1], args[2])));
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.Any), parameterCount: 1, translator: new GenericMethodCompiler(args =>
@@ -389,10 +394,12 @@ namespace DotVVM.Framework.Compilation.Javascript
             }
 
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.OrderBy), parameterCount: 2,
-                translator: new GenericMethodCompiler(args => new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("orderBy").Invoke(args[1], args[2]),
+                translator: new GenericMethodCompiler((jArgs, dArgs) => new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("orderBy")
+                    .Invoke(jArgs[1], jArgs[2], new JsLiteral((GetDelegateReturnType(dArgs.Last().Type).IsEnum) ? GetDelegateReturnType(dArgs.Last().Type).GetTypeHash() : null)),
                 check: (method, _, arguments) => EnsureIsComparableInJavascript(method, arguments.Last().Type.GetGenericArguments().Last())));
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.OrderByDescending), parameterCount: 2,
-                translator: new GenericMethodCompiler(args => new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("orderByDesc").Invoke(args[1], args[2]),
+                translator: new GenericMethodCompiler((JsExpression[] jArgs, Expression[] dArgs) => new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("orderByDesc")
+                    .Invoke(jArgs[1], jArgs[2], new JsLiteral((GetDelegateReturnType(dArgs.Last().Type).IsEnum) ? GetDelegateReturnType(dArgs.Last().Type).GetTypeHash() : null)),
                 check: (method, _, arguments) => EnsureIsComparableInJavascript(method, arguments.Last().Type.GetGenericArguments().Last())));
 
             var selectMethod = typeof(Enumerable).GetMethods(BindingFlags.Public | BindingFlags.Static)

--- a/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -345,10 +345,11 @@ namespace DotVVM.Framework.Compilation.Javascript
                 return true;
             }
 
-            Type GetDelegateReturnType(Type type)
-            {
-                return type.GetGenericArguments().Last();
-            }
+            bool IsDelegateReturnTypeEnum(Type type)
+                => type.GetGenericArguments().Last().IsEnum;
+
+            string GetDelegateReturnTypeHash(Type type)
+                => type.GetGenericArguments().Last().GetTypeHash();
 
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.All), parameterCount: 2, translator: new GenericMethodCompiler(args =>
                 new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("all").Invoke(args[1], args[2])));
@@ -395,11 +396,11 @@ namespace DotVVM.Framework.Compilation.Javascript
 
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.OrderBy), parameterCount: 2,
                 translator: new GenericMethodCompiler((jArgs, dArgs) => new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("orderBy")
-                    .Invoke(jArgs[1], jArgs[2], new JsLiteral((GetDelegateReturnType(dArgs.Last().Type).IsEnum) ? GetDelegateReturnType(dArgs.Last().Type).GetTypeHash() : null)),
+                    .Invoke(jArgs[1], jArgs[2], new JsLiteral((IsDelegateReturnTypeEnum(dArgs.Last().Type)) ? GetDelegateReturnTypeHash(dArgs.Last().Type) : null)),
                 check: (method, _, arguments) => EnsureIsComparableInJavascript(method, arguments.Last().Type.GetGenericArguments().Last())));
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.OrderByDescending), parameterCount: 2,
-                translator: new GenericMethodCompiler((JsExpression[] jArgs, Expression[] dArgs) => new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("orderByDesc")
-                    .Invoke(jArgs[1], jArgs[2], new JsLiteral((GetDelegateReturnType(dArgs.Last().Type).IsEnum) ? GetDelegateReturnType(dArgs.Last().Type).GetTypeHash() : null)),
+                translator: new GenericMethodCompiler((jArgs, dArgs) => new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("orderByDesc")
+                    .Invoke(jArgs[1], jArgs[2], new JsLiteral((IsDelegateReturnTypeEnum(dArgs.Last().Type)) ? GetDelegateReturnTypeHash(dArgs.Last().Type) : null)),
                 check: (method, _, arguments) => EnsureIsComparableInJavascript(method, arguments.Last().Type.GetGenericArguments().Last())));
 
             var selectMethod = typeof(Enumerable).GetMethods(BindingFlags.Public | BindingFlags.Static)

--- a/src/DotVVM.Framework/Resources/Scripts/collections/sortingHelper.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/collections/sortingHelper.ts
@@ -1,16 +1,13 @@
 ﻿import { getTypeInfo } from "../metadata/typeMap";
-import { primitiveTypes } from "../metadata/primitiveTypes";
-import { keys } from "../utils/objects";
 type ElementType = string | number | boolean;
 
-export const orderBy = <T>(array: T[], selector: (item: T) => ElementType) =>
-    orderByImpl(array, selector, getComparer(array[0], selector, true))
+export const orderBy = <T>(array: T[], selector: (item: T) => ElementType, typeId: string) =>
+    orderByImpl(array, selector, getComparer(typeId, true))
 
-export const orderByDesc = <T>(array: T[], selector: (item: T) => ElementType) =>
-    orderByImpl(array, selector, getComparer(array[0], selector, false))
+export const orderByDesc = <T>(array: T[], selector: (item: T) => ElementType, typeId: string) =>
+    orderByImpl(array, selector, getComparer(typeId, false))
 
 function orderByImpl<T>(array: T[], selector: (item: T) => ElementType, compare: (first: ElementType, second: ElementType) => number): T[] {
-
     if ((!array || array.length < 2))
         return array;
 
@@ -20,13 +17,9 @@ function orderByImpl<T>(array: T[], selector: (item: T) => ElementType, compare:
         .map(({ item }) => item);
 }
 
-function getComparer<T>(element: T, selector: (item: T) => ElementType, ascending: boolean): (first: ElementType, second: ElementType) => number {
-    let metadataInfo = getMetadataInfo(element, selector(element));
-
-    if (metadataInfo !== null && metadataInfo.type === "object") {
-        throw new Error("Can not compare objects!");
-    }
-    else if (metadataInfo !== null && metadataInfo.type === "enum") {
+function getComparer(typeId: string | null, ascending: boolean): (first: ElementType, second: ElementType) => number {
+    let metadataInfo = (typeId !== null) ? getTypeInfo(typeId) : null;
+    if (metadataInfo !== null && metadataInfo.type === "enum") {
         // Enums should be compared based on their underlying primitive values
         // This is the same behaviour as used by .NET
         let enumMetadataInfo = metadataInfo as EnumTypeMetadata;
@@ -42,95 +35,6 @@ function getComparer<T>(element: T, selector: (item: T) => ElementType, ascendin
             return defaultPrimitivesComparer(first, second, ascending);
         }
     }
-}
-
-function getMetadataInfo(original: any, selected: any): TypeMetadata | null {
-    var path = getPath(original, selected);
-    if (path === null) {
-        return null;
-    }
-    else {
-        let typeId = ko.unwrap((ko.unwrap(original).$type)) as string;
-        let type = typeId as TypeDefinition;
-        let pathSegmentIndex = 0;
-
-        while (pathSegmentIndex < path.length) {
-            if (Array.isArray(type)) {
-                const index = parseInt(path[pathSegmentIndex++]);
-                type = type[index];
-            }
-            else if (typeof type === "object") {
-                if (type.type == "nullable") {
-                    type = type.inner;
-                }
-                else if (type.type === "dynamic") {
-                    // No metadata available
-                    return null;
-                }
-            }
-            else if (typeof type === "string") {
-                if (type in primitiveTypes) {
-                    // No metadata available
-                    return null;
-                } else {
-                    let metadata = getTypeInfo(type);
-                    if (metadata && metadata.type === "object") {
-                        let pathSegment = path[pathSegmentIndex++];
-                        type = metadata.properties[pathSegment].type;
-                    }
-                    else if (metadata && metadata.type === "enum") {
-                        return metadata;
-                    }
-                }
-            }
-        }
-
-        return resolveMetadata(type);
-    }
-}
-
-function resolveMetadata(type: TypeDefinition): TypeMetadata | null { 
-    if (!Array.isArray(type) && typeof type === "object" && type.type === "nullable") {
-        // Unwrap nullables
-        type = type.inner;
-    }
-    
-    if (Array.isArray(type) || (typeof type === "object" && type.type === "dynamic")) {
-        // We can not retrieve metadata for arrays and dynamics
-        throw new Error("Could not resolve metadata!");
-    }
-
-    if (type as string in primitiveTypes) {
-        // No metadata available
-        return null;
-    }
-    else {
-        return getTypeInfo(type as string);
-    }
-}
-
-function getPath(from: any, target: any): string[] | null {
-    from = ko.unwrap(from);
-    target = ko.unwrap(target);
-
-    if (from == target)
-        return [];
-
-    for (let key of keys(from)) {
-        let item = ko.unwrap(from[key]);
-        if (item && typeof item === "object") {
-            let subPath = getPath(item, target);
-            if (subPath) {
-                subPath.unshift(key);
-                return subPath;
-            }
-        }
-        else if (item === target) {
-            return [key];
-        }
-    }
-
-    return null;
 }
 
 const defaultPrimitivesComparer = (first: ElementType, second: ElementType, ascending: boolean) => {

--- a/src/DotVVM.Framework/Resources/Scripts/collections/sortingHelper.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/collections/sortingHelper.ts
@@ -24,8 +24,8 @@ function getComparer(typeId: string | null, ascending: boolean): (first: Element
         // This is the same behaviour as used by .NET
         let enumMetadataInfo = metadataInfo as EnumTypeMetadata;
         return function (first: ElementType, second: ElementType) {
-            let firstNumeric = enumMetadataInfo.values[first as string];
-            let secondNumeric = enumMetadataInfo.values[second as string];
+            let firstNumeric = (typeof (first) === "number") ? first : enumMetadataInfo.values[first as string];
+            let secondNumeric = (typeof (second) === "number") ? second : enumMetadataInfo.values[second as string];
             return defaultPrimitivesComparer(firstNumeric, secondNumeric, ascending);
         }
     }

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/LambdaExpressions/StaticCommandsViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/LambdaExpressions/StaticCommandsViewModel.cs
@@ -20,7 +20,7 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.LambdaExpressions
             new CustomerData() {Id = 7, Name = "John", Category = Category.Red, RegisteredAt = DateTime.Parse("2020-05-28T20:57:41"), IsActive = true, FinishedTransactions = 12 },
             new CustomerData() {Id = 8, Name = "Johnny", Category = Category.Red, RegisteredAt = DateTime.Parse("2018-01-21T07:03:41"), IsActive = false, FinishedTransactions = 15 },
             new CustomerData() {Id = 9, Name = "Robert", Category = Category.Green, RegisteredAt = DateTime.Parse("2019-05-22T18:58:33"), IsActive = true, FinishedTransactions = 19 },
-            new CustomerData() {Id = 10, Name = "Roger", Category = Category.Blue, RegisteredAt = DateTime.Parse("2020-12-01T06:57:57"), IsActive = false, FinishedTransactions = 27 }
+            new CustomerData() {Id = 10, Name = "Roger", Category = (Category)(-1), RegisteredAt = DateTime.Parse("2020-12-01T06:57:57"), IsActive = false, FinishedTransactions = 27 }
         };
 
         public List<CustomerData> FilteredCustomers { get; set; }
@@ -31,6 +31,8 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.LambdaExpressions
 
         public class CustomerData
         {
+            public string AString { get; set; } = "Red";
+            public int ANumber { get; set; } = 1;
             public int Id { get; set; }
             public string Name { get; set; }
             public Category Category { get; set; }
@@ -41,9 +43,9 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.LambdaExpressions
 
         public enum Category
         {
-            Red,
-            Green,
-            Blue
+            Red = 1,
+            Green = 2,
+            Blue = 3
         }
     }
 }


### PR DESCRIPTION
It was possible to simplify current implementation of `OrderBy` and `OrderByDescending`. This also resolved some previously discovered issues regarding comparing by value vs by reference.