### PR TITLE
Capability properties will implicitly use capability name as property name

### DIFF
--- a/src/Framework/Framework/Compilation/ControlTree/DefaultControlResolver.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/DefaultControlResolver.cs
@@ -118,12 +118,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
                     if (DotvvmCapabilityProperty.GetCapabilities(type).Any(c => c.PropertyType == capabilityType))
                         continue;
 
-                    var name = capabilityType.Name;
-                    // auto append Capability to the end. Tends to prevent conflicts
-                    if (!name.EndsWith("capability", StringComparison.OrdinalIgnoreCase))
-                        name += "Capability";
-
-                    DotvvmCapabilityProperty.RegisterCapability(type.Name, type, capabilityType, capabilityAttributeProvider: new CustomAttributesProvider());
+                    DotvvmCapabilityProperty.RegisterCapability(type, capabilityType, capabilityAttributeProvider: new CustomAttributesProvider());
                 }
             }
         }

--- a/src/Framework/Framework/Controls/ButtonBase.cs
+++ b/src/Framework/Framework/Controls/ButtonBase.cs
@@ -55,12 +55,9 @@ namespace DotVVM.Framework.Controls
             set => TextOrContentCapabilityProperty.SetValue(this, value);
         }
         public static readonly DotvvmCapabilityProperty TextOrContentCapabilityProperty =
-            DotvvmCapabilityProperty.RegisterCapability("TextOrContentCapability", typeof(ButtonBase), typeof(TextOrContentCapability),
-                control => TextOrContentCapability.FromChildren((ButtonBase)control, TextProperty),
-                (control, boxedValue) => {
-                    var value = (TextOrContentCapability)boxedValue!;
-                    value.WriteToChildren((DotvvmControl)control, TextProperty);
-                }
+            DotvvmCapabilityProperty.RegisterCapability<TextOrContentCapability, ButtonBase>(
+                control => TextOrContentCapability.FromChildren(control, TextProperty),
+                (control, value) => value.WriteToChildren(control, TextProperty)
             );
 
         /// <summary>

--- a/src/Framework/Framework/Controls/CheckableControlBase.cs
+++ b/src/Framework/Framework/Controls/CheckableControlBase.cs
@@ -73,12 +73,9 @@ namespace DotVVM.Framework.Controls
             set => TextOrContentCapabilityProperty.SetValue(this, value);
         }
         public static readonly DotvvmCapabilityProperty TextOrContentCapabilityProperty =
-            DotvvmCapabilityProperty.RegisterCapability("TextOrContentCapability", typeof(CheckableControlBase), typeof(TextOrContentCapability),
-                control => TextOrContentCapability.FromChildren((CheckableControlBase)control, TextProperty),
-                (control, boxedValue) => {
-                    var value = (TextOrContentCapability?)boxedValue ?? new TextOrContentCapability();
-                    value.WriteToChildren((CheckableControlBase)control, TextProperty);
-                }
+            DotvvmCapabilityProperty.RegisterCapability<TextOrContentCapability, CheckableControlBase>(
+                control => TextOrContentCapability.FromChildren(control, TextProperty),
+                (control, value) => value.WriteToChildren(control, TextProperty)
             );
 
         /// <summary>

--- a/src/Framework/Framework/Controls/HtmlGenericControl.cs
+++ b/src/Framework/Framework/Controls/HtmlGenericControl.cs
@@ -133,21 +133,7 @@ namespace DotVVM.Framework.Controls
             set => this.SetValue(HtmlCapabilityProperty, value);
         }
         public static readonly DotvvmCapabilityProperty HtmlCapabilityProperty =
-            DotvvmCapabilityProperty.RegisterCapability("HtmlCapability", typeof(HtmlGenericControl), typeof(HtmlCapability),
-                control => new HtmlCapability {
-                    Visible = control.GetValueOrBinding<bool>(VisibleProperty),
-                    Attributes = VirtualPropertyGroupDictionary<object?>.CreatePropertyDictionary(control, AttributesGroupDescriptor),
-                    CssClasses = VirtualPropertyGroupDictionary<bool>.CreatePropertyDictionary(control, CssClassesGroupDescriptor),
-                    CssStyles = VirtualPropertyGroupDictionary<object>.CreatePropertyDictionary(control, CssStylesGroupDescriptor)
-                },
-                (control, boxedValue) => {
-                    var value = (HtmlCapability?)boxedValue ?? new HtmlCapability();
-                    control.SetValue(VisibleProperty, value.Visible);
-                    ((HtmlGenericControl)control).Attributes.CopyFrom(value.Attributes, clear: true);
-                    ((HtmlGenericControl)control).CssClasses.CopyFrom(value.CssClasses, clear: true);
-                    ((HtmlGenericControl)control).CssStyles.CopyFrom(value.CssStyles, clear: true);
-                }
-            );
+            DotvvmCapabilityProperty.RegisterCapability<HtmlCapability, HtmlGenericControl>();
 
         /// <summary>
         /// Gets a value whether this control renders a HTML tag.

--- a/src/Framework/Framework/Controls/RouteLink.cs
+++ b/src/Framework/Framework/Controls/RouteLink.cs
@@ -77,10 +77,9 @@ namespace DotVVM.Framework.Controls
             set => TextOrContentCapabilityProperty.SetValue(this, value);
         }
         public static readonly DotvvmCapabilityProperty TextOrContentCapabilityProperty =
-            DotvvmCapabilityProperty.RegisterCapability("TextOrContentCapability", typeof(RouteLink), typeof(TextOrContentCapability),
-                control => TextOrContentCapability.FromChildren((RouteLink)control, TextProperty),
-                (control, boxedValue) => {
-                    var value = (TextOrContentCapability?)boxedValue ?? new TextOrContentCapability();
+            DotvvmCapabilityProperty.RegisterCapability<TextOrContentCapability, RouteLink>(
+                control => TextOrContentCapability.FromChildren(control, TextProperty),
+                (control, value) => {
                     value.WriteToChildren((DotvvmControl)control, TextProperty);
                 }
             );

--- a/src/Tests/Runtime/CapabilityPropertyTests.cs
+++ b/src/Tests/Runtime/CapabilityPropertyTests.cs
@@ -86,16 +86,16 @@ namespace DotVVM.Framework.Tests.Runtime
             public static readonly DotvvmProperty SomethingProperty =
                 DotvvmProperty.Register<string, TestControl2>(nameof(Something), "blbost2");            
 
-            public static readonly DotvvmProperty AnotherHtmlCapabilityProperty =
-                DotvvmCapabilityProperty.RegisterCapability<HtmlCapability, TestControl2>(nameof(AnotherHtmlCapabilityProperty), "AnotherHtml:");
+            public static readonly DotvvmProperty AnotherHtml_HtmlCapabilityProperty =
+                DotvvmCapabilityProperty.RegisterCapability<HtmlCapability, TestControl2>("AnotherHtml:");
         }
 
         public class TestControl3:
             DotvvmControl,
             IObjectWithCapability<TestNestedCapability>
         {       
-            public static readonly DotvvmProperty TestCapabilityProperty =
-                DotvvmCapabilityProperty.RegisterCapability<TestNestedCapability, TestControl3>(nameof(TestCapabilityProperty));
+            public static readonly DotvvmProperty TestNestedCapabilityProperty =
+                DotvvmCapabilityProperty.RegisterCapability<TestNestedCapability, TestControl3>();
         }
         public class TestControl4:
             HtmlGenericControl,


### PR DESCRIPTION
More specifically `prefix + capabilityType.Name` is used as a default name for
these DotvvmProperties. When declared using RegisterCapability method,
name other can be specified. However, properties declared implicitly
through GetContents arguments or through other capabilities
will ignore the argument/property name and use the
capability name instead