### PR TITLE
Fixed `getItem` translation for dictionary

### DIFF
--- a/src/DotVVM.Framework/Resources/Scripts/collections/dictionaryHelper.ts
+++ b/src/DotVVM.Framework/Resources/Scripts/collections/dictionaryHelper.ts
@@ -14,7 +14,7 @@ export function getItem<Key, Value>(dictionary: Dictionary<Key, Value>, identifi
         throw Error("Provided key \"" + identifier + "\" is not present in the dictionary!");
     }
 
-    return dictionary[index].Value;
+    return ko.unwrap(dictionary[index]).Value;
 }
 
 export function remove<Key, Value>(observable: any, identifier: Key): boolean {


### PR DESCRIPTION
This PR fixes an issue with missing `ko.unwrap(...)` call within dictionary indexer's get method translation.

I am not even sure how this worked before as there are various tests that utilize this translation. However, while fixing another issue I discovered that the `ko.unwrap(...)` is necessary in some cases.