### PR TITLE
Changed visibility of `TypeInferer` to public

### DIFF
--- a/src/Framework/Framework/Compilation/Inference/ITypeInferer.cs
+++ b/src/Framework/Framework/Compilation/Inference/ITypeInferer.cs
@@ -9,7 +9,7 @@ using DotVVM.Framework.Compilation.Inference.Results;
 
 namespace DotVVM.Framework.Compilation.Inference
 {
-    internal interface ITypeInferer
+    public interface ITypeInferer
     {
         void BeginFunctionCall(MethodGroupExpression? target, int argsCount);
         void EndFunctionCall();
@@ -20,7 +20,7 @@ namespace DotVVM.Framework.Compilation.Inference
         IFluentInferer Infer(Type? expectedType = null);
     }
 
-    internal interface IFluentInferer
+    public interface IFluentInferer
     {
         LambdaTypeInferenceResult Lambda(int argsCount);
     }

--- a/src/Framework/Framework/Compilation/Inference/Inferers/LambdaInferer.cs
+++ b/src/Framework/Framework/Compilation/Inference/Inferers/LambdaInferer.cs
@@ -10,7 +10,7 @@ using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Compilation.Inference
 {
-    internal partial class TypeInferer
+    public partial class TypeInferer
     {
         LambdaTypeInferenceResult IFluentInferer.Lambda(int argsCount)
         {

--- a/src/Framework/Framework/Compilation/Inference/Results/ITypeInferenceResult.cs
+++ b/src/Framework/Framework/Compilation/Inference/Results/ITypeInferenceResult.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace DotVVM.Framework.Compilation.Inference.Results
 {
-    internal interface ITypeInferenceResult
+    public interface ITypeInferenceResult
     {
         bool Result { get; }
         Type? Type { get; }

--- a/src/Framework/Framework/Compilation/Inference/Results/LambdaTypeInferenceResult.cs
+++ b/src/Framework/Framework/Compilation/Inference/Results/LambdaTypeInferenceResult.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace DotVVM.Framework.Compilation.Inference.Results
 {
-    internal class LambdaTypeInferenceResult : ITypeInferenceResult
+    public class LambdaTypeInferenceResult : ITypeInferenceResult
     {
         public bool Result { get; private set; }
         public Type? Type { get; private set; }

--- a/src/Framework/Framework/Compilation/Inference/TypeInferer.cs
+++ b/src/Framework/Framework/Compilation/Inference/TypeInferer.cs
@@ -12,7 +12,7 @@ using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Compilation.Inference
 {
-    internal partial class TypeInferer : ITypeInferer, IFluentInferer
+    public partial class TypeInferer : ITypeInferer, IFluentInferer
     {
         private readonly Stack<InfererContext> contextStack;
         private Type? expectedType;


### PR DESCRIPTION
As we are adding support for lambda functions to VS Extension, it would be nice to have also type inference capabilities for the Intellisense. Using this we could provide type information for individual parameters as the user is typing a lambda function.