### PR TITLE
Fixed issue with assigning to arrays and lists

### DIFF
--- a/src/DotVVM.Framework.Tests/Binding/BindingCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests/Binding/BindingCompilationTests.cs
@@ -784,6 +784,22 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        public void BindingCompiler_ListIndexer_Get()
+        {
+            TestViewModel5 vm = new TestViewModel5();
+            var result = ExecuteBinding("List[1]", new[] { vm });
+            Assert.AreEqual(2, result);
+        }
+
+        [TestMethod]
+        public void BindingCompiler_ListIndexer_Set()
+        {
+            TestViewModel5 vm = new TestViewModel5();
+            ExecuteBinding("List[1] = 111", new[] { vm }, null, expectedType: typeof(void));
+            Assert.AreEqual(111, vm.List[1]);
+        }
+
+        [TestMethod]
         public void BindingCompiler_MultiBlockExpression_EnumAtEnd_CorrectResult()
         {
             TestViewModel vm = new TestViewModel { StringProp = "a" };
@@ -1041,6 +1057,9 @@ namespace DotVVM.Framework.Tests.Binding
             { 2, 22 },
             { 3, 33 }
         };
+
+        public List<int> List { get; set; } = new List<int>() { 1, 2, 3 };
+        public int[] Array { get; set; } = new int[] { 1, 2, 3 };
     }
 
     struct TestStruct

--- a/src/DotVVM.Framework.Tests/Binding/BindingCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests/Binding/BindingCompilationTests.cs
@@ -800,6 +800,22 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        public void BindingCompiler_ArrayElement_Get()
+        {
+            TestViewModel5 vm = new TestViewModel5();
+            var result = ExecuteBinding("Array[1]", new[] { vm });
+            Assert.AreEqual(2, result);
+        }
+
+        [TestMethod]
+        public void BindingCompiler_ArrayElement_Set()
+        {
+            TestViewModel5 vm = new TestViewModel5();
+            ExecuteBinding("Array[1] = 111", new[] { vm }, null, expectedType: typeof(void));
+            Assert.AreEqual(111, vm.Array[1]);
+        }
+
+        [TestMethod]
         public void BindingCompiler_MultiBlockExpression_EnumAtEnd_CorrectResult()
         {
             TestViewModel vm = new TestViewModel { StringProp = "a" };

--- a/src/DotVVM.Framework.Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests/Binding/JavascriptCompilationTests.cs
@@ -386,6 +386,20 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        public void JsTranslator_ArrayElement_Get()
+        {
+            var result = CompileBinding("Array[1]", typeof(TestViewModel5));
+            Assert.AreEqual("Array()[1]", result);
+        }
+
+        [TestMethod]
+        public void JsTranslator_ArrayElement_Set()
+        {
+            var result = CompileBinding("Array[1] = 123", new[] { typeof(TestViewModel5) }, typeof(void));
+            Assert.AreEqual("dotvvm.translations.array.setItem(Array,1,123)", result);
+        }
+
+        [TestMethod]
         public void JsTranslator_ListIndexer_Get()
         {
             var result = CompileBinding("List[1]", typeof(TestViewModel5));

--- a/src/DotVVM.Framework.Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests/Binding/JavascriptCompilationTests.cs
@@ -386,6 +386,20 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        public void JsTranslator_ListIndexer_Get()
+        {
+            var result = CompileBinding("List[1]", typeof(TestViewModel5));
+            Assert.AreEqual("List()[1]", result);
+        }
+
+        [TestMethod]
+        public void JsTranslator_ListIndexer_Set()
+        {
+            var result = CompileBinding("List[1] = 123", new[] { typeof(TestViewModel5) }, typeof(void));
+            Assert.AreEqual("dotvvm.translations.array.setItem(List,1,123)", result);
+        }
+
+        [TestMethod]
         public void JsTranslator_DictionaryIndexer_Get()
         {
             var result = CompileBinding("Dictionary[1]", typeof(TestViewModel5));

--- a/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -123,6 +123,8 @@ namespace DotVVM.Framework.Compilation.Javascript
                 BuildIndexer(args[0], args[1], method.DeclaringType.GetProperty("Item"));
             JsExpression listSetIndexer(JsExpression[] args, MethodInfo method) =>
                 new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("setItem").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1], args[2]);
+            JsExpression arrayElementSetter(JsExpression[] args, MethodInfo method) =>
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("setItem").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[2], args[1]);
             JsExpression dictionaryGetIndexer(JsExpression[] args, MethodInfo method) =>
                 new JsIdentifierExpression("dotvvm").Member("translations").Member("dictionary").Member("getItem").Invoke(args[0], args[1]);
             JsExpression dictionarySetIndexer(JsExpression[] args, MethodInfo method) =>
@@ -138,6 +140,7 @@ namespace DotVVM.Framework.Compilation.Javascript
             AddMethodTranslator(typeof(IDictionary<,>), "get_Item", new GenericMethodCompiler(dictionaryGetIndexer));
             AddMethodTranslator(typeof(Dictionary<,>), "set_Item", new GenericMethodCompiler(dictionarySetIndexer));
             AddMethodTranslator(typeof(IDictionary<,>), "set_Item", new GenericMethodCompiler(dictionarySetIndexer));
+            AddMethodTranslator(typeof(Array).GetMethod(nameof(Array.SetValue), new[] { typeof(object), typeof(int) }), new GenericMethodCompiler(arrayElementSetter));
             AddPropertyGetterTranslator(typeof(Nullable<>), "Value", new GenericMethodCompiler((JsExpression[] args, MethodInfo method) => args[0]));
             AddPropertyGetterTranslator(typeof(Nullable<>), "HasValue",
                 new GenericMethodCompiler(args => new JsBinaryExpression(args[0], BinaryOperatorType.NotEqual, new JsLiteral(null))));

--- a/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -119,19 +119,21 @@ namespace DotVVM.Framework.Compilation.Javascript
             AddPropertyGetterTranslator(typeof(string), nameof(string.Length), lengthMethod);
             AddMethodTranslator(typeof(Enums), "GetNames", new EnumGetNamesMethodTranslator(), 0);
 
-            JsExpression listIndexer(JsExpression[] args, MethodInfo method) =>
+            JsExpression listGetIndexer(JsExpression[] args, MethodInfo method) =>
                 BuildIndexer(args[0], args[1], method.DeclaringType.GetProperty("Item"));
+            JsExpression listSetIndexer(JsExpression[] args, MethodInfo method) =>
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("setItem").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1], args[2]);
             JsExpression dictionaryGetIndexer(JsExpression[] args, MethodInfo method) =>
                 new JsIdentifierExpression("dotvvm").Member("translations").Member("dictionary").Member("getItem").Invoke(args[0], args[1]);
             JsExpression dictionarySetIndexer(JsExpression[] args, MethodInfo method) =>
                 new JsIdentifierExpression("dotvvm").Member("translations").Member("dictionary").Member("setItem").Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[1], args[2]);
 
-            AddMethodTranslator(typeof(IList), "get_Item", new GenericMethodCompiler(listIndexer));
-            AddMethodTranslator(typeof(IList<>), "get_Item", new GenericMethodCompiler(listIndexer));
-            AddMethodTranslator(typeof(List<>), "get_Item", new GenericMethodCompiler(listIndexer));
-            AddMethodTranslator(typeof(IList), "set_Item", new GenericMethodCompiler(listIndexer));
-            AddMethodTranslator(typeof(IList<>), "set_Item", new GenericMethodCompiler(listIndexer));
-            AddMethodTranslator(typeof(List<>), "set_Item", new GenericMethodCompiler(listIndexer));
+            AddMethodTranslator(typeof(IList), "get_Item", new GenericMethodCompiler(listGetIndexer));
+            AddMethodTranslator(typeof(IList<>), "get_Item", new GenericMethodCompiler(listGetIndexer));
+            AddMethodTranslator(typeof(List<>), "get_Item", new GenericMethodCompiler(listGetIndexer));
+            AddMethodTranslator(typeof(IList), "set_Item", new GenericMethodCompiler(listSetIndexer));
+            AddMethodTranslator(typeof(IList<>), "set_Item", new GenericMethodCompiler(listSetIndexer));
+            AddMethodTranslator(typeof(List<>), "set_Item", new GenericMethodCompiler(listSetIndexer));
             AddMethodTranslator(typeof(Dictionary<,>), "get_Item", new GenericMethodCompiler(dictionaryGetIndexer));
             AddMethodTranslator(typeof(IDictionary<,>), "get_Item", new GenericMethodCompiler(dictionaryGetIndexer));
             AddMethodTranslator(typeof(Dictionary<,>), "set_Item", new GenericMethodCompiler(dictionarySetIndexer));

--- a/src/DotVVM.Framework/Resources/Scripts/collections/arrayHelper.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/collections/arrayHelper.ts
@@ -19,7 +19,8 @@ export {
     removeFirst,
     removeLast,
     removeRange,
-    reverse
+    reverse,
+    setItem
 }
 
 function add<T>(observable: any, element: T): void {
@@ -179,5 +180,14 @@ function removeLast<T>(observable: any, predicate: (s: T) => boolean): void {
 function reverse<T>(observable: any): void {
     let array = Array.from<T>(observable.state);
     array.reverse();
+    observable.setState(array);
+}
+
+function setItem<T>(observable: any, index: number, value: T): void {
+    let array = Array.from<T>(observable.state);
+    if (index < 0 || index >= array.length)
+        throw Error("Index out of range!");
+
+    array[index] = value;
     observable.setState(array);
 }

--- a/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
+++ b/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
@@ -58,6 +58,7 @@
     <None Remove="Views\FeatureSamples\CommandActionFilter\CommandActionFilter.dothtml" />
     <None Remove="Views\FeatureSamples\JavascriptTranslation\DictionaryIndexerTranslation.dothtml" />
     <None Remove="Views\FeatureSamples\JavascriptTranslation\GenericMethodTranslation.dothtml" />
+    <None Remove="Views\FeatureSamples\JavascriptTranslation\ListIndexerTranslation.dothtml" />
     <None Remove="Views\FeatureSamples\JavascriptTranslation\ListMethodTranslations.dothtml" />
     <None Remove="Views\FeatureSamples\JsDirectives\BasicSample.dothtml" />
     <None Remove="Views\FeatureSamples\LambdaExpressions\ClientSideFiltering.dothtml" />

--- a/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
+++ b/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
@@ -59,6 +59,7 @@
     <None Remove="Views\FeatureSamples\BindingVariables\StaticCommandVariablesWithService_Simple.dothtml" />
     <None Remove="Views\FeatureSamples\Caching\CachedValues.dothtml" />
     <None Remove="Views\FeatureSamples\CommandActionFilter\CommandActionFilter.dothtml" />
+    <None Remove="Views\FeatureSamples\JavascriptTranslation\ArrayTranslation.dothtml" />
     <None Remove="Views\FeatureSamples\JavascriptTranslation\DictionaryIndexerTranslation.dothtml" />
     <None Remove="Views\FeatureSamples\JavascriptTranslation\GenericMethodTranslation.dothtml" />
     <None Remove="Views\FeatureSamples\JavascriptTranslation\ListIndexerTranslation.dothtml" />

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/JavascriptTranslation/ArrayTranslationViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/JavascriptTranslation/ArrayTranslationViewModel.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.JavascriptTranslation
+{
+    public class ArrayTranslationViewModel : DotvvmViewModelBase
+    {
+        public string[] Array { get; set; } = new string[] { "value1", "value2", "value3" };
+
+        public int Index { get; set; }
+        public string Value { get; set; }
+    }
+}
+

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/JavascriptTranslation/ListIndexerTranslationViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/JavascriptTranslation/ListIndexerTranslationViewModel.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.JavascriptTranslation
+{
+    public class ListIndexerTranslationViewModel : DotvvmViewModelBase
+    {
+        public List<string> List { get; set; } = new List<string>() { "value1", "value2", "value3" };
+
+        public int Index { get; set; }
+        public string Value { get; set; }
+    }
+}
+

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/JavascriptTranslation/ArrayTranslation.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/JavascriptTranslation/ArrayTranslation.dothtml
@@ -1,0 +1,32 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.JavascriptTranslation.ArrayTranslationViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+
+    <h1>Array testing</h1>
+
+    <dot:Repeater DataSource="{value: Array}">
+        <p>
+            <span>INDEX: "{{value: _index}}"</span>
+            <span>VALUE: "{{value: _this}}"</span>
+        </p>
+    </dot:Repeater>
+
+    <h2>Operations</h2>
+    <p>
+        <span>INDEX:</span> <dot:TextBox data-ui="index" Text="{value: Index}" /> <br />
+        <span>VALUE:</span> <dot:TextBox data-ui="value" Text="{value: Value}" /> <br />
+    </p>
+
+    <dot:Button data-ui="set" Text="Set" Click="{staticCommand: Array[Index] = Value}" />
+
+</body>
+</html>
+
+

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/JavascriptTranslation/ListIndexerTranslation.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/JavascriptTranslation/ListIndexerTranslation.dothtml
@@ -1,0 +1,31 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.JavascriptTranslation.ListIndexerTranslationViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+    <h1>List testing</h1>
+
+    <dot:Repeater DataSource="{value: List}">
+        <p>
+            <span>INDEX: "{{value: _index}}"</span>
+            <span>VALUE: "{{value: _this}}"</span>
+        </p>
+    </dot:Repeater>
+
+    <h2>Operations</h2>
+    <p>
+        <span>INDEX:</span> <dot:TextBox data-ui="index" Text="{value: Index}" /> <br />
+        <span>VALUE:</span> <dot:TextBox data-ui="value" Text="{value: Value}" /> <br />
+    </p>
+
+    <dot:Button data-ui="set" Text="Set" Click="{staticCommand: List[Index] = Value}" />
+
+</body>
+</html>
+
+

--- a/src/DotVVM.Samples.Tests/Feature/ArrayTranslationTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/ArrayTranslationTests.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Samples.Tests.Base;
+using DotVVM.Testing.Abstractions;
+using Riganti.Selenium.Core;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DotVVM.Samples.Tests.Feature
+{
+    public class ArrayTranslationTests : AppSeleniumTest
+    {
+        [Fact]
+        public void Feature_ArrayTranslation_SetItem()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_JavascriptTranslation_ArrayTranslation);
+
+                // Set list index
+                var indexTextbox = browser.FindElements("input[data-ui=index]");
+                indexTextbox.FirstOrDefault().Clear().SendKeys("0");
+                // Set list value
+                var valueTextbox = browser.FindElements("input[data-ui=value]");
+                valueTextbox.FirstOrDefault().Clear().SendKeys("Hello world");
+                // Change element
+                var setButton = browser.FindElements("input[data-ui=set]");
+                setButton.FirstOrDefault().Click();
+
+                var spans = browser.FindElements("span");
+                AssertUI.TextEquals(spans.ElementAt(0), "INDEX: \"0\"");
+                AssertUI.TextEquals(spans.ElementAt(1), "VALUE: \"Hello world\"");
+            });
+        }
+
+        public ArrayTranslationTests(ITestOutputHelper output) : base(output)
+        {
+
+        }
+    }
+}

--- a/src/DotVVM.Samples.Tests/Feature/ListTranslationTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/ListTranslationTests.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Samples.Tests.Base;
+using DotVVM.Testing.Abstractions;
+using Riganti.Selenium.Core;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DotVVM.Samples.Tests.Feature
+{
+    public class ListTranslationTests : AppSeleniumTest
+    {
+        [Fact]
+        public void Feature_ListTranslation_SetItem()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_JavascriptTranslation_ListIndexerTranslation);
+
+                // Set list index
+                var indexTextbox = browser.FindElements("input[data-ui=index]");
+                indexTextbox.FirstOrDefault().Clear().SendKeys("0");
+                // Set list value
+                var valueTextbox = browser.FindElements("input[data-ui=value]");
+                valueTextbox.FirstOrDefault().Clear().SendKeys("Hello world");
+                // Change element
+                var setButton = browser.FindElements("input[data-ui=set]");
+                setButton.FirstOrDefault().Click();
+
+                var spans = browser.FindElements("span");
+                AssertUI.TextEquals(spans.ElementAt(0), "INDEX: \"0\"");
+                AssertUI.TextEquals(spans.ElementAt(1), "VALUE: \"Hello world\"");
+            });
+        }
+
+        public ListTranslationTests(ITestOutputHelper output) : base(output)
+        {
+
+        }
+    }
+}

--- a/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
@@ -167,8 +167,6 @@ namespace DotVVM.Testing.Abstractions
         public const string Errors_InvalidRouteName = "Errors/InvalidRouteName";
         public const string Errors_InvalidServiceDirective = "Errors/InvalidServiceDirective";
         public const string Errors_InvalidViewModel = "Errors/InvalidViewModel";
-        public const string Errors_JsDirectiveNotFound = "Errors/JsDirectiveNotFound";
-        public const string Errors_JsDirectiveNotScriptModule = "Errors/JsDirectiveNotScriptModule";
         public const string Errors_MalformedBinding = "Errors/MalformedBinding";
         public const string Errors_MarkupControlInvalidViewModel = "Errors/MarkupControlInvalidViewModel";
         public const string Errors_MasterPageRequiresDifferentViewModel = "Errors/MasterPageRequiresDifferentViewModel";
@@ -225,6 +223,8 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_JavascriptEvents_JavascriptEvents = "FeatureSamples/JavascriptEvents/JavascriptEvents";
         public const string FeatureSamples_JavascriptTranslation_DictionaryIndexerTranslation = "FeatureSamples/JavascriptTranslation/DictionaryIndexerTranslation";
         public const string FeatureSamples_JavascriptTranslation_GenericMethodTranslation = "FeatureSamples/JavascriptTranslation/GenericMethodTranslation";
+        public const string FeatureSamples_JavascriptTranslation_ListIndexerTranslation = "FeatureSamples/JavascriptTranslation/ListIndexerTranslation";
+        public const string FeatureSamples_JavascriptTranslation_ListMethodTranslations = "FeatureSamples/JavascriptTranslation/ListMethodTranslations";
         public const string FeatureSamples_JavascriptTranslation_MathMethodTranslation = "FeatureSamples/JavascriptTranslation/MathMethodTranslation";
         public const string FeatureSamples_LambdaExpressions_ClientSideFiltering = "FeatureSamples/LambdaExpressions/ClientSideFiltering";
         public const string FeatureSamples_LambdaExpressions_LambdaExpressions = "FeatureSamples/LambdaExpressions/LambdaExpressions";

--- a/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
@@ -224,6 +224,7 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_HtmlTag_NonPairHtmlTag = "FeatureSamples/HtmlTag/NonPairHtmlTag";
         public const string FeatureSamples_IdGeneration_IdGeneration = "FeatureSamples/IdGeneration/IdGeneration";
         public const string FeatureSamples_JavascriptEvents_JavascriptEvents = "FeatureSamples/JavascriptEvents/JavascriptEvents";
+        public const string FeatureSamples_JavascriptTranslation_ArrayTranslation = "FeatureSamples/JavascriptTranslation/ArrayTranslation";
         public const string FeatureSamples_JavascriptTranslation_DictionaryIndexerTranslation = "FeatureSamples/JavascriptTranslation/DictionaryIndexerTranslation";
         public const string FeatureSamples_JavascriptTranslation_GenericMethodTranslation = "FeatureSamples/JavascriptTranslation/GenericMethodTranslation";
         public const string FeatureSamples_JavascriptTranslation_ListIndexerTranslation = "FeatureSamples/JavascriptTranslation/ListIndexerTranslation";


### PR DESCRIPTION
Resolves #977. This PR fixes issues that occurred in staticCommands when assigning into lists and arrays.

**Changes**:
- **Lists**: Registered JS translation for set_Indexer on Lists and provided its implementation that updates observables
- **Arrays**: Assignments to array elements are compiled using an explicit call to `Array.SetValue(value, index)`. This step made it possible to register a JS translation for array element assignments. The typescript implementation is the shared with lists.