### PR TITLE
Recommend users to use integrity hashes on scripts

### DIFF
--- a/src/Framework/Framework/Hosting/DotvvmRequestContextExtensions.cs
+++ b/src/Framework/Framework/Hosting/DotvvmRequestContextExtensions.cs
@@ -17,6 +17,7 @@ using System.Threading.Tasks;
 using DotVVM.Framework.Routing;
 using DotVVM.Framework.Hosting;
 using DotVVM.Core.Storage;
+using DotVVM.Framework.Runtime;
 
 public static class DotvvmRequestContextExtensions
 {
@@ -235,5 +236,15 @@ public static class DotvvmRequestContextExtensions
         var generatedFileId = returnedFileStorage.StoreFileAsync(stream, metadata).Result;
         context.SetRedirectResponse(context.TranslateVirtualPath("~/dotvvmReturnedFile?id=" + generatedFileId));
         throw new DotvvmInterruptRequestExecutionException(InterruptReason.ReturnFile, fileName);
+    }
+
+    public static void DebugWarning(this IDotvvmRequestContext context, string message, Exception? relatedException = null, DotvvmBindableObject? relatedControl = null)
+    {
+        if (context.Configuration.Debug)
+        {
+            context.Services
+                .GetRequiredService<RuntimeWarningCollector>()
+                .Warn(new DotvvmRuntimeWarning(message, relatedException, relatedControl));
+        }
     }
 }

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeResources.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeResources.json
@@ -48,7 +48,6 @@
           "DebugUrl": "x"
         },
         "MimeType": "text/javascript",
-        "VerifyResourceIntegrity": true,
         "IntegrityHash": "hash, maybe"
       },
       "r2": {
@@ -93,7 +92,6 @@
           "DebugUrl": "s"
         },
         "MimeType": "text/css",
-        "VerifyResourceIntegrity": true,
         "IntegrityHash": "hash, maybe"
       }
     }


### PR DESCRIPTION
* when possible (a local fallback script is available), we'll render
  the integrity hash automatically

* Otherwise a debug warning will be shown that recommends the users to
  either server the resource locally or specify the IntegrityHash property. The warning can be also silenced by setting VerifyResourceIntegrity to false.
