### PR TITLE
Added helper functions for working with type metadata

### DIFF
--- a/src/DotVVM.Framework/Resources/Scripts/dotvvm-root.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/dotvvm-root.ts
@@ -25,6 +25,7 @@ import * as viewModuleManager from './viewModules/viewModuleManager'
 import { notifyModuleLoaded } from './postback/resourceLoader'
 import { logError, logWarning, logInfo, logInfoVerbose, level, logPostBackScriptError } from "./utils/logging"
 import { orderBy, orderByDesc } from './collections/sortingHelper'
+import * as metadataHelper from './metadata/metadataHelper'
 import * as arrayHelper from './collections/arrayHelper'
 import * as stringHelper from './utils/stringHelper'
 
@@ -98,6 +99,12 @@ const dotvvmExports = {
         serializeDate,
         parseDate,
         deserialize
+    },
+    metadata: {
+        getTypeId: metadataHelper.getTypeId,
+        getTypeMetadata: metadataHelper.getTypeMetadata,
+        getEnumMetadata: metadataHelper.getEnumMetadata,
+        getEnumValue: metadataHelper.getEnumValue
     },
     viewModules: {
         registerOne: viewModuleManager.registerViewModule,

--- a/src/DotVVM.Framework/Resources/Scripts/metadata/metadataHelper.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/metadata/metadataHelper.ts
@@ -1,0 +1,40 @@
+﻿import { getTypeInfo } from "./typeMap";
+
+export function getTypeId(viewModel: any): string {
+    if (typeof viewModel !== "object") {
+        throw Error("Expected object but received: " + typeof viewModel);
+    }
+
+    return ko.unwrap(viewModel.$type);
+}
+
+export function getTypeMetadata(viewModel: any): TypeMetadata {
+    let typeId = getTypeId(viewModel);
+    return getTypeInfo(typeId);
+}
+
+export function getEnumMetadata(enumMetadataId: string): EnumTypeMetadata {
+    let metadata = getTypeInfo(enumMetadataId);
+    if (metadata.type !== "enum") {
+        throw new Error("Expected enum, but received object");
+    }
+
+    return metadata as EnumTypeMetadata;
+}
+
+export function getEnumValue(identifier: string | number, enumMetadataId: string): number | null {
+    let metadata = getEnumMetadata(enumMetadataId);
+    if (typeof identifier === "string") {
+        return metadata.values[identifier];
+    }
+    else {
+        // Ensure this number is not already defined
+        for (const key in metadata.values) {
+            if (metadata.values[key] === identifier) {
+                return null;
+            }
+        }
+
+        return identifier;
+    }
+}

--- a/src/DotVVM.Framework/Resources/Scripts/metadata/metadataHelper.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/metadata/metadataHelper.ts
@@ -17,7 +17,7 @@ export function getEnumMetadata(enumMetadataId: string): EnumTypeMetadata {
     return metadata as EnumTypeMetadata;
 }
 
-export function getEnumValue(identifier: string | number, enumMetadataId: string): number | null {
+export function getEnumValue(identifier: string | number, enumMetadataId: string): number | undefined {
     let metadata = getEnumMetadata(enumMetadataId);
     if (typeof identifier === "string") {
         return metadata.values[identifier];

--- a/src/DotVVM.Framework/Resources/Scripts/metadata/metadataHelper.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/metadata/metadataHelper.ts
@@ -1,15 +1,10 @@
 ﻿import { getTypeInfo } from "./typeMap";
 
-export function getTypeId(viewModel: any): string {
-    if (typeof viewModel !== "object") {
-        throw Error("Expected object but received: " + typeof viewModel);
-    }
-
-    return ko.unwrap(viewModel.$type);
+export function getTypeId(viewModel: object): string | undefined {
+    return ko.unwrap((viewModel as any).$type);
 }
 
-export function getTypeMetadata(viewModel: any): TypeMetadata {
-    let typeId = getTypeId(viewModel);
+export function getTypeMetadata(typeId: string): TypeMetadata {
     return getTypeInfo(typeId);
 }
 
@@ -28,13 +23,6 @@ export function getEnumValue(identifier: string | number, enumMetadataId: string
         return metadata.values[identifier];
     }
     else {
-        // Ensure this number is not already defined
-        for (const key in metadata.values) {
-            if (metadata.values[key] === identifier) {
-                return null;
-            }
-        }
-
         return identifier;
     }
 }


### PR DESCRIPTION
DotVVM previously lacked better support for accessing type metadata. To resolve this issue, this PR introduces some helper functions into `dotvvm.metadata.*`