### PR TITLE
Added JS translations for string method overloads with `StringComparison`

### DIFF
--- a/src/DotVVM.Framework.Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests/Binding/JavascriptCompilationTests.cs
@@ -1002,12 +1002,26 @@ namespace DotVVM.Framework.Tests.Binding
         [DataRow("StringProp.ToUpperInvariant()", "StringProp().toUpperCase()")]
         [DataRow("StringProp.ToLowerInvariant()", "StringProp().toLowerCase()")]
         [DataRow("StringProp.IndexOf('test')", "StringProp().indexOf(\"test\")")]
+        [DataRow("StringProp.IndexOf('test',StringComparison.InvariantCultureIgnoreCase)",
+            "dotvvm.translations.string.indexOf(StringProp(),0,\"test\",\"InvariantCultureIgnoreCase\")")]
         [DataRow("StringProp.IndexOf('test',1)", "StringProp().indexOf(\"test\",1)")]
+        [DataRow("StringProp.IndexOf('test',1,StringComparison.InvariantCultureIgnoreCase)",
+            "dotvvm.translations.string.indexOf(StringProp(),1,\"test\",\"InvariantCultureIgnoreCase\")")]
         [DataRow("StringProp.LastIndexOf('test')", "StringProp().lastIndexOf(\"test\")")]
+        [DataRow("StringProp.LastIndexOf('test',StringComparison.InvariantCultureIgnoreCase)",
+            "dotvvm.translations.string.lastIndexOf(StringProp(),0,\"test\",\"InvariantCultureIgnoreCase\")")]
         [DataRow("StringProp.LastIndexOf('test',2)", "StringProp().lastIndexOf(\"test\",2)")]
+        [DataRow("StringProp.LastIndexOf('test',2,StringComparison.InvariantCultureIgnoreCase)",
+            "dotvvm.translations.string.lastIndexOf(StringProp(),2,\"test\",\"InvariantCultureIgnoreCase\")")]
         [DataRow("StringProp.Contains('test')", "StringProp().includes(\"test\")")]
+        [DataRow("StringProp.Contains('test',StringComparison.InvariantCultureIgnoreCase)",
+            "dotvvm.translations.string.contains(StringProp(),\"test\",\"InvariantCultureIgnoreCase\")")]
         [DataRow("StringProp.StartsWith('test')", "StringProp().startsWith(\"test\")")]
+        [DataRow("StringProp.StartsWith('test',StringComparison.InvariantCultureIgnoreCase)",
+            "dotvvm.translations.string.startsWith(StringProp(),\"test\",\"InvariantCultureIgnoreCase\")")]
         [DataRow("StringProp.EndsWith('test')", "StringProp().endsWith(\"test\")")]
+        [DataRow("StringProp.EndsWith('test',StringComparison.InvariantCultureIgnoreCase)",
+            "dotvvm.translations.string.endsWith(StringProp(),\"test\",\"InvariantCultureIgnoreCase\")")]
         [DataRow("string.IsNullOrEmpty(StringProp)", "StringProp()==null||StringProp()===\"\"")]
         public void JavascriptCompilation_StringFunctions(string input, string expected)
         {

--- a/src/DotVVM.Framework/Binding/HelperNamespace/NetFrameworkExtensions.cs
+++ b/src/DotVVM.Framework/Binding/HelperNamespace/NetFrameworkExtensions.cs
@@ -23,5 +23,13 @@ namespace DotVVM.Framework.Binding.HelperNamespace
         {
             return text.Split(new[] { delimiter }, options);
         }
+
+        /// <summary>
+        /// This is an extension method that allows using unavailable string.Contains(..) overload in .NET Framework
+        /// </summary>
+        public static bool Contains(this string haystack, string needle, StringComparison options)
+        {
+            return haystack.IndexOf(needle, options) != -1;
+        }
     }
 }

--- a/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -236,12 +236,20 @@ namespace DotVVM.Framework.Compilation.Javascript
 
             AddMethodTranslator(typeof(string), nameof(string.IndexOf), parameters: new[] { typeof(string) }, translator: new GenericMethodCompiler(
                 a => a[0].Member("indexOf").Invoke(a[1])));
+            AddMethodTranslator(typeof(string), nameof(string.IndexOf), parameters: new[] { typeof(string), typeof(StringComparison) }, translator: new GenericMethodCompiler(
+                a => new JsIdentifierExpression("dotvvm").Member("translations").Member("string").Member("indexOf").Invoke(a[0], new JsLiteral(0), a[1], a[2])));
             AddMethodTranslator(typeof(string), nameof(string.IndexOf), parameters: new[] { typeof(string), typeof(int) }, translator: new GenericMethodCompiler(
                 a => a[0].Member("indexOf").Invoke(a[1], a[2])));
+            AddMethodTranslator(typeof(string), nameof(string.IndexOf), parameters: new[] { typeof(string), typeof(int), typeof(StringComparison) }, translator: new GenericMethodCompiler(
+                a => new JsIdentifierExpression("dotvvm").Member("translations").Member("string").Member("indexOf").Invoke(a[0], a[2], a[1], a[3])));
             AddMethodTranslator(typeof(string), nameof(string.LastIndexOf), parameters: new[] { typeof(string) }, translator: new GenericMethodCompiler(
                 a => a[0].Member("lastIndexOf").Invoke(a[1])));
+            AddMethodTranslator(typeof(string), nameof(string.LastIndexOf), parameters: new[] { typeof(string), typeof(StringComparison) }, translator: new GenericMethodCompiler(
+                a => new JsIdentifierExpression("dotvvm").Member("translations").Member("string").Member("lastIndexOf").Invoke(a[0], new JsLiteral(0), a[1], a[2])));
             AddMethodTranslator(typeof(string), nameof(string.LastIndexOf), parameters: new[] { typeof(string), typeof(int) }, translator: new GenericMethodCompiler(
                 a => a[0].Member("lastIndexOf").Invoke(a[1], a[2])));
+            AddMethodTranslator(typeof(string), nameof(string.LastIndexOf), parameters: new[] { typeof(string), typeof(int), typeof(StringComparison) }, translator: new GenericMethodCompiler(
+                a => new JsIdentifierExpression("dotvvm").Member("translations").Member("string").Member("lastIndexOf").Invoke(a[0], a[2], a[1], a[3])));
             AddMethodTranslator(typeof(string), nameof(string.ToUpper), parameterCount: 0, translator: new GenericMethodCompiler(
                 a => a[0].Member("toLocaleUpperCase").Invoke()));
             AddMethodTranslator(typeof(string), nameof(string.ToLower), parameterCount: 0, translator: new GenericMethodCompiler(
@@ -252,10 +260,16 @@ namespace DotVVM.Framework.Compilation.Javascript
                 a => a[0].Member("toLowerCase").Invoke()));
             AddMethodTranslator(typeof(string), nameof(string.Contains), parameters: new[] { typeof(string) }, translator: new GenericMethodCompiler(
                 a => a[0].Member("includes").Invoke(a[1])));
+            AddMethodTranslator(typeof(string), nameof(string.Contains), parameters: new[] { typeof(string), typeof(StringComparison) }, translator: new GenericMethodCompiler(
+                a => new JsIdentifierExpression("dotvvm").Member("translations").Member("string").Member("contains").Invoke(a[0], a[1], a[2])));
             AddMethodTranslator(typeof(string), nameof(string.StartsWith), parameters: new[] { typeof(string) }, translator: new GenericMethodCompiler(
                 a => a[0].Member("startsWith").Invoke(a[1])));
+            AddMethodTranslator(typeof(string), nameof(string.StartsWith), parameters: new[] { typeof(string), typeof(StringComparison) }, translator: new GenericMethodCompiler(
+                a => new JsIdentifierExpression("dotvvm").Member("translations").Member("string").Member("startsWith").Invoke(a[0], a[1], a[2])));
             AddMethodTranslator(typeof(string), nameof(string.EndsWith), parameters: new[] { typeof(string) }, translator: new GenericMethodCompiler(
                 a => a[0].Member("endsWith").Invoke(a[1])));
+            AddMethodTranslator(typeof(string), nameof(string.EndsWith), parameters: new[] { typeof(string), typeof(StringComparison) }, translator: new GenericMethodCompiler(
+                a => new JsIdentifierExpression("dotvvm").Member("translations").Member("string").Member("endsWith").Invoke(a[0], a[1], a[2])));
             AddMethodTranslator(typeof(string), nameof(string.IsNullOrEmpty), parameters: new[] { typeof(string) }, translator: new GenericMethodCompiler(
                 a => new JsBinaryExpression(
                     new JsBinaryExpression(a[1], BinaryOperatorType.Equal, new JsLiteral(null)),

--- a/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -282,6 +282,9 @@ namespace DotVVM.Framework.Compilation.Javascript
             AddMethodTranslator(typeof(string), nameof(string.Replace), parameters: new[] { typeof(string), typeof(string) }, translator: new GenericMethodCompiler(
                 args => args[0].Member("split").Invoke(args[1]).Member("join").Invoke(args[2])));
 
+            AddMethodTranslator(typeof(string), nameof(string.Contains), parameters: new[] { typeof(string) }, translator: new GenericMethodCompiler(
+                a => a[0].Member("includes").Invoke(a[1])));
+
             var splitMethod = typeof(string).GetMethods(BindingFlags.Public | BindingFlags.Instance).SingleOrDefault(m => m.Name == nameof(string.Split)
                 && m.GetParameters().Length == 2 && m.GetParameters()[0].ParameterType == typeof(string) && m.GetParameters()[1].ParameterType == typeof(StringSplitOptions));
             var genericSplitCompiler = new GenericMethodCompiler(args => new JsIdentifierExpression("dotvvm").Member("translations").Member("string").Member("split").Invoke(args[0], args[1], args[2]));
@@ -289,6 +292,8 @@ namespace DotVVM.Framework.Compilation.Javascript
             if (splitMethod == null)
             {
                 // Some overloads are not available in .NET Framework, therefore we substitute some with custom extensions
+                AddMethodTranslator(typeof(NetFrameworkExtensions), nameof(NetFrameworkExtensions.Contains), parameters: new[] { typeof(string), typeof(string), typeof(StringComparison) }, translator: new GenericMethodCompiler(
+                    a => new JsIdentifierExpression("dotvvm").Member("translations").Member("string").Member("contains").Invoke(a[1], a[2], a[3])));
                 AddMethodTranslator(typeof(NetFrameworkExtensions), nameof(NetFrameworkExtensions.Split), parameters: new[] { typeof(string), typeof(char), typeof(StringSplitOptions) },
                     translator: genericExtensionSplitCompiler);
                 AddMethodTranslator(typeof(NetFrameworkExtensions), nameof(NetFrameworkExtensions.Split), parameters: new[] { typeof(string), typeof(string), typeof(StringSplitOptions) },
@@ -296,23 +301,10 @@ namespace DotVVM.Framework.Compilation.Javascript
             }
             else
             {
-                AddMethodTranslator(typeof(string), nameof(string.Split), parameters: new[] { typeof(char), typeof(StringSplitOptions) }, translator: genericSplitCompiler);
-                AddMethodTranslator(typeof(string), nameof(string.Split), parameters: new[] { typeof(string), typeof(StringSplitOptions) }, translator: genericSplitCompiler);
-            }
-
-            AddMethodTranslator(typeof(string), nameof(string.Contains), parameters: new[] { typeof(string) }, translator: new GenericMethodCompiler(
-                a => a[0].Member("includes").Invoke(a[1])));
-            var containsMethod = typeof(string).GetMethods(BindingFlags.Public | BindingFlags.Instance).SingleOrDefault(m => m.Name == nameof(string.Contains)
-                && m.GetParameters().Length == 2 && m.GetParameters()[1].ParameterType == typeof(StringComparison));
-            if (containsMethod == null)
-            {
-                AddMethodTranslator(typeof(NetFrameworkExtensions), nameof(NetFrameworkExtensions.Contains), parameters: new[] { typeof(string), typeof(string), typeof(StringComparison) }, translator: new GenericMethodCompiler(
-                    a => new JsIdentifierExpression("dotvvm").Member("translations").Member("string").Member("contains").Invoke(a[1], a[2], a[3])));
-            }
-            else
-            {
                 AddMethodTranslator(typeof(string), nameof(string.Contains), parameters: new[] { typeof(string), typeof(StringComparison) }, translator: new GenericMethodCompiler(
                     a => new JsIdentifierExpression("dotvvm").Member("translations").Member("string").Member("contains").Invoke(a[0], a[1], a[2])));
+                AddMethodTranslator(typeof(string), nameof(string.Split), parameters: new[] { typeof(char), typeof(StringSplitOptions) }, translator: genericSplitCompiler);
+                AddMethodTranslator(typeof(string), nameof(string.Split), parameters: new[] { typeof(string), typeof(StringSplitOptions) }, translator: genericSplitCompiler);
             }
 
             AddMethodTranslator(typeof(string), nameof(NetFrameworkExtensions.Split), parameters: new[] { typeof(char[]) },

--- a/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -258,10 +258,6 @@ namespace DotVVM.Framework.Compilation.Javascript
                 a => a[0].Member("toUpperCase").Invoke()));
             AddMethodTranslator(typeof(string), nameof(string.ToLowerInvariant), parameterCount: 0, translator: new GenericMethodCompiler(
                 a => a[0].Member("toLowerCase").Invoke()));
-            AddMethodTranslator(typeof(string), nameof(string.Contains), parameters: new[] { typeof(string) }, translator: new GenericMethodCompiler(
-                a => a[0].Member("includes").Invoke(a[1])));
-            AddMethodTranslator(typeof(string), nameof(string.Contains), parameters: new[] { typeof(string), typeof(StringComparison) }, translator: new GenericMethodCompiler(
-                a => new JsIdentifierExpression("dotvvm").Member("translations").Member("string").Member("contains").Invoke(a[0], a[1], a[2])));
             AddMethodTranslator(typeof(string), nameof(string.StartsWith), parameters: new[] { typeof(string) }, translator: new GenericMethodCompiler(
                 a => a[0].Member("startsWith").Invoke(a[1])));
             AddMethodTranslator(typeof(string), nameof(string.StartsWith), parameters: new[] { typeof(string), typeof(StringComparison) }, translator: new GenericMethodCompiler(
@@ -304,8 +300,23 @@ namespace DotVVM.Framework.Compilation.Javascript
                 AddMethodTranslator(typeof(string), nameof(string.Split), parameters: new[] { typeof(string), typeof(StringSplitOptions) }, translator: genericSplitCompiler);
             }
 
+            AddMethodTranslator(typeof(string), nameof(string.Contains), parameters: new[] { typeof(string) }, translator: new GenericMethodCompiler(
+                a => a[0].Member("includes").Invoke(a[1])));
+            var containsMethod = typeof(string).GetMethods(BindingFlags.Public | BindingFlags.Instance).SingleOrDefault(m => m.Name == nameof(string.Contains)
+                && m.GetParameters().Length == 2 && m.GetParameters()[1].ParameterType == typeof(StringComparison));
+            if (containsMethod == null)
+            {
+                AddMethodTranslator(typeof(NetFrameworkExtensions), nameof(NetFrameworkExtensions.Contains), parameters: new[] { typeof(string), typeof(string), typeof(StringComparison) }, translator: new GenericMethodCompiler(
+                    a => new JsIdentifierExpression("dotvvm").Member("translations").Member("string").Member("contains").Invoke(a[1], a[2], a[3])));
+            }
+            else
+            {
+                AddMethodTranslator(typeof(string), nameof(string.Contains), parameters: new[] { typeof(string), typeof(StringComparison) }, translator: new GenericMethodCompiler(
+                    a => new JsIdentifierExpression("dotvvm").Member("translations").Member("string").Member("contains").Invoke(a[0], a[1], a[2])));
+            }
+
             AddMethodTranslator(typeof(string), nameof(NetFrameworkExtensions.Split), parameters: new[] { typeof(char[]) },
-                    translator: new GenericMethodCompiler(args => args[0].Member("split").Invoke(args[1])));
+                translator: new GenericMethodCompiler(args => args[0].Member("split").Invoke(args[1])));
         }
 
         private void AddDefaultMathTranslations()

--- a/src/DotVVM.Framework/Resources/Scripts/tests/stringHelper.test.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/tests/stringHelper.test.ts
@@ -1,0 +1,37 @@
+﻿import * as stringHelper from '../utils/stringHelper'
+
+test("string.Contains translation", () => {
+    expect(stringHelper.contains("Hello world", "world", "")).toBe(true);
+    expect(stringHelper.contains("Hello world", "WORLD", "")).toBe(false);
+    expect(stringHelper.contains("Hello world", "WORLD", "InvariantCultureIgnoreCase")).toBe(true);
+})
+
+test("string.EndsWith translation", () => {
+    expect(stringHelper.endsWith("Hello world!", "world", "")).toBe(false);
+    expect(stringHelper.endsWith("Hello world", "WORLD", "")).toBe(false);
+    expect(stringHelper.endsWith("Hello world", "world", "")).toBe(true);
+    expect(stringHelper.endsWith("Hello world", "WORLD", "InvariantCultureIgnoreCase")).toBe(true);
+})
+
+test("string.StartsWith translation", () => {
+    expect(stringHelper.startsWith("Hello world", "hello", "")).toBe(false);
+    expect(stringHelper.startsWith("!Hello world", "Hello", "")).toBe(false);
+    expect(stringHelper.startsWith("Hello world", "Hello", "")).toBe(true);
+    expect(stringHelper.startsWith("Hello world", "HELLO", "InvariantCultureIgnoreCase")).toBe(true);
+})
+
+test("string.IndexOf translation", () => {
+    expect(stringHelper.indexOf("Hello world", 0, "aaaa", "")).toBe(-1);
+    expect(stringHelper.indexOf("Hello world", 0, "Hello", "")).toBe(0);
+    expect(stringHelper.indexOf("Hello world", 1, "Hello", "")).toBe(-1);
+    expect(stringHelper.indexOf("Hello world", 6, "WORLD", "")).toBe(-1);
+    expect(stringHelper.indexOf("Hello world", 6, "WORLD", "InvariantCultureIgnoreCase")).toBe(6);
+})
+
+test("string.LastIndexOf translation", () => {
+    expect(stringHelper.lastIndexOf("Hello world", 0, "aaaa", "")).toBe(-1);
+    expect(stringHelper.lastIndexOf("Hello world", 0, "Hello", "")).toBe(0);
+    expect(stringHelper.lastIndexOf("Hello world", 1, "Hello", "")).toBe(-1);
+    expect(stringHelper.lastIndexOf("Hello world", 6, "WORLD", "")).toBe(-1);
+    expect(stringHelper.lastIndexOf("Hello world", 6, "WORLD", "InvariantCultureIgnoreCase")).toBe(6);
+})

--- a/src/DotVVM.Framework/Resources/Scripts/utils/stringHelper.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/utils/stringHelper.ts
@@ -1,4 +1,36 @@
-﻿export function split<T>(text: string, delimiter: string, options: string): string[] {
+﻿export function contains(haystack: string, needle: string, options: string): boolean {
+    const normalized = normalizeStrings(haystack, needle, options);
+    return normalized.haystack.includes(normalized.needle);
+}
+
+export function endsWith(haystack: string, needle: string, options: string): boolean {
+    const normalized = normalizeStrings(haystack, needle, options);
+    return normalized.haystack.endsWith(normalized.needle);
+}
+
+export function startsWith(haystack: string, needle: string, options: string): boolean {
+    const normalized = normalizeStrings(haystack, needle, options);
+    return normalized.haystack.startsWith(normalized.needle);
+}
+
+export function indexOf(haystack: string, startIndex: number, needle: string, options: string): number {
+    const normalized = normalizeStrings(haystack, needle, options);
+    return normalized.haystack.indexOf(needle, startIndex);
+}
+
+export function lastIndexOf(haystack: string, startIndex: number, needle: string, options: string): number {
+    const normalized = normalizeStrings(haystack, needle, options);
+    return normalized.haystack.indexOf(needle, startIndex);
+}
+
+function normalizeStrings(haystack: string, needle: string, options: string): { haystack: string, needle: string } {
+    if (options.endsWith("IgnoreCase")) {
+        return { haystack: haystack.toUpperCase(), needle: needle.toUpperCase() };
+    }
+    return { haystack: haystack, needle: needle };
+}
+
+export function split(text: string, delimiter: string, options: string): string[] {
     let tokens = text.split(delimiter);
     if (options === "RemoveEmptyEntries") {
         tokens = tokens.filter(t => t);

--- a/src/DotVVM.Framework/Resources/Scripts/utils/stringHelper.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/utils/stringHelper.ts
@@ -15,12 +15,12 @@ export function startsWith(haystack: string, needle: string, options: string): b
 
 export function indexOf(haystack: string, startIndex: number, needle: string, options: string): number {
     const normalized = normalizeStrings(haystack, needle, options);
-    return normalized.haystack.indexOf(needle, startIndex);
+    return normalized.haystack.indexOf(normalized.needle, startIndex);
 }
 
 export function lastIndexOf(haystack: string, startIndex: number, needle: string, options: string): number {
     const normalized = normalizeStrings(haystack, needle, options);
-    return normalized.haystack.indexOf(needle, startIndex);
+    return normalized.haystack.indexOf(normalized.needle, startIndex);
 }
 
 function normalizeStrings(haystack: string, needle: string, options: string): { haystack: string, needle: string } {

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/JavascriptTranslation/StringMethodTranslations.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/JavascriptTranslation/StringMethodTranslations.dothtml
@@ -1,4 +1,5 @@
 ﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.JavascriptTranslation.StringMethodTranslationsViewModel, DotVVM.Samples.Common
+@import System
 
 <!DOCTYPE html>
 
@@ -11,27 +12,67 @@
 
     <h2 data-ui="main-text">{{value:Joke}}</h2>
     <p>Value</p><dot:TextBox Text="{value: Value}" data-ui="textbox" />
-    <dot:Button Text="Contains(value)" Click="{staticCommand: OperationResult = Joke.Contains(Value).ToString()}" />
-    <dot:Button Text="EndsWith(value)" Click="{staticCommand: OperationResult = Joke.EndsWith(Value).ToString()}" />
 
-    <dot:Button Text="IndexOf(value)" Click="{staticCommand: Index = Joke.IndexOf(Value)}" />
-    <dot:Button Text="IndexOf(value,30)" Click="{staticCommand: Index = Joke.IndexOf(Value, 30)}" />
+    <p>
+        <dot:Button Text="Contains(value)" Click="{staticCommand: OperationResult = Joke.Contains(Value).ToString()}" />
+        <dot:Button Text="Contains(value,InvariantCulture)" Click="{staticCommand: OperationResult = Joke.Contains(Value, StringComparison.InvariantCulture)}" />
+        <dot:Button Text="Contains(value,InvariantCultureIgnoreCase)" Click="{staticCommand: OperationResult = Joke.Contains(Value, StringComparison.InvariantCultureIgnoreCase)}" />
+    </p>
 
-    <dot:Button Text="IsNullOrEmpty(value)" Click="{staticCommand: OperationResult = String.IsNullOrEmpty(Value).ToString()}" />
+    <p>
+        <dot:Button Text="EndsWith(value)" Click="{staticCommand: OperationResult = Joke.EndsWith(Value).ToString()}" />
+        <dot:Button Text="EndsWith(value,InvariantCulture)" Click="{staticCommand: OperationResult = Joke.EndsWith(Value, StringComparison.InvariantCulture).ToString()}" />
+        <dot:Button Text="EndsWith(value,InvariantCultureIgnoreCase)" Click="{staticCommand: OperationResult = Joke.EndsWith(Value, StringComparison.InvariantCultureIgnoreCase).ToString()}" />
+    </p>
 
-    <dot:Button Text="Join(., list)" Click="{staticCommand: OperationResult = String.Join('.', JoinList)}" />
-    <dot:Button Text="Join( JOIN , array)" Click="{staticCommand: OperationResult = String.Join(" JOIN ", JoinArray)}" />
+    <p>
+        <dot:Button Text="IndexOf(value)" Click="{staticCommand: Index = Joke.IndexOf(Value)}" />
+        <dot:Button Text="IndexOf(value,InvariantCulture)" Click="{staticCommand: Index = Joke.IndexOf(Value, StringComparison.InvariantCulture)}" />
+        <dot:Button Text="IndexOf(value,InvariantCultureIgnoreCase)" Click="{staticCommand: Index = Joke.IndexOf(Value, StringComparison.InvariantCultureIgnoreCase)}" />
 
-    <dot:Button Text="LastIndexOf(value)" Click="{staticCommand: Index = Joke.LastIndexOf(Value)}" />
-    <dot:Button Text="LastIndexOf(value, 30)" Click="{staticCommand: Index = Joke.LastIndexOf(Value, 30)}" />
+        <dot:Button Text="IndexOf(value,30)" Click="{staticCommand: Index = Joke.IndexOf(Value, 30)}" />
+        <dot:Button Text="IndexOf(value,30,InvariantCulture)" Click="{staticCommand: Index = Joke.IndexOf(Value, 30, StringComparison.InvariantCulture)}" />
+        <dot:Button Text="IndexOf(value,30,InvariantCultureIgnoreCase)" Click="{staticCommand: Index = Joke.IndexOf(Value, 30, StringComparison.InvariantCultureIgnoreCase)}" />
+    </p>
 
-    <dot:Button Text="Replace(a, A)" Click="{staticCommand: OperationResult = Joke.Replace("a", "A")}" />
+    <p>
+        <dot:Button Text="IsNullOrEmpty(value)" Click="{staticCommand: OperationResult = String.IsNullOrEmpty(Value).ToString()}" />
+    </p>
 
-    <dot:Button Text="Split((char)?)" Click="{staticCommand: SplitArray = Joke.Split('?')}" />
-    <dot:Button Text="Split((string)do)" Click="{staticCommand: SplitArray = Joke.Split("do")}" />
+    <p>
+        <dot:Button Text="Join(., list)" Click="{staticCommand: OperationResult = String.Join('.', JoinList)}" />
+        <dot:Button Text="Join( JOIN , array)" Click="{staticCommand: OperationResult = String.Join(" JOIN ", JoinArray)}" />
+    </p>
 
-    <dot:Button Text="ToLower()" Click="{staticCommand: OperationResult = Joke.ToLower()}" />
-    <dot:Button Text="ToUpper()" Click="{staticCommand: OperationResult = Joke.ToUpper()}" />
+    <p>
+        <dot:Button Text="LastIndexOf(value)" Click="{staticCommand: Index = Joke.LastIndexOf(Value)}" />
+        <dot:Button Text="LastIndexOf(value,InvariantCulture)" Click="{staticCommand: Index = Joke.LastIndexOf(Value, StringComparison.InvariantCulture)}" />
+        <dot:Button Text="LastIndexOf(value,InvariantCultureIgnoreCase)" Click="{staticCommand: Index = Joke.LastIndexOf(Value, StringComparison.InvariantCultureIgnoreCase)}" />
+
+        <dot:Button Text="LastIndexOf(value,30)" Click="{staticCommand: Index = Joke.LastIndexOf(Value, 30)}" />
+        <dot:Button Text="LastIndexOf(value,30,InvariantCulture)" Click="{staticCommand: Index = Joke.LastIndexOf(Value, 30, StringComparison.InvariantCulture)}" />
+        <dot:Button Text="LastIndexOf(value,30,InvariantCultureIgnoreCase)" Click="{staticCommand: Index = Joke.LastIndexOf(Value, 30, StringComparison.InvariantCultureIgnoreCase)}" />
+    </p>  
+
+    <p>
+        <dot:Button Text="Replace(a, A)" Click="{staticCommand: OperationResult = Joke.Replace("a", "A")}" />
+    </p>
+
+    <p>
+        <dot:Button Text="Split((char)?)" Click="{staticCommand: SplitArray = Joke.Split('?')}" />
+        <dot:Button Text="Split((string)do)" Click="{staticCommand: SplitArray = Joke.Split("do")}" />
+    </p>
+
+    <p>
+        <dot:Button Text="StartsWith(value)" Click="{staticCommand: OperationResult = Joke.StartsWith(Value).ToString()}" />
+        <dot:Button Text="StartsWith(value,InvariantCulture)" Click="{staticCommand: OperationResult = Joke.StartsWith(Value, StringComparison.InvariantCulture).ToString()}" />
+        <dot:Button Text="StartsWith(value,InvariantCultureIgnoreCase)" Click="{staticCommand: OperationResult = Joke.StartsWith(Value, StringComparison.InvariantCultureIgnoreCase).ToString()}" />
+    </p>
+
+    <p>
+        <dot:Button Text="ToLower()" Click="{staticCommand: OperationResult = Joke.ToLower()}" />
+        <dot:Button Text="ToUpper()" Click="{staticCommand: OperationResult = Joke.ToUpper()}" />
+    </p>
 
     <p>Operation result</p><h2 data-ui="operation-result">{{value: OperationResult}}</h2>
     <p>IndexOf result:</p> <h2 data-ui="index-result">{{value: Index}}</h2>

--- a/src/DotVVM.Samples.Tests/Feature/StaticCommandStringMethodTests .cs
+++ b/src/DotVVM.Samples.Tests/Feature/StaticCommandStringMethodTests .cs
@@ -45,6 +45,27 @@ namespace DotVVM.Samples.Tests.Feature
                 AssertUI.InnerTextEquals(result, "false");
             });
         }
+
+        [Fact]
+        public void Feature_StaticCommand_String_Method_Contains_WithCaseSensitivity()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_JavascriptTranslation_StringMethodTranslations);
+
+                var textbox = browser.First("[data-ui=textbox]");
+                var buttonCaseSensitive = browser.First($"//input[@value='Contains(value,InvariantCulture)']", By.XPath);
+                var buttonCaseInsensitive = browser.First($"//input[@value='Contains(value,InvariantCultureIgnoreCase)']", By.XPath);
+                var result = browser.First("[data-ui=operation-result]");
+
+                textbox.Click().SendKeys("BECAUSE");
+                buttonCaseSensitive.Click();
+                AssertUI.InnerTextEquals(result, "false");
+
+                buttonCaseInsensitive.Click();
+                AssertUI.InnerTextEquals(result, "true");
+            });
+        }
+
         [Fact]
         public void Feature_StaticCommand_String_Method_EndsWith()
         {
@@ -73,6 +94,27 @@ namespace DotVVM.Samples.Tests.Feature
                 AssertUI.InnerTextEquals(result, "false");
             });
         }
+
+        [Fact]
+        public void Feature_StaticCommand_String_Method_EndsWith_WithCaseSensitivity()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_JavascriptTranslation_StringMethodTranslations);
+
+                var textbox = browser.First("[data-ui=textbox]");
+                var buttonCaseSensitive = browser.First($"//input[@value='EndsWith(value,InvariantCulture)']", By.XPath);
+                var buttonCaseInsensitive = browser.First($"//input[@value='EndsWith(value,InvariantCultureIgnoreCase)']", By.XPath);
+                var result = browser.First("[data-ui=operation-result]");
+
+                textbox.Click().SendKeys("c#.");
+                buttonCaseSensitive.Click();
+                AssertUI.InnerTextEquals(result, "false");
+
+                buttonCaseInsensitive.Click();
+                AssertUI.InnerTextEquals(result, "true");
+            });
+        }
+
         [Fact]
         public void Feature_StaticCommand_String_Method_IndexOf()
         {
@@ -101,6 +143,27 @@ namespace DotVVM.Samples.Tests.Feature
                 AssertUI.InnerTextEquals(result, "5");
             });
         }
+
+        [Fact]
+        public void Feature_StaticCommand_String_Method_IndexOf_WithCaseSensitivity()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_JavascriptTranslation_StringMethodTranslations);
+
+                var textbox = browser.First("[data-ui=textbox]");
+                var buttonCaseSensitive = browser.First($"//input[@value='IndexOf(value,InvariantCulture)']", By.XPath);
+                var buttonCaseInsensitive = browser.First($"//input[@value='IndexOf(value,InvariantCultureIgnoreCase)']", By.XPath);
+                var result = browser.First("[data-ui=index-result]");
+
+                textbox.Click().SendKeys("GLASSES");
+                buttonCaseSensitive.Click();
+                AssertUI.InnerTextEquals(result, "-1");
+
+                buttonCaseInsensitive.Click();
+                AssertUI.InnerTextEquals(result, "37");
+            });
+        }
+
         [Fact]
         public void Feature_StaticCommand_String_Method_IndexOf_StartIndex()
         {
@@ -127,6 +190,26 @@ namespace DotVVM.Samples.Tests.Feature
 
                 button.Click();
                 AssertUI.InnerTextEquals(result, "30");
+            });
+        }
+
+        [Fact]
+        public void Feature_StaticCommand_String_Method_IndexOf_StartIndex_WithCaseSensitivity()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_JavascriptTranslation_StringMethodTranslations);
+
+                var textbox = browser.First("[data-ui=textbox]");
+                var buttonCaseSensitive = browser.First($"//input[@value='IndexOf(value,30,InvariantCulture)']", By.XPath);
+                var buttonCaseInsensitive = browser.First($"//input[@value='IndexOf(value,30,InvariantCultureIgnoreCase)']", By.XPath);
+                var result = browser.First("[data-ui=index-result]");
+
+                textbox.Click().SendKeys("GLASSES");
+                buttonCaseSensitive.Click();
+                AssertUI.InnerTextEquals(result, "-1");
+
+                buttonCaseInsensitive.Click();
+                AssertUI.InnerTextEquals(result, "37");
             });
         }
 
@@ -215,6 +298,27 @@ namespace DotVVM.Samples.Tests.Feature
                 AssertUI.InnerTextEquals(result, "63");
             });
         }
+
+        [Fact]
+        public void Feature_StaticCommand_String_Method_LastIndexOf_WithCaseSensitivity()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_JavascriptTranslation_StringMethodTranslations);
+
+                var textbox = browser.First("[data-ui=textbox]");
+                var buttonCaseSensitive = browser.First($"//input[@value='LastIndexOf(value,InvariantCulture)']", By.XPath);
+                var buttonCaseInsensitive = browser.First($"//input[@value='LastIndexOf(value,InvariantCultureIgnoreCase)']", By.XPath);
+                var result = browser.First("[data-ui=index-result]");
+
+                textbox.Click().SendKeys("GLASSES");
+                buttonCaseSensitive.Click();
+                AssertUI.InnerTextEquals(result, "-1");
+
+                buttonCaseInsensitive.Click();
+                AssertUI.InnerTextEquals(result, "37");
+            });
+        }
+
         [Fact]
         public void Feature_StaticCommand_String_Method_LastIndexOf_StartIndex()
         {
@@ -223,7 +327,7 @@ namespace DotVVM.Samples.Tests.Feature
 
                 
                 var textbox = browser.First("[data-ui=textbox]");
-                var button = browser.First($"//input[@value='LastIndexOf(value, 30)']", By.XPath);
+                var button = browser.First($"//input[@value='LastIndexOf(value,30)']", By.XPath);
                 var result = browser.First("[data-ui=index-result]");
 
                 textbox.Click();
@@ -243,6 +347,27 @@ namespace DotVVM.Samples.Tests.Feature
                 AssertUI.InnerTextEquals(result, "30");
             });
         }
+
+        [Fact]
+        public void Feature_StaticCommand_String_Method_LastIndexOf_StartIndex_WithCaseSensitivity()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_JavascriptTranslation_StringMethodTranslations);
+
+                var textbox = browser.First("[data-ui=textbox]");
+                var buttonCaseSensitive = browser.First($"//input[@value='LastIndexOf(value,30,InvariantCulture)']", By.XPath);
+                var buttonCaseInsensitive = browser.First($"//input[@value='LastIndexOf(value,30,InvariantCultureIgnoreCase)']", By.XPath);
+                var result = browser.First("[data-ui=index-result]");
+
+                textbox.Click().SendKeys("GLASSES");
+                buttonCaseSensitive.Click();
+                AssertUI.InnerTextEquals(result, "-1");
+
+                buttonCaseInsensitive.Click();
+                AssertUI.InnerTextEquals(result, "37");
+            });
+        }
+
         [Fact]
         public void Feature_StaticCommand_String_Method_Replace()
         {
@@ -287,6 +412,27 @@ namespace DotVVM.Samples.Tests.Feature
                 AssertUI.InnerTextEquals(result[2], "not C#.");
             });
         }
+
+        [Fact]
+        public void Feature_StaticCommand_String_Method_StartsWith_WithCaseSensitivity()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_JavascriptTranslation_StringMethodTranslations);
+
+                var textbox = browser.First("[data-ui=textbox]");
+                var buttonCaseSensitive = browser.First($"//input[@value='StartsWith(value,InvariantCulture)']", By.XPath);
+                var buttonCaseInsensitive = browser.First($"//input[@value='StartsWith(value,InvariantCultureIgnoreCase)']", By.XPath);
+                var result = browser.First("[data-ui=operation-result]");
+
+                textbox.Click().SendKeys("WHY");
+                buttonCaseSensitive.Click();
+                AssertUI.InnerTextEquals(result, "false");
+
+                buttonCaseInsensitive.Click();
+                AssertUI.InnerTextEquals(result, "true");
+            });
+        }
+
         [Fact]
         public void Feature_StaticCommand_String_Method_ChangeLetters()
         {


### PR DESCRIPTION
This PR adds another batch of JS translations for string methods:

- `string.Contains(string value, StringComparison options)`
- `string.EndsWith(string value, StringComparison options)`
- `string.IndexOf(string value, StringComparison options)`
- `string.IndexOf(string value, int startIndex, StringComparison options)`
- `string.LastIndexOf(string value, StringComparison options)`
- `string.LastIndexOf(string value, int startIndex, StringComparison options)`
- `string.StartsWith(string value, StringComparison options)`

The only truly recognized values from `StringComparison` enums are `InvariantCulture` and `InvariantCultureIgnoreCase` with the `InvariantCulture` being the default. Once this feature gets merged I will update relevant documentation pages accordingly.