### PR TITLE
Add a switch that lists dotprops to the compiler

### DIFF
--- a/src/DotVVM.CommandLine/DotVVM.CommandLine.csproj
+++ b/src/DotVVM.CommandLine/DotVVM.CommandLine.csproj
@@ -4,7 +4,6 @@
     <AssemblyTitle>DotVVM.CommandLine</AssemblyTitle>
     <AssemblyName>dotnet-dotvvm</AssemblyName>
     <VersionPrefix>3.1.0</VersionPrefix>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyOriginatorKeyFile>dotvvmwizard.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <OutputType>Exe</OutputType>

--- a/src/DotVVM.Compiler/CompilerArgs.cs
+++ b/src/DotVVM.Compiler/CompilerArgs.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace DotVVM.Compiler
+{
+    [Serializable]
+    public record CompilerArgs
+    {
+        private static readonly string[] HelpOptions = new string[] {
+            "--help", "-h", "-?", "/help", "/h", "/?"
+        };
+        private const string ListPropertiesOption = "--list-props";
+
+        public CompilerArgs(
+            FileInfo assemblyFile,
+            DirectoryInfo projectDir,
+            bool isHelp = false,
+            bool isListProperties = false)
+        {
+            AssemblyFile = assemblyFile;
+            ProjectDir = projectDir;
+            IsHelp = isHelp;
+            IsListProperties = isListProperties;
+        }
+
+        public FileInfo AssemblyFile { get; init; }
+        public DirectoryInfo ProjectDir { get; init; }
+        public bool IsHelp { get; init; }
+        public bool IsListProperties { get; init;}
+
+        public static bool TryParse(string[] args, out CompilerArgs parsed)
+        {
+            // To minimize dependencies, this tool deliberately reinvents the wheel instead of using System.CommandLine.
+            parsed = new CompilerArgs(null!, null!);
+            int i = 0;
+            for (; i < args.Length; ++i)
+            {
+                if (HelpOptions.Contains(args[i]))
+                {
+                    parsed = parsed with { IsHelp = true };
+                }
+                else if (args[i] == ListPropertiesOption)
+                {
+                    parsed = parsed with { IsListProperties = true };
+                }
+                else
+                {
+                    break;
+                }
+            }
+            // i now contains the number of parsed OPTIONS
+            if (args.Length - i != 2)
+            {
+                Console.Error.Write($"The executable expects 2 arguments. Got {args.Length - i}.");
+                return false;
+            }
+
+            parsed = parsed with {
+                AssemblyFile = new FileInfo(args[i]),
+                ProjectDir = new DirectoryInfo(args[i + 1])
+            };
+            if (!parsed.AssemblyFile.Exists)
+            {
+                Console.Error.Write($"Assembly '{parsed.AssemblyFile}' does not exist.");
+                return false;
+            }
+
+            if (!parsed.ProjectDir.Exists)
+            {
+                Console.Error.Write($"Project directory '{parsed.ProjectDir}' does not exist.");
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/src/DotVVM.Compiler/DefaultCompilerExecutor.cs
+++ b/src/DotVVM.Compiler/DefaultCompilerExecutor.cs
@@ -51,6 +51,7 @@ namespace DotVVM.Compiler
                     .ToArray();
                 if (props.Length != 0)
                 {
+                    var columnCount = types.Max(p => p.Name.Length);
                     Console.WriteLine(type.Name);
                     foreach(var prop in props)
                     {
@@ -71,10 +72,10 @@ namespace DotVVM.Compiler
                             info.Add("changed-context");
                         }
 
-                        Console.Write($"\t{prop.Name}");
+                        Console.Write($"\t{prop.Name.PadRight(columnCount)}");
                         if (info.Count != 0)
                         {
-                            Console.Write($" [{string.Join(", ", info)}]");
+                            Console.Write($"\t[{string.Join(", ", info)}]");
                         }
                         Console.WriteLine();
                     }

--- a/src/DotVVM.Compiler/DefaultCompilerExecutor.cs
+++ b/src/DotVVM.Compiler/DefaultCompilerExecutor.cs
@@ -2,21 +2,60 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Compilation.Static;
+using DotVVM.Framework.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DotVVM.Compiler
 {
     public class DefaultCompilerExecutor : ICompilerExecutor
     {
-        public bool ExecuteCompile(FileInfo assemblyFile, DirectoryInfo? projectDir)
+        private readonly Assembly assembly;
+
+        public DefaultCompilerExecutor(Assembly assembly)
         {
-            var assembly = Assembly.LoadFile(assemblyFile.FullName);
-            var projectDirPath = projectDir?.FullName ?? Directory.GetCurrentDirectory();
+            this.assembly = assembly;
+        }
+
+        public bool ExecuteCompile(CompilerArgs args)
+        {
+            if (args.IsListProperties)
+            {
+                ListProperties();
+                return true;
+            }
+
+            var projectDirPath = args.ProjectDir?.FullName ?? Directory.GetCurrentDirectory();
             var reports = StaticViewCompiler.CompileAll(assembly, projectDirPath);
             var logger = new DefaultCompilationReportLogger();
             using var err = Console.OpenStandardError();
             logger.Log(err, reports);
             return reports.Length == 0;
+        }
+
+        private void ListProperties()
+        {
+            var configuration = DotvvmConfiguration.CreateInternal(_ => {});
+            // NB: This forces DotVVM to register all properties on all types.
+            _ = configuration.ServiceProvider.GetRequiredService<IControlResolver>();
+            var types = assembly.GetTypes().OrderBy(t => t.FullName).ToArray();
+            foreach (var type in types)
+            {
+                var props = DotvvmProperty.ResolveProperties(type)
+                    .Where(p => p.DeclaringType == type)
+                    .OrderBy(p => p.Name)
+                    .ToArray();
+                if (props.Length != 0)
+                {
+                    Console.WriteLine(type.FullName);
+                    foreach(var prop in props)
+                    {
+                        Console.WriteLine($"\t{prop.Name}");
+                    }
+                }
+            }
         }
     }
 }

--- a/src/DotVVM.Compiler/DependencyContextCompilerExecutor.cs
+++ b/src/DotVVM.Compiler/DependencyContextCompilerExecutor.cs
@@ -10,13 +10,19 @@ namespace DotVVM.Compiler
 {
     public class DependencyContextCompilerExecutor : ICompilerExecutor
     {
-        private readonly DefaultCompilerExecutor inner = new();
+        private readonly Assembly assembly;
+        private readonly DefaultCompilerExecutor inner;
 
-        public bool ExecuteCompile(FileInfo assemblyFile, DirectoryInfo? projectDir)
+        public DependencyContextCompilerExecutor(Assembly assembly)
         {
-            var assembly = Assembly.LoadFile(assemblyFile.FullName);
+            this.assembly = assembly;
+            inner = new(assembly);
+        }
+
+        public bool ExecuteCompile(CompilerArgs args)
+        {
             ReplaceDefaultDependencyContext(assembly);
-            return inner.ExecuteCompile(assemblyFile, projectDir);
+            return inner.ExecuteCompile(args);
         }
 
         private static void ReplaceDefaultDependencyContext(Assembly projectAssembly)

--- a/src/DotVVM.Compiler/DotVVM.Compiler.csproj
+++ b/src/DotVVM.Compiler/DotVVM.Compiler.csproj
@@ -10,7 +10,7 @@ for some reason. What fun. -->
 
   <!-- Related to compilation -->
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net461;net50</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461;net5.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <OutputType>Exe</OutputType>
     <LangVersion>9.0</LangVersion>
@@ -52,10 +52,6 @@ for some reason. What fun. -->
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-
-  <!-- <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'" Version="">
-    <PackageReference Include="" />
-  </ItemGroup> -->
 
   <ItemGroup>
     <None Include="dotvvmwizard.snk" />

--- a/src/DotVVM.Compiler/ICompilerExecutor.cs
+++ b/src/DotVVM.Compiler/ICompilerExecutor.cs
@@ -1,9 +1,7 @@
-using System.IO;
-
 namespace DotVVM.Compiler
 {
     public interface ICompilerExecutor
     {
-        bool ExecuteCompile(FileInfo assemblyFile, DirectoryInfo? projectDir);
+        bool ExecuteCompile(CompilerArgs args);
     }
 }

--- a/src/DotVVM.Compiler/IsExternalInit.cs
+++ b/src/DotVVM.Compiler/IsExternalInit.cs
@@ -1,0 +1,8 @@
+#if !NET5_0_OR_GREATER
+
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit {}
+}
+
+#endif

--- a/src/DotVVM.Compiler/IsExternalInit.cs
+++ b/src/DotVVM.Compiler/IsExternalInit.cs
@@ -1,7 +1,12 @@
 #if !NET5_0_OR_GREATER
 
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
 namespace System.Runtime.CompilerServices
 {
+    [DebuggerNonUserCode]
+    [ExcludeFromCodeCoverage]
     internal static class IsExternalInit {}
 }
 

--- a/src/DotVVM.Compiler/Program.cs
+++ b/src/DotVVM.Compiler/Program.cs
@@ -25,19 +25,6 @@ Options:
 
         public static int Main(string[] args)
         {
-#if NETCOREAPP3_1_OR_GREATER
-            var r = Microsoft.Extensions.DependencyModel.DependencyContext.Default.RuntimeLibraries
-                .Where(l => l.Name.Contains("DotVVM")).ToArray();
-            var c = Microsoft.Extensions.DependencyModel.DependencyContext.Default.CompileLibraries
-                .Where(l => l.Name.Contains("DotVVM")).ToArray();
-            foreach(var context in System.Runtime.Loader.AssemblyLoadContext.All)
-            {
-                context.Resolving += (c, n) => {
-                    return null;
-                };
-            }
-#endif
-
             if (!CompilerArgs.TryParse(args, out var parsed))
             {
                 PrintHelp(Console.Error);

--- a/src/DotVVM.Compiler/ProjectLoader.cs
+++ b/src/DotVVM.Compiler/ProjectLoader.cs
@@ -19,8 +19,8 @@ namespace DotVVM.Compiler
                     : null;
             };
 
-            _ = System.Runtime.Loader.AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
-            return new DependencyContextCompilerExecutor();
+            var assembly = System.Runtime.Loader.AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
+            return new DependencyContextCompilerExecutor(assembly);
 
 #elif NET461
             var setup = new AppDomainSetup

--- a/src/DotVVM.Framework/Compilation/Static/ConfigurationInitializer.cs
+++ b/src/DotVVM.Framework/Compilation/Static/ConfigurationInitializer.cs
@@ -41,7 +41,7 @@ namespace DotVVM.Framework.Compilation.Static
             var dotvvmStartupType = GetDotvvmStartupType(assembly);
             if (dotvvmStartupType is null)
             {
-                throw new ArgumentException("Could not found an implementation of IDotvvmStartup "
+                throw new ArgumentException("Could not find an implementation of IDotvvmStartup "
                     + $"in '{assembly.FullName}'.");
             }
 


### PR DESCRIPTION
Adds a `--list-props` switch to the `DotVVM.Compiler` that loads an assembly and lists all `DotvvmProperties` declared inside it. It's meant for internal usage, can break in the future, and thus cannot be invoked through `DotVVM.CommandLine`.

Besides that, this PR makes a few refactorings to facilitate the switch and adds a proper help text.

If you want to try the switch out, build the `DotVVM.Compiler` project, `cd` to `src/DotVVM.Compiler`, and:

* If your DotVVM project targets .NET Core 3.1:
```bash
dotnet run -f netcoreapp3.1 -- --list-props "<path to your project's dll>" "<path to your project's dir>"
```

* If your DotVVM project targets .NET 5:
```bash
dotnet run -f net5.0 -- --list-props "<path to your project's dll>" "<path to your project's dir>"
```

* If your DotVVM project targets OWIN:
```bash
dotnet run -f net461 -- --list-props "<path to your project's dll>" "<path to your project's dir>"
```