### PR TITLE
Capabilities may use existing properties

### DIFF
--- a/src/Framework/Framework/Binding/DotvvmCapabilityProperty.Helpers.cs
+++ b/src/Framework/Framework/Binding/DotvvmCapabilityProperty.Helpers.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Utils;
+
+namespace DotVVM.Framework.Binding
+{
+    public partial class DotvvmCapabilityProperty
+    {
+        internal static class Helpers
+        {
+            public static ValueOrBinding<T>? GetOptionalValueOrBinding<T>(DotvvmBindableObject c, DotvvmProperty p)
+            {
+                if (c.properties.TryGet(p, out var x))
+                    return ValueOrBinding<T>.FromBoxedValue(x);
+                else return null;
+            }
+            public static ValueOrBinding<T> GetValueOrBinding<T>(DotvvmBindableObject c, DotvvmProperty p)
+            {
+                if (!c.properties.TryGet(p, out var x))
+                    x = p.DefaultValue;
+                return ValueOrBinding<T>.FromBoxedValue(x);
+            }
+            public static void SetOptionalValueOrBinding<T>(DotvvmBindableObject c, DotvvmProperty p, ValueOrBinding<T>? val)
+            {
+                if (val.HasValue)
+                {
+                    var v = val.GetValueOrDefault();
+                    var boxedVal = v.BindingOrDefault ?? v.BoxedValue;
+                    c.properties.Set(p, boxedVal);
+                }
+                else
+                {
+                    c.properties.Remove(p);
+                }
+            }
+            public static void SetValueOrBinding<T>(DotvvmBindableObject c, DotvvmProperty p, ValueOrBinding<T> val)
+            {
+                // TODO: remove the property in case of default value?
+                var boxedVal = val.BindingOrDefault ?? val.BoxedValue;
+                c.properties.Set(p, boxedVal);
+            }
+
+            public static Type GetDictionaryElement(Type type)
+            {
+                if (type.IsGenericType && (type.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>) || type.GetGenericTypeDefinition() == typeof(IDictionary<,>)))
+                {
+                    var args = type.GetGenericArguments();
+                    if (args[0] != typeof(string))
+                        throw new Exception("Property group Dictionary must have a string key.");
+                    else
+                        return args[1];
+                }
+                else throw new NotSupportedException($"{type.FullName} is not supported property group type. Use IDictionary<K, V> or IReadOnlyDictionary<K, V>.");
+
+            }
+
+            public static (LambdaExpression getter, LambdaExpression setter) CreatePropertyLambdas(Type type, ParameterExpression valueParameter, DotvvmProperty property)
+            {
+                var unwrappedType = type.UnwrapNullableType();
+                if (typeof(IBinding).IsAssignableFrom(type))
+                {
+                    var getValueRawMethod = typeof(DotvvmBindableObject).GetMethod("GetValueRaw");
+                    var setValueRawMethod = typeof(DotvvmBindableObject).GetMethod("SetValueRaw", new[] { typeof(DotvvmProperty), typeof(object) });
+                    return (
+                        Expression.Lambda(
+                            Expression.Convert(
+                                Expression.Call(currentControlParameter, getValueRawMethod, Expression.Constant(property), Expression.Constant(false)),
+                                type
+                            ),
+                            currentControlParameter
+                        ),
+                        Expression.Lambda(
+                            Expression.Call(currentControlParameter, setValueRawMethod, Expression.Constant(property), Expression.Convert(valueParameter, typeof(object))),
+                            currentControlParameter, valueParameter
+                        )
+                    );
+                }
+                else if (unwrappedType.IsGenericType && unwrappedType.GetGenericTypeDefinition() == typeof(ValueOrBinding<>))
+                {
+                    // could hamper some optimizations, we can fix it later if needed
+                    if (property.GetType() != typeof(DotvvmProperty))
+                        throw new NotSupportedException($"Can not create getter/setter for ValueOrBinding and {property.GetType()}");
+                    if (property.IsValueInherited)
+                        throw new NotSupportedException($"Can not create getter/setter for ValueOrBinding and inherited property");
+
+                    var isNullable = type.IsNullable();
+                    var innerType = unwrappedType.GetGenericArguments().Single();
+                    var getValueOrBindingMethod =
+                        typeof(Helpers).GetMethod(
+                            isNullable ? "GetOptionalValueOrBinding" : "GetValueOrBinding"
+                        ).MakeGenericMethod(innerType);
+                    var setValueOrBindingMethod =
+                        typeof(Helpers).GetMethod(
+                            isNullable ? "SetOptionalValueOrBinding" : "SetValueOrBinding"
+                        ).MakeGenericMethod(innerType);
+                    return (
+                        Expression.Lambda(
+                            Expression.Call(getValueOrBindingMethod, currentControlParameter, Expression.Constant(property)),
+                            currentControlParameter
+                        ),
+                        Expression.Lambda(
+                            Expression.Call(setValueOrBindingMethod, currentControlParameter, Expression.Constant(property), valueParameter),
+                            currentControlParameter, valueParameter
+                        )
+                    );
+                }
+                else
+                {
+                    var getValueMethod = (from m in typeof(DotvvmBindableObject).GetMethods()
+                                        where m.Name == "GetValue" && !m.IsGenericMethod
+                                        select m).Single();
+                    var setValueMethod = typeof(DotvvmBindableObject).GetMethod("SetValue", new[] { typeof(DotvvmProperty), typeof(object) });
+                    return (
+                        Expression.Lambda(
+                            Expression.Convert(
+                                Expression.Call(currentControlParameter, getValueMethod, Expression.Constant(property), Expression.Constant(false)),
+                                type
+                            ),
+                            currentControlParameter
+                        ),
+                        Expression.Lambda(
+                            Expression.Call(currentControlParameter, setValueMethod, Expression.Constant(property), Expression.Convert(valueParameter, typeof(object))),
+                            currentControlParameter, valueParameter
+                        )
+                    );
+                }
+            }
+
+        }
+    }
+}

--- a/src/Framework/Framework/Utils/ReflectionUtils.cs
+++ b/src/Framework/Framework/Utils/ReflectionUtils.cs
@@ -16,6 +16,7 @@ using DotVVM.Framework.Compilation.Binding;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
+using DotVVM.Framework.Binding;
 
 namespace DotVVM.Framework.Utils
 {
@@ -378,6 +379,17 @@ namespace DotVVM.Framework.Utils
             else if (type.IsGenericType && typeof(ValueTask<>).IsAssignableFrom(type.GetGenericTypeDefinition()))
                 return type.GetGenericArguments()[0];
 #endif
+            else
+                return type;
+        }
+
+        public static Type UnwrapValueOrBinding(this Type type)
+        {
+            type = type.UnwrapNullableType();
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ValueOrBinding<>))
+                return type.GenericTypeArguments.Single();
+            else if (typeof(ValueOrBinding).IsAssignableFrom(type))
+                return typeof(object);
             else
                 return type;
         }

--- a/src/Tests/Runtime/CapabilityPropertyTests.cs
+++ b/src/Tests/Runtime/CapabilityPropertyTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Compilation.ControlTree;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.ResourceManagement;
+using DotVVM.Framework.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotVVM.Framework.Tests.Runtime
+{
+    [TestClass]
+    public class CapabilityPropertyTests
+    {
+        // initialize properties
+        IControlResolver x = DotvvmTestHelper.DefaultConfig.ServiceProvider.GetRequiredService<IControlResolver>();
+
+        [DataTestMethod]
+        [DataRow(typeof(TestControl1), "Something", "blbost")]
+        [DataRow(typeof(TestControl1), "SomethingElse", "baf")]
+        [DataRow(typeof(TestControl1), "Visible", true)]
+        [DataRow(typeof(TestControl1), "ID", null)]
+        [DataRow(typeof(TestControl2), "ID", null)]
+        [DataRow(typeof(TestControl2), "Something", "blbost2")]
+        [DataRow(typeof(TestControl2), "SomethingElse", "baf")]
+        [DataRow(typeof(TestControl2), "AnotherHtml:Visible", true)]
+        [DataRow(typeof(TestControl3), "Something", "abc")]
+        [DataRow(typeof(TestControl3), "SomethingElse", "baf")]
+        [DataRow(typeof(TestControl4), "Something", "abc")]
+        [DataRow(typeof(TestControl4), "SomethingElse", "baf")]
+        public void ControlDefaultValues(Type control, string property, object value)
+        {
+            var c = (DotvvmBindableObject)Activator.CreateInstance(control);
+            var allProps = DotvvmProperty.ResolveProperties(control).Select(p => p.Name);
+            var prop = DotvvmProperty.ResolveProperty(control, property);
+            Assert.IsNotNull(prop, $"{control.Name}.{property} is not defined. These properties exist: {string.Join(", ", allProps)}");
+            var realValue = c.GetValue(prop);
+
+            Assert.AreEqual(value, realValue);
+        }
+
+        [DataTestMethod]
+        [DataRow(typeof(TestControl1), "HtmlCapability;TestCapability")]
+        [DataRow(typeof(TestControl2), "HtmlCapability;HtmlCapability;TestCapability")]
+        [DataRow(typeof(TestControl3), "HtmlCapability;TestCapability;TestNestedCapability")]
+        [DataRow(typeof(TestControl4), "HtmlCapability;TestCapability;TestNestedCapability")]
+        [DataRow(typeof(HtmlGenericControl), "HtmlCapability")]
+        [DataRow(typeof(Button), "HtmlCapability;TextOrContentCapability")]
+        public void ControlRegisteredCapabilities(Type control, string capabilities)
+        {
+            var c = DotvvmCapabilityProperty.GetCapabilities(control).Select(c => c.PropertyType.Name).ToArray();
+            Array.Sort(c);
+
+            Assert.AreEqual(
+                capabilities,
+                string.Join(";", c)
+            );
+        }
+
+        public class TestControl1:
+            HtmlGenericControl,
+            IObjectWithCapability<HtmlCapability>,
+            IObjectWithCapability<TestCapability>
+        {
+            public string Something
+            {
+                get { return (string)GetValue(SomethingProperty); }
+                set { SetValue(SomethingProperty, value); }
+            }
+            public static readonly DotvvmProperty SomethingProperty =
+                DotvvmProperty.Register<string, TestControl1>(nameof(Something), "blbost");
+        }
+
+        public class TestControl2:
+            HtmlGenericControl,
+            IObjectWithCapability<TestCapability>
+        {
+            public string Something
+            {
+                get { return (string)GetValue(SomethingProperty); }
+                set { SetValue(SomethingProperty, value); }
+            }
+            public static readonly DotvvmProperty SomethingProperty =
+                DotvvmProperty.Register<string, TestControl2>(nameof(Something), "blbost2");            
+
+            public static readonly DotvvmProperty AnotherHtmlCapabilityProperty =
+                DotvvmCapabilityProperty.RegisterCapability<HtmlCapability, TestControl2>(nameof(AnotherHtmlCapabilityProperty), "AnotherHtml:");
+        }
+
+        public class TestControl3:
+            DotvvmControl,
+            IObjectWithCapability<TestNestedCapability>
+        {       
+            public static readonly DotvvmProperty TestCapabilityProperty =
+                DotvvmCapabilityProperty.RegisterCapability<TestNestedCapability, TestControl3>(nameof(TestCapabilityProperty));
+        }
+        public class TestControl4:
+            HtmlGenericControl,
+            IObjectWithCapability<TestNestedCapability>
+        {       
+        }
+
+        [DotvvmControlCapability]
+        public sealed class TestCapability
+        {
+            public string Something { get; set; } = "kokosovina";
+            public string SomethingElse { get; set; } = "baf";
+        }
+
+        [DotvvmControlCapability]
+        public sealed class TestNestedCapability
+        {
+            public string Something { get; set; } = "abc";
+            public TestCapability Test { get; set; }
+            public HtmlCapability Html { get; set; }
+        }
+
+    }
+}


### PR DESCRIPTION
Before, all properties were declared new, and a conflict exception
was raised. Now it's allowed if the type matches, which allow
adding capabilities to existing controls.

This PR depends on #1129