### PR TITLE
state manager: Updating non-existed array element does nothing

### DIFF
--- a/src/DotVVM.Framework/Resources/Scripts/state-manager.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/state-manager.ts
@@ -326,8 +326,12 @@ function createWrappedObservable<T>(initialValue: DeepReadonly<T>, typeHint: Typ
                     }
                     const indexForClosure = index
                     newContents[index] = createWrappedObservable(newVal[index], Array.isArray(typeHint) ? typeHint[0] : void 0, update => updater((viewModelArray: any) => {
-                        const newElement = update(viewModelArray![indexForClosure])
-                        const newArray = createArray(viewModelArray!)
+                        if (viewModelArray == null || viewModelArray.length <= indexForClosure) {
+                            // the item or the array does not exist anymore
+                            return viewModelArray
+                        }
+                        const newElement = update(viewModelArray[indexForClosure])
+                        const newArray = createArray(viewModelArray)
                         newArray[indexForClosure] = newElement
                         return Object.freeze(newArray) as any
                     }))

--- a/src/DotVVM.Framework/Resources/Scripts/tests/stateManagement.test.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/tests/stateManagement.test.ts
@@ -438,3 +438,21 @@ test("push on observable array - automatic coercion happens", () => {
     expect(vm.Array()[2]).toEqual(oldValue);
 
 })
+
+test("update of element in array that stops existing", () => {
+
+    vm.Array([
+        { Id: 1 },
+        { Id: 3 }
+    ])
+    expect(vm.Array.state.length).toEqual(2)
+    const a = vm.Array()[1]()
+    a.Id(10)
+    expect(vm.Array.state[1].Id).toEqual(10)
+    vm.Array([ { Id: 1 } ])
+    expect(vm.Array.state.length).toEqual(1)
+    a.Id(10)
+    expect(vm.Array.state.length).toEqual(1)
+    expect(vm.Array.state[0]).toEqual({ $type: "t2", Id: 1 })
+
+})


### PR DESCRIPTION
This was previously updating the array element with undefined value,
which causes pretty weird problems in cases when staticCommand affecting
the array element updates it after it was removed from the viewmodel