### PR TITLE
Decorator support added for composite controls

### DIFF
--- a/src/DotVVM.Framework/Controls/CompositeControlDecoratorAttribute.cs
+++ b/src/DotVVM.Framework/Controls/CompositeControlDecoratorAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DotVVM.Framework.Controls
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public class CompositeControlDecoratorAttribute : Attribute 
+    {
+        public Type DecoratorType { get; }
+
+        public CompositeControlDecoratorAttribute(Type decoratorType)
+        {
+            this.DecoratorType = decoratorType;
+        }
+
+    }
+}

--- a/src/DotVVM.Samples.Common/Controls/CompositeControlSample.cs
+++ b/src/DotVVM.Samples.Common/Controls/CompositeControlSample.cs
@@ -1,14 +1,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.ComponentModel;
 using DotVVM.Framework.Binding;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Binding.Properties;
 using DotVVM.Framework.Controls.Infrastructure;
 using DotVVM.Framework.Utils;
 
 namespace DotVVM.Samples.BasicSamples.Controls
 {
+    [CompositeControlDecorator(typeof(EnabledCompositeControlDecorator))]
     public class CompositeControlSample: CompositeControl
     {
         public static DotvvmControl GetContents(
@@ -43,6 +46,22 @@ namespace DotVVM.Samples.BasicSamples.Controls
                 HtmlCapability = html
             }
             .SetBinding(r => r.DataSource, dataSource);
+        }
+    }
+
+    public class EnabledCompositeControlDecorator
+    {
+        public static DotvvmControl DecorateControl(
+            DotvvmControl control,
+
+            [DefaultValue(null)] IValueBinding<bool> enabled
+        )
+        {
+            if (enabled != null)
+            {
+                control.SetBinding(FormControls.EnabledProperty, enabled);
+            }
+            return control;
         }
     }
 }

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/CompositeControls/BasicSampleViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/CompositeControls/BasicSampleViewModel.cs
@@ -13,6 +13,7 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.CompositeControls
             new SampleItem { EditableNumber = 12, Title = "Second Number" },
         };
         public bool Visible { get; set; }
+        public bool Enabled { get; set; } = true;
     }
 
     public class SampleItem

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/CompositeControls/BasicSample.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/CompositeControls/BasicSample.dothtml
@@ -13,17 +13,19 @@
                                TitleBinding="{value: "[" + _index + "] " + Title}"
                                NumberBinding="{value: EditableNumber}"
                                style="color: blue"
-                               inner-li:style="border: 1px green solid" inner-li:Visible="{value: Visible}" />
-    
+                               inner-li:style="border: 1px green solid" inner-li:Visible="{value: Visible}"
+                               Enabled="{value: Enabled}" />
+
 
     <p>
         Numbers:
     </p>
     <dot:Repeater WrapperTagName="p" DataSource="{value: List}">
-        {{value: EditableNumber}}
+         {{value: EditableNumber}}
     </dot:Repeater>
 
     <dot:CheckBox Checked="{value: Visible}" Text="Visible" />
+    <dot:CheckBox Checked="{value: Enabled}" Text="Enabled" />
 
 </body>
 </html>


### PR DESCRIPTION
When implementing wrappers for Fluent UI, I discovered many cases where it would be useful to be able to specify a "decorator" for the composite control.

The decorator can add additional properties, and wrap the generated control with some other code.
The first argument of the decorator is the result of the `GetContents` method, and the decorator must return the same type (single control or a collection).

```CSHARP
    public class EnabledCompositeControlDecorator
    {
        public static DotvvmControl DecorateControl(
            DotvvmControl control,

            [DefaultValue(null)] IValueBinding<bool> enabled
        )
        {
            if (enabled != null)
            {
                control.SetBinding(FormControls.EnabledProperty, enabled);
            }
            return control;
        }
    }
```

The decorators are added on the `CompositeControl` using an attribute - my plan is to be able to apply them on a base class.

```CSHARP
[CompositeControlDecorator(typeof(EnabledCompositeControlDecorator))]
```