### PR TITLE
Removed usage of culture-sensitive string operations

### DIFF
--- a/src/DotVVM.CommandLine/Names.cs
+++ b/src/DotVVM.CommandLine/Names.cs
@@ -27,7 +27,7 @@ namespace DotVVM.CommandLine
             }
 
             var sb = new StringBuilder(name);
-            sb[0] = char.ToUpper(sb[0]);
+            sb[0] = char.ToUpperInvariant(sb[0]);
             return sb.ToString();
         }
 
@@ -39,7 +39,7 @@ namespace DotVVM.CommandLine
             }
 
             var sb = new StringBuilder(viewName);
-            sb[0] = char.ToUpper(sb[0]);
+            sb[0] = char.ToUpperInvariant(sb[0]);
 
             if (!viewName.EndsWith(ViewModelClassSuffix, StringComparison.CurrentCultureIgnoreCase))
             {

--- a/src/DotVVM.CommandLine/OpenApi/ApiClientUtils.cs
+++ b/src/DotVVM.CommandLine/OpenApi/ApiClientUtils.cs
@@ -91,7 +91,7 @@ namespace DotVVM.CommandLine.OpenApi
             var pathSegments = operation.Path.Trim('/').Split('/').Where(s => !s.Contains('{')).ToArray();
             var lastPathSegment = pathSegments.LastOrDefault();
             var path = string.Concat(pathSegments.Take(pathSegments.Length - 1).Select(s => s + "_"));
-            return path + operation.Method.ToString()[0].ToString().ToUpper() + operation.Method.ToString().Substring(1).ToLower() + ConversionUtilities.ConvertToUpperCamelCase(lastPathSegment.Replace('_', '-'), false);
+            return path + operation.Method.ToString()[0].ToString().ToUpperInvariant() + operation.Method.ToString().Substring(1).ToLowerInvariant() + ConversionUtilities.ConvertToUpperCamelCase(lastPathSegment.Replace('_', '-'), false);
         }
     }
 }

--- a/src/DotVVM.Framework.Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests/Binding/JavascriptCompilationTests.cs
@@ -602,7 +602,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableMax(string binding, string property, bool nullable)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestArraysViewModel) });
-            Assert.AreEqual($"dotvvm.translations.array.max({property}(),function(arg){{return ko.unwrap(arg);}},{(!nullable).ToString().ToLower()})", result);
+            Assert.AreEqual($"dotvvm.translations.array.max({property}(),function(arg){{return ko.unwrap(arg);}},{(!nullable).ToString().ToLowerInvariant()})", result);
         }
 
         [TestMethod]
@@ -629,7 +629,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableMax_WithSelector(string binding, string property, bool nullable)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestArraysViewModel) });
-            Assert.AreEqual($"dotvvm.translations.array.max({property}(),function(item){{return -ko.unwrap(item);}},{(!nullable).ToString().ToLower()})", result);
+            Assert.AreEqual($"dotvvm.translations.array.max({property}(),function(item){{return -ko.unwrap(item);}},{(!nullable).ToString().ToLowerInvariant()})", result);
         }
 
         [TestMethod]
@@ -656,7 +656,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableMin(string binding, string property, bool nullable)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestArraysViewModel) });
-            Assert.AreEqual($"dotvvm.translations.array.min({property}(),function(arg){{return ko.unwrap(arg);}},{(!nullable).ToString().ToLower()})", result);
+            Assert.AreEqual($"dotvvm.translations.array.min({property}(),function(arg){{return ko.unwrap(arg);}},{(!nullable).ToString().ToLowerInvariant()})", result);
         }
 
         [TestMethod]
@@ -683,7 +683,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableMin_WithSelector(string binding, string property, bool nullable)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestArraysViewModel) });
-            Assert.AreEqual($"dotvvm.translations.array.min({property}(),function(item){{return -ko.unwrap(item);}},{(!nullable).ToString().ToLower()})", result);
+            Assert.AreEqual($"dotvvm.translations.array.min({property}(),function(item){{return -ko.unwrap(item);}},{(!nullable).ToString().ToLowerInvariant()})", result);
         }
 
         [TestMethod]
@@ -941,8 +941,10 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [DataTestMethod]
-        [DataRow("StringProp.ToUpper()", "StringProp().toUpperCase()")]
-        [DataRow("StringProp.ToLower()", "StringProp().toLowerCase()")]
+        [DataRow("StringProp.ToUpper()", "StringProp().toLocaleUpperCase()")]
+        [DataRow("StringProp.ToLower()", "StringProp().toLocaleLowerCase()")]
+        [DataRow("StringProp.ToUpperInvariant()", "StringProp().toUpperCase()")]
+        [DataRow("StringProp.ToLowerInvariant()", "StringProp().toLowerCase()")]
         [DataRow("StringProp.IndexOf('test')", "StringProp().indexOf(\"test\")")]
         [DataRow("StringProp.IndexOf('test',1)", "StringProp().indexOf(\"test\",1)")]
         [DataRow("StringProp.LastIndexOf('test')", "StringProp().lastIndexOf(\"test\")")]

--- a/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -231,8 +231,12 @@ namespace DotVVM.Framework.Compilation.Javascript
             AddMethodTranslator(typeof(string), nameof(string.LastIndexOf), parameters: new[] { typeof(string), typeof(int) }, translator: new GenericMethodCompiler(
                 a => a[0].Member("lastIndexOf").Invoke(a[1], a[2])));
             AddMethodTranslator(typeof(string), nameof(string.ToUpper), parameterCount: 0, translator: new GenericMethodCompiler(
-                a => a[0].Member("toUpperCase").Invoke()));
+                a => a[0].Member("toLocaleUpperCase").Invoke()));
             AddMethodTranslator(typeof(string), nameof(string.ToLower), parameterCount: 0, translator: new GenericMethodCompiler(
+                a => a[0].Member("toLocaleLowerCase").Invoke()));
+            AddMethodTranslator(typeof(string), nameof(string.ToUpperInvariant), parameterCount: 0, translator: new GenericMethodCompiler(
+                a => a[0].Member("toUpperCase").Invoke()));
+            AddMethodTranslator(typeof(string), nameof(string.ToLowerInvariant), parameterCount: 0, translator: new GenericMethodCompiler(
                 a => a[0].Member("toLowerCase").Invoke()));
             AddMethodTranslator(typeof(string), nameof(string.Contains), parameters: new[] { typeof(string) }, translator: new GenericMethodCompiler(
                 a => a[0].Member("includes").Invoke(a[1])));

--- a/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/BindingParser.cs
+++ b/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/BindingParser.cs
@@ -893,7 +893,7 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
 
         private static object? ParseNumberLiteral(string text, out string? error)
         {
-            text = text.ToLower();
+            text = text.ToLowerInvariant();
             error = null;
             NumberLiteralSuffix type = NumberLiteralSuffix.None;
             var lastDigit = text[text.Length - 1];

--- a/src/DotVVM.Framework/Controls/KnockoutHelper.cs
+++ b/src/DotVVM.Framework/Controls/KnockoutHelper.cs
@@ -307,7 +307,7 @@ namespace DotVVM.Framework.Controls
             {
                 return null;
             }
-            var handlerName = $"concurrency-{mode.ToString().ToLower()}";
+            var handlerName = $"concurrency-{mode.ToString().ToLowerInvariant()}";
             if ("default".Equals(queueName))
             {
                 return JsonConvert.ToString(handlerName);

--- a/src/DotVVM.Framework/Controls/RouteLink.cs
+++ b/src/DotVVM.Framework/Controls/RouteLink.cs
@@ -111,7 +111,7 @@ namespace DotVVM.Framework.Controls
 
         protected virtual void WriteEnabledBinding(IHtmlWriter writer, bool binding)
         {
-            writer.AddKnockoutDataBind("dotvvm-enable", binding.ToString().ToLower());
+            writer.AddKnockoutDataBind("dotvvm-enable", binding.ToString().ToLowerInvariant());
         }
 
         protected virtual void WriteEnabledBinding(IHtmlWriter writer, IValueBinding binding)

--- a/src/DotVVM.Framework/Controls/RouteLinkHelpers.cs
+++ b/src/DotVVM.Framework/Controls/RouteLinkHelpers.cs
@@ -159,7 +159,7 @@ namespace DotVVM.Framework.Controls
             {
                 expression = JsonConvert.SerializeObject(param.Value, DefaultSerializerSettingsProvider.Instance.Settings);
             }
-            return KnockoutHelper.MakeStringLiteral(caseSensitive ? param.Key : param.Key.ToLower()) + ": " + expression;
+            return KnockoutHelper.MakeStringLiteral(caseSensitive ? param.Key : param.Key.ToLowerInvariant()) + ": " + expression;
         }
 
         private static void EnsureValidBindingType(IBinding binding)

--- a/src/DotVVM.Framework/Controls/ValidationSummary.cs
+++ b/src/DotVVM.Framework/Controls/ValidationSummary.cs
@@ -75,9 +75,9 @@ namespace DotVVM.Framework.Controls
             var group = new KnockoutBindingGroup();
             {
                 group.Add("target", expression);
-                group.Add("includeErrorsFromChildren", IncludeErrorsFromChildren.ToString().ToLower());
-                group.Add("includeErrorsFromTarget", IncludeErrorsFromTarget.ToString().ToLower());
-                group.Add("hideWhenValid", HideWhenValid.ToString().ToLower());
+                group.Add("includeErrorsFromChildren", IncludeErrorsFromChildren.ToString().ToLowerInvariant());
+                group.Add("includeErrorsFromTarget", IncludeErrorsFromTarget.ToString().ToLowerInvariant());
+                group.Add("hideWhenValid", HideWhenValid.ToString().ToLowerInvariant());
             }
             writer.AddKnockoutDataBind("dotvvm-validationSummary", group);
 

--- a/src/DotVVM.Framework/Hosting/MarkupFile.cs
+++ b/src/DotVVM.Framework/Hosting/MarkupFile.cs
@@ -18,7 +18,7 @@ namespace DotVVM.Framework.Hosting
         {
             unchecked
             {
-                return ((FullPath != null ? FullPath.ToLower().GetHashCode() : 0) * 397) ^ LastWriteDateTimeUtc.GetHashCode();
+                return ((FullPath != null ? FullPath.ToLowerInvariant().GetHashCode() : 0) * 397) ^ LastWriteDateTimeUtc.GetHashCode();
             }
         }
 

--- a/src/DotVVM.Framework/ResourceManagement/ClientGlobalize/JQueryGlobalizeScriptCreator.cs
+++ b/src/DotVVM.Framework/ResourceManagement/ClientGlobalize/JQueryGlobalizeScriptCreator.cs
@@ -156,8 +156,8 @@ namespace DotVVM.Framework.ResourceManagement.ClientGlobalize
                     names = di.MonthNames,
                     namesAbbr = di.AbbreviatedMonthNames
                 },
-                AM = new[] { di.AMDesignator, di.AMDesignator.ToLower(), di.AMDesignator.ToUpper() },
-                PM = new[] { di.PMDesignator, di.PMDesignator.ToLower(), di.PMDesignator.ToUpper() },
+                AM = new[] { di.AMDesignator, di.AMDesignator.ToLowerInvariant(), di.AMDesignator.ToUpperInvariant() },
+                PM = new[] { di.PMDesignator, di.PMDesignator.ToLowerInvariant(), di.PMDesignator.ToUpperInvariant() },
                 eras = di.Calendar.Eras.Select(era => new { offset = 0, start = (string)null, name = di.GetEraName(era) }).ToArray(),
                 twoDigitYearMax = di.Calendar.TwoDigitYearMax,
                 patterns = new

--- a/src/DotVVM.Samples.BasicSamples.Api.AspNetCore/ViewModels/GeneratorViewModel.cs
+++ b/src/DotVVM.Samples.BasicSamples.Api.AspNetCore/ViewModels/GeneratorViewModel.cs
@@ -156,7 +156,7 @@ namespace DotVVM.Samples.BasicSamples.Api.AspNetCore.ViewModels
             var pathSegments = operation.Path.Trim('/').Split('/').Where(s => !s.Contains('{')).ToArray();
             var lastPathSegment = pathSegments.LastOrDefault();
             var path = string.Concat(pathSegments.Take(pathSegments.Length - 1).Select(s => s + "_"));
-            return path + operation.Method.ToString()[0].ToString().ToUpper() + operation.Method.ToString().Substring(1).ToLower() + ConversionUtilities.ConvertToUpperCamelCase(lastPathSegment.Replace('_', '-'), false);
+            return path + operation.Method.ToString()[0].ToString().ToUpperInvariant() + operation.Method.ToString().Substring(1).ToLowerInvariant() + ConversionUtilities.ConvertToUpperCamelCase(lastPathSegment.Replace('_', '-'), false);
         }
     }
 

--- a/src/DotVVM.Samples.Tests/ErrorsTests.cs
+++ b/src/DotVVM.Samples.Tests/ErrorsTests.cs
@@ -83,7 +83,7 @@ namespace DotVVM.Samples.Tests
                 AssertUI.InnerText(browser.First("[class='exceptionMessage']")
                 ,
                         s =>
-                            s.ToLowerInvariant().Contains("was not recognized as a valid Boolean.".ToLowerInvariant())
+                            s.ToLowerInvariant().Contains("was not recognized as a valid boolean.")
                             , "Expected message is 'was not recognized as a valid Boolean.'");
 
                 AssertUI.InnerText(browser.First("[class='errorUnderline']")

--- a/src/DotVVM.Samples.Tests/ErrorsTests.cs
+++ b/src/DotVVM.Samples.Tests/ErrorsTests.cs
@@ -83,7 +83,7 @@ namespace DotVVM.Samples.Tests
                 AssertUI.InnerText(browser.First("[class='exceptionMessage']")
                 ,
                         s =>
-                            s.ToLower().Contains("was not recognized as a valid Boolean.".ToLower())
+                            s.ToLowerInvariant().Contains("was not recognized as a valid Boolean.".ToLowerInvariant())
                             , "Expected message is 'was not recognized as a valid Boolean.'");
 
                 AssertUI.InnerText(browser.First("[class='errorUnderline']")

--- a/src/DotVVM.Samples.Tests/Feature/ViewModelProtectionTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/ViewModelProtectionTests.cs
@@ -132,7 +132,7 @@ namespace DotVVM.Samples.Tests.Feature
             radios.RemoveAt(checkedRadioIndex);
             radios.ForEach(s => AssertUI.IsNotChecked(s));
 
-            AssertUI.TextEquals(selectedColorElement, selectedColor.ToString().ToLower());
+            AssertUI.TextEquals(selectedColorElement, selectedColor.ToString().ToLowerInvariant());
         }
 
         private void RunComplexViewModelProtectionTest(Action<IBrowserWrapper> beforePostback, Action<IBrowserWrapper> afterPostback)


### PR DESCRIPTION
Resolves #950. This PR changes all occurrences of `.ToUpper()` and `.ToLower()` to their culture-invariant alternatives. I also fixed JS translations and introduced two new:

**Changed translations**:

- `string.ToLower()` maps to `String.prototype.toLocaleLowerCase()`
- `string.ToUpper()` maps to `String.prototype.toLocaleUpperCase()`

**New translations**:
- `string.ToLowerInvariant()` maps to `String.prototype.toLowerCase()`
- `string.ToUpperInvariant()` maps to `String.prototype.toUpperCase()`