### PR TITLE
Refactored JavaScript translations

### DIFF
--- a/src/DotVVM.Framework.Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests/Binding/JavascriptCompilationTests.cs
@@ -389,35 +389,35 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_DictionaryIndexer_Get()
         {
             var result = CompileBinding("Dictionary[1]", typeof(TestViewModel5));
-            Assert.AreEqual("dotvvm.translations.dictionaryHelper.getItem(Dictionary(),1)", result);
+            Assert.AreEqual("dotvvm.translations.dictionary.getItem(Dictionary(),1)", result);
         }
 
         [TestMethod]
         public void JsTranslator_DictionaryIndexer_Set()
         {
             var result = CompileBinding("Dictionary[1] = 123", new[] { typeof(TestViewModel5) }, typeof(void));
-            Assert.AreEqual("dotvvm.translations.dictionaryHelper.setItem(Dictionary,1,123)", result);
+            Assert.AreEqual("dotvvm.translations.dictionary.setItem(Dictionary,1,123)", result);
         }
 
         [TestMethod]
         public void JsTranslator_DictionaryClear()
         {
             var result = CompileBinding("Dictionary.Clear()", new[] { typeof(TestViewModel5) }, typeof(void));
-            Assert.AreEqual("dotvvm.translations.dictionaryHelper.clear(Dictionary)", result);
+            Assert.AreEqual("dotvvm.translations.dictionary.clear(Dictionary)", result);
         }
 
         [TestMethod]
         public void JsTranslator_DictionaryContainsKey()
         {
             var result = CompileBinding("Dictionary.ContainsKey(123)", new[] { typeof(TestViewModel5) }, typeof(bool));
-            Assert.AreEqual("dotvvm.translations.dictionaryHelper.containsKey(Dictionary(),123)", result);
+            Assert.AreEqual("dotvvm.translations.dictionary.containsKey(Dictionary(),123)", result);
         }
 
         [TestMethod]
         public void JsTranslator_DictionaryRemove()
         {
             var result = CompileBinding("Dictionary.Remove(123)", new[] { typeof(TestViewModel5) }, typeof(bool));
-            Assert.AreEqual("dotvvm.translations.dictionaryHelper.remove(Dictionary,123)", result);
+            Assert.AreEqual("dotvvm.translations.dictionary.remove(Dictionary,123)", result);
         }
 
         [TestMethod]
@@ -477,21 +477,21 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_ListAdd()
         {
             var result = CompileBinding("LongList.Add(11)", new[] { typeof(TestViewModel) }, typeof(void), null);
-            Assert.AreEqual("dotvvm.translations.arrayHelper.add(LongList,11)", result);
+            Assert.AreEqual("dotvvm.translations.array.add(LongList,11)", result);
         }
 
         [TestMethod]
         public void JsTranslator_ListAddOrUpdate()
         {
             var result = CompileBinding("LongList.AddOrUpdate(12345L, (long item) => item == 12345, (long item) => 54321L)", new[] { typeof(TestViewModel) }, typeof(void), new[] { new NamespaceImport("DotVVM.Framework.Binding.HelperNamespace") });
-            Assert.AreEqual("dotvvm.translations.arrayHelper.addOrUpdate(LongList,12345,function(item){return ko.unwrap(item)==12345;},function(item){return 54321;})", result);
+            Assert.AreEqual("dotvvm.translations.array.addOrUpdate(LongList,12345,function(item){return ko.unwrap(item)==12345;},function(item){return 54321;})", result);
         }
 
         [TestMethod]
         public void JsTranslator_ListAddRange()
         {
             var result = CompileBinding("LongList.AddRange(LongArray)", new[] { typeof(TestViewModel) }, typeof(void), null);
-            Assert.AreEqual("dotvvm.translations.arrayHelper.addRange(LongList,LongArray())", result);
+            Assert.AreEqual("dotvvm.translations.array.addRange(LongList,LongArray())", result);
         }
 
         [TestMethod]
@@ -516,7 +516,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_ListClear()
         {
             var result = CompileBinding("LongList.Clear()", new[] { typeof(TestViewModel) }, typeof(void), null);
-            Assert.AreEqual("dotvvm.translations.arrayHelper.clear(LongList)", result);
+            Assert.AreEqual("dotvvm.translations.array.clear(LongList)", result);
         }
 
         [TestMethod]
@@ -525,7 +525,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableFirstOrDefault(string binding)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
-            Assert.AreEqual("dotvvm.translations.arrayHelper.firstOrDefault(LongArray(),function(arg){return true;})", result);
+            Assert.AreEqual("dotvvm.translations.array.firstOrDefault(LongArray(),function(arg){return true;})", result);
         }
 
         [TestMethod]
@@ -534,21 +534,21 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableFirstOrDefaultParametrized(string binding)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
-            Assert.AreEqual("dotvvm.translations.arrayHelper.firstOrDefault(LongArray(),function(item){return ko.unwrap(item)>0;})", result);
+            Assert.AreEqual("dotvvm.translations.array.firstOrDefault(LongArray(),function(item){return ko.unwrap(item)>0;})", result);
         }
 
         [TestMethod]
         public void JsTranslator_ListInsert()
         {
             var result = CompileBinding("LongList.Insert(1, 12345)", new[] { typeof(TestViewModel) }, typeof(void), null);
-            Assert.AreEqual("dotvvm.translations.arrayHelper.insert(LongList,1,12345)", result);
+            Assert.AreEqual("dotvvm.translations.array.insert(LongList,1,12345)", result);
         }
 
         [TestMethod]
         public void JsTranslator_ListInsertRange()
         {
             var result = CompileBinding("LongList.InsertRange(1, LongArray)", new[] { typeof(TestViewModel) }, typeof(void), null);
-            Assert.AreEqual("dotvvm.translations.arrayHelper.insertRange(LongList,1,LongArray())", result);
+            Assert.AreEqual("dotvvm.translations.array.insertRange(LongList,1,LongArray())", result);
         }
 
         [TestMethod]
@@ -557,7 +557,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableLastOrDefault(string binding)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
-            Assert.AreEqual("dotvvm.translations.arrayHelper.lastOrDefault(LongArray(),function(arg){return true;})", result);
+            Assert.AreEqual("dotvvm.translations.array.lastOrDefault(LongArray(),function(arg){return true;})", result);
         }
 
         [TestMethod]
@@ -566,7 +566,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableLastOrDefaultParametrized(string binding)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
-            Assert.AreEqual("dotvvm.translations.arrayHelper.lastOrDefault(LongArray(),function(item){return ko.unwrap(item)>0;})", result);
+            Assert.AreEqual("dotvvm.translations.array.lastOrDefault(LongArray(),function(item){return ko.unwrap(item)>0;})", result);
         }
 
         [TestMethod]
@@ -602,7 +602,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableMax(string binding, string property, bool nullable)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestArraysViewModel) });
-            Assert.AreEqual($"dotvvm.translations.arrayHelper.max({property}(),function(arg){{return ko.unwrap(arg);}},{(!nullable).ToString().ToLower()})", result);
+            Assert.AreEqual($"dotvvm.translations.array.max({property}(),function(arg){{return ko.unwrap(arg);}},{(!nullable).ToString().ToLower()})", result);
         }
 
         [TestMethod]
@@ -629,7 +629,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableMax_WithSelector(string binding, string property, bool nullable)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestArraysViewModel) });
-            Assert.AreEqual($"dotvvm.translations.arrayHelper.max({property}(),function(item){{return -ko.unwrap(item);}},{(!nullable).ToString().ToLower()})", result);
+            Assert.AreEqual($"dotvvm.translations.array.max({property}(),function(item){{return -ko.unwrap(item);}},{(!nullable).ToString().ToLower()})", result);
         }
 
         [TestMethod]
@@ -656,7 +656,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableMin(string binding, string property, bool nullable)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestArraysViewModel) });
-            Assert.AreEqual($"dotvvm.translations.arrayHelper.min({property}(),function(arg){{return ko.unwrap(arg);}},{(!nullable).ToString().ToLower()})", result);
+            Assert.AreEqual($"dotvvm.translations.array.min({property}(),function(arg){{return ko.unwrap(arg);}},{(!nullable).ToString().ToLower()})", result);
         }
 
         [TestMethod]
@@ -683,7 +683,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableMin_WithSelector(string binding, string property, bool nullable)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestArraysViewModel) });
-            Assert.AreEqual($"dotvvm.translations.arrayHelper.min({property}(),function(item){{return -ko.unwrap(item);}},{(!nullable).ToString().ToLower()})", result);
+            Assert.AreEqual($"dotvvm.translations.array.min({property}(),function(item){{return -ko.unwrap(item);}},{(!nullable).ToString().ToLower()})", result);
         }
 
         [TestMethod]
@@ -699,7 +699,7 @@ namespace DotVVM.Framework.Tests.Binding
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestArraysViewModel) });
             var typeHash = (comparedType.IsEnum) ? $"\"{comparedType.GetTypeHash()}\"" : "null";
-            Assert.AreEqual($"dotvvm.translations.arrayHelper.orderBy(ObjectArray(),function(item){{return ko.unwrap(item).{key}();}},{typeHash})", result);
+            Assert.AreEqual($"dotvvm.translations.array.orderBy(ObjectArray(),function(item){{return ko.unwrap(item).{key}();}},{typeHash})", result);
         }
 
         [TestMethod]
@@ -724,7 +724,7 @@ namespace DotVVM.Framework.Tests.Binding
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestArraysViewModel) });
             var typeHash = (comparedType.IsEnum) ? $"\"{comparedType.GetTypeHash()}\"" : "null";
-            Assert.AreEqual($"dotvvm.translations.arrayHelper.orderByDesc(ObjectArray(),function(item){{return ko.unwrap(item).{key}();}},{typeHash})", result);
+            Assert.AreEqual($"dotvvm.translations.array.orderByDesc(ObjectArray(),function(item){{return ko.unwrap(item).{key}();}},{typeHash})", result);
         }
 
         [TestMethod]
@@ -740,35 +740,35 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_ListRemoveAt()
         {
             var result = CompileBinding("LongList.RemoveAt(1)", new[] { typeof(TestViewModel) }, typeof(void), null);
-            Assert.AreEqual("dotvvm.translations.arrayHelper.removeAt(LongList,1)", result);
+            Assert.AreEqual("dotvvm.translations.array.removeAt(LongList,1)", result);
         }
 
         [TestMethod]
         public void JsTranslator_ListRemoveFirst()
         {
             var result = CompileBinding("LongList.RemoveFirst((long item) => item == 2)", new[] { typeof(TestViewModel) }, typeof(void), new[] { new NamespaceImport("DotVVM.Framework.Binding.HelperNamespace") });
-            Assert.AreEqual("dotvvm.translations.arrayHelper.removeFirst(LongList,function(item){return ko.unwrap(item)==2;})", result);
+            Assert.AreEqual("dotvvm.translations.array.removeFirst(LongList,function(item){return ko.unwrap(item)==2;})", result);
         }
 
         [TestMethod]
         public void JsTranslator_ListRemoveLast()
         {
             var result = CompileBinding("LongList.RemoveLast((long item) => item == 2)", new[] { typeof(TestViewModel) }, typeof(void), new[] { new NamespaceImport("DotVVM.Framework.Binding.HelperNamespace") });
-            Assert.AreEqual("dotvvm.translations.arrayHelper.removeLast(LongList,function(item){return ko.unwrap(item)==2;})", result);
+            Assert.AreEqual("dotvvm.translations.array.removeLast(LongList,function(item){return ko.unwrap(item)==2;})", result);
         }
 
         [TestMethod]
         public void JsTranslator_ListRemoveRange()
         {
             var result = CompileBinding("LongList.RemoveRange(1, 5)", new[] { typeof(TestViewModel) }, typeof(void), null);
-            Assert.AreEqual("dotvvm.translations.arrayHelper.removeRange(LongList,1,5)", result);
+            Assert.AreEqual("dotvvm.translations.array.removeRange(LongList,1,5)", result);
         }
 
         [TestMethod]
         public void JsTranslator_ListReverse()
         {
             var result = CompileBinding("LongList.Reverse()", new[] { typeof(TestViewModel) }, typeof(void), null);
-            Assert.AreEqual("dotvvm.translations.arrayHelper.reverse(LongList)", result);
+            Assert.AreEqual("dotvvm.translations.array.reverse(LongList)", result);
         }
 
         [TestMethod]
@@ -810,7 +810,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_StringSplit_WithOptions(string binding, string delimiter, string options)
         {
             var result = CompileBinding(binding, new[] { typeof(TestViewModel) });
-            Assert.AreEqual($"dotvvm.translations.stringHelper.split(StringProp(),\"{delimiter}\",\"{options}\")", result);
+            Assert.AreEqual($"dotvvm.translations.string.split(StringProp(),\"{delimiter}\",\"{options}\")", result);
         }
 
         [TestMethod]

--- a/src/DotVVM.Framework.Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests/Binding/JavascriptCompilationTests.cs
@@ -389,35 +389,35 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_DictionaryIndexer_Get()
         {
             var result = CompileBinding("Dictionary[1]", typeof(TestViewModel5));
-            Assert.AreEqual("dotvvm.dictionaryHelper.getItem(Dictionary(),1)", result);
+            Assert.AreEqual("dotvvm.translations.dictionaryHelper.getItem(Dictionary(),1)", result);
         }
 
         [TestMethod]
         public void JsTranslator_DictionaryIndexer_Set()
         {
             var result = CompileBinding("Dictionary[1] = 123", new[] { typeof(TestViewModel5) }, typeof(void));
-            Assert.AreEqual("dotvvm.dictionaryHelper.setItem(Dictionary,1,123)", result);
+            Assert.AreEqual("dotvvm.translations.dictionaryHelper.setItem(Dictionary,1,123)", result);
         }
 
         [TestMethod]
         public void JsTranslator_DictionaryClear()
         {
             var result = CompileBinding("Dictionary.Clear()", new[] { typeof(TestViewModel5) }, typeof(void));
-            Assert.AreEqual("dotvvm.dictionaryHelper.clear(Dictionary)", result);
+            Assert.AreEqual("dotvvm.translations.dictionaryHelper.clear(Dictionary)", result);
         }
 
         [TestMethod]
         public void JsTranslator_DictionaryContainsKey()
         {
             var result = CompileBinding("Dictionary.ContainsKey(123)", new[] { typeof(TestViewModel5) }, typeof(bool));
-            Assert.AreEqual("dotvvm.dictionaryHelper.containsKey(Dictionary(),123)", result);
+            Assert.AreEqual("dotvvm.translations.dictionaryHelper.containsKey(Dictionary(),123)", result);
         }
 
         [TestMethod]
         public void JsTranslator_DictionaryRemove()
         {
             var result = CompileBinding("Dictionary.Remove(123)", new[] { typeof(TestViewModel5) }, typeof(bool));
-            Assert.AreEqual("dotvvm.dictionaryHelper.remove(Dictionary,123)", result);
+            Assert.AreEqual("dotvvm.translations.dictionaryHelper.remove(Dictionary,123)", result);
         }
 
         [TestMethod]
@@ -477,21 +477,21 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_ListAdd()
         {
             var result = CompileBinding("LongList.Add(11)", new[] { typeof(TestViewModel) }, typeof(void), null);
-            Assert.AreEqual("dotvvm.arrayHelper.add(LongList,11)", result);
+            Assert.AreEqual("dotvvm.translations.arrayHelper.add(LongList,11)", result);
         }
 
         [TestMethod]
         public void JsTranslator_ListAddOrUpdate()
         {
             var result = CompileBinding("LongList.AddOrUpdate(12345L, (long item) => item == 12345, (long item) => 54321L)", new[] { typeof(TestViewModel) }, typeof(void), new[] { new NamespaceImport("DotVVM.Framework.Binding.HelperNamespace") });
-            Assert.AreEqual("dotvvm.arrayHelper.addOrUpdate(LongList,12345,function(item){return ko.unwrap(item)==12345;},function(item){return 54321;})", result);
+            Assert.AreEqual("dotvvm.translations.arrayHelper.addOrUpdate(LongList,12345,function(item){return ko.unwrap(item)==12345;},function(item){return 54321;})", result);
         }
 
         [TestMethod]
         public void JsTranslator_ListAddRange()
         {
             var result = CompileBinding("LongList.AddRange(LongArray)", new[] { typeof(TestViewModel) }, typeof(void), null);
-            Assert.AreEqual("dotvvm.arrayHelper.addRange(LongList,LongArray())", result);
+            Assert.AreEqual("dotvvm.translations.arrayHelper.addRange(LongList,LongArray())", result);
         }
 
         [TestMethod]
@@ -500,7 +500,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableAll(string binding)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
-            Assert.AreEqual("dotvvm.arrayHelper.all(LongArray(),function(item){return ko.unwrap(item)>0;})", result);
+            Assert.AreEqual("dotvvm.translations.arrayHelper.all(LongArray(),function(item){return ko.unwrap(item)>0;})", result);
         }
 
         [TestMethod]
@@ -509,14 +509,14 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableAny(string binding)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
-            Assert.AreEqual("dotvvm.arrayHelper.any(LongArray(),function(item){return ko.unwrap(item)>0;})", result);
+            Assert.AreEqual("dotvvm.translations.arrayHelper.any(LongArray(),function(item){return ko.unwrap(item)>0;})", result);
         }
 
         [TestMethod]
         public void JsTranslator_ListClear()
         {
             var result = CompileBinding("LongList.Clear()", new[] { typeof(TestViewModel) }, typeof(void), null);
-            Assert.AreEqual("dotvvm.arrayHelper.clear(LongList)", result);
+            Assert.AreEqual("dotvvm.translations.arrayHelper.clear(LongList)", result);
         }
 
         [TestMethod]
@@ -525,7 +525,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableFirstOrDefault(string binding)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
-            Assert.AreEqual("dotvvm.arrayHelper.firstOrDefault(LongArray(),function(arg){return true;})", result);
+            Assert.AreEqual("dotvvm.translations.arrayHelper.firstOrDefault(LongArray(),function(arg){return true;})", result);
         }
 
         [TestMethod]
@@ -534,21 +534,21 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableFirstOrDefaultParametrized(string binding)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
-            Assert.AreEqual("dotvvm.arrayHelper.firstOrDefault(LongArray(),function(item){return ko.unwrap(item)>0;})", result);
+            Assert.AreEqual("dotvvm.translations.arrayHelper.firstOrDefault(LongArray(),function(item){return ko.unwrap(item)>0;})", result);
         }
 
         [TestMethod]
         public void JsTranslator_ListInsert()
         {
             var result = CompileBinding("LongList.Insert(1, 12345)", new[] { typeof(TestViewModel) }, typeof(void), null);
-            Assert.AreEqual("dotvvm.arrayHelper.insert(LongList,1,12345)", result);
+            Assert.AreEqual("dotvvm.translations.arrayHelper.insert(LongList,1,12345)", result);
         }
 
         [TestMethod]
         public void JsTranslator_ListInsertRange()
         {
             var result = CompileBinding("LongList.InsertRange(1, LongArray)", new[] { typeof(TestViewModel) }, typeof(void), null);
-            Assert.AreEqual("dotvvm.arrayHelper.insertRange(LongList,1,LongArray())", result);
+            Assert.AreEqual("dotvvm.translations.arrayHelper.insertRange(LongList,1,LongArray())", result);
         }
 
         [TestMethod]
@@ -557,7 +557,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableLastOrDefault(string binding)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
-            Assert.AreEqual("dotvvm.arrayHelper.lastOrDefault(LongArray(),function(arg){return true;})", result);
+            Assert.AreEqual("dotvvm.translations.arrayHelper.lastOrDefault(LongArray(),function(arg){return true;})", result);
         }
 
         [TestMethod]
@@ -566,7 +566,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableLastOrDefaultParametrized(string binding)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
-            Assert.AreEqual("dotvvm.arrayHelper.lastOrDefault(LongArray(),function(item){return ko.unwrap(item)>0;})", result);
+            Assert.AreEqual("dotvvm.translations.arrayHelper.lastOrDefault(LongArray(),function(item){return ko.unwrap(item)>0;})", result);
         }
 
         [TestMethod]
@@ -602,7 +602,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableMax(string binding, string property, bool nullable)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestArraysViewModel) });
-            Assert.AreEqual($"dotvvm.arrayHelper.max({property}(),function(arg){{return ko.unwrap(arg);}},{(!nullable).ToString().ToLower()})", result);
+            Assert.AreEqual($"dotvvm.translations.arrayHelper.max({property}(),function(arg){{return ko.unwrap(arg);}},{(!nullable).ToString().ToLower()})", result);
         }
 
         [TestMethod]
@@ -629,7 +629,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableMax_WithSelector(string binding, string property, bool nullable)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestArraysViewModel) });
-            Assert.AreEqual($"dotvvm.arrayHelper.max({property}(),function(item){{return -ko.unwrap(item);}},{(!nullable).ToString().ToLower()})", result);
+            Assert.AreEqual($"dotvvm.translations.arrayHelper.max({property}(),function(item){{return -ko.unwrap(item);}},{(!nullable).ToString().ToLower()})", result);
         }
 
         [TestMethod]
@@ -656,7 +656,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableMin(string binding, string property, bool nullable)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestArraysViewModel) });
-            Assert.AreEqual($"dotvvm.arrayHelper.min({property}(),function(arg){{return ko.unwrap(arg);}},{(!nullable).ToString().ToLower()})", result);
+            Assert.AreEqual($"dotvvm.translations.arrayHelper.min({property}(),function(arg){{return ko.unwrap(arg);}},{(!nullable).ToString().ToLower()})", result);
         }
 
         [TestMethod]
@@ -683,7 +683,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableMin_WithSelector(string binding, string property, bool nullable)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestArraysViewModel) });
-            Assert.AreEqual($"dotvvm.arrayHelper.min({property}(),function(item){{return -ko.unwrap(item);}},{(!nullable).ToString().ToLower()})", result);
+            Assert.AreEqual($"dotvvm.translations.arrayHelper.min({property}(),function(item){{return -ko.unwrap(item);}},{(!nullable).ToString().ToLower()})", result);
         }
 
         [TestMethod]
@@ -699,7 +699,7 @@ namespace DotVVM.Framework.Tests.Binding
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestArraysViewModel) });
             var typeHash = (comparedType.IsEnum) ? $"\"{comparedType.GetTypeHash()}\"" : "null";
-            Assert.AreEqual($"dotvvm.arrayHelper.orderBy(ObjectArray(),function(item){{return ko.unwrap(item).{key}();}},{typeHash})", result);
+            Assert.AreEqual($"dotvvm.translations.arrayHelper.orderBy(ObjectArray(),function(item){{return ko.unwrap(item).{key}();}},{typeHash})", result);
         }
 
         [TestMethod]
@@ -724,7 +724,7 @@ namespace DotVVM.Framework.Tests.Binding
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestArraysViewModel) });
             var typeHash = (comparedType.IsEnum) ? $"\"{comparedType.GetTypeHash()}\"" : "null";
-            Assert.AreEqual($"dotvvm.arrayHelper.orderByDesc(ObjectArray(),function(item){{return ko.unwrap(item).{key}();}},{typeHash})", result);
+            Assert.AreEqual($"dotvvm.translations.arrayHelper.orderByDesc(ObjectArray(),function(item){{return ko.unwrap(item).{key}();}},{typeHash})", result);
         }
 
         [TestMethod]
@@ -740,35 +740,35 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_ListRemoveAt()
         {
             var result = CompileBinding("LongList.RemoveAt(1)", new[] { typeof(TestViewModel) }, typeof(void), null);
-            Assert.AreEqual("dotvvm.arrayHelper.removeAt(LongList,1)", result);
+            Assert.AreEqual("dotvvm.translations.arrayHelper.removeAt(LongList,1)", result);
         }
 
         [TestMethod]
         public void JsTranslator_ListRemoveFirst()
         {
             var result = CompileBinding("LongList.RemoveFirst((long item) => item == 2)", new[] { typeof(TestViewModel) }, typeof(void), new[] { new NamespaceImport("DotVVM.Framework.Binding.HelperNamespace") });
-            Assert.AreEqual("dotvvm.arrayHelper.removeFirst(LongList,function(item){return ko.unwrap(item)==2;})", result);
+            Assert.AreEqual("dotvvm.translations.arrayHelper.removeFirst(LongList,function(item){return ko.unwrap(item)==2;})", result);
         }
 
         [TestMethod]
         public void JsTranslator_ListRemoveLast()
         {
             var result = CompileBinding("LongList.RemoveLast((long item) => item == 2)", new[] { typeof(TestViewModel) }, typeof(void), new[] { new NamespaceImport("DotVVM.Framework.Binding.HelperNamespace") });
-            Assert.AreEqual("dotvvm.arrayHelper.removeLast(LongList,function(item){return ko.unwrap(item)==2;})", result);
+            Assert.AreEqual("dotvvm.translations.arrayHelper.removeLast(LongList,function(item){return ko.unwrap(item)==2;})", result);
         }
 
         [TestMethod]
         public void JsTranslator_ListRemoveRange()
         {
             var result = CompileBinding("LongList.RemoveRange(1, 5)", new[] { typeof(TestViewModel) }, typeof(void), null);
-            Assert.AreEqual("dotvvm.arrayHelper.removeRange(LongList,1,5)", result);
+            Assert.AreEqual("dotvvm.translations.arrayHelper.removeRange(LongList,1,5)", result);
         }
 
         [TestMethod]
         public void JsTranslator_ListReverse()
         {
             var result = CompileBinding("LongList.Reverse()", new[] { typeof(TestViewModel) }, typeof(void), null);
-            Assert.AreEqual("dotvvm.arrayHelper.reverse(LongList)", result);
+            Assert.AreEqual("dotvvm.translations.arrayHelper.reverse(LongList)", result);
         }
 
         [TestMethod]
@@ -810,7 +810,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_StringSplit_WithOptions(string binding, string delimiter, string options)
         {
             var result = CompileBinding(binding, new[] { typeof(TestViewModel) });
-            Assert.AreEqual($"dotvvm.stringHelper.split(StringProp(),\"{delimiter}\",\"{options}\")", result);
+            Assert.AreEqual($"dotvvm.translations.stringHelper.split(StringProp(),\"{delimiter}\",\"{options}\")", result);
         }
 
         [TestMethod]

--- a/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -122,9 +122,9 @@ namespace DotVVM.Framework.Compilation.Javascript
             JsExpression listIndexer(JsExpression[] args, MethodInfo method) =>
                 BuildIndexer(args[0], args[1], method.DeclaringType.GetProperty("Item"));
             JsExpression dictionaryGetIndexer(JsExpression[] args, MethodInfo method) =>
-                new JsIdentifierExpression("dotvvm").Member("dictionaryHelper").Member("getItem").Invoke(args[0], args[1]);
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("dictionaryHelper").Member("getItem").Invoke(args[0], args[1]);
             JsExpression dictionarySetIndexer(JsExpression[] args, MethodInfo method) =>
-                new JsIdentifierExpression("dotvvm").Member("dictionaryHelper").Member("setItem").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1], args[2]);
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("dictionaryHelper").Member("setItem").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1], args[2]);
 
             AddMethodTranslator(typeof(IList), "get_Item", new GenericMethodCompiler(listIndexer));
             AddMethodTranslator(typeof(IList<>), "get_Item", new GenericMethodCompiler(listIndexer));
@@ -259,8 +259,8 @@ namespace DotVVM.Framework.Compilation.Javascript
 
             var splitMethod = typeof(string).GetMethods(BindingFlags.Public | BindingFlags.Instance).SingleOrDefault(m => m.Name == nameof(string.Split)
                 && m.GetParameters().Length == 2 && m.GetParameters()[0].ParameterType == typeof(string) && m.GetParameters()[1].ParameterType == typeof(StringSplitOptions));
-            var genericSplitCompiler = new GenericMethodCompiler(args => new JsIdentifierExpression("dotvvm").Member("stringHelper").Member("split").Invoke(args[0], args[1], args[2]));
-            var genericExtensionSplitCompiler = new GenericMethodCompiler(args => new JsIdentifierExpression("dotvvm").Member("stringHelper").Member("split").Invoke(args[1], args[2], args[3]));
+            var genericSplitCompiler = new GenericMethodCompiler(args => new JsIdentifierExpression("dotvvm").Member("translations").Member("stringHelper").Member("split").Invoke(args[0], args[1], args[2]));
+            var genericExtensionSplitCompiler = new GenericMethodCompiler(args => new JsIdentifierExpression("dotvvm").Member("translations").Member("stringHelper").Member("split").Invoke(args[1], args[2], args[3]));
             if (splitMethod == null)
             {
                 // Some overloads are not available in .NET Framework, therefore we substitute some with custom extensions
@@ -369,52 +369,52 @@ namespace DotVVM.Framework.Compilation.Javascript
                 => type.GetGenericArguments().Last().GetTypeHash();
 
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.All), parameterCount: 2, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("all").Invoke(args[1], args[2])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("all").Invoke(args[1], args[2])));
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.Any), parameterCount: 1, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("any").Invoke(args[1], returnTrueFunc.Clone())));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("any").Invoke(args[1], returnTrueFunc.Clone())));
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.Any), parameterCount: 2, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("any").Invoke(args[1], args[2])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("any").Invoke(args[1], args[2])));
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.Concat), parameterCount: 2, translator: new GenericMethodCompiler(args => args[1].Member("concat").Invoke(args[2])));
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.Count), parameterCount: 1, translator: new GenericMethodCompiler(args => args[1].Member("length")));
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.Distinct), parameterCount: 1,
-                translator: new GenericMethodCompiler(args => new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("distinct").Invoke(args[1]),
+                translator: new GenericMethodCompiler(args => new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("distinct").Invoke(args[1]),
                 check: (method, target, arguments) => EnsureIsComparableInJavascript(method, target?.Type ?? ReflectionUtils.GetEnumerableType(arguments.First().Type))));
 
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.ElementAt), parameterCount: 2, parameterFilter: p => p[1].ParameterType == typeof(int),
                 translator: new GenericMethodCompiler((args, method) => BuildIndexer(args[1], args[2], method)));
 
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.FirstOrDefault), parameterCount: 1, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("firstOrDefault").Invoke(args[1], returnTrueFunc.Clone()).WithAnnotation(ResultIsObservableAnnotation.Instance)));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("firstOrDefault").Invoke(args[1], returnTrueFunc.Clone()).WithAnnotation(ResultIsObservableAnnotation.Instance)));
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.FirstOrDefault), parameterCount: 2, parameterFilter: p => p[1].ParameterType.IsGenericType && p[1].ParameterType.GetGenericTypeDefinition() == typeof(Func<,>), translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("firstOrDefault").Invoke(args[1], args[2]).WithAnnotation(ResultIsObservableAnnotation.Instance)));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("firstOrDefault").Invoke(args[1], args[2]).WithAnnotation(ResultIsObservableAnnotation.Instance)));
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.LastOrDefault), parameterCount: 1, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("lastOrDefault").Invoke(args[1], returnTrueFunc.Clone()).WithAnnotation(ResultIsObservableAnnotation.Instance)));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("lastOrDefault").Invoke(args[1], returnTrueFunc.Clone()).WithAnnotation(ResultIsObservableAnnotation.Instance)));
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.LastOrDefault), parameterCount: 2, parameterFilter: p => p[1].ParameterType.IsGenericType && p[1].ParameterType.GetGenericTypeDefinition() == typeof(Func<,>), translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("lastOrDefault").Invoke(args[1], args[2]).WithAnnotation(ResultIsObservableAnnotation.Instance)));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("lastOrDefault").Invoke(args[1], args[2]).WithAnnotation(ResultIsObservableAnnotation.Instance)));
 
             foreach (var type in new[] { typeof(int), typeof(long), typeof(float), typeof(double), typeof(decimal), typeof(int?), typeof(long?), typeof(float?), typeof(double?), typeof(decimal?) })
             {
                 AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.Max), parameters: new[] { typeof(IEnumerable<>).MakeGenericType(type) }, translator: new GenericMethodCompiler(args =>
-                    new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("max").Invoke(args[1], selectIdentityFunc.Clone(), new JsLiteral(!type.IsNullable()))));
+                    new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("max").Invoke(args[1], selectIdentityFunc.Clone(), new JsLiteral(!type.IsNullable()))));
                 var maxSelect = typeof(Enumerable).GetMethods(BindingFlags.Public | BindingFlags.Static)
                     .Where(m => m.Name == nameof(Enumerable.Max) && m.GetParameters().Length == 2 && m.GetParameters().Last().ParameterType.GetGenericArguments().Last() == type).Single();
                 AddMethodTranslator(maxSelect, translator: new GenericMethodCompiler(args =>
-                    new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("max").Invoke(args[1], args[2], new JsLiteral(!type.IsNullable()))));
+                    new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("max").Invoke(args[1], args[2], new JsLiteral(!type.IsNullable()))));
 
                 AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.Min), parameters: new[] { typeof(IEnumerable<>).MakeGenericType(type) }, translator: new GenericMethodCompiler(args =>
-                    new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("min").Invoke(args[1], selectIdentityFunc.Clone(), new JsLiteral(!type.IsNullable()))));
+                    new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("min").Invoke(args[1], selectIdentityFunc.Clone(), new JsLiteral(!type.IsNullable()))));
                 var minSelect = typeof(Enumerable).GetMethods(BindingFlags.Public | BindingFlags.Static)
                     .Where(m => m.Name == nameof(Enumerable.Min) && m.GetParameters().Length == 2 && m.GetParameters().Last().ParameterType.GetGenericArguments().Last() == type).Single();
                 AddMethodTranslator(minSelect, translator: new GenericMethodCompiler(args =>
-                    new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("min").Invoke(args[1], args[2], new JsLiteral(!type.IsNullable()))));
+                    new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("min").Invoke(args[1], args[2], new JsLiteral(!type.IsNullable()))));
             }
 
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.OrderBy), parameterCount: 2,
-                translator: new GenericMethodCompiler((jArgs, dArgs) => new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("orderBy")
+                translator: new GenericMethodCompiler((jArgs, dArgs) => new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("orderBy")
                     .Invoke(jArgs[1], jArgs[2], new JsLiteral((IsDelegateReturnTypeEnum(dArgs.Last().Type)) ? GetDelegateReturnTypeHash(dArgs.Last().Type) : null)),
                 check: (method, _, arguments) => EnsureIsComparableInJavascript(method, arguments.Last().Type.GetGenericArguments().Last())));
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.OrderByDescending), parameterCount: 2,
-                translator: new GenericMethodCompiler((jArgs, dArgs) => new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("orderByDesc")
+                translator: new GenericMethodCompiler((jArgs, dArgs) => new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("orderByDesc")
                     .Invoke(jArgs[1], jArgs[2], new JsLiteral((IsDelegateReturnTypeEnum(dArgs.Last().Type)) ? GetDelegateReturnTypeHash(dArgs.Last().Type) : null)),
                 check: (method, _, arguments) => EnsureIsComparableInJavascript(method, arguments.Last().Type.GetGenericArguments().Last())));
 
@@ -436,41 +436,41 @@ namespace DotVVM.Framework.Compilation.Javascript
         private void AddDefaultDictionaryTranslations()
         {
             AddMethodTranslator(typeof(Dictionary<,>), "Clear", parameterCount: 0, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("dictionaryHelper").Member("clear").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance))));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("dictionaryHelper").Member("clear").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance))));
             AddMethodTranslator(typeof(Dictionary<,>), "ContainsKey", parameterCount: 1, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("dictionaryHelper").Member("containsKey").Invoke(args[0], args[1])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("dictionaryHelper").Member("containsKey").Invoke(args[0], args[1])));
             AddMethodTranslator(typeof(Dictionary<,>), "Remove", parameterCount: 1, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("dictionaryHelper").Member("remove").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("dictionaryHelper").Member("remove").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1])));
         }
 
         private void AddDefaultListTranslations()
         {
             AddMethodTranslator(typeof(List<>), "Add", parameterCount: 1, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("add").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("add").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1])));
             AddMethodTranslator(typeof(List<>), "AddRange", parameterCount: 1, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("addRange").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("addRange").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1])));
             AddMethodTranslator(typeof(List<>), "Clear", parameterCount: 0, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("clear").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance))));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("clear").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance))));
             AddMethodTranslator(typeof(List<>), "Insert", parameterCount: 2, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("insert").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1], args[2])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("insert").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1], args[2])));
             AddMethodTranslator(typeof(List<>), "InsertRange", parameterCount: 2, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("insertRange").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1], args[2])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("insertRange").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1], args[2])));
             AddMethodTranslator(typeof(List<>), "RemoveAt", parameterCount: 1, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("removeAt").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("removeAt").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1])));
             AddMethodTranslator(typeof(List<>), "RemoveAll", parameterCount: 1, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("removeAll").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("removeAll").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1])));
             AddMethodTranslator(typeof(List<>), "RemoveRange", parameterCount: 2, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("removeRange").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1], args[2])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("removeRange").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1], args[2])));
             AddMethodTranslator(typeof(List<>), "Reverse", parameterCount: 0, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("reverse").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance))));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("reverse").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance))));
 
             // DotVVM list extensions:
             AddMethodTranslator(typeof(ListExtensions), "AddOrUpdate", parameterCount: 4, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("addOrUpdate").Invoke(args[1].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[2], args[3], args[4])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("addOrUpdate").Invoke(args[1].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[2], args[3], args[4])));
             AddMethodTranslator(typeof(ListExtensions), "RemoveFirst", parameterCount: 2, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("removeFirst").Invoke(args[1].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[2])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("removeFirst").Invoke(args[1].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[2])));
             AddMethodTranslator(typeof(ListExtensions), "RemoveLast", parameterCount: 2, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("arrayHelper").Member("removeLast").Invoke(args[1].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[2])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("removeLast").Invoke(args[1].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[2])));
         }
 
         public JsExpression TryTranslateCall(LazyTranslatedExpression context, LazyTranslatedExpression[] args, MethodInfo method)

--- a/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -122,9 +122,9 @@ namespace DotVVM.Framework.Compilation.Javascript
             JsExpression listIndexer(JsExpression[] args, MethodInfo method) =>
                 BuildIndexer(args[0], args[1], method.DeclaringType.GetProperty("Item"));
             JsExpression dictionaryGetIndexer(JsExpression[] args, MethodInfo method) =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("dictionaryHelper").Member("getItem").Invoke(args[0], args[1]);
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("dictionary").Member("getItem").Invoke(args[0], args[1]);
             JsExpression dictionarySetIndexer(JsExpression[] args, MethodInfo method) =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("dictionaryHelper").Member("setItem").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1], args[2]);
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("dictionary").Member("setItem").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1], args[2]);
 
             AddMethodTranslator(typeof(IList), "get_Item", new GenericMethodCompiler(listIndexer));
             AddMethodTranslator(typeof(IList<>), "get_Item", new GenericMethodCompiler(listIndexer));
@@ -258,8 +258,8 @@ namespace DotVVM.Framework.Compilation.Javascript
 
             var splitMethod = typeof(string).GetMethods(BindingFlags.Public | BindingFlags.Instance).SingleOrDefault(m => m.Name == nameof(string.Split)
                 && m.GetParameters().Length == 2 && m.GetParameters()[0].ParameterType == typeof(string) && m.GetParameters()[1].ParameterType == typeof(StringSplitOptions));
-            var genericSplitCompiler = new GenericMethodCompiler(args => new JsIdentifierExpression("dotvvm").Member("translations").Member("stringHelper").Member("split").Invoke(args[0], args[1], args[2]));
-            var genericExtensionSplitCompiler = new GenericMethodCompiler(args => new JsIdentifierExpression("dotvvm").Member("translations").Member("stringHelper").Member("split").Invoke(args[1], args[2], args[3]));
+            var genericSplitCompiler = new GenericMethodCompiler(args => new JsIdentifierExpression("dotvvm").Member("translations").Member("string").Member("split").Invoke(args[0], args[1], args[2]));
+            var genericExtensionSplitCompiler = new GenericMethodCompiler(args => new JsIdentifierExpression("dotvvm").Member("translations").Member("string").Member("split").Invoke(args[1], args[2], args[3]));
             if (splitMethod == null)
             {
                 // Some overloads are not available in .NET Framework, therefore we substitute some with custom extensions
@@ -373,40 +373,40 @@ namespace DotVVM.Framework.Compilation.Javascript
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.Concat), parameterCount: 2, translator: new GenericMethodCompiler(args => args[1].Member("concat").Invoke(args[2])));
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.Count), parameterCount: 1, translator: new GenericMethodCompiler(args => args[1].Member("length")));
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.Distinct), parameterCount: 1,
-                translator: new GenericMethodCompiler(args => new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("distinct").Invoke(args[1]),
+                translator: new GenericMethodCompiler(args => new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("distinct").Invoke(args[1]),
                 check: (method, target, arguments) => EnsureIsComparableInJavascript(method, target?.Type ?? ReflectionUtils.GetEnumerableType(arguments.First().Type))));
 
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.ElementAt), parameterCount: 2, parameterFilter: p => p[1].ParameterType == typeof(int),
                 translator: new GenericMethodCompiler((args, method) => BuildIndexer(args[1], args[2], method)));
 
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.FirstOrDefault), parameterCount: 1, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("firstOrDefault").Invoke(args[1], returnTrueFunc.Clone()).WithAnnotation(ResultIsObservableAnnotation.Instance)));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("firstOrDefault").Invoke(args[1], returnTrueFunc.Clone()).WithAnnotation(ResultIsObservableAnnotation.Instance)));
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.FirstOrDefault), parameterCount: 2, parameterFilter: p => p[1].ParameterType.IsGenericType && p[1].ParameterType.GetGenericTypeDefinition() == typeof(Func<,>), translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("firstOrDefault").Invoke(args[1], args[2]).WithAnnotation(ResultIsObservableAnnotation.Instance)));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("firstOrDefault").Invoke(args[1], args[2]).WithAnnotation(ResultIsObservableAnnotation.Instance)));
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.LastOrDefault), parameterCount: 1, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("lastOrDefault").Invoke(args[1], returnTrueFunc.Clone()).WithAnnotation(ResultIsObservableAnnotation.Instance)));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("lastOrDefault").Invoke(args[1], returnTrueFunc.Clone()).WithAnnotation(ResultIsObservableAnnotation.Instance)));
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.LastOrDefault), parameterCount: 2, parameterFilter: p => p[1].ParameterType.IsGenericType && p[1].ParameterType.GetGenericTypeDefinition() == typeof(Func<,>), translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("lastOrDefault").Invoke(args[1], args[2]).WithAnnotation(ResultIsObservableAnnotation.Instance)));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("lastOrDefault").Invoke(args[1], args[2]).WithAnnotation(ResultIsObservableAnnotation.Instance)));
 
             foreach (var type in new[] { typeof(int), typeof(long), typeof(float), typeof(double), typeof(decimal), typeof(int?), typeof(long?), typeof(float?), typeof(double?), typeof(decimal?) })
             {
                 AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.Max), parameters: new[] { typeof(IEnumerable<>).MakeGenericType(type) }, translator: new GenericMethodCompiler(args =>
-                    new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("max").Invoke(args[1], selectIdentityFunc.Clone(), new JsLiteral(!type.IsNullable()))));
+                    new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("max").Invoke(args[1], selectIdentityFunc.Clone(), new JsLiteral(!type.IsNullable()))));
                 AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.Max), parameterCount: 2, parameterFilter: p => p[1].ParameterType.GetGenericArguments().Last() == type, translator: new GenericMethodCompiler(args =>
-                    new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("max").Invoke(args[1], args[2], new JsLiteral(!type.IsNullable()))));
+                    new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("max").Invoke(args[1], args[2], new JsLiteral(!type.IsNullable()))));
 
                 AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.Min), parameters: new[] { typeof(IEnumerable<>).MakeGenericType(type) }, translator: new GenericMethodCompiler(args =>
-                    new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("min").Invoke(args[1], selectIdentityFunc.Clone(), new JsLiteral(!type.IsNullable()))));
+                    new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("min").Invoke(args[1], selectIdentityFunc.Clone(), new JsLiteral(!type.IsNullable()))));
                 AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.Min), parameterCount: 2, parameterFilter: p => p[1].ParameterType.GetGenericArguments().Last() == type, translator: new GenericMethodCompiler(args =>
-                    new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("min").Invoke(args[1], args[2], new JsLiteral(!type.IsNullable()))));
+                    new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("min").Invoke(args[1], args[2], new JsLiteral(!type.IsNullable()))));
             }
 
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.OrderBy), parameterCount: 2,
-                translator: new GenericMethodCompiler((jArgs, dArgs) => new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("orderBy")
+                translator: new GenericMethodCompiler((jArgs, dArgs) => new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("orderBy")
                     .Invoke(jArgs[1], jArgs[2], new JsLiteral((IsDelegateReturnTypeEnum(dArgs.Last().Type)) ? GetDelegateReturnTypeHash(dArgs.Last().Type) : null)),
                 check: (method, _, arguments) => EnsureIsComparableInJavascript(method, arguments.Last().Type.GetGenericArguments().Last())));
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.OrderByDescending), parameterCount: 2,
-                translator: new GenericMethodCompiler((jArgs, dArgs) => new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("orderByDesc")
+                translator: new GenericMethodCompiler((jArgs, dArgs) => new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("orderByDesc")
                     .Invoke(jArgs[1], jArgs[2], new JsLiteral((IsDelegateReturnTypeEnum(dArgs.Last().Type)) ? GetDelegateReturnTypeHash(dArgs.Last().Type) : null)),
                 check: (method, _, arguments) => EnsureIsComparableInJavascript(method, arguments.Last().Type.GetGenericArguments().Last())));
 
@@ -426,41 +426,41 @@ namespace DotVVM.Framework.Compilation.Javascript
         private void AddDefaultDictionaryTranslations()
         {
             AddMethodTranslator(typeof(Dictionary<,>), "Clear", parameterCount: 0, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("dictionaryHelper").Member("clear").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance))));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("dictionary").Member("clear").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance))));
             AddMethodTranslator(typeof(Dictionary<,>), "ContainsKey", parameterCount: 1, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("dictionaryHelper").Member("containsKey").Invoke(args[0], args[1])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("dictionary").Member("containsKey").Invoke(args[0], args[1])));
             AddMethodTranslator(typeof(Dictionary<,>), "Remove", parameterCount: 1, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("dictionaryHelper").Member("remove").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("dictionary").Member("remove").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1])));
         }
 
         private void AddDefaultListTranslations()
         {
             AddMethodTranslator(typeof(List<>), "Add", parameterCount: 1, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("add").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("add").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1])));
             AddMethodTranslator(typeof(List<>), "AddRange", parameterCount: 1, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("addRange").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("addRange").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1])));
             AddMethodTranslator(typeof(List<>), "Clear", parameterCount: 0, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("clear").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance))));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("clear").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance))));
             AddMethodTranslator(typeof(List<>), "Insert", parameterCount: 2, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("insert").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1], args[2])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("insert").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1], args[2])));
             AddMethodTranslator(typeof(List<>), "InsertRange", parameterCount: 2, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("insertRange").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1], args[2])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("insertRange").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1], args[2])));
             AddMethodTranslator(typeof(List<>), "RemoveAt", parameterCount: 1, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("removeAt").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("removeAt").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1])));
             AddMethodTranslator(typeof(List<>), "RemoveAll", parameterCount: 1, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("removeAll").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("removeAll").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1])));
             AddMethodTranslator(typeof(List<>), "RemoveRange", parameterCount: 2, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("removeRange").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1], args[2])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("removeRange").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1], args[2])));
             AddMethodTranslator(typeof(List<>), "Reverse", parameterCount: 0, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("reverse").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance))));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("reverse").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance))));
 
             // DotVVM list extensions:
             AddMethodTranslator(typeof(ListExtensions), "AddOrUpdate", parameterCount: 4, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("addOrUpdate").Invoke(args[1].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[2], args[3], args[4])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("addOrUpdate").Invoke(args[1].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[2], args[3], args[4])));
             AddMethodTranslator(typeof(ListExtensions), "RemoveFirst", parameterCount: 2, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("removeFirst").Invoke(args[1].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[2])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("removeFirst").Invoke(args[1].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[2])));
             AddMethodTranslator(typeof(ListExtensions), "RemoveLast", parameterCount: 2, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("arrayHelper").Member("removeLast").Invoke(args[1].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[2])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("removeLast").Invoke(args[1].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[2])));
         }
 
         public JsExpression TryTranslateCall(LazyTranslatedExpression context, LazyTranslatedExpression[] args, MethodInfo method)

--- a/src/DotVVM.Framework/Resources/Scripts/dotvvm-root.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/dotvvm-root.ts
@@ -124,9 +124,11 @@ const dotvvmExports = {
         logPostBackScriptError,
         level
     },
-    arrayHelper,
-    dictionaryHelper,
-    stringHelper
+    translations: {
+        arrayHelper,
+        dictionaryHelper,
+        stringHelper
+    }
 }
 
 if (compileConstants.isSpa) {

--- a/src/DotVVM.Framework/Resources/Scripts/dotvvm-root.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/dotvvm-root.ts
@@ -24,11 +24,10 @@ import * as eventHub from './api/eventHub'
 import * as viewModuleManager from './viewModules/viewModuleManager'
 import { notifyModuleLoaded } from './postback/resourceLoader'
 import { logError, logWarning, logInfo, logInfoVerbose, level, logPostBackScriptError } from "./utils/logging"
-import { orderBy, orderByDesc } from './collections/sortingHelper'
 import * as metadataHelper from './metadata/metadataHelper'
-import * as arrayHelper from './collections/arrayHelper'
-import * as dictionaryHelper from './collections/dictionaryHelper'
-import * as stringHelper from './utils/stringHelper'
+import * as array from './collections/arrayHelper'
+import * as dictionary from './collections/dictionaryHelper'
+import * as string from './utils/stringHelper'
 
 if (compileConstants.nomodules) {
     addPolyfills()
@@ -125,10 +124,10 @@ const dotvvmExports = {
         level
     },
     translations: {
-        arrayHelper,
-        dictionaryHelper,
-        stringHelper
-    }
+        array,
+        dictionary,
+        string
+    } as any
 }
 
 if (compileConstants.isSpa) {


### PR DESCRIPTION
This PR introduces following changes:
- `arrayHelper`, `dictionaryHelper` and `stringHelper` were moved into `dotvvm.translations` and no longer pollute dotvvm root
- Registrations that previously required complex logic to select `MethodInfo` were rewritten using parameterFilter lambdas

#1009 should be merged first.