### PR TITLE
Added JavaScript translations for `DateTime` and `WebUtility`

### DIFF
--- a/src/DotVVM.Framework.Tests/Binding/BindingCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests/Binding/BindingCompilationTests.cs
@@ -912,6 +912,7 @@ namespace DotVVM.Framework.Tests.Binding
         public TestViewModel2 TestViewModel2B { get; set; }
         public TestEnum EnumProperty { get; set; }
         public string StringProp2 { get; set; }
+        public DateTime DateTime { get; set; }
         public DateTime? DateFrom { get; set; }
         public DateTime? DateTo { get; set; }
         public object Time { get; set; } = TimeSpan.FromSeconds(5);

--- a/src/DotVVM.Framework.Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests/Binding/JavascriptCompilationTests.cs
@@ -850,6 +850,20 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        [DataRow("DateTime.Year", "getFullYear", false)]
+        [DataRow("DateTime.Month", "getMonth", true)]
+        [DataRow("DateTime.Day", "getDate", false)]
+        [DataRow("DateTime.Hour", "getHours", false)]
+        [DataRow("DateTime.Minute", "getMinutes", false)]
+        [DataRow("DateTime.Second", "getSeconds", false)]
+        [DataRow("DateTime.Millisecond", "getMilliseconds", false)]
+        public void JsTranslator_DateTime_Property_Getters(string binding, string jsFunction, bool increment = false)
+        {
+            var result = CompileBinding(binding, new[] { typeof(TestViewModel) });
+            Assert.AreEqual($"new Date(DateTime()).{jsFunction}(){(increment ? "+1" : string.Empty)}", result);
+        }
+
+        [TestMethod]
         public void JavascriptCompilation_GuidToString()
         {
             var result = CompileBinding("GuidProp != Guid.Empty ? GuidProp.ToString() : ''", typeof(TestViewModel));

--- a/src/DotVVM.Framework.Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests/Binding/JavascriptCompilationTests.cs
@@ -864,6 +864,20 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        public void JsTranslator_WebUtility_UrlEncode()
+        {
+            var result = CompileBinding("WebUtility.UrlEncode(\"Hello World!\")", new[] { new NamespaceImport("System.Net") }, new[] { typeof(TestViewModel) });
+            Assert.AreEqual($"encodeURIComponent(\"Hello World!\")", result);
+        }
+
+        [TestMethod]
+        public void JsTranslator_WebUtility_UrlDecode()
+        {
+            var result = CompileBinding("WebUtility.UrlDecode(\"Hello%20World!\")", new[] { new NamespaceImport("System.Net") }, new[] { typeof(TestViewModel) });
+            Assert.AreEqual($"decodeURIComponent(\"Hello%20World!\")", result);
+        }
+
+        [TestMethod]
         public void JavascriptCompilation_GuidToString()
         {
             var result = CompileBinding("GuidProp != Guid.Empty ? GuidProp.ToString() : ''", typeof(TestViewModel));

--- a/src/DotVVM.Framework/Compilation/CompiledAssemblyCache.cs
+++ b/src/DotVVM.Framework/Compilation/CompiledAssemblyCache.cs
@@ -68,10 +68,12 @@ namespace DotVVM.Framework.Compilation
                     typeof(DotvvmConfiguration).Assembly,
 #if DotNetCore
                     Assembly.Load(new AssemblyName("System.Runtime")),
+                    Assembly.Load(new AssemblyName("System.Private.CoreLib")),
                     Assembly.Load(new AssemblyName("System.Collections.Concurrent")),
                     Assembly.Load(new AssemblyName("System.Collections")),
 #else
-                    typeof(List<>).Assembly
+                    typeof(List<>).Assembly,
+                    typeof(System.Net.WebUtility).Assembly
 #endif
                 });
 

--- a/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -160,6 +160,7 @@ namespace DotVVM.Framework.Compilation.Javascript
             AddDefaultDictionaryTranslations();
             AddDefaultListTranslations();
             AddDefaultMathTranslations();
+            AddDefaultDateTimeTranslations();
         }
 
         private void AddDefaultToStringTranslations()
@@ -465,6 +466,27 @@ namespace DotVVM.Framework.Compilation.Javascript
                 new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("removeFirst").Invoke(args[1].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[2])));
             AddMethodTranslator(typeof(ListExtensions), "RemoveLast", parameterCount: 2, translator: new GenericMethodCompiler(args =>
                 new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("removeLast").Invoke(args[1].WithAnnotation(ShouldBeObservableAnnotation.Instance), args[2])));
+        }
+
+        private void AddDefaultDateTimeTranslations()
+        {
+            JsExpression IncrementExpression(JsExpression left, int value)
+                => new JsBinaryExpression(left, BinaryOperatorType.Plus, new JsLiteral(value));
+
+            AddPropertyGetterTranslator(typeof(DateTime), nameof(DateTime.Year), translator: new GenericMethodCompiler(args =>
+                new JsNewExpression(new JsIdentifierExpression("Date"), args[0]).Member("getFullYear").Invoke()));
+            AddPropertyGetterTranslator(typeof(DateTime), nameof(DateTime.Month), translator: new GenericMethodCompiler(args =>
+                IncrementExpression(new JsNewExpression(new JsIdentifierExpression("Date"), args[0]).Member("getMonth").Invoke(), 1)));
+            AddPropertyGetterTranslator(typeof(DateTime), nameof(DateTime.Day), translator: new GenericMethodCompiler(args =>
+                new JsNewExpression(new JsIdentifierExpression("Date"), args[0]).Member("getDate").Invoke()));
+            AddPropertyGetterTranslator(typeof(DateTime), nameof(DateTime.Hour), translator: new GenericMethodCompiler(args =>
+                new JsNewExpression(new JsIdentifierExpression("Date"), args[0]).Member("getHours").Invoke()));
+            AddPropertyGetterTranslator(typeof(DateTime), nameof(DateTime.Minute), translator: new GenericMethodCompiler(args =>
+                new JsNewExpression(new JsIdentifierExpression("Date"), args[0]).Member("getMinutes").Invoke()));
+            AddPropertyGetterTranslator(typeof(DateTime), nameof(DateTime.Second), translator: new GenericMethodCompiler(args =>
+                new JsNewExpression(new JsIdentifierExpression("Date"), args[0]).Member("getSeconds").Invoke()));
+            AddPropertyGetterTranslator(typeof(DateTime), nameof(DateTime.Millisecond), translator: new GenericMethodCompiler(args =>
+                new JsNewExpression(new JsIdentifierExpression("Date"), args[0]).Member("getMilliseconds").Invoke()));
         }
 
         public JsExpression TryTranslateCall(LazyTranslatedExpression context, LazyTranslatedExpression[] args, MethodInfo method)

--- a/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
 using DotVVM.Framework.Binding;
@@ -153,6 +154,11 @@ namespace DotVVM.Framework.Compilation.Javascript
                     return JavascriptTranslationVisitor.TranslateViewModelProperty(args[0], (MemberInfo)dotvvmproperty.PropertyInfo ?? dotvvmproperty.PropertyType.GetTypeInfo(), name: dotvvmproperty.Name);
                 }
             ));
+
+            AddMethodTranslator(typeof(WebUtility), nameof(WebUtility.UrlEncode), translator: new GenericMethodCompiler(
+                args => new JsIdentifierExpression("encodeURIComponent").Invoke(args[1])));
+            AddMethodTranslator(typeof(WebUtility), nameof(WebUtility.UrlDecode), translator: new GenericMethodCompiler(
+                args => new JsIdentifierExpression("decodeURIComponent").Invoke(args[1])));
 
             AddDefaultToStringTranslations();
             AddDefaultStringTranslations();

--- a/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
+++ b/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
@@ -63,6 +63,7 @@
     <None Remove="Views\FeatureSamples\JavascriptTranslation\DictionaryIndexerTranslation.dothtml" />
     <None Remove="Views\FeatureSamples\JavascriptTranslation\GenericMethodTranslation.dothtml" />
     <None Remove="Views\FeatureSamples\JavascriptTranslation\ListMethodTranslations.dothtml" />
+    <None Remove="Views\FeatureSamples\JavascriptTranslation\WebUtilityTranslations.dothtml" />
     <None Remove="Views\FeatureSamples\JsDirectives\BasicSample.dothtml" />
     <None Remove="Views\FeatureSamples\LambdaExpressions\ClientSideFiltering.dothtml" />
     <None Remove="Views\FeatureSamples\LambdaExpressions\LambdaExpressions.dothtml" />

--- a/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
+++ b/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
@@ -59,6 +59,7 @@
     <None Remove="Views\FeatureSamples\BindingVariables\StaticCommandVariablesWithService_Simple.dothtml" />
     <None Remove="Views\FeatureSamples\Caching\CachedValues.dothtml" />
     <None Remove="Views\FeatureSamples\CommandActionFilter\CommandActionFilter.dothtml" />
+    <None Remove="Views\FeatureSamples\JavascriptTranslation\DateTimeTranslations.dothtml" />
     <None Remove="Views\FeatureSamples\JavascriptTranslation\DictionaryIndexerTranslation.dothtml" />
     <None Remove="Views\FeatureSamples\JavascriptTranslation\GenericMethodTranslation.dothtml" />
     <None Remove="Views\FeatureSamples\JavascriptTranslation\ListMethodTranslations.dothtml" />

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/JavascriptTranslation/DateTimeTranslationsViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/JavascriptTranslation/DateTimeTranslationsViewModel.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.JavascriptTranslation
+{
+    public class DateTimeTranslationsViewModel : DotvvmViewModelBase
+    {
+        public DateTime DateTimeProp { get; set; } = DateTime.UtcNow;
+    }
+}
+

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/JavascriptTranslation/WebUtilityTranslationsViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/JavascriptTranslation/WebUtilityTranslationsViewModel.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.JavascriptTranslation
+{
+    public class WebUtilityTranslationsViewModel : DotvvmViewModelBase
+    {
+        public string InputString { get; set; } = "Encoding test \"&?<>";
+    }
+}
+

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/JavascriptTranslation/DateTimeTranslations.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/JavascriptTranslation/DateTimeTranslations.dothtml
@@ -1,0 +1,47 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.JavascriptTranslation.DateTimeTranslationsViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+
+    <h1>DateTime testing</h1>
+    <dot:TextBox data-ui="textbox" Text="{value: DateTimeProp}" />
+
+    <p>
+        <span>Year: </span>
+        <span data-ui="year">{{value: DateTimeProp.Year}}</span>
+    </p>
+    <p>
+        <span>Month: </span>
+        <span data-ui="month">{{value: DateTimeProp.Month}}</span>
+    </p>
+    <p>
+        <span>Day: </span>
+        <span data-ui="day">{{value: DateTimeProp.Day}}</span>
+    </p>
+    <p>
+        <span>Hour: </span>
+        <span data-ui="hour">{{value: DateTimeProp.Hour}}</span>
+    </p>
+    <p>
+        <span>Minute: </span>
+        <span data-ui="minute">{{value: DateTimeProp.Minute}}</span>
+    </p>
+    <p>
+        <span>Second: </span>
+        <span data-ui="second">{{value: DateTimeProp.Second}}</span>
+    </p>
+    <p>
+        <span>Millisecond: </span>
+        <span data-ui="millisecond">{{value: DateTimeProp.Millisecond}}</span>
+    </p>
+
+</body>
+</html>
+
+

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/JavascriptTranslation/WebUtilityTranslations.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/JavascriptTranslation/WebUtilityTranslations.dothtml
@@ -1,0 +1,33 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.JavascriptTranslation.WebUtilityTranslationsViewModel, DotVVM.Samples.Common
+@import System.Net
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+
+    <h1>WebUtility Url(En|De)code testing</h1>
+
+    <p>
+        <span><b>Input:</b></span>
+        <dot:TextBox data-ui="textbox" Text="{value: InputString}" />
+    </p>
+
+    <p>
+        <span><b>Encoded:</b></span>
+        <span data-ui="encoded">{{value: WebUtility.UrlEncode(InputString)}}</span>
+    </p>
+
+    <p>
+        <span><b>Decoded:</b></span>
+        <span data-ui="decoded">{{value: WebUtility.UrlDecode(WebUtility.UrlEncode(InputString))}}</span>
+    </p>
+
+</body>
+</html>
+
+

--- a/src/DotVVM.Samples.Tests/Feature/DateTimeTranslationTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/DateTimeTranslationTests.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Samples.Tests.Base;
+using DotVVM.Testing.Abstractions;
+using Riganti.Selenium.Core;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DotVVM.Samples.Tests.Feature
+{
+    public class DateTimeTranslationTests : AppSeleniumTest
+    {
+        [Fact]
+        public void Feature_DateTime_PropertyTranslations()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_JavascriptTranslation_DateTimeTranslations);
+
+                var stringDateTime = "6/28/2021 3:28:31 PM";
+
+                var textbox = browser.FindElements("input[data-ui=textbox]").FirstOrDefault();
+                textbox.Clear().SendKeys(stringDateTime).SendEnterKey();
+
+                var spanYear = browser.FindElements("span[data-ui=year]").FirstOrDefault();
+                AssertUI.TextEquals(spanYear, "2021");
+                var spanMonth = browser.FindElements("span[data-ui=month]").FirstOrDefault();
+                AssertUI.TextEquals(spanMonth, "6");
+                var spanDay = browser.FindElements("span[data-ui=day]").FirstOrDefault();
+                AssertUI.TextEquals(spanDay, "28");
+                var spanHour = browser.FindElements("span[data-ui=hour]").FirstOrDefault();
+                AssertUI.TextEquals(spanHour, "15");
+                var spanMinute = browser.FindElements("span[data-ui=minute]").FirstOrDefault();
+                AssertUI.TextEquals(spanMinute, "28");
+                var spanSecond = browser.FindElements("span[data-ui=second]").FirstOrDefault();
+                AssertUI.TextEquals(spanSecond, "31");
+                var spanMillisecond = browser.FindElements("span[data-ui=millisecond]").FirstOrDefault();
+                AssertUI.TextEquals(spanMillisecond, "0");
+            });
+        }
+
+        public DateTimeTranslationTests(ITestOutputHelper output) : base(output)
+        {
+        }
+    }
+}

--- a/src/DotVVM.Samples.Tests/Feature/WebUtilityTranslationTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/WebUtilityTranslationTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Samples.Tests.Base;
+using DotVVM.Testing.Abstractions;
+using Riganti.Selenium.Core;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DotVVM.Samples.Tests.Feature
+{
+    public class WebUtilityTranslationTests : AppSeleniumTest
+    {
+        [Fact]
+        public void Feature_WebUtility_UrlEncodeDecode()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_JavascriptTranslation_WebUtilityTranslations);
+                var inputText = @"Encoding test ""&?<>";
+
+                var textbox = browser.FindElements("input[data-ui=textbox]").FirstOrDefault();
+                textbox.Clear().SendKeys(inputText).SendEnterKey();
+
+                var spanEncoded = browser.FindElements("span[data-ui=encoded]").FirstOrDefault();
+                AssertUI.TextEquals(spanEncoded, "Encoding%20test%20%22%26%3F%3C%3E");
+                var spanDecoded = browser.FindElements("span[data-ui=decoded]").FirstOrDefault();
+                AssertUI.TextEquals(spanDecoded, inputText);
+            });
+        }
+
+        public WebUtilityTranslationTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+    }
+}

--- a/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
@@ -167,8 +167,6 @@ namespace DotVVM.Testing.Abstractions
         public const string Errors_InvalidRouteName = "Errors/InvalidRouteName";
         public const string Errors_InvalidServiceDirective = "Errors/InvalidServiceDirective";
         public const string Errors_InvalidViewModel = "Errors/InvalidViewModel";
-        public const string Errors_JsDirectiveNotFound = "Errors/JsDirectiveNotFound";
-        public const string Errors_JsDirectiveNotScriptModule = "Errors/JsDirectiveNotScriptModule";
         public const string Errors_MalformedBinding = "Errors/MalformedBinding";
         public const string Errors_MarkupControlInvalidViewModel = "Errors/MarkupControlInvalidViewModel";
         public const string Errors_MasterPageRequiresDifferentViewModel = "Errors/MasterPageRequiresDifferentViewModel";
@@ -226,6 +224,7 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_HtmlTag_NonPairHtmlTag = "FeatureSamples/HtmlTag/NonPairHtmlTag";
         public const string FeatureSamples_IdGeneration_IdGeneration = "FeatureSamples/IdGeneration/IdGeneration";
         public const string FeatureSamples_JavascriptEvents_JavascriptEvents = "FeatureSamples/JavascriptEvents/JavascriptEvents";
+        public const string FeatureSamples_JavascriptTranslation_DateTimeTranslations = "FeatureSamples/JavascriptTranslation/DateTimeTranslations";
         public const string FeatureSamples_JavascriptTranslation_DictionaryIndexerTranslation = "FeatureSamples/JavascriptTranslation/DictionaryIndexerTranslation";
         public const string FeatureSamples_JavascriptTranslation_GenericMethodTranslation = "FeatureSamples/JavascriptTranslation/GenericMethodTranslation";
         public const string FeatureSamples_JavascriptTranslation_ListMethodTranslations = "FeatureSamples/JavascriptTranslation/ListMethodTranslations";

--- a/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
@@ -229,6 +229,7 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_JavascriptTranslation_GenericMethodTranslation = "FeatureSamples/JavascriptTranslation/GenericMethodTranslation";
         public const string FeatureSamples_JavascriptTranslation_ListMethodTranslations = "FeatureSamples/JavascriptTranslation/ListMethodTranslations";
         public const string FeatureSamples_JavascriptTranslation_MathMethodTranslation = "FeatureSamples/JavascriptTranslation/MathMethodTranslation";
+        public const string FeatureSamples_JavascriptTranslation_WebUtilityTranslations = "FeatureSamples/JavascriptTranslation/WebUtilityTranslations";
         public const string FeatureSamples_LambdaExpressions_ClientSideFiltering = "FeatureSamples/LambdaExpressions/ClientSideFiltering";
         public const string FeatureSamples_LambdaExpressions_LambdaExpressions = "FeatureSamples/LambdaExpressions/LambdaExpressions";
         public const string FeatureSamples_LambdaExpressions_StaticCommands = "FeatureSamples/LambdaExpressions/StaticCommands";


### PR DESCRIPTION
Resolves #831. This PR adds the following JS translations:

### `DateTime` property getters

* `Year`
* `Month`
* `Day`
* `Hour`
* `Minute`
* `Second`
* `Millisecond`

### `WebUtility` methods
Use these together with `@import System.Net`
* `UrlEncode(str)` mapped to `encodeURIComponent(str)`
* `UrlDecode(str)` mapped to `decodeURIComponent(str)`