### PR TITLE
Actually use setState in deserialize function

### DIFF
--- a/src/DotVVM.Framework/Resources/Scripts/serialization/deserialize.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/serialization/deserialize.ts
@@ -12,6 +12,7 @@ export function deserialize(viewModel: any, target?: any, deserializeAll: boolea
     if (ko.isObservable(target) && "setState" in target) {
         target.setState(unmapKnockoutObservables(viewModel))
         target[notifySymbol as any](target.state)
+        return target
     }
 
     if (isPrimitive(viewModel)) {


### PR DESCRIPTION
The previous version assigned the new value into state manager,
but it then immediately did the old deserialize logic.
The deserialization forces creation of all observables in the tree, even
if they are not used in the view, which is what makes it so slow