### PR TITLE
HtmlGenericControl supports numeric and boolean values for attributes

### DIFF
--- a/src/DotVVM.Framework/Controls/HtmlGenericControl.cs
+++ b/src/DotVVM.Framework/Controls/HtmlGenericControl.cs
@@ -332,17 +332,17 @@ namespace DotVVM.Framework.Controls
                         writer.AddAttribute(name, name);
                     }
                 }
-                else if (type == typeof(DateTime))
-                {
-                    writer.AddAttribute(name, ((DateTime)value).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));   // date format defined by the HTML specs
-                }
                 else if (type.IsEnum || type == typeof(Guid))
                 {
                     writer.AddAttribute(name, value.ToString());
                 }
                 else
                 {
-                    throw new NotSupportedException($"Attribute value of type '{value.GetType().FullName}' is not supported.");
+                    // DateTime and related are not supported here intentionally.
+                    // It is not clear in which format it should be rendered - on some places, the HTML specs requires just yyyy-MM-dd,
+                    // but in case of Web Components, the users may want to pass the whole date, or use a specific format
+
+                    throw new NotSupportedException($"Attribute value of type '{value.GetType().FullName}' is not supported. Please convert the value to string, e. g. by using ToString()");
                 }
             }
         }

--- a/src/DotVVM.Framework/Controls/HtmlGenericControl.cs
+++ b/src/DotVVM.Framework/Controls/HtmlGenericControl.cs
@@ -318,32 +318,28 @@ namespace DotVVM.Framework.Controls
             {
                 AddHtmlAttribute(writer, name, ((IStaticValueBinding)value).Evaluate(this));
             }
+            else if (value is bool boolValue)
+            {
+                if (boolValue)
+                {
+                    writer.AddAttribute(name, name);
+                }
+            }
+            else if (value is Enum || value is Guid)
+            {
+                writer.AddAttribute(name, value.ToString());
+            }
+            else if (ReflectionUtils.IsNumericType(value.GetType()))
+            {
+                writer.AddAttribute(name, Convert.ToString(value, CultureInfo.InvariantCulture));
+            }
             else
             {
-                var type = ReflectionUtils.UnwrapNullableType(value.GetType());
-                if (ReflectionUtils.IsNumericType(type))
-                {
-                    writer.AddAttribute(name, Convert.ToString(value, CultureInfo.InvariantCulture));
-                }
-                else if (type == typeof(bool))
-                {
-                    if ((bool)value)
-                    {
-                        writer.AddAttribute(name, name);
-                    }
-                }
-                else if (type.IsEnum || type == typeof(Guid))
-                {
-                    writer.AddAttribute(name, value.ToString());
-                }
-                else
-                {
-                    // DateTime and related are not supported here intentionally.
-                    // It is not clear in which format it should be rendered - on some places, the HTML specs requires just yyyy-MM-dd,
-                    // but in case of Web Components, the users may want to pass the whole date, or use a specific format
+                // DateTime and related are not supported here intentionally.
+                // It is not clear in which format it should be rendered - on some places, the HTML specs requires just yyyy-MM-dd,
+                // but in case of Web Components, the users may want to pass the whole date, or use a specific format
 
-                    throw new NotSupportedException($"Attribute value of type '{value.GetType().FullName}' is not supported. Please convert the value to string, e. g. by using ToString()");
-                }
+                throw new NotSupportedException($"Attribute value of type '{value.GetType().FullName}' is not supported. Please convert the value to string, e. g. by using ToString()");
             }
         }
 

--- a/src/DotVVM.Samples.Common/Controls/AttributeToStringConversionControl.cs
+++ b/src/DotVVM.Samples.Common/Controls/AttributeToStringConversionControl.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Hosting;
+
+namespace DotVVM.Samples.Common.Controls
+{
+    public class AttributeToStringConversionControl : HtmlGenericControl
+    {
+        public double Value
+        {
+            get { return (int)GetValue(ValueProperty); }
+            set { SetValue(ValueProperty, value); }
+        }
+        public static readonly DotvvmProperty ValueProperty
+            = DotvvmProperty.Register<double, AttributeToStringConversionControl>(c => c.Value, 0);
+
+        public AttributeToStringConversionControl() : base("input")
+        {
+        }
+
+        protected override void AddAttributesToRender(IHtmlWriter writer, IDotvvmRequestContext context)
+        {
+            writer.AddAttribute("type", "range");
+            writer.AddAttribute("min", "1");
+            writer.AddAttribute("max", "100");
+            writer.AddAttribute("step", "0.1");
+
+            base.AddAttributesToRender(writer, context);
+        }
+
+        protected override void OnPreRender(IDotvvmRequestContext context)
+        {
+            Attributes["value"] = GetValueRaw(ValueProperty);
+        }
+
+        protected override void RenderBeginTag(IHtmlWriter writer, IDotvvmRequestContext context)
+        {
+            writer.RenderSelfClosingTag("input");
+        }
+
+        protected override void RenderEndTag(IHtmlWriter writer, IDotvvmRequestContext context)
+        {
+        }
+
+    }
+}

--- a/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
+++ b/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
@@ -53,6 +53,7 @@
     <None Remove="Views\Errors\InvalidServiceDirective.dothtml" />
     <None Remove="Views\Errors\InvalidLocationFallback.dothtml" />
     <None Remove="Views\Errors\ResourceCircularDependency.dothtml" />
+    <None Remove="Views\FeatureSamples\Attribute\ToStringConversion.dothtml" />
     <None Remove="Views\FeatureSamples\Caching\CachedValues.dothtml" />
     <None Remove="Views\FeatureSamples\CommandActionFilter\CommandActionFilter.dothtml" />
     <None Remove="Views\FeatureSamples\JavascriptTranslation\GenericMethodTranslation.dothtml" />

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/Attribute/ToStringConversionViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/Attribute/ToStringConversionViewModel.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.Attribute
+{
+    public class ToStringConversionViewModel : DotvvmViewModelBase
+    {
+
+        public double NumberValue { get; set; } = 45.3;
+
+        public bool IsOpen { get; set; }
+    }
+}
+

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/Attribute/ToStringConversion.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/Attribute/ToStringConversion.dothtml
@@ -1,0 +1,36 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.Attribute.ToStringConversionViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+
+    <h2>Numeric values converted to strings</h2>
+    <p>
+        <cc:AttributeToStringConversionControl Value="{value: NumberValue}" />
+        <cc:AttributeToStringConversionControl Value="15" />
+        <cc:AttributeToStringConversionControl Value="{resource: 30}" />
+    </p>
+
+    <h2>Boolean values add/remove attribute</h2>
+    <p>
+        <dot:CheckBox Checked="{value: IsOpen}" Text="Show details" />
+    </p>
+    <details open="{value: IsOpen}">
+        Details
+    </details>
+    <details open="{resource: true}">
+        Details 2
+    </details>
+    <details open="{resource: false}">
+        Details 3
+    </details>
+
+</body>
+</html>
+
+

--- a/src/DotVVM.Samples.Tests/Feature/AttributeTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/AttributeTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Samples.Tests.Base;
+using DotVVM.Testing.Abstractions;
+using Riganti.Selenium.Core;
+using Xunit;
+
+namespace DotVVM.Samples.Tests.Feature
+{
+    public class AttributeTests : AppSeleniumTest
+    {
+        public AttributeTests(Xunit.Abstractions.ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void Feature_Attribute_ToStringConversion()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_Attribute_ToStringConversion);
+
+                // numbers
+                AssertUI.Attribute(browser.ElementAt("input[type=range]", 0), "value", a => a == "45.3");
+                AssertUI.HasAttribute(browser.ElementAt("input[type=range]", 0), "data-bind");
+
+                AssertUI.Attribute(browser.ElementAt("input[type=range]", 1), "value", a => a == "15");
+                AssertUI.HasNotAttribute(browser.ElementAt("input[type=range]", 1), "data-bind");
+
+                AssertUI.Attribute(browser.ElementAt("input[type=range]", 2), "value", a => a == "30");
+                AssertUI.HasNotAttribute(browser.ElementAt("input[type=range]", 2), "data-bind");
+
+                // bool
+                AssertUI.HasNotAttribute(browser.ElementAt("details", 0), "open");
+                AssertUI.HasAttribute(browser.ElementAt("details", 0), "data-bind");
+
+                AssertUI.HasAttribute(browser.ElementAt("details", 1), "open");
+                AssertUI.HasNotAttribute(browser.ElementAt("details", 1), "data-bind");
+
+                AssertUI.HasNotAttribute(browser.ElementAt("details", 2), "open");
+                AssertUI.HasNotAttribute(browser.ElementAt("details", 2), "data-bind");
+
+                browser.Single("input[type=checkbox]").Click();
+                AssertUI.HasAttribute(browser.ElementAt("details", 0), "open");
+
+                browser.Single("input[type=checkbox]").Click();
+                AssertUI.HasNotAttribute(browser.ElementAt("details", 0), "open");
+            });
+        }
+    }
+}

--- a/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
@@ -192,6 +192,7 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_Api_GridViewDataSetOwin = "FeatureSamples/Api/GridViewDataSetOwin";
         public const string FeatureSamples_AttachedProperties_AttachedProperties = "FeatureSamples/AttachedProperties/AttachedProperties";
         public const string FeatureSamples_Attribute_SpecialCharacters = "FeatureSamples/Attribute/SpecialCharacters";
+        public const string FeatureSamples_Attribute_ToStringConversion = "FeatureSamples/Attribute/ToStringConversion";
         public const string FeatureSamples_BindableCssStyles_BindableCssStyles = "FeatureSamples/BindableCssStyles/BindableCssStyles";
         public const string FeatureSamples_BindingContexts_BindingContext = "FeatureSamples/BindingContexts/BindingContext";
         public const string FeatureSamples_BindingContexts_CollectionContext = "FeatureSamples/BindingContexts/CollectionContext";


### PR DESCRIPTION
When playing with Web Components, I've found out that binding non-string values in attributes work for value bindings, but not for resource bindings - an exception about unsupported attribute type was thrown.

I've added support for:
* numeric types
* `bool`, the attribute is omitted when it's `false`
* enums and `Guid` (I am just calling `ToString`)

I haven't added a special case for `DateTime` as it is not clear whether the user wants to bind just the date (for example into `input[type=date]`), or both date and time, and in what format. 