### PR TITLE
Fixed issues with extension methods

### DIFF
--- a/src/DotVVM.Framework.Tests/Binding/CustomExtensionMethodTests.cs
+++ b/src/DotVVM.Framework.Tests/Binding/CustomExtensionMethodTests.cs
@@ -88,12 +88,43 @@ namespace DotVVM.Framework.Tests.Binding
             // Not imported extension
             CreateCall(notImportedTarget, Array.Empty<Expression>(), new[] { new NamespaceImport("DotVVM.Framework.Tests.Binding") });
         }
+
+        [TestMethod]
+        public void Call_ExtensionMethodsWithOptionalArguments_UseDefaultValue()
+        {
+            var importedTarget = new MethodGroupExpression() {
+                MethodName = nameof(TestExtensions.ExtensionMethodWithOptionalArgument),
+                Target = Expression.Constant(11)
+            };
+
+            // Imported extension
+            var expression = CreateCall(importedTarget, Array.Empty<Expression>(), new[] { new NamespaceImport("DotVVM.Framework.Tests.Binding") });
+            var result = Expression.Lambda<Func<int>>(expression).Compile().Invoke();
+            Assert.AreEqual(321, result);
+        }
+
+        [TestMethod]
+        public void Call_ExtensionMethodsWithOptionalArguments_OverrideDefaultValue()
+        {
+            var importedTarget = new MethodGroupExpression() {
+                MethodName = nameof(TestExtensions.ExtensionMethodWithOptionalArgument),
+                Target = Expression.Constant(11)
+            };
+
+            // Imported extension
+            var expression = CreateCall(importedTarget, new[] { Expression.Constant(123) }, new[] { new NamespaceImport("DotVVM.Framework.Tests.Binding") });
+            var result = Expression.Lambda<Func<int>>(expression).Compile().Invoke();
+            Assert.AreEqual(123, result);
+        }
     }
 
     public static class TestExtensions
     {
         public static int Increment(this int number)
             => ++number;
+
+        public static int ExtensionMethodWithOptionalArgument(this int number, int arg = 321)
+            => arg;
     }
 
     namespace AmbiguousExtensions

--- a/src/DotVVM.Framework.Tests/Binding/CustomExtensionMethodTests.cs
+++ b/src/DotVVM.Framework.Tests/Binding/CustomExtensionMethodTests.cs
@@ -98,7 +98,7 @@ namespace DotVVM.Framework.Tests.Binding
             };
 
             // Imported extension
-            var expression = CreateCall(importedTarget, Array.Empty<Expression>(), new[] { new NamespaceImport("DotVVM.Framework.Tests.Binding") });
+            var expression = CreateCall(importedTarget, Array.Empty<Expression>(), new[] { new NamespaceImport("DotVVM.Framework.Tests.Binding"), new NamespaceImport("DotVVM.Framework.Tests.Binding") });
             var result = Expression.Lambda<Func<int>>(expression).Compile().Invoke();
             Assert.AreEqual(321, result);
         }
@@ -115,6 +115,24 @@ namespace DotVVM.Framework.Tests.Binding
             var expression = CreateCall(importedTarget, new[] { Expression.Constant(123) }, new[] { new NamespaceImport("DotVVM.Framework.Tests.Binding") });
             var result = Expression.Lambda<Func<int>>(expression).Compile().Invoke();
             Assert.AreEqual(123, result);
+        }
+
+        [TestMethod]
+        public void Call_ExtensionMethods_DuplicitImport_DoesNotThrow()
+        {
+            var importedTarget = new MethodGroupExpression() {
+                MethodName = nameof(TestExtensions.Increment),
+                Target = Expression.Constant(11)
+            };
+
+            // Imported extension
+            var expression = CreateCall(importedTarget, Array.Empty<Expression>(),
+                new[] {
+                    new NamespaceImport("DotVVM.Framework.Tests.Binding"),
+                    new NamespaceImport("DotVVM.Framework.Tests.Binding")
+                });
+            var result = Expression.Lambda<Func<int>>(expression).Compile().Invoke();
+            Assert.AreEqual(12, result);
         }
     }
 

--- a/src/DotVVM.Framework/Compilation/Binding/MemberExpressionFactory.cs
+++ b/src/DotVVM.Framework/Compilation/Binding/MemberExpressionFactory.cs
@@ -192,7 +192,7 @@ namespace DotVVM.Framework.Compilation.Binding
             if (method.IsExtension)
             {
                 // Change to a static call
-                var newArguments = new[] { target }.Concat(arguments);
+                var newArguments = new[] { method.Arguments.First() }.Concat(method.Arguments.Skip(1));
                 return Expression.Call(method.Method, newArguments);
             }
             return Expression.Call(target, method.Method, method.Arguments);

--- a/src/DotVVM.Framework/Compilation/Binding/MemberExpressionFactory.cs
+++ b/src/DotVVM.Framework/Compilation/Binding/MemberExpressionFactory.cs
@@ -248,8 +248,8 @@ namespace DotVVM.Framework.Compilation.Binding
 
         private IEnumerable<MethodInfo> GetAllExtensionMethods()
         {
-            foreach (var ns in importedNamespaces)
-                foreach (var method in extensionMethodsCache.GetExtensionsForNamespace(ns.Namespace))
+            foreach (var ns in importedNamespaces.Select(ns => ns.Namespace).Distinct())
+                foreach (var method in extensionMethodsCache.GetExtensionsForNamespace(ns))
                     yield return method;
         }
 

--- a/src/DotVVM.Framework/Compilation/Binding/MemberExpressionFactory.cs
+++ b/src/DotVVM.Framework/Compilation/Binding/MemberExpressionFactory.cs
@@ -192,8 +192,7 @@ namespace DotVVM.Framework.Compilation.Binding
             if (method.IsExtension)
             {
                 // Change to a static call
-                var newArguments = new[] { method.Arguments.First() }.Concat(method.Arguments.Skip(1));
-                return Expression.Call(method.Method, newArguments);
+                return Expression.Call(method.Method, method.Arguments);
             }
             return Expression.Call(target, method.Method, method.Arguments);
         }


### PR DESCRIPTION
This PR fixes two issues that can be observed when compiling extension method calls. These issues were found while testing #1057.

1. Repeated importing of the same namespace ends with `"Found ambiguous overloads of method ..."`.
      - This is due to the fact that individual methods are enumerated multiple times (once for each import)
2. Extension methods with default parameter values fail when the default value should have been used
      - Default values were not added to the argument list
      - This caused the invocation of `Expression.Call(...)` to throw as the arguments count did not match parameters count