### PR TITLE
Inline script will use hash ID to identify

### DIFF
--- a/src/DotVVM.Framework/Controls/InlineScript.cs
+++ b/src/DotVVM.Framework/Controls/InlineScript.cs
@@ -8,6 +8,7 @@ using DotVVM.Framework.Binding;
 using DotVVM.Framework.Compilation.Parser;
 using DotVVM.Framework.Controls.Infrastructure;
 using DotVVM.Framework.ResourceManagement;
+using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Controls
 {
@@ -22,13 +23,13 @@ namespace DotVVM.Framework.Controls
         /// Gets or sets the comma-separated list of resources that should be loaded before this script is executed.
         /// </summary>
         [MarkupOptions(AllowBinding = false)]
-        public string? Dependencies
+        public string[] Dependencies
         {
-            get { return (string?)GetValue(DependenciesProperty); }
+            get { return (string[])GetValue(DependenciesProperty)! ?? new string[] { ResourceConstants.DotvvmResourceName }; }
             set { SetValue(DependenciesProperty, value); }
         }
         public static readonly DotvvmProperty DependenciesProperty =
-            DotvvmProperty.Register<string, InlineScript>(c => c.Dependencies, ResourceConstants.DotvvmResourceName);
+            DotvvmProperty.Register<string[], InlineScript>(c => c.Dependencies, new string[] { ResourceConstants.DotvvmResourceName });
 
         [MarkupOptions(MappingMode = MappingMode.InnerElement, AllowBinding = false)]
         public string? Script
@@ -45,18 +46,10 @@ namespace DotVVM.Framework.Controls
             var script = Script;
             if (script is object && !string.IsNullOrWhiteSpace(script))
             {
-                var dep = Dependencies?.Split(',') ?? new string[] { ResourceConstants.DotvvmResourceName };
-                context.ResourceManager.AddStartupScript("inlinescript_" + (ClientID ?? GetScriptUniqueId()), script, dep);
+                context.ResourceManager.AddInlineScript(script, Dependencies);
             }
 
             base.OnPreRender(context);
-        }
-
-        private string GetScriptUniqueId()
-        {
-            var uniqueId = GetDotvvmUniqueId() as string;
-            if (uniqueId == null) throw new DotvvmControlException(this, $"Can not generate ID for InlineScript inside client template. Try to assign it ID manually.");
-            return uniqueId;
         }
 
         protected override void RenderContents(IHtmlWriter writer, IDotvvmRequestContext context)

--- a/src/DotVVM.Framework/ResourceManagement/ResourceManager.cs
+++ b/src/DotVVM.Framework/ResourceManagement/ResourceManager.cs
@@ -81,7 +81,7 @@ namespace DotVVM.Framework.ResourceManagement
         /// <returns>Resource ID</returns>
         public string AddTemplateResource(string template)
         {
-            var resourceId = HashUtils.HashAndBase64Encode(Encoding.Unicode.GetBytes(template));
+            var resourceId = HashUtils.HashAndBase64Encode(template);
             if (!requiredResources.ContainsKey(resourceId))
             {
                 AddRequiredResource(resourceId, new TemplateResource(template));
@@ -188,6 +188,20 @@ namespace DotVVM.Framework.ResourceManagement
         public void AddStartupScript(string javascriptCode, bool defer, params string[] dependentResourceNames)
         {
             AddRequiredResource(new InlineScriptResource(javascriptCode, defer: defer) { Dependencies = dependentResourceNames });
+        }
+
+        /// <summary> Adds a script tag with inline content. The script is identified by the hash of it's content, so it will be in the page only once. </summary>
+        public string AddInlineScript(string javascriptCode, params string[] dependentResourceNames)
+        {
+            var resourceId = "iscr_" + HashUtils.HashAndBase64Encode(javascriptCode);
+            if (!requiredResources.ContainsKey(resourceId))
+            {
+                var defer = dependentResourceNames.Any(IsDeferred);
+                AddRequiredResource(resourceId, new InlineScriptResource(javascriptCode, defer: defer) { Dependencies = dependentResourceNames });
+            }
+
+            return resourceId;
+
         }
 
         /// <summary>


### PR DESCRIPTION
This means that each script will be only included once, but
it will start working in Repeaters and other kinds of client-side
templates.

Additionally, when bound to a value using resource binding,
one InlineScript will be able to generate multiple resources if the resource
bidning differs for collection rows, for example