### PR TITLE
fix OnPreInit invocation on dotvvm markup control

### DIFF
--- a/src/DotVVM.Framework/Controls/DotvvmMarkupControl.cs
+++ b/src/DotVVM.Framework/Controls/DotvvmMarkupControl.cs
@@ -28,7 +28,6 @@ namespace DotVVM.Framework.Controls
         /// </summary>
         public DotvvmMarkupControl() : this("div")
         {
-            LifecycleRequirements |= ControlLifecycleRequirements.PreInit;
         }
 
         /// <summary>
@@ -36,6 +35,7 @@ namespace DotVVM.Framework.Controls
         /// </summary>
         public DotvvmMarkupControl(string? wrapperTagName) : base(wrapperTagName)
         {
+            LifecycleRequirements |= ControlLifecycleRequirements.PreInit;
             SetValue(Internal.IsNamingContainerProperty, true);
             SetValue(Internal.IsControlBindingTargetProperty, true);
         }


### PR DESCRIPTION
This caused weird bugs when this constructor was used and
the markup control contained @js directive, since the resource was not loaded
