### PR TITLE
Fix redirection in staticCommand & SPA

### DIFF
--- a/src/DotVVM.Framework/Resources/Scripts/global-declarations.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/global-declarations.ts
@@ -13,7 +13,7 @@ type DotvvmPostbackErrorLike = {
     readonly reason: DotvvmPostbackErrorReason
 }
 
-type DotvvmPostbackErrorReason =
+type DotvvmPostbackErrorReason = (
     | { type: 'handler', handlerName: string, message?: string }
     | { type: 'network', err?: any }
     | { type: 'gate' }
@@ -23,7 +23,8 @@ type DotvvmPostbackErrorReason =
     | { type: 'event' }
     | { type: 'validation', responseObject: any, response?: Response }
     | { type: 'abort' }
-    & { options?: PostbackOptions }
+    | { type: 'redirect', responseObject: any, response?: Response }
+    ) & { options?: PostbackOptions }
 
 type PostbackCommandType = "postback" | "staticCommand" | "spaNavigation"
 

--- a/src/DotVVM.Framework/Resources/Scripts/postback/redirect.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/postback/redirect.ts
@@ -26,7 +26,7 @@ export async function handleRedirect(options: PostbackOptions, resultObject: any
         url,
         replace,
         serverResponseObject: resultObject,
-        response: response
+        response: response,
     }
     events.redirect.trigger(redirectArgs);
 

--- a/src/DotVVM.Framework/Resources/Scripts/postback/staticCommand.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/postback/staticCommand.ts
@@ -2,7 +2,6 @@ import { serialize } from '../serialization/serialize';
 import { getInitialUrl } from '../dotvvm-base';
 import * as events from '../events';
 import * as http from './http'
-import { handleRedirect } from './redirect';
 import { getKnownTypes, updateTypeInfo } from '../metadata/typeMap';
 import { DotvvmPostbackError } from '../shared-classes';
 
@@ -37,9 +36,11 @@ export async function staticCommandPostback(sender: HTMLElement, command: string
 
         if ("action" in response.result) {
             if (response.result.action == "redirect") {
-                // redirect
-                await handleRedirect(options, response.result, response.response!);
-                return;
+                throw new DotvvmPostbackError({
+                    type: "redirect",
+                    response: response.response,
+                    responseObject: response.result
+                })
             } else {
                 throw new Error(`Invalid action ${response.result.action}`);
             }


### PR DESCRIPTION
Fixes problems with redirecting staticCommand in SPA
- the redirect worked, but since no exception was thrown, rest of the command continued to run, which caused problems on the new page
- now it throws an exception, which cancels rest of the binding
- also, the exception may be similarly thrown by a user function if it would want to make a redirect