### PR TITLE
Reduce redundant noise in generated HTML

### DIFF
--- a/src/Framework/Framework/Controls/KnockoutHelper.cs
+++ b/src/Framework/Framework/Controls/KnockoutHelper.cs
@@ -413,7 +413,7 @@ namespace DotVVM.Framework.Controls
         /// <summary>
         /// Encodes the string so it can be used in Javascript code.
         /// </summary>
-        public static string MakeStringLiteral(string value, bool useApos = true)
+        public static string MakeStringLiteral(string value, bool useApos = false)
         {
             return JsonConvert.ToString(value, useApos ? '\'' : '"', StringEscapeHandling.Default);
         }

--- a/src/Framework/Framework/DotVVM.Framework.csproj
+++ b/src/Framework/Framework/DotVVM.Framework.csproj
@@ -113,7 +113,7 @@
     <DefineConstants>$(DefineConstants);DotNetCore</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">
-    <DefineConstants>$(DefineConstants);CSharp8Polyfill;INTERNAL_NULLABLE_ATTRIBUTES</DefineConstants>
+    <DefineConstants>$(DefineConstants);CSharp8Polyfill;NoSpan;INTERNAL_NULLABLE_ATTRIBUTES</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>

--- a/src/Framework/Framework/Hosting/ErrorPages/DotvvmErrorPageRenderer.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/DotvvmErrorPageRenderer.cs
@@ -21,7 +21,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
         {
             try
             {
-                context.Response.ContentType = "text/html";
+                context.Response.ContentType = "text/html; charset=utf-8";
 
                 var text = (Formatter ?? (Formatter = CreateDefaultWithDemystifier()))
                     .ErrorHtml(error, context);

--- a/src/Tests/ControlTests/testoutputs/CompositeControlTests.WrappedRepeaterControl.html
+++ b/src/Tests/ControlTests/testoutputs/CompositeControlTests.WrappedRepeaterControl.html
@@ -4,7 +4,7 @@
 		
 		<!-- simple list -->
 		<p data-bind="foreach: { &quot;data&quot;: List }">
-			<button onclick="dotvvm.postBack(this,[&quot;List/[$index]&quot;],&quot;WHRHt9Mi4BuLdRIz&quot;,'',null,[&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button">
+			<button onclick="dotvvm.postBack(this,[&quot;List/[$index]&quot;],&quot;WHRHt9Mi4BuLdRIz&quot;,&quot;&quot;,null,[&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button">
 				<!-- ko text: $parent.Label() + $data -->
 				<!-- /ko -->
 			</button>

--- a/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.PostbackHandlers.html
+++ b/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.PostbackHandlers.html
@@ -2,10 +2,10 @@
 	<head></head>
 	<body>
 		One handler
-		<input onclick="dotvvm.postBack(this,[],&quot;8UxwOb8axY9NSuJp&quot;,'',null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
+		<input onclick="dotvvm.postBack(this,[],&quot;8UxwOb8axY9NSuJp&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
 		Two handlers
-		<input data-msg="ahoj" onclick="dotvvm.postBack(this,[],&quot;2suRIvLX7+StPC7x&quot;,'',null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,{message:&quot;ahoj&quot;}],&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
+		<input data-msg="ahoj" onclick="dotvvm.postBack(this,[],&quot;2suRIvLX7+StPC7x&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,{message:&quot;ahoj&quot;}],&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
 		One handler, because override
-		<input data-msg="ahoj" onclick="dotvvm.postBack(this,[],&quot;b80b5Lh9K50jj3q2&quot;,'',null,[[&quot;confirm&quot;,{message:&quot;C&quot;}],&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
+		<input data-msg="ahoj" onclick="dotvvm.postBack(this,[],&quot;b80b5Lh9K50jj3q2&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;C&quot;}],&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
 	</body>
 </html>

--- a/src/Tests/ControlTests/testoutputs/SimpleControlTests.RouteLink.html
+++ b/src/Tests/ControlTests/testoutputs/SimpleControlTests.RouteLink.html
@@ -6,7 +6,7 @@
 		<a href="/Simple" onclick="event.stopPropagation();return !this.hasAttribute('disabled');">Click me</a>
 		
 		<!-- client rendering, no params, query and suffix -->
-		<a data-bind="attr: { &quot;href&quot;: '/' + &quot;Simple&quot; + dotvvm.buildUrlSuffix('#mySuffix', {'Binding': int,'Constant': &quot;c/y&quot;}) }" href="/Simple?Binding=10000000&amp;Constant=c%2Fy#mySuffix" onclick="event.stopPropagation();return !this.hasAttribute('disabled');">Click me</a>
+		<a data-bind="attr: { &quot;href&quot;: '/' + &quot;Simple&quot; + dotvvm.buildUrlSuffix(&quot;#mySuffix&quot;, {&quot;Binding&quot;: int,&quot;Constant&quot;: &quot;c/y&quot;}) }" href="/Simple?Binding=10000000&amp;Constant=c%2Fy#mySuffix" onclick="event.stopPropagation();return !this.hasAttribute('disabled');">Click me</a>
 		
 		<!-- client rendering, no params, text binding -->
 		<a data-bind="text: Label" href="/Simple" onclick="event.stopPropagation();return !this.hasAttribute('disabled');">My Label</a>
@@ -15,7 +15,7 @@
 		<a href="/Simple" onclick="event.stopPropagation();return !this.hasAttribute('disabled');">Click me</a>
 		
 		<!-- server rendering, no params, query and suffix -->
-		<a data-bind="attr: { &quot;href&quot;: '/' + &quot;Simple&quot; + dotvvm.buildUrlSuffix('#mySuffix', {'Binding': int,'Constant': &quot;c/y&quot;}) }" href="/Simple?Binding=10000000&amp;Constant=c%2Fy#mySuffix" onclick="event.stopPropagation();return !this.hasAttribute('disabled');">Click me</a>
+		<a data-bind="attr: { &quot;href&quot;: '/' + &quot;Simple&quot; + dotvvm.buildUrlSuffix(&quot;#mySuffix&quot;, {&quot;Binding&quot;: int,&quot;Constant&quot;: &quot;c/y&quot;}) }" href="/Simple?Binding=10000000&amp;Constant=c%2Fy#mySuffix" onclick="event.stopPropagation();return !this.hasAttribute('disabled');">Click me</a>
 		
 		<!-- server rendering, no params, text binding -->
 		<a data-bind="text: Label" href="/Simple" onclick="event.stopPropagation();return !this.hasAttribute('disabled');">My Label</a>
@@ -24,10 +24,10 @@
 		<a href="/WithParams/A-1" onclick="event.stopPropagation();return !this.hasAttribute('disabled');">Click me</a>
 		
 		<!-- client rendering, static params, query and suffix -->
-		<a data-bind="attr: { &quot;href&quot;: '/' + dotvvm.buildRouteUrl(&quot;WithParams/{a}-{b}/{c}&quot;, {'b': &quot;1&quot;,'a': &quot;A&quot;}) + dotvvm.buildUrlSuffix('#mySuffix', {'Binding': int,'Constant': &quot;c/y&quot;}) }" href="/WithParams/A-1?Binding=10000000&amp;Constant=c%2Fy#mySuffix" onclick="event.stopPropagation();return !this.hasAttribute('disabled');">Click me</a>
+		<a data-bind="attr: { &quot;href&quot;: '/' + dotvvm.buildRouteUrl(&quot;WithParams/{a}-{b}/{c}&quot;, {&quot;b&quot;: &quot;1&quot;,&quot;a&quot;: &quot;A&quot;}) + dotvvm.buildUrlSuffix(&quot;#mySuffix&quot;, {&quot;Binding&quot;: int,&quot;Constant&quot;: &quot;c/y&quot;}) }" href="/WithParams/A-1?Binding=10000000&amp;Constant=c%2Fy#mySuffix" onclick="event.stopPropagation();return !this.hasAttribute('disabled');">Click me</a>
 		
 		<!-- client rendering, dynamic params, query and suffix -->
-		<a data-bind="attr: { &quot;href&quot;: '/' + dotvvm.buildRouteUrl(&quot;WithParams/{a}-{b}/{c}&quot;, {'b': int,'a': Label}) + dotvvm.buildUrlSuffix('#mySuffix', {'Binding': int,'Constant': &quot;c/y&quot;}) }" href="/WithParams/My%20Label-10000000?Binding=10000000&amp;Constant=c%2Fy#mySuffix" onclick="event.stopPropagation();return !this.hasAttribute('disabled');">Click me</a>
+		<a data-bind="attr: { &quot;href&quot;: '/' + dotvvm.buildRouteUrl(&quot;WithParams/{a}-{b}/{c}&quot;, {&quot;b&quot;: int,&quot;a&quot;: Label}) + dotvvm.buildUrlSuffix(&quot;#mySuffix&quot;, {&quot;Binding&quot;: int,&quot;Constant&quot;: &quot;c/y&quot;}) }" href="/WithParams/My%20Label-10000000?Binding=10000000&amp;Constant=c%2Fy#mySuffix" onclick="event.stopPropagation();return !this.hasAttribute('disabled');">Click me</a>
 		
 		<!-- client rendering, static params, text binding -->
 		<a data-bind="text: Label" href="/WithParams/A-1" onclick="event.stopPropagation();return !this.hasAttribute('disabled');">My Label</a>
@@ -36,10 +36,10 @@
 		<a href="/WithParams/A-1" onclick="event.stopPropagation();return !this.hasAttribute('disabled');">Click me</a>
 		
 		<!-- server rendering, static params, query and suffix -->
-		<a data-bind="attr: { &quot;href&quot;: '/' + dotvvm.buildRouteUrl(&quot;WithParams/{a}-{b}/{c}&quot;, {'b': &quot;1&quot;,'a': &quot;A&quot;}) + dotvvm.buildUrlSuffix('#mySuffix', {'Binding': int,'Constant': &quot;c/y&quot;}) }" href="/WithParams/A-1?Binding=10000000&amp;Constant=c%2Fy#mySuffix" onclick="event.stopPropagation();return !this.hasAttribute('disabled');">Click me</a>
+		<a data-bind="attr: { &quot;href&quot;: '/' + dotvvm.buildRouteUrl(&quot;WithParams/{a}-{b}/{c}&quot;, {&quot;b&quot;: &quot;1&quot;,&quot;a&quot;: &quot;A&quot;}) + dotvvm.buildUrlSuffix(&quot;#mySuffix&quot;, {&quot;Binding&quot;: int,&quot;Constant&quot;: &quot;c/y&quot;}) }" href="/WithParams/A-1?Binding=10000000&amp;Constant=c%2Fy#mySuffix" onclick="event.stopPropagation();return !this.hasAttribute('disabled');">Click me</a>
 		
 		<!-- server rendering, dynamic params, query and suffix -->
-		<a data-bind="attr: { &quot;href&quot;: '/' + dotvvm.buildRouteUrl(&quot;WithParams/{a}-{b}/{c}&quot;, {'b': int,'a': Label}) + dotvvm.buildUrlSuffix('#mySuffix', {'Binding': int,'Constant': &quot;c/y&quot;}) }" href="/WithParams/My%20Label-10000000?Binding=10000000&amp;Constant=c%2Fy#mySuffix" onclick="event.stopPropagation();return !this.hasAttribute('disabled');">Click me</a>
+		<a data-bind="attr: { &quot;href&quot;: '/' + dotvvm.buildRouteUrl(&quot;WithParams/{a}-{b}/{c}&quot;, {&quot;b&quot;: int,&quot;a&quot;: Label}) + dotvvm.buildUrlSuffix(&quot;#mySuffix&quot;, {&quot;Binding&quot;: int,&quot;Constant&quot;: &quot;c/y&quot;}) }" href="/WithParams/My%20Label-10000000?Binding=10000000&amp;Constant=c%2Fy#mySuffix" onclick="event.stopPropagation();return !this.hasAttribute('disabled');">Click me</a>
 		
 		<!-- server rendering, static params, text binding -->
 		<a data-bind="text: Label" href="/WithParams/A-1" onclick="event.stopPropagation();return !this.hasAttribute('disabled');">My Label</a>

--- a/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModule.html
+++ b/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModule.html
@@ -19,7 +19,7 @@
 		<script type="module">import * as m0 from '/dotvvmResource/myModule/myModule';dotvvm.viewModules.registerMany({'myModule': m0});</script>
 		
 		<!-- Resource viewModule.init.6DLlOTYMqGV5yPAJoz5k_moKDBgEmZ3_HLLQ2zKDo74 of type ViewModuleInitResource. -->
-		<script type="module">dotvvm.viewModules.init('myModule', 'p0', document.body);</script>
+		<script type="module">dotvvm.viewModules.init("myModule", "p0", document.body);</script>
 	</head>
 	<body>
 		<input id="__dot_viewmodel_root" type="hidden" value="{

--- a/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModuleInControl.html
+++ b/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModuleInControl.html
@@ -22,7 +22,7 @@
 		<script type="module">import * as m0 from '/dotvvmResource/viewModule/viewModule';dotvvm.viewModules.registerMany({'viewModule': m0});</script>
 		
 		<!-- Resource viewModule.init.HIj399FcjVwbyaIvDKFctn7Ghr0UMajY-haUgZypcHs of type ViewModuleInitResource. -->
-		<script type="module">dotvvm.viewModules.init('viewModule', 'p0', document.body);</script>
+		<script type="module">dotvvm.viewModules.init("viewModule", "p0", document.body);</script>
 	</head>
 	<body>
 		<div>

--- a/src/Tests/Runtime/DotvvmControlRenderedHtmlTests.cs
+++ b/src/Tests/Runtime/DotvvmControlRenderedHtmlTests.cs
@@ -31,8 +31,8 @@ namespace DotVVM.Framework.Tests.Runtime
             var viewModel = new[] { "ROW 1", "ROW 2", "ROW 3" };
             var html = InvokeLifecycleAndRender(gridView, CreateContext(viewModel));
 
-            Assert.IsTrue(html.Contains("ROW 2"));
-            Assert.IsTrue(html.Contains("class=\"lol\""));
+            StringAssert.Contains(html, "ROW 2");
+            StringAssert.Contains(html, "class=lol");
         }
 
         [TestMethod]
@@ -100,7 +100,7 @@ namespace DotVVM.Framework.Tests.Runtime
                 { "test", new TextBox(){ Type = TextBoxType.Date }, TextBox.TypeProperty }
             });
             html.RenderSelfClosingTag("span");
-            Assert.AreEqual("<spandata-bind=\"tt:{&quot;test&quot;:&quot;Date&quot;}\"/>", writer.ToString().Replace(" ", ""));
+            Assert.AreEqual("<spandata-bind='tt:{\"test\":\"Date\"}'/>", writer.ToString().Replace(" ", ""));
         }
 
         [TestMethod]

--- a/src/Tests/Runtime/HtmlWriterTests.cs
+++ b/src/Tests/Runtime/HtmlWriterTests.cs
@@ -28,7 +28,7 @@ namespace DotVVM.Framework.Tests.Runtime
                 a.AddKnockoutDataBind("a", new KnockoutBindingGroup());
                 a.RenderSelfClosingTag("b");
             });
-            Assert.AreEqual("<b data-bind=\"a: {}\"/>", text);
+            Assert.AreEqual("<b data-bind=\"a: {}\" />", text);
         }
     }
 }

--- a/src/Tests/Runtime/ScriptEndingTests.cs
+++ b/src/Tests/Runtime/ScriptEndingTests.cs
@@ -61,7 +61,7 @@ namespace DotVVM.Framework.Tests.Runtime
             foreach (var a in resources)
                 a.Render(w, cx, forbiddenString);
 
-            Assert.IsFalse(output.ToString().Contains(forbiddenString));
+            Assert.IsFalse(output.ToString().Contains(forbiddenString), $"{output} : {forbiddenString}");
         }
     }
 }


### PR DESCRIPTION
Implemented custom HtmlEncoding that takes into account if
we are writing attribute and if quotes or apostrophes are used.
We can also assume that we use UTF-8 encoding.
That allows us to encode less characters which improves readability
of the generated code and performance (I will prepare results from benchmarking before we merge this)