### PR TITLE
Fixed issue with byte[] serialization

### DIFF
--- a/src/DotVVM.Framework/Configuration/DefaultSerializerSettingsProvider.cs
+++ b/src/DotVVM.Framework/Configuration/DefaultSerializerSettingsProvider.cs
@@ -27,7 +27,8 @@ namespace DotVVM.Framework.Configuration
                 {
                     new DotvvmDateTimeConverter(),
                     new StringEnumConverter(),
-                    new DotvvmDictionaryConverter()
+                    new DotvvmDictionaryConverter(),
+                    new DotvvmByteArrayConverter()
                 }
             };
         }

--- a/src/DotVVM.Framework/ViewModel/Serialization/DotvvmByteArrayConverter.cs
+++ b/src/DotVVM.Framework/ViewModel/Serialization/DotvvmByteArrayConverter.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace DotVVM.Framework.ViewModel.Serialization
+{
+    public class DotvvmByteArrayConverter : JsonConverter
+    {
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+            else if (reader.TokenType == JsonToken.StartArray)
+            {
+                var list = new List<byte>();
+                while (reader.Read())
+                {
+                    switch (reader.TokenType)
+                    {
+                        case JsonToken.Integer:
+                            list.Add((byte)reader.Value);
+                            break;
+                        case JsonToken.EndArray:
+                            return list.ToArray();
+                        default:
+                            throw new FormatException($"Unexpected token while reading byte array: {reader.TokenType}");
+                    }
+                }
+
+                throw new FormatException($"Unexpected end of array!");
+            }
+            else
+            {
+                throw new FormatException($"Expected StartArray token, but instead got {reader.TokenType}!");
+            }
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+
+            var array = (byte[])value;
+            writer.WriteStartArray();
+            foreach (var item in array)
+                writer.WriteValue(item);
+            writer.WriteEndArray();
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(byte[]);
+        }
+    }
+}

--- a/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
+++ b/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
@@ -60,6 +60,7 @@
     <None Remove="Views\FeatureSamples\LambdaExpressions\ClientSideFiltering.dothtml" />
     <None Remove="Views\FeatureSamples\LambdaExpressions\LambdaExpressions.dothtml" />
     <None Remove="Views\FeatureSamples\Localization\Globalize.dothtml" />
+    <None Remove="Views\FeatureSamples\Serialization\ByteArray.dothtml" />
     <None Remove="Views\FeatureSamples\Serialization\TimeSpan.dothtml" />
     <None Remove="Views\FeatureSamples\Serialization\EnumSerializationCoercion.dothtml" />
     <None Remove="Views\FeatureSamples\Serialization\SerializationDateTimeOffset.dothtml" />

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/Serialization/ByteArrayViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/Serialization/ByteArrayViewModel.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.Serialization
+{
+    public class ByteArrayViewModel : DotvvmViewModelBase
+    {
+        public byte[] Bytes { get; set; } = new byte[] { 1, 2, 3, 4, 5 };
+    }
+}
+

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/Serialization/ByteArray.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/Serialization/ByteArray.dothtml
@@ -1,0 +1,24 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.Serialization.ByteArrayViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+
+    <h1>Byte array serialization sample</h1>
+
+    <span>Size: {{value: Bytes.Length}}</span>
+    <dot:Repeater DataSource="{value: Bytes}">
+        <p>
+            <span>{{value: _this}}</span>
+        </p>
+    </dot:Repeater>
+
+</body>
+</html>
+
+

--- a/src/DotVVM.Samples.Tests/Feature/SerializationTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/SerializationTests.cs
@@ -1,4 +1,5 @@
-﻿using DotVVM.Samples.Tests.Base;
+﻿using System.Linq;
+using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
 using OpenQA.Selenium;
 using Riganti.Selenium.Core;
@@ -241,6 +242,22 @@ namespace DotVVM.Samples.Tests.Feature
                     AssertUI.TextEquals(result, "-1");
                     AssertUI.TextEquals(result2, "Two");
                 }, 5000);
+            });
+        }
+
+        [Fact]
+        public void Feature_Serialization_ByteArray()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_Serialization_ByteArray);
+
+                var spans = browser.FindElements("span");
+                Assert.Equal("Size: 5", spans.First().GetText());
+                Assert.Equal("1", spans.Skip(1).First().GetText());
+                Assert.Equal("2", spans.Skip(2).First().GetText());
+                Assert.Equal("3", spans.Skip(3).First().GetText());
+                Assert.Equal("4", spans.Skip(4).First().GetText());
+                Assert.Equal("5", spans.Skip(5).First().GetText());
             });
         }
 

--- a/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
@@ -275,14 +275,15 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_Resources_OnlineNonameResourceLoad = "FeatureSamples/Resources/OnlineNonameResourceLoad";
         public const string FeatureSamples_Resources_RequiredOnPostback = "FeatureSamples/Resources/RequiredOnPostback";
         public const string FeatureSamples_ReturnedFile_ReturnedFileSample = "FeatureSamples/ReturnedFile/ReturnedFileSample";
+        public const string FeatureSamples_Serialization_ByteArray = "FeatureSamples/Serialization/ByteArray";
         public const string FeatureSamples_Serialization_DeserializationVirtualElements = "FeatureSamples/Serialization/DeserializationVirtualElements";
         public const string FeatureSamples_Serialization_Dictionary = "FeatureSamples/Serialization/Dictionary";
         public const string FeatureSamples_Serialization_EnumSerializationCoercion = "FeatureSamples/Serialization/EnumSerializationCoercion";
         public const string FeatureSamples_Serialization_EnumSerializationWithJsonConverter = "FeatureSamples/Serialization/EnumSerializationWithJsonConverter";
         public const string FeatureSamples_Serialization_ObservableCollectionShouldContainObservables = "FeatureSamples/Serialization/ObservableCollectionShouldContainObservables";
         public const string FeatureSamples_Serialization_Serialization = "FeatureSamples/Serialization/Serialization";
-        public const string FeatureSamples_Serialization_TimeSpan = "FeatureSamples/Serialization/TimeSpan";
         public const string FeatureSamples_Serialization_SerializationDateTimeOffset = "FeatureSamples/Serialization/SerializationDateTimeOffset";
+        public const string FeatureSamples_Serialization_TimeSpan = "FeatureSamples/Serialization/TimeSpan";
         public const string FeatureSamples_ServerComments_ServerComments = "FeatureSamples/ServerComments/ServerComments";
         public const string FeatureSamples_ServerSideStyles_ServerSideStyles = "FeatureSamples/ServerSideStyles/ServerSideStyles";
         public const string FeatureSamples_ServerSideStyles_ServerSideStyles_ControlProperties = "FeatureSamples/ServerSideStyles/ServerSideStyles_ControlProperties";


### PR DESCRIPTION
Resolves #1011. This PR changes serialization strategy for `byte[]` from base64-encoded string to a regular JSON array.