### PR TITLE
Fixed issues with string interpolation

### DIFF
--- a/src/DotVVM.Framework.Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests/Binding/JavascriptCompilationTests.cs
@@ -133,7 +133,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JavascriptCompilation_InterpolatedString(string expression)
         {
             var js = CompileBinding(expression, new[] { typeof(TestViewModel) }, typeof(string));
-            Assert.AreEqual("dotvvm.globalize.format(\"Interpolated {0} {1}\",[StringProp(),StringProp()])", js);
+            Assert.AreEqual("dotvvm.translations.string.format(\"Interpolated {0} {1}\",[StringProp(),StringProp()])", js);
         }
 
         [TestMethod]

--- a/src/DotVVM.Framework.Tests/Parser/Binding/BindingTokenizerTests.cs
+++ b/src/DotVVM.Framework.Tests/Parser/Binding/BindingTokenizerTests.cs
@@ -260,6 +260,19 @@ namespace DotVVM.Framework.Tests.Parser.Binding
         }
 
         [TestMethod]
+        [DataRow("$'{{'   ", "$'{{'", "   ")]
+        [DataRow("$'}}'   ", "$'}}'", "   ")]
+        public void BindingTokenizer_InterpolatedString_DoNotReadPastString(string expression, string text1, string text2)
+        {
+            var tokens = Tokenize(expression);
+            Assert.AreEqual(2, tokens.Count);
+            Assert.AreEqual(tokens[0].Type, BindingTokenType.InterpolatedStringToken);
+            Assert.AreEqual(tokens[1].Type, BindingTokenType.WhiteSpace);
+            Assert.AreEqual(text1, tokens[0].Text);
+            Assert.AreEqual(text2, tokens[1].Text);
+        }
+
+        [TestMethod]
         public void BindingTokenizer_UnaryOperator_BunchingOperators_Valid()
         {
             var tokens = Tokenize("A(!IsDisplayed)");

--- a/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/DotVVM.Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -223,16 +223,15 @@ namespace DotVVM.Framework.Compilation.Javascript
 
         private void AddDefaultStringTranslations()
         {
-            var stringFormatTranslator = new GenericMethodCompiler(
-                args => new JsIdentifierExpression("dotvvm").Member("globalize").Member("format").Invoke(args[1], new JsArrayExpression(args.Skip(2)))
-            );
             // TODO: string.Format could be two-way
-            AddMethodTranslator(typeof(string).GetMethod("Format", new[] { typeof(string), typeof(object) }), stringFormatTranslator);
-            AddMethodTranslator(typeof(string).GetMethod("Format", new[] { typeof(string), typeof(object), typeof(object) }), stringFormatTranslator);
-            AddMethodTranslator(typeof(string).GetMethod("Format", new[] { typeof(string), typeof(object), typeof(object), typeof(object) }), stringFormatTranslator);
+            AddMethodTranslator(typeof(string).GetMethod("Format", new[] { typeof(string), typeof(object) }), translator: new GenericMethodCompiler(
+                args => new JsIdentifierExpression("dotvvm").Member("globalize").Member("format").Invoke(args[1], args[2])));
+            AddMethodTranslator(typeof(string).GetMethod("Format", new[] { typeof(string), typeof(object), typeof(object) }), new GenericMethodCompiler(
+                args => new JsIdentifierExpression("dotvvm").Member("globalize").Member("format").Invoke(args[1], args[2], args[3])));
+            AddMethodTranslator(typeof(string).GetMethod("Format", new[] { typeof(string), typeof(object), typeof(object), typeof(object) }), new GenericMethodCompiler(
+                args => new JsIdentifierExpression("dotvvm").Member("globalize").Member("format").Invoke(args[1], args[2], args[3], args[4])));
             AddMethodTranslator(typeof(string).GetMethod("Format", new[] { typeof(string), typeof(object[]) }), new GenericMethodCompiler(
-                args => new JsIdentifierExpression("dotvvm").Member("globalize").Member("format").Invoke(args[1], args[2])
-            ));
+                args => new JsIdentifierExpression("dotvvm").Member("translations").Member("string").Member("format").Invoke(args[1], args[2])));
 
             AddMethodTranslator(typeof(string), nameof(string.IndexOf), parameters: new[] { typeof(string) }, translator: new GenericMethodCompiler(
                 a => a[0].Member("indexOf").Invoke(a[1])));

--- a/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/BindingParser.cs
+++ b/src/DotVVM.Framework/Compilation/Parser/Binding/Parser/BindingParser.cs
@@ -697,6 +697,7 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
                 // interpolated string
 
                 Read();
+                SkipWhiteSpace();
 
                 var (format, arguments) = ParseInterpolatedString(token.Text, out var error);
                 var node = CreateNode(new InterpolatedStringBindingParserNode(format, arguments), startIndex);

--- a/src/DotVVM.Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenizer.cs
+++ b/src/DotVVM.Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenizer.cs
@@ -344,35 +344,43 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Tokenizer
             errorMessage = null;
         }
 
-        internal static void ReadInterpolatedString(Func<char> peekFunction, Func<char> readFunction, out string? errorMessage)
+        internal static void ReadInterpolatedString(Func<int, char> peekFunction, Func<char> readFunction, out string? errorMessage)
         {
             readFunction();
             var quoteChar = readFunction();
             var exprDepth = 0;
 
-            while (peekFunction() != quoteChar || exprDepth != 0)
+            while (peekFunction(0) != quoteChar || exprDepth != 0)
             {
-                if (peekFunction() == NullChar)
+                if (peekFunction(0) == NullChar)
                 {
                     errorMessage = "Interpolated string was not closed!";
                     return;
                 }
 
-                if (peekFunction() == '\\' && exprDepth == 0)
+                if (peekFunction(0) == '\\' && exprDepth == 0)
                 {
                     readFunction();
                 }
-                else if (peekFunction() == '{')
+                else if (peekFunction(0) == '{' && peekFunction(1) != '{')
                 {
                     exprDepth++;
                 }
-                else if (peekFunction() == '}')
+                else if (peekFunction(0) == '{' && peekFunction(1) == '{')
+                {
+                    readFunction();
+                }
+                else if (peekFunction(0) == '}' && peekFunction(1) != '}')
                 {
                     if (--exprDepth <= -1)
                     {
                         errorMessage = "Could not find matching '{' character!";
                         return;
                     }
+                }
+                else if (peekFunction(0) == '}' && peekFunction(1) == '}')
+                {
+                    readFunction();
                 }
 
                 readFunction();

--- a/src/DotVVM.Framework/Resources/Scripts/utils/stringHelper.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/utils/stringHelper.ts
@@ -1,4 +1,6 @@
-﻿export function split<T>(text: string, delimiter: string, options: string): string[] {
+﻿import { format as formatImpl } from "../DotVVM.Globalize";
+
+export function split<T>(text: string, delimiter: string, options: string): string[] {
     let tokens = text.split(delimiter);
     if (options === "RemoveEmptyEntries") {
         tokens = tokens.filter(t => t);
@@ -10,4 +12,8 @@
 export function join<T>(elements: T[], delimiter: string): string {
     let unwrappedElements = elements.map(ko.unwrap);
     return unwrappedElements.join(delimiter);
+}
+
+export function format(pattern: string, expressions: any[]): string {
+    return formatImpl(pattern, ...expressions);
 }

--- a/src/DotVVM.Samples.BasicSamples.Owin/package-lock.json
+++ b/src/DotVVM.Samples.BasicSamples.Owin/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
+++ b/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
@@ -76,6 +76,7 @@
     <None Remove="Views\FeatureSamples\Serialization\TimeSpan.dothtml" />
     <None Remove="Views\FeatureSamples\Serialization\EnumSerializationCoercion.dothtml" />
     <None Remove="Views\FeatureSamples\Serialization\SerializationDateTimeOffset.dothtml" />
+    <None Remove="Views\FeatureSamples\StringInterpolation\StringInterpolation.dothtml" />
     <None Remove="Views\FeatureSamples\ViewModules\Incrementer.dotcontrol" />
     <None Remove="Views\FeatureSamples\ViewModules\IncrementerInRepeater.dothtml" />
     <None Remove="Views\FeatureSamples\ViewModules\ModuleControl.dotcontrol" />

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/StringInterpolation/StringInterpolationViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/StringInterpolation/StringInterpolationViewModel.cs
@@ -10,6 +10,7 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.StringInterpolation
     public class StringInterpolationViewModel : DotvvmViewModelBase
     {
         public string Name { get; set; } = "Mark";
+        public string Name2 { get; set; } = "John";
         public int Age { get; set; } = 24;
         public int IntNumber { get; set; } = -1508;
         public double DoubleNumber { get; set; } = 15.0896;

--- a/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/StringInterpolation/StringInterpolationViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/FeatureSamples/StringInterpolation/StringInterpolationViewModel.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.StringInterpolation
+{
+    public class StringInterpolationViewModel : DotvvmViewModelBase
+    {
+        public string Name { get; set; } = "Mark";
+        public int Age { get; set; } = 24;
+        public int IntNumber { get; set; } = -1508;
+        public double DoubleNumber { get; set; } = 15.0896;
+        public DateTime Date { get; set; } = new DateTime(2016, 7, 15, 3, 15, 0);
+    }
+}
+

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/StringInterpolation/StringInterpolation.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/StringInterpolation/StringInterpolation.dothtml
@@ -9,31 +9,43 @@
 </head>
 <body>
     <dot:RequiredResource Name="globalize" />
+    <h2>Basic Strings</h2>
+    <p data-ui="names">{{value: $'Hello, {Name} and {Name2}'}}</p>
 
-    <p>{{value: $'Hello, {Name} and {Name}'}}</p>
+    <p data-ui="date">{{value: $'Today is {Date:dd/MM/yyyy}!'}}</p>
 
-    <p data-ui="text">{{value: $'Today is {Date:dd/MM/yyyy}!'}}</p>
-
-    <dot:Literal Text="{value: $'Tomorrow is {Date:dd/MM/yyyy}!'}" />
+    <dot:Literal Text="{value: $'Today is {Date:dd/MM/yyyy}!'}" data-ui="date-literal" />
 
     <h2>Standard Numeric Format Strings</h2>
-    <%--    <p data-ui="standard-numeric-format1">{{value: $"No format: {IntNumber}"}}</p>
+    <p data-ui="standard-numeric-format1">{{value: $"No format: {IntNumber}"}}</p>
     <p data-ui="standard-numeric-format2">{{value: $"C2 format: {DoubleNumber:C2}"}}</p>
     <p data-ui="standard-numeric-format3">{{value: $"G1 format: {DoubleNumber:g1}"}}</p>
     <p data-ui="standard-numeric-format4">{{value: $"N format: {IntNumber:N}"}}</p>
-    <p data-ui="standard-numeric-format5">{{value: $"D8 format: {IntNumber:D8}"}}</p>--%>
+    <p data-ui="standard-numeric-format5">{{value: $"D8 format: {IntNumber:D8}"}}</p>
+    <p data-ui="standard-numeric-format6">{{value: $"P format: {DoubleNumber:P,}"}}</p>
 
     <h2>Custom Numeric Format Strings</h2>
-    <%--<p data-ui="custom-numeric-format1">{{value: $"No format: {DoubleNumber:#}"}}</p>--%>
+    <p data-ui="custom-numeric-format1">{{value: $"{DoubleNumber} (#####.#) -> {DoubleNumber:#####.#}"}}</p>
+    <p data-ui="custom-numeric-format2">{{value: $"{DoubleNumber} (00000.0) -> {DoubleNumber:00000.0}"}}</p>
+    <p data-ui="custom-numeric-format3">{{value: $"{DoubleNumber} (#####) -> {DoubleNumber:#####}"}}</p>
 
     <h2>Standard Date and Time Format Strings</h2>
     <p data-ui="date-format1">{{value: $"No format: {Date}"}}</p>
-    <%--<p data-ui="date-format2">{{value: $"O format: {Date:D}"}}</p>
-    <p data-ui="date-format3">{{value: $"O format: {Date:F}"}}</p>
-    <p data-ui="date-format4">{{value: $"O format: {Date:G}"}}</p>--%>
+    <p data-ui="date-format2">{{value: $"D format: {Date:D} |X| d format: {Date:d}"}}</p>
+    <p data-ui="date-format3">{{value: $"F format: {Date:F} |X| f format: {Date:f}"}}</p>
+    <p data-ui="date-format4">{{value: $"G format: {Date:G} |X| g format: {Date:g}"}}</p>
+    <p data-ui="date-format5">{{value: $"M format: {Date:M}"}}</p>
+    <p data-ui="date-format6">{{value: $"T format: {Date:T} |X| t format: {Date:t}"}}</p>
+    <p data-ui="date-format7">{{value: $"Y format: {Date:Y}"}}</p>
+    <%--<p data-ui="date-format6">{{value: $"s format: {Date:s}"}}</p>--%>
+
+    <h2>Custom Date And Time Format Strings</h2>
+    <p data-ui="custom-date-format1">{{value: $"dd MMM yyyy hh:mm tt PST format: {Date:dd MMM yyyy hh:mm tt PST}"}}</p>
+    <p data-ui="custom-date-format2">{{value: $"ddd dd MM yyyy  format: {Date:ddd dd MM yyyy}"}}</p>
+    <p data-ui="custom-date-format3">{{value: $"dddd dd MMMM yyyy  format: {Date:dddd dd MMMM yyyy}"}}</p>
 
     <h2>Special characters</h2>
-    <p data-ui="special-char1">{{value: $"He asked, \"Is your name {Name}?\", but didn't wait for a reply :-{{" }}<</p>
+    <p data-ui="special-char1">{{value: $"He asked, \"Is your name {Name}?\", but didn't wait for a reply :-{{" }}</p>
     <p data-ui="special-char2">{{value: $"{Name} is {Age} year{(Age == 1 ? "" : "s")} old."}}</p>
 
 </body>

--- a/src/DotVVM.Samples.Common/Views/FeatureSamples/StringInterpolation/StringInterpolation.dothtml
+++ b/src/DotVVM.Samples.Common/Views/FeatureSamples/StringInterpolation/StringInterpolation.dothtml
@@ -1,0 +1,41 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.StringInterpolation.StringInterpolationViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+    <dot:RequiredResource Name="globalize" />
+
+    <p>{{value: $'Hello, {Name} and {Name}'}}</p>
+
+    <p data-ui="text">{{value: $'Today is {Date:dd/MM/yyyy}!'}}</p>
+
+    <dot:Literal Text="{value: $'Tomorrow is {Date:dd/MM/yyyy}!'}" />
+
+    <h2>Standard Numeric Format Strings</h2>
+    <%--    <p data-ui="standard-numeric-format1">{{value: $"No format: {IntNumber}"}}</p>
+    <p data-ui="standard-numeric-format2">{{value: $"C2 format: {DoubleNumber:C2}"}}</p>
+    <p data-ui="standard-numeric-format3">{{value: $"G1 format: {DoubleNumber:g1}"}}</p>
+    <p data-ui="standard-numeric-format4">{{value: $"N format: {IntNumber:N}"}}</p>
+    <p data-ui="standard-numeric-format5">{{value: $"D8 format: {IntNumber:D8}"}}</p>--%>
+
+    <h2>Custom Numeric Format Strings</h2>
+    <%--<p data-ui="custom-numeric-format1">{{value: $"No format: {DoubleNumber:#}"}}</p>--%>
+
+    <h2>Standard Date and Time Format Strings</h2>
+    <p data-ui="date-format1">{{value: $"No format: {Date}"}}</p>
+    <%--<p data-ui="date-format2">{{value: $"O format: {Date:D}"}}</p>
+    <p data-ui="date-format3">{{value: $"O format: {Date:F}"}}</p>
+    <p data-ui="date-format4">{{value: $"O format: {Date:G}"}}</p>--%>
+
+    <h2>Special characters</h2>
+    <p data-ui="special-char1">{{value: $"He asked, \"Is your name {Name}?\", but didn't wait for a reply :-{{" }}<</p>
+    <p data-ui="special-char2">{{value: $"{Name} is {Age} year{(Age == 1 ? "" : "s")} old."}}</p>
+
+</body>
+</html>
+

--- a/src/DotVVM.Samples.Tests/Feature/StringInterpolationTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/StringInterpolationTests.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Samples.Tests.Base;
+using DotVVM.Testing.Abstractions;
+using Riganti.Selenium.Core;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DotVVM.Samples.Tests.Feature
+{
+    public class StringInterpolationTests : AppSeleniumTest
+    {
+        [Fact]
+        public void Feature_StringInterpolation_SpecialCharacterTest()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_StringInterpolation);
+            });
+
+
+        }
+        public StringInterpolationTests(ITestOutputHelper output) : base(output)
+        {
+        }
+    }
+}

--- a/src/DotVVM.Samples.Tests/Feature/StringInterpolationTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/StringInterpolationTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
+using OpenQA.Selenium;
 using Riganti.Selenium.Core;
 using Xunit;
 using Xunit.Abstractions;
@@ -18,9 +19,82 @@ namespace DotVVM.Samples.Tests.Feature
         {
             RunInAllBrowsers(browser => {
                 browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_StringInterpolation);
+                var text1 = browser.Single("special-char1", SelectByDataUi);
+                var text2 = browser.Single("special-char2", SelectByDataUi);
+
+                AssertUI.TextEquals(text1, "He asked, \"Is your name Mark ? \", but didn't wait for a reply :-{");
+                AssertUI.TextEquals(text2, "Mark is 24 years old.");
             });
+        }
+        [Fact]
+        public void Feature_StringInterpolation_StandardNumericFormatTest()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_StringInterpolation);
+                var text1 = browser.Single("standard-numeric-format1", SelectByDataUi);
+                var text2 = browser.Single("standard-numeric-format2", SelectByDataUi);
+                var text3 = browser.Single("standard-numeric-format3", SelectByDataUi);
+                var text4 = browser.Single("standard-numeric-format4", SelectByDataUi);
+                var text5 = browser.Single("standard-numeric-format5", SelectByDataUi);
+                var text6 = browser.Single("standard-numeric-format6", SelectByDataUi);
 
+                AssertUI.TextEquals(text1, "No format: -1508");
+                AssertUI.TextEquals(text2, "C2 format: $15.09");
+                AssertUI.TextEquals(text3, "G1 format: 15.0896");
+                AssertUI.TextEquals(text4, "N format: -1,508.00");
+                AssertUI.TextEquals(text5, "D8 format: -00001508");
+                AssertUI.TextEquals(text6, "P format: 1,508 %");
+            });
+        }
+        [Fact]
+        public void Feature_StringInterpolation_CustomNumericFormatTest()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_StringInterpolation);
+                var text1 = browser.Single("custom-numeric-format1", SelectByDataUi);
+                var text2 = browser.Single("custom-numeric-format2", SelectByDataUi);
+                var text3 = browser.Single("custom-numeric-format3", SelectByDataUi);
 
+                AssertUI.TextEquals(text1, "15.0896 (#####.#) -> 15.1");
+                AssertUI.TextEquals(text2, "15.0896 (00000.0) -> 00015.1");
+                AssertUI.TextEquals(text3, "15.0896 (#####) -> 15");
+            });
+        }
+        [Fact]
+        public void Feature_StringInterpolation_StandardDateFormatTest()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_StringInterpolation);
+                var text1 = browser.Single("date-format1", SelectByDataUi);
+                var text2 = browser.Single("date-format2", SelectByDataUi);
+                var text3 = browser.Single("date-format3", SelectByDataUi);
+                var text4 = browser.Single("date-format4", SelectByDataUi);
+                var text5 = browser.Single("date-format5", SelectByDataUi);
+                var text6 = browser.Single("date-format6", SelectByDataUi);
+                var text7 = browser.Single("date-format7", SelectByDataUi);
+
+                AssertUI.TextEquals(text1, "No format: 2016-07-15T03:15:00.0000000");
+                AssertUI.TextEquals(text2, "D format: Friday, July 15, 2016 |X| d format: 7/15/2016");
+                AssertUI.TextEquals(text3, "F format: Friday, July 15, 2016 3:15:00 AM |X| f format: Friday, July 15, 2016 3:15 AM");
+                AssertUI.TextEquals(text4, "G format: 7/15/2016 3:15:00 AM |X| g format: 7/15/2016 3:15 AM");
+                AssertUI.TextEquals(text5, "M format: July 15");
+                AssertUI.TextEquals(text6, "T format: 3:15:00 AM |X| t format: 3:15 AM");
+                AssertUI.TextEquals(text7, "Y format: 2016 July");
+            });
+        }
+        [Fact]
+        public void Feature_StringInterpolation_CustomDateFormatTest()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_StringInterpolation);
+                var text1 = browser.Single("custom-date-format1", SelectByDataUi);
+                var text2 = browser.Single("custom-date-format2", SelectByDataUi);
+                var text3 = browser.Single("custom-date-format3", SelectByDataUi);
+
+                AssertUI.TextEquals(text1, "dd MMM yyyy hh:mm tt PST format: 15 Jul 2016 03:15 AM PST");
+                AssertUI.TextEquals(text2, "ddd dd MM yyyy format: Fri 15 07 2016");
+                AssertUI.TextEquals(text3, "dddd dd MMMM yyyy format: Friday 15 July 2016");
+            });
         }
         public StringInterpolationTests(ITestOutputHelper output) : base(output)
         {

--- a/src/DotVVM.Samples.Tests/Feature/StringInterpolationTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/StringInterpolationTests.cs
@@ -22,7 +22,7 @@ namespace DotVVM.Samples.Tests.Feature
                 var text1 = browser.Single("special-char1", SelectByDataUi);
                 var text2 = browser.Single("special-char2", SelectByDataUi);
 
-                AssertUI.TextEquals(text1, "He asked, \"Is your name Mark ? \", but didn't wait for a reply :-{");
+                AssertUI.TextEquals(text1, "He asked, \"Is your name Mark?\", but didn't wait for a reply :-{");
                 AssertUI.TextEquals(text2, "Mark is 24 years old.");
             });
         }

--- a/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
@@ -313,6 +313,7 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_StaticCommand_StaticCommand_NullBinding = "FeatureSamples/StaticCommand/StaticCommand_NullBinding";
         public const string FeatureSamples_StaticCommand_StaticCommand_TaskSequence = "FeatureSamples/StaticCommand/StaticCommand_TaskSequence";
         public const string FeatureSamples_StaticCommand_StaticCommand_ValueAssignmentInControl = "FeatureSamples/StaticCommand/StaticCommand_ValueAssignmentInControl";
+        public const string FeatureSamples_StringInterpolation = "FeatureSamples/StringInterpolation/StringInterpolation";
         public const string FeatureSamples_UsageValidation_OverrideValidation = "FeatureSamples/UsageValidation/OverrideValidation";
         public const string FeatureSamples_Validation_ClientSideObservableUpdate = "FeatureSamples/Validation/ClientSideObservableUpdate";
         public const string FeatureSamples_Validation_CustomValidation = "FeatureSamples/Validation/CustomValidation";


### PR DESCRIPTION
This PR fixes a few issues that were found during testing string interpolation feature.

1. `dotvvm.globalization.format` function was incorrectly called. This could have caused rendering of `undefined value`s when user specified multiple interpolated expressions
2. `dotvvm.globalization.format` incorrectly interpretted formatting options. This caused that many formatting options were unrecognized by the globalization library
3. `BindingTokenizer` could have read one character past the string boundary. This was only observable when a string ends with `{{` or `}}` sequence. Rendered strings had additional character (always the ending quotation mark).
4. `BindingParser` was not skipping whitespaces after parsing interpolated string. This caused parsing exceptions in some cases.

Together with @fero02 we also found some additional minor issues related to the `dotvvm.globalization` library that will be addressed in a separate PR.