### PR TITLE
Fixed implementations of `GetNodes` and `GetChildNodes`

### DIFF
--- a/src/DotVVM.Framework.Tests/Binding/BindingCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests/Binding/BindingCompilationTests.cs
@@ -345,7 +345,6 @@ namespace DotVVM.Framework.Tests.Binding
         [TestMethod]
         [DataRow("(TestViewModel vm) => vm.IntProp = 11")]
         [DataRow("(TestViewModel vm) => vm.GetEnum()")]
-        [DataRow("(TestViewModel vm) => ()")]
         [DataRow("(TestViewModel vm) => ;")]
         public void BindingCompiler_Valid_LambdaToAction(string expr)
         {

--- a/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/FormattedBindingParserNode.cs
+++ b/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/FormattedBindingParserNode.cs
@@ -19,8 +19,11 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
             this.Format = format;
         }
 
+        public override IEnumerable<BindingParserNode> EnumerateNodes()
+            => base.EnumerateNodes().Concat(Node.EnumerateNodes());
+
         public override IEnumerable<BindingParserNode> EnumerateChildNodes()
-            => base.EnumerateNodes().Concat(new[] { Node });
+            => new[] { Node };
 
         public override string ToDisplayString()
             => $"{Node.ToDisplayString()}:{Format}";

--- a/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/InterpolatedStringBindingParserNode.cs
+++ b/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/InterpolatedStringBindingParserNode.cs
@@ -20,8 +20,11 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
             this.Arguments = arguments;
         }
 
+        public override IEnumerable<BindingParserNode> EnumerateNodes()
+            => base.EnumerateNodes().Concat(Arguments.SelectMany(arg => arg.EnumerateNodes()));
+
         public override IEnumerable<BindingParserNode> EnumerateChildNodes()
-            => base.EnumerateNodes().Concat(Arguments);
+           => Arguments;
 
         public override string ToDisplayString()
             => $"String.Format(\"{Format}\", {Arguments.Select(arg => arg.ToDisplayString()).StringJoin(", ")})";

--- a/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/LambdaBindingParserNode.cs
+++ b/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/LambdaBindingParserNode.cs
@@ -22,8 +22,11 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
             this.BodyExpression = body;
         }
 
+        public override IEnumerable<BindingParserNode> EnumerateNodes()
+            => base.EnumerateNodes().Concat(ParameterExpressions.SelectMany(param => param.EnumerateNodes()).Concat(BodyExpression.EnumerateNodes()));
+
         public override IEnumerable<BindingParserNode> EnumerateChildNodes()
-            => base.EnumerateNodes().Concat(ParameterExpressions).Concat(BodyExpression.EnumerateNodes());
+            => ParameterExpressions.Concat(new[] { BodyExpression });
 
         public override string ToDisplayString()
             => $"({ParameterExpressions.Select(p => p.ToDisplayString()).StringJoin(", ")}) => {BodyExpression.ToDisplayString()}";
@@ -47,8 +50,11 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
         public void SetResolvedType(Type argumentType)
             => ResolvedType = argumentType;
 
+        public override IEnumerable<BindingParserNode> EnumerateNodes()
+            => base.EnumerateNodes().Concat((Type != null) ? Type.EnumerateNodes().Concat(Name.EnumerateNodes()) : Name.EnumerateNodes());
+
         public override IEnumerable<BindingParserNode> EnumerateChildNodes()
-            => (Type != null) ? base.EnumerateNodes().Concat(new[] { Type, Name }) : base.EnumerateNodes().Concat(new[] { Name });
+            => (Type != null) ? new[] { Type, Name } : new[] { Name };
 
         public override string ToDisplayString()
             => $"{Type?.ToDisplayString()} {Name.ToDisplayString()}";

--- a/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/TypeOrFunctionReferenceBindingParserNode.cs
+++ b/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/TypeOrFunctionReferenceBindingParserNode.cs
@@ -18,12 +18,11 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
             this.TypeArguments = typeArguments ?? new List<TypeReferenceBindingParserNode>(0);
         }
 
+        public override IEnumerable<BindingParserNode> EnumerateNodes()
+            => base.EnumerateNodes().Concat(TypeOrFunction.EnumerateNodes()).Concat(TypeArguments.SelectMany(arg => arg.EnumerateNodes()));
+
         public override IEnumerable<BindingParserNode> EnumerateChildNodes()
-        {
-            yield return TypeOrFunction;
-            foreach (var arg in TypeArguments)
-                yield return arg;
-        }
+            => new[] { TypeOrFunction }.Concat(TypeArguments);
 
         public override string ToDisplayString()
         {

--- a/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/TypeReferenceBindingParserNode.cs
+++ b/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/TypeReferenceBindingParserNode.cs
@@ -22,10 +22,11 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
             this.Type = type;
         }
 
+        public override IEnumerable<BindingParserNode> EnumerateNodes()
+            => base.EnumerateNodes().Concat(Type.EnumerateNodes());
+
         public override IEnumerable<BindingParserNode> EnumerateChildNodes()
-        {
-            yield return Type;
-        }
+            => new[] { Type };
 
         public override string ToDisplayString()
             => Type.ToDisplayString();
@@ -41,10 +42,11 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
             this.ElementType = elementType;
         }
 
+        public override IEnumerable<BindingParserNode> EnumerateNodes()
+            => base.EnumerateNodes().Concat(ElementType.EnumerateNodes());
+
         public override IEnumerable<BindingParserNode> EnumerateChildNodes()
-        {
-            yield return ElementType;
-        }
+            => new[] { ElementType };
 
         public override string ToDisplayString()
             => $"{ElementType.ToDisplayString()}[]";
@@ -62,12 +64,11 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
             this.Arguments = arguments;
         }
 
+        public override IEnumerable<BindingParserNode> EnumerateNodes()
+            => base.EnumerateNodes().Concat(Type.EnumerateNodes()).Concat(Arguments.SelectMany(arg => arg.EnumerateNodes()));
+
         public override IEnumerable<BindingParserNode> EnumerateChildNodes()
-        {
-            yield return Type;
-            foreach (var arg in Arguments)
-                yield return arg;
-        }
+            => new[] { Type }.Concat(Arguments);
 
         public override string ToDisplayString()
             => $"{Type.ToDisplayString()}<{string.Join(", ", Arguments.Select(e => e.ToDisplayString()))}>";
@@ -83,10 +84,11 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
             this.InnerType = innerType;
         }
 
+        public override IEnumerable<BindingParserNode> EnumerateNodes()
+            => base.EnumerateNodes().Concat(InnerType.EnumerateNodes());
+
         public override IEnumerable<BindingParserNode> EnumerateChildNodes()
-        {
-            yield return InnerType;
-        }
+            => new[] { InnerType };
 
         public override string ToDisplayString()
             => $"{InnerType.ToDisplayString()}?";


### PR DESCRIPTION
This PR fixes implementations of `GetNodes` and `GetChildNodes` on recently added binding parser nodes. Alongside this change I removed a single unit test that was identified as faulty once node enumerables were fixed.

This change is necessary in order to add support for new data-binding constructs in DotVVM VS Extension