### PR TITLE
Enable access to parent extension parameters

### DIFF
--- a/src/DotVVM.Framework.Testing/BindingTestHelper.cs
+++ b/src/DotVVM.Framework.Testing/BindingTestHelper.cs
@@ -60,22 +60,25 @@ namespace DotVVM.Framework.Testing
                 TypeConversion.ImplicitConversion(parsedExpression, expectedType, true, true);
         }
 
-        public ParametrizedCode ValueBindingToParametrizedCode(string expression, Type[] contexts, Type? expectedType = null, NamespaceImport[]? imports = null, bool nullChecks = false, bool niceMode = true)
+        public ParametrizedCode ValueBindingToParametrizedCode(string expression, Type[] contexts, Type? expectedType = null, NamespaceImport[]? imports = null, bool nullChecks = false, bool niceMode = true) =>
+            ValueBindingToParametrizedCode(expression, CreateDataContext(contexts), expectedType, imports, nullChecks, niceMode);
+        public ParametrizedCode ValueBindingToParametrizedCode(string expression, DataContextStack context, Type? expectedType = null, NamespaceImport[]? imports = null, bool nullChecks = false, bool niceMode = true)
         {
             expectedType ??= typeof(object);
 
-            var context = CreateDataContext(contexts);
             var expressionTree = ParseBinding(expression, context, expectedType, imports);
             var jsExpression = JavascriptTranslator.CompileToJavascript(expressionTree, context);
             return BindingPropertyResolvers.FormatJavascript(jsExpression, allowObservableResult: true, nullChecks: nullChecks, niceMode: niceMode);
         }
 
-        public string ValueBindingToJs(string expression, Type[] contexts, Type? expectedType = null, NamespaceImport[]? imports = null, bool nullChecks = false, bool niceMode = true)
-        {
-            return JavascriptTranslator.FormatKnockoutScript(
+        public string ValueBindingToJs(string expression, Type[] contexts, Type? expectedType = null, NamespaceImport[]? imports = null, bool nullChecks = false, bool niceMode = true) =>
+            JavascriptTranslator.FormatKnockoutScript(
                 ValueBindingToParametrizedCode(expression, contexts, expectedType, imports, nullChecks, niceMode)
             );
-        }
+        public string ValueBindingToJs(string expression, DataContextStack context, Type? expectedType = null, NamespaceImport[]? imports = null, bool nullChecks = false, bool niceMode = true) =>
+            JavascriptTranslator.FormatKnockoutScript(
+                ValueBindingToParametrizedCode(expression, context, expectedType, imports, nullChecks, niceMode)
+            );
 
         public ValueBindingExpression<T> ValueBinding<T>(string expression, Type[] contexts)
         {

--- a/src/DotVVM.Framework.Tests/Binding/BindingCompilationTests.cs
+++ b/src/DotVVM.Framework.Tests/Binding/BindingCompilationTests.cs
@@ -43,9 +43,13 @@ namespace DotVVM.Framework.Tests.Binding
             {
                 context = DataContextStack.Create(contexts[i].GetType(), context);
             }
+            return ExecuteBinding(expression, context, contexts, control, imports, expectedType);
+        }
+        public object ExecuteBinding(string expression, DataContextStack contextType, object[] contexts, DotvvmControl control, NamespaceImport[] imports = null, Type expectedType = null)
+        {
             Array.Reverse(contexts);
             var binding = new ResourceBindingExpression(bindingService, new object[] {
-                context,
+                contextType,
                 new OriginalStringBindingProperty(expression),
                 new BindingParserOptions(typeof(ResourceBindingExpression), importNamespaces: imports?.ToImmutableList()),
                 new ExpectedTypeBindingProperty(expectedType ?? typeof(object))
@@ -645,6 +649,43 @@ namespace DotVVM.Framework.Tests.Binding
             var result = ExecuteBinding("Alias.Property", new object[0], null,
                 new NamespaceImport[] { new NamespaceImport("DotVVM.Framework.Tests.Binding.TestNamespace2.TestClass2", alias: "Alias") });
             Assert.AreEqual(TestNamespace2.TestClass2.Property, result);
+        }
+
+        [TestMethod]
+        [DataRow("_index", 21)]
+        [DataRow("_parent._index", 10)]
+        [DataRow("_root._index", 10)]
+        [DataRow("_parent0._index", 21)]
+        [DataRow("_this._collection.IsOdd", true)]
+        [DataRow("_parent._collection.IsOdd", false)]
+        public void BindingCompiler_IndexExtensionParameter(string expr, object expectedResult)
+        {
+            var dc1 = DataContextStack.Create(
+                typeof(string),
+                extensionParameters: new BindingExtensionParameter[] {
+                    new CurrentCollectionIndexExtensionParameter(),
+                    new BindingCollectionInfoExtensionParameter("_collection")
+                });
+            var dc2 = DataContextStack.Create(
+                typeof(string),
+                parent: dc1,
+                extensionParameters: new BindingExtensionParameter[] {
+                    new CurrentCollectionIndexExtensionParameter(),
+                    new BindingCollectionInfoExtensionParameter("_collection")
+                });
+
+            var control1 = new DataItemContainer() { DataItemIndex = 10 };
+            control1.SetDataContextType(dc1);
+            var control2 = new DataItemContainer() { DataItemIndex = 21 };
+            control2.SetDataContextType(dc2);
+            control1.Children.Add(control2);
+            var html = new HtmlGenericControl("span");
+            control2.Children.Add(html);
+
+            var result = ExecuteBinding(expr, dc2, new object[] { "a", "b" }, html);
+            Assert.AreEqual(expectedResult, result);
+            var result2 = ExecuteBinding(expr, dc2, new object[] { "a", "b" }, control2);
+            Assert.AreEqual(expectedResult, result2);
         }
 
 

--- a/src/DotVVM.Framework/Binding/BindingHelper.cs
+++ b/src/DotVVM.Framework/Binding/BindingHelper.cs
@@ -71,8 +71,13 @@ namespace DotVVM.Framework.Binding
         public static (int stepsUp, DotvvmBindableObject target) FindDataContextTarget(this IBinding binding, DotvvmBindableObject control)
         {
             if (control == null) throw new InvalidOperationException($"Can not evaluate binding without any dataContext.");
-            var controlContext = (DataContextStack?)control.GetValue(Internal.DataContextTypeProperty);
             var bindingContext = binding.GetProperty<DataContextStack>(ErrorHandlingMode.ReturnNull);
+            return FindDataContextTarget(control, bindingContext, binding);
+        }
+
+        internal static (int stepsUp, DotvvmBindableObject target) FindDataContextTarget(DotvvmBindableObject control, DataContextStack? bindingContext, object? contextObject)
+        {
+            var controlContext = (DataContextStack?)control.GetValue(Internal.DataContextTypeProperty);
             if (bindingContext == null || controlContext == null || controlContext.Equals(bindingContext)) return (0, control);
 
             var changes = 0;
@@ -84,7 +89,7 @@ namespace DotVVM.Framework.Binding
                 if (a.properties.Contains(DotvvmBindableObject.DataContextProperty)) changes++;
             }
 
-            throw new NotSupportedException($"Could not find DataContext space of binding '{binding}'. The DataContextType property of the binding does not correspond to DataContextType of the {control.GetType().Name} not any of its ancestor. Control's context is {controlContext}, binding's context is {bindingContext}.");
+            throw new NotSupportedException($"Could not find DataContext space of '{contextObject}'. The DataContextType property of the binding does not correspond to DataContextType of the {control.GetType().Name} not any of its ancestor. Control's context is {controlContext}, binding's context is {bindingContext}.");
         }
 
         /// <summary>

--- a/src/DotVVM.Framework/Compilation/Binding/ExpressionBuildingVisitor.cs
+++ b/src/DotVVM.Framework/Compilation/Binding/ExpressionBuildingVisitor.cs
@@ -12,6 +12,8 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using DotVVM.Framework.Compilation.Parser.Binding.Parser.Annotations;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Compilation.ControlTree.Resolved;
 
 namespace DotVVM.Framework.Compilation.Binding
 {
@@ -19,6 +21,7 @@ namespace DotVVM.Framework.Compilation.Binding
     {
         public TypeRegistry Registry { get; set; }
         public Expression? Scope { get; set; }
+        /// <summary> We use the parser to parse directives where only type name is expected. At that place, the flag is set to true otherwise it's false </summary>
         public bool ResolveOnlyTypeName { get; set; }
         public Type? ExpectedType { get; set; }
         public ImmutableDictionary<string, ParameterExpression> Variables { get; set; } =
@@ -85,11 +88,6 @@ namespace DotVVM.Framework.Compilation.Binding
                 }
                 throw new AggregateException(currentErrors);
             }
-        }
-
-        protected void RegisterSymbols(IEnumerable<KeyValuePair<string, Expression>> symbols)
-        {
-            Registry = Registry.AddSymbols(symbols);
         }
 
         public override Expression Visit(BindingParserNode node)
@@ -358,7 +356,34 @@ namespace DotVVM.Framework.Compilation.Binding
                 return resolvedTypeExpression;
             }
 
-            return memberExpressionFactory.GetMember(target, nameNode.Name, typeParameters, onlyMemberTypes: ResolveOnlyTypeName);
+            // we try to resolve member access into an extension parameter
+            // for example _parent._index should resolve into the _index extension parameter on the parent context
+            var extensionParameter = TryResolveExtensionParameter(target, nameNode);
+            
+            // even when we find the extension parameter, member properties should have priority (for compatibility, at least)
+
+            return
+                memberExpressionFactory.GetMember(
+                    target, nameNode.Name, typeParameters,
+                    throwExceptions: extensionParameter is null,
+                    onlyMemberTypes: ResolveOnlyTypeName
+                ) ?? extensionParameter!;
+        }
+
+        Expression? TryResolveExtensionParameter(Expression target, IdentifierNameBindingParserNode nameNode)
+        {
+            // target is _parent, _this, _root, ...
+            if (target.GetParameterAnnotation() is BindingParameterAnnotation { ExtensionParameter: null, DataContext: {} dataContext } &&
+                // name is simple (no generics)
+                nameNode is SimpleNameBindingParserNode { Name: {} name } &&
+                dataContext.ExtensionParameters.FirstOrDefault(e => e.Identifier == name) is {} parameter)
+            {
+                return Expression.Parameter(
+                    ResolvedTypeDescriptor.ToSystemType(parameter.ParameterType) ?? typeof(UnknownTypeSentinel),
+                    parameter.Identifier
+                ).AddParameterAnnotation(new BindingParameterAnnotation(dataContext, parameter));
+            }
+            return null;
         }
 
         protected override Expression VisitGenericName(GenericNameBindingParserNode node)

--- a/src/DotVVM.Framework/Compilation/BindingCompiler.cs
+++ b/src/DotVVM.Framework/Compilation/BindingCompiler.cs
@@ -20,6 +20,7 @@ using DotVVM.Framework.Compilation.Javascript.Ast;
 using DotVVM.Framework.Binding.Properties;
 using DotVVM.Framework.Controls;
 using System.Diagnostics;
+using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Compilation
 {
@@ -56,8 +57,17 @@ namespace DotVVM.Framework.Compilation
                 {
                     if (ann.ExtensionParameter != null)
                     {
-                        // T+ inherited dataContext
-                        return ann.ExtensionParameter.GetServerEquivalent(CurrentControlParameter);
+                        // handle data context hierarchy
+                        var friendlyIdentifier = $"extension parameter {ann.ExtensionParameter.Identifier}";
+                        var targetControl =
+                            ContextMap[ann.DataContext] == 0
+                                ? CurrentControlParameter
+                                : ExpressionUtils.Replace(
+                                    (DotvvmBindableObject control) => BindingHelper.FindDataContextTarget(control, ann.DataContext, friendlyIdentifier).target,
+                                    CurrentControlParameter
+                                ).OptimizeConstants();
+
+                        return ann.ExtensionParameter.GetServerEquivalent(targetControl);
                     }
                     else
                     {

--- a/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
+++ b/src/DotVVM.Samples.Common/DotVVM.Samples.Common.csproj
@@ -38,6 +38,7 @@
     <None Remove="Views\ControlSamples\MultiSelect\hardcoded.dothtml" />
     <None Remove="Views\ControlSamples\RadioButton\Nullable.dothtml" />
     <None Remove="Views\ControlSamples\RadioButton\RadioButton_Objects.dothtml" />
+    <None Remove="Views\ControlSamples\Repeater\IndexInNestedRepeater.dothtml" />
     <None Remove="Views\ControlSamples\Repeater\NamedTemplate.dothtml" />
     <None Remove="Views\ControlSamples\RouteLink\RouteLinkQueryParameters.dothtml" />
     <None Remove="Views\ControlSamples\UpdateProgress\UpdateProgressQueues.dothtml" />

--- a/src/DotVVM.Samples.Common/ViewModels/ControlSamples/Repeater/IndexInNestedRepeaterViewModel.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/ControlSamples/Repeater/IndexInNestedRepeaterViewModel.cs
@@ -6,7 +6,7 @@ using DotVVM.Framework.ViewModel;
 
 namespace DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.Repeater
 {
-    public class NestedRepeaterViewModel : DotvvmViewModelBase
+    public class IndexInNestedRepeaterViewModel : DotvvmViewModelBase
     {
 
         public List<NestedRepeaterEntry> Children { get; set; }
@@ -28,7 +28,16 @@ namespace DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.Repeater
                         {
                             new NestedRepeaterEntry() { Name = "Subchild 1", Children = new List<NestedRepeaterEntry>()
                                 {
-                                    new NestedRepeaterEntry() { Name = "SubSubchild 1" }
+                                    new NestedRepeaterEntry() { Name = "SubSubchild 1" },
+                                    new NestedRepeaterEntry() { Name = "SubSubchild 2" }
+                                }
+                            },
+                            new NestedRepeaterEntry() { Name = "Subchild 2", Children = new List<NestedRepeaterEntry>()
+                                {
+                                    new NestedRepeaterEntry() { Name = "SubSubchild 1" },
+                                    new NestedRepeaterEntry() { Name = "SubSubchild 2" },
+                                    new NestedRepeaterEntry() { Name = "SubSubchild 3" },
+                                    new NestedRepeaterEntry() { Name = "SubSubchild 4" }
                                 }
                             },
                             new NestedRepeaterEntry() { Name = "Subchild 2" },

--- a/src/DotVVM.Samples.Common/ViewModels/ControlSamples/Repeater/NestedRepeaterEntry.cs
+++ b/src/DotVVM.Samples.Common/ViewModels/ControlSamples/Repeater/NestedRepeaterEntry.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.Repeater
+{
+    public class NestedRepeaterEntry
+    {
+        public string Name { get; set; }
+
+        public List<NestedRepeaterEntry> Children { get; set; }
+
+        public NestedRepeaterEntry Entry { get; set; }
+    }
+}

--- a/src/DotVVM.Samples.Common/Views/ControlSamples/Repeater/IndexInNestedRepeater.dothtml
+++ b/src/DotVVM.Samples.Common/Views/ControlSamples/Repeater/IndexInNestedRepeater.dothtml
@@ -8,7 +8,8 @@
     <title>Hello from DotVVM!</title>
 </head>
 <body ClientIDMode="Static">
-
+    <p> Checks that _index, _parent._index, ... work correctly. Each row should have the form "{parent indexes} - {_index}"
+    <p> Client rendering:
 
     <%--  Do not change the spans and the index format !!! The test recursively iterates all nodes and checks span content that has to be in format -x-y-z... --%>
     <div ID="client-side">
@@ -34,6 +35,8 @@
             </ItemTemplate>
         </dot:Repeater>
     </div>
+
+    <p> Server rendering:
 
     <div ID="server-side">
         <dot:Repeater DataSource="{value: Children}" WrapperTagName="ul" RenderSettings.Mode="Server">

--- a/src/DotVVM.Samples.Common/Views/ControlSamples/Repeater/IndexInNestedRepeater.dothtml
+++ b/src/DotVVM.Samples.Common/Views/ControlSamples/Repeater/IndexInNestedRepeater.dothtml
@@ -1,0 +1,65 @@
+﻿@viewModel DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.Repeater.IndexInNestedRepeaterViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title>Hello from DotVVM!</title>
+</head>
+<body ClientIDMode="Static">
+
+
+    <%--  Do not change the spans and the index format !!! The test recursively iterates all nodes and checks span content that has to be in format -x-y-z... --%>
+    <div ID="client-side">
+        <dot:Repeater DataSource="{value: Children}" WrapperTagName="ul">
+            <ItemTemplate>
+                <li>
+                    <span>{{value:  "-"+(_index+1)}}</span>
+                    <dot:Repeater DataSource="{value: Children}" WrapperTagName="ul">
+                        <ItemTemplate>
+                            <li>
+                                <span> {{value:  "-"+(_parent._index +1)+"-"+ (_index+1)}}</span>
+                                <dot:Repeater DataSource="{value: Children}" WrapperTagName="ul">
+                                    <ItemTemplate>
+                                        <li>
+                                            <span>{{value:"-"+(_parent2._index +1)+"-"+ (_parent._index +1)+"-"+ (_index+1)}}</span>
+                                        </li>
+                                    </ItemTemplate>
+                                </dot:Repeater>
+                            </li>
+                        </ItemTemplate>
+                    </dot:Repeater>
+                </li>
+            </ItemTemplate>
+        </dot:Repeater>
+    </div>
+
+    <div ID="server-side">
+        <dot:Repeater DataSource="{value: Children}" WrapperTagName="ul" RenderSettings.Mode="Server">
+            <ItemTemplate>
+                <li>
+                    <span>{{value:  "-"+(_index+1)}}</span>
+                    <dot:Repeater DataSource="{value: Children}" WrapperTagName="ul">
+                        <ItemTemplate>
+                            <li>
+                                <span> {{value:  "-"+(_parent._index +1)+"-"+ (_index+1)}}</span>
+                                <dot:Repeater DataSource="{value: Children}" WrapperTagName="ul">
+                                    <ItemTemplate>
+                                        <li>
+                                            <span>{{value:"-"+(_parent2._index +1)+"-"+ (_parent._index +1)+"-"+ (_index+1)}}</span>
+                                        </li>
+                                    </ItemTemplate>
+                                </dot:Repeater>
+                            </li>
+                        </ItemTemplate>
+                    </dot:Repeater>
+                </li>
+            </ItemTemplate>
+        </dot:Repeater>
+    </div>
+
+    <p ID="result">{{value: ClickedChild}}</p>
+
+</body>
+</html>

--- a/src/DotVVM.Samples.Tests/Control/NestedRepeaterTests.cs
+++ b/src/DotVVM.Samples.Tests/Control/NestedRepeaterTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
 using Riganti.Selenium.Core;
@@ -56,6 +57,36 @@ namespace DotVVM.Samples.Tests.Control
                 browser.ElementAt("a", 11).Click();
                 AssertUI.InnerTextEquals(result, "Child 3 Subchild 1");
             });
+        }
+        [Theory]
+        [InlineData("#client-side")]
+        [InlineData("#server-side")]
+        public void Control_Repeater_IndexInNestedRepeater(string sampleId)
+        {
+            base.RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.ControlSamples_Repeater_IndexInNestedRepeater);
+                browser.WaitUntilDotvvmInited();
+
+                var sample = browser.First(sampleId).First("ul");
+                CheckRepeaterIndexesRecursively(sample, 0, "");
+            });
+        }
+
+        private void CheckRepeaterIndexesRecursively(IElementWrapper ulElement, int level, string testText)
+        {
+            for (int i = 0; i < ulElement.Children.Count; i++)
+            {
+                var result = testText + "-" + (i + 1).ToString();
+                var child = ulElement.Children[i];
+                AssertUI.TagName(child, "li");
+                TestOutput.WriteLine($"Testing level {level} / child {i}");
+                AssertUI.InnerTextEquals(child.First("span"), result);
+                var innerUL = child.FirstOrDefault("ul");
+                if (innerUL is not null)
+                {
+                    CheckRepeaterIndexesRecursively(innerUL, level + 1, testText + "-" + (i + 1).ToString());
+                }
+            }
         }
 
         [Fact]

--- a/src/DotVVM.Samples.Tests/Feature/StringInterpolationTests.cs
+++ b/src/DotVVM.Samples.Tests/Feature/StringInterpolationTests.cs
@@ -18,7 +18,7 @@ namespace DotVVM.Samples.Tests.Feature
         public void Feature_StringInterpolation_SpecialCharacterTest()
         {
             RunInAllBrowsers(browser => {
-                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_StringInterpolation);
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_StringInterpolation_StringInterpolation);
                 var text1 = browser.Single("special-char1", SelectByDataUi);
                 var text2 = browser.Single("special-char2", SelectByDataUi);
 
@@ -30,7 +30,7 @@ namespace DotVVM.Samples.Tests.Feature
         public void Feature_StringInterpolation_StandardNumericFormatTest()
         {
             RunInAllBrowsers(browser => {
-                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_StringInterpolation);
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_StringInterpolation_StringInterpolation);
                 var text1 = browser.Single("standard-numeric-format1", SelectByDataUi);
                 var text2 = browser.Single("standard-numeric-format2", SelectByDataUi);
                 var text3 = browser.Single("standard-numeric-format3", SelectByDataUi);
@@ -50,7 +50,7 @@ namespace DotVVM.Samples.Tests.Feature
         public void Feature_StringInterpolation_CustomNumericFormatTest()
         {
             RunInAllBrowsers(browser => {
-                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_StringInterpolation);
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_StringInterpolation_StringInterpolation);
                 var text1 = browser.Single("custom-numeric-format1", SelectByDataUi);
                 var text2 = browser.Single("custom-numeric-format2", SelectByDataUi);
                 var text3 = browser.Single("custom-numeric-format3", SelectByDataUi);
@@ -64,7 +64,7 @@ namespace DotVVM.Samples.Tests.Feature
         public void Feature_StringInterpolation_StandardDateFormatTest()
         {
             RunInAllBrowsers(browser => {
-                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_StringInterpolation);
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_StringInterpolation_StringInterpolation);
                 var text1 = browser.Single("date-format1", SelectByDataUi);
                 var text2 = browser.Single("date-format2", SelectByDataUi);
                 var text3 = browser.Single("date-format3", SelectByDataUi);
@@ -86,7 +86,7 @@ namespace DotVVM.Samples.Tests.Feature
         public void Feature_StringInterpolation_CustomDateFormatTest()
         {
             RunInAllBrowsers(browser => {
-                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_StringInterpolation);
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_StringInterpolation_StringInterpolation);
                 var text1 = browser.Single("custom-date-format1", SelectByDataUi);
                 var text2 = browser.Single("custom-date-format2", SelectByDataUi);
                 var text3 = browser.Single("custom-date-format3", SelectByDataUi);

--- a/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/DotVVM.Testing.Abstractions/SamplesRouteUrls.designer.cs
@@ -107,6 +107,7 @@ namespace DotVVM.Testing.Abstractions
         public const string ControlSamples_RadioButton_RadioButton_Objects = "ControlSamples/RadioButton/RadioButton_Objects";
         public const string ControlSamples_Repeater_CollectionIndex = "ControlSamples/Repeater/CollectionIndex";
         public const string ControlSamples_Repeater_DataSourceNull = "ControlSamples/Repeater/DataSourceNull";
+        public const string ControlSamples_Repeater_IndexInNestedRepeater = "ControlSamples/Repeater/IndexInNestedRepeater";
         public const string ControlSamples_Repeater_NamedTemplate = "ControlSamples/Repeater/NamedTemplate";
         public const string ControlSamples_Repeater_NestedRepeater = "ControlSamples/Repeater/NestedRepeater";
         public const string ControlSamples_Repeater_NestedRepeaterWithControl = "ControlSamples/Repeater/NestedRepeaterWithControl";
@@ -231,8 +232,8 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_JavascriptTranslation_ListIndexerTranslation = "FeatureSamples/JavascriptTranslation/ListIndexerTranslation";
         public const string FeatureSamples_JavascriptTranslation_ListMethodTranslations = "FeatureSamples/JavascriptTranslation/ListMethodTranslations";
         public const string FeatureSamples_JavascriptTranslation_MathMethodTranslation = "FeatureSamples/JavascriptTranslation/MathMethodTranslation";
-        public const string FeatureSamples_JavascriptTranslation_WebUtilityTranslations = "FeatureSamples/JavascriptTranslation/WebUtilityTranslations";
         public const string FeatureSamples_JavascriptTranslation_StringMethodTranslations = "FeatureSamples/JavascriptTranslation/StringMethodTranslations";
+        public const string FeatureSamples_JavascriptTranslation_WebUtilityTranslations = "FeatureSamples/JavascriptTranslation/WebUtilityTranslations";
         public const string FeatureSamples_LambdaExpressions_ClientSideFiltering = "FeatureSamples/LambdaExpressions/ClientSideFiltering";
         public const string FeatureSamples_LambdaExpressions_LambdaExpressions = "FeatureSamples/LambdaExpressions/LambdaExpressions";
         public const string FeatureSamples_LambdaExpressions_StaticCommands = "FeatureSamples/LambdaExpressions/StaticCommands";
@@ -313,7 +314,7 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_StaticCommand_StaticCommand_NullBinding = "FeatureSamples/StaticCommand/StaticCommand_NullBinding";
         public const string FeatureSamples_StaticCommand_StaticCommand_TaskSequence = "FeatureSamples/StaticCommand/StaticCommand_TaskSequence";
         public const string FeatureSamples_StaticCommand_StaticCommand_ValueAssignmentInControl = "FeatureSamples/StaticCommand/StaticCommand_ValueAssignmentInControl";
-        public const string FeatureSamples_StringInterpolation = "FeatureSamples/StringInterpolation/StringInterpolation";
+        public const string FeatureSamples_StringInterpolation_StringInterpolation = "FeatureSamples/StringInterpolation/StringInterpolation";
         public const string FeatureSamples_UsageValidation_OverrideValidation = "FeatureSamples/UsageValidation/OverrideValidation";
         public const string FeatureSamples_Validation_ClientSideObservableUpdate = "FeatureSamples/Validation/ClientSideObservableUpdate";
         public const string FeatureSamples_Validation_CustomValidation = "FeatureSamples/Validation/CustomValidation";


### PR DESCRIPTION
The syntax is _parent._index, _root._index and so on. _this._index can also
be used, athough it's of little practical use. Only difference between
_index and _this._index is that the _this will disallow access to
parameters which are inherited from above. For example, _this._page will only
work in the root data context while _page works essentialy everywhere.

resolves #392