### PR TITLE
Remove JS unit tests from Azure CI

### DIFF
--- a/ci/linux/run.sh
+++ b/ci/linux/run.sh
@@ -22,7 +22,6 @@ NPM_BUILD=1
 SLN_RESTORE=1
 SLN_BUILD=1
 UNIT_TESTS=1
-JS_TESTS=1
 UI_TESTS=1
 
 while true; do
@@ -44,7 +43,6 @@ Options:
     --[no-]sln-restore  Restore NuGet packages (default = 1).
     --[no-]sln-build    Build ~/ci/linux/Linux.sln (default = 1).
     --[no-]unit-tests   Run the Framework tests (default = 1).
-    --[no-]js-tests     Run Framework's Jest tests (default = 1).
     --[no-]ui-tests     Run the AspNetCoreLatest tests (default = 1).
 EOF
             shift
@@ -58,7 +56,6 @@ EOF
             SLN_RESTORE=$VALUE
             SLN_BUILD=$VALUE
             UNIT_TESTS=$VALUE
-            JS_TESTS=$VALUE
             UI_TESTS=$VALUE
             shift
             continue
@@ -239,14 +236,6 @@ if [ $UNIT_TESTS -eq 1 ]; then
             --logger 'trx;LogFileName=unit-test-results.trx' \
             --results-directory \"$TEST_RESULTS_DIR\" \
             --collect \"Code Coverage\""
-fi
-
-if [ $JS_TESTS -eq 1 ]; then
-    run_named_command "JS tests" \
-        "cd \"$ROOT/src/Framework/Framework\" \
-            && npx jest --ci --reporters=\"jest-junit\" \
-            && cp ./junit.xml \"$TEST_RESULTS_DIR/js-test-results.xml\" \
-            && cd \"$ROOT\""
 fi
 
 if [ $UI_TESTS -eq 1 ]; then

--- a/ci/windows/run.ps1
+++ b/ci/windows/run.ps1
@@ -9,7 +9,6 @@ param(
     [switch] $NoSlnRestore = $false,
     [switch] $NoSlnBuild = $false,
     [switch] $NoUnitTests = $false,
-    [switch] $NoJSTests = $false,
     [switch] $NoUITests = $false)
 
 # ==================
@@ -139,15 +138,6 @@ if ($NoUnitTests -ne $true) {
             --logger "trx;LogFileName=unit-test-results.trx" `
             --results-directory "$testResultsDir" `
             --collect "Code Coverage"
-    }
-}
-
-if ($NoJSTests -ne $true) {
-    Run-Command "JS tests" {
-        Set-Location "$Root\src\Framework\Framework"
-        npx jest --ci --reporters="jest-junit"
-        Copy-Item junit.xml "$testResultsDir\js-test-results.xml"
-        Set-Location "$Root"
     }
 }
 


### PR DESCRIPTION
It only induces instability into the pipeline and it's handled by the
Github Action