### PR TITLE
Fixed issue in type inferer when unifying same types

### DIFF
--- a/src/DotVVM.Framework.Tests/Binding/BindingCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests/Binding/BindingCompilationTests.cs
@@ -345,6 +345,18 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        [DataRow("List.RemoveFirst(item => item == 2)", new[] { 1, 3 })]
+        [DataRow("List.RemoveLast(item => item == 2)", new[] { 1, 3 })]
+        [DataRow("List.AddOrUpdate(11, i => i == 2, i => 22)", new[] { 1, 22, 3 })]
+        [DataRow("List.AddOrUpdate(11, i => i == 22, i => 33)", new[] { 1, 2, 3, 11 })]
+        public void BindingCompiler_MoreComplexInference(string expr, int[] result)
+        {
+            var viewModel = new TestViewModel() { StringProp = "abc", List = new List<int>() { 1, 2, 3 } };
+            ExecuteBinding(expr, new[] { viewModel }, null, new[] { new NamespaceImport("DotVVM.Framework.Binding.HelperNamespace") }, expectedType: typeof(void));
+            CollectionAssert.AreEqual(result, viewModel.List);
+        }
+
+        [TestMethod]
         [DataRow("(int arg, float arg) => ;", DisplayName = "Can not use same identifier for multiple parameters")]
         [DataRow("(object _this) => ;", DisplayName = "Can not use already used identifiers for parameters")]
         public void BindingCompiler_Invalid_LambdaParameters(string expr)

--- a/src/DotVVM.Framework.Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests/Binding/JavascriptCompilationTests.cs
@@ -511,7 +511,7 @@ namespace DotVVM.Framework.Tests.Binding
         [TestMethod]
         public void JsTranslator_ListAddOrUpdate()
         {
-            var result = CompileBinding("LongList.AddOrUpdate(12345L, (long item) => item == 12345, (long item) => 54321L)", new[] { typeof(TestViewModel) }, typeof(void), new[] { new NamespaceImport("DotVVM.Framework.Binding.HelperNamespace") });
+            var result = CompileBinding("LongList.AddOrUpdate(12345L, item => item == 12345, item => 54321L)", new[] { typeof(TestViewModel) }, typeof(void), new[] { new NamespaceImport("DotVVM.Framework.Binding.HelperNamespace") });
             Assert.AreEqual("dotvvm.translations.array.addOrUpdate(LongList,12345,function(item){return ko.unwrap(item)==12345;},function(item){return 54321;})", result);
         }
 

--- a/src/DotVVM.Framework/Compilation/Inference/TypeInferer.cs
+++ b/src/DotVVM.Framework/Compilation/Inference/TypeInferer.cs
@@ -122,6 +122,9 @@ namespace DotVVM.Framework.Compilation.Inference
 
         private bool TryInferInstantiation(Type generic, Type concrete, Dictionary<string, Type> generics)
         {
+            if (generic == concrete)
+                return true;
+
             if (generic.IsGenericParameter)
             {
                 // We found the instantiation


### PR DESCRIPTION
This PR fixes an issue with type inferer. Unification of two exactly same types is valid and must always succeed. Previously, type inferer did not handle this edge-case well, which caused issues with infering lambda parameters on more complex methods, such as on `ListExtensions.AddOrUpdate(...)` method.