### PR TITLE
Add a MSBuild task for running `yarn build`

### DIFF
--- a/src/DotVVM.Framework/DotVVM.Framework.csproj
+++ b/src/DotVVM.Framework/DotVVM.Framework.csproj
@@ -128,4 +128,32 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- the wildcard would not work in Target.Inputs, it only works in Include -->
+    <TypescriptFile Include="Resources/Scripts/**/*.ts" />
+  </ItemGroup>
+
+  <!-- DispatchToInnerBuilds is there to run it just once for all TargetFrameworks -->
+  <Target Name="CompileJS" Inputs="@(TypescriptFile)" Outputs="obj/javascript/root-only/dotvvm-root.js;obj/javascript/root-only-debug/dotvvm-root.js;obj/javascript/root-spa/dotvvm-root.js;obj/javascript/root-spa-debug/dotvvm-root.js"
+    BeforeTargets="DispatchToInnerBuilds">
+
+    <!-- Check if yarn exists, so we can fallback to npm otherwise -->
+    <!-- Some Linux distros use yarnpkg as name for  -->
+    <Exec Command="yarnpkg --version" IgnoreExitCode="True" ConsoleToMsBuild="True" ContinueOnError="true">
+      <Output TaskParameter="ExitCode" PropertyName="YarnVersionExitCode" />
+    </Exec>
+
+    <Exec Command="yarnpkg install --frozen-lockfile" Condition="'$(YarnVersionExitCode)' == '0'" ContinueOnError="true"/>
+    <Exec Command="npm ci" Condition="'$(YarnVersionExitCode)' != '0'" ContinueOnError="true"/>
+
+    <Exec Command="yarnpkg build-production" Condition="'$(YarnVersionExitCode)' == '0'" ContinueOnError="true" YieldDuringToolExecution="True" ConsoleToMSBuild="true"/>
+    <Exec Command="yarnpkg build-development" Condition="'$(YarnVersionExitCode)' == '0'" ContinueOnError="true" YieldDuringToolExecution="True" ConsoleToMSBuild="true"/>
+    <Exec Command="yarnpkg build-polyfills" Condition="'$(YarnVersionExitCode)' == '0'" ContinueOnError="true" YieldDuringToolExecution="True" ConsoleToMSBuild="true"/>
+
+    <Exec Command="npm run build-production" Condition="'$(YarnVersionExitCode)' != '0'" ContinueOnError="true" YieldDuringToolExecution="True" />
+    <Exec Command="npm run build-development" Condition="'$(YarnVersionExitCode)' != '0'" ContinueOnError="true" YieldDuringToolExecution="True" />
+    <Exec Command="npm run build-polyfills" Condition="'$(YarnVersionExitCode)' != '0'" ContinueOnError="true" YieldDuringToolExecution="True"  />
+  </Target>
+
 </Project>

--- a/src/DotVVM.Framework/rollup.config.js
+++ b/src/DotVVM.Framework/rollup.config.js
@@ -1,7 +1,6 @@
 import typescript from '@rollup/plugin-typescript'
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
-import livereload from 'rollup-plugin-livereload';
 import { terser } from 'rollup-plugin-terser'
 import replace from '@rollup/plugin-replace';
 
@@ -79,7 +78,6 @@ const config = ({ minify, input, output, spa, legacy }) => ({
                 ascii_only: true
             }
         }),
-        //!production && livereload('public')
     ]
 })
 


### PR DESCRIPTION
In case yarn is not installed, npm is used.
Yarn is preferred, because it takes less time to run it, so it's
less annoying.
The Target only runs when any typescript file is changed,
otherwise it's skipped by MSBuild

In case there are some JS error, the build should continue normally,
so hopefully it won't cause some build issues

This should solve the problem that we forget to build the JS and
then something does not work. And when someone clones the repo,
it just won't compile because the JS files are missing