### PR TITLE
Add test for runtime change of data context of commands

### DIFF
--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslator.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslator.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using DotVVM.Framework.Binding;
+using DotVVM.Framework.Binding.Expressions;
 using DotVVM.Framework.Binding.HelperNamespace;
 using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Compilation.Javascript.Ast;
@@ -116,6 +117,7 @@ namespace DotVVM.Framework.Compilation.Javascript
             return expression.AssignParameters(o =>
                 o is ViewModelSymbolicParameter vm ? GetKnockoutViewModelParameter(vm.ParentIndex + dataContextLevel).ToParametrizedCode() :
                 o is ContextSymbolicParameter context ? GetKnockoutContextParameter(context.ParentIndex + dataContextLevel).ToParametrizedCode() :
+                o == CommandBindingExpression.OptionalKnockoutContextParameter ? GetKnockoutContextParameter(dataContextLevel).ToParametrizedCode() :
                 default
             );
         }

--- a/src/Framework/Framework/Controls/Button.cs
+++ b/src/Framework/Framework/Controls/Button.cs
@@ -9,6 +9,7 @@ using DotVVM.Framework.Compilation.Validation;
 using DotVVM.Framework.Controls.Infrastructure;
 using DotVVM.Framework.Hosting;
 using DotVVM.Framework.Compilation.ControlTree;
+using DotVVM.Framework.Binding.Expressions;
 
 namespace DotVVM.Framework.Controls
 {
@@ -49,10 +50,25 @@ namespace DotVVM.Framework.Controls
         /// </summary>
         public Button() : base("input")
         {
-            if (ButtonTagName == ButtonTagName.button)
-            {
-                TagName = "button";
-            }
+        }
+
+        public Button(
+            ValueOrBinding<string> text,
+            ICommandBinding click,
+            ButtonTagName tagName = ButtonTagName.input
+        ) : this(new TextOrContentCapability(text), click, tagName)
+        {
+        }
+
+        public Button(
+            TextOrContentCapability content,
+            ICommandBinding click,
+            ButtonTagName tagName = ButtonTagName.button
+        ) : base(tagName == ButtonTagName.input ? "input" : "button")
+        {
+            content.WriteToChildren(this, TextProperty);
+            SetBinding(ClickProperty, click);
+            ButtonTagName = tagName;
         }
 
         protected internal override void OnPreRender(IDotvvmRequestContext context)

--- a/src/Framework/Framework/Controls/KnockoutHelper.cs
+++ b/src/Framework/Framework/Controls/KnockoutHelper.cs
@@ -171,7 +171,7 @@ namespace DotVVM.Framework.Controls
             var abortSignal = options.AbortSignal ?? CodeParameterAssignment.FromIdentifier("undefined");
 
             var optionalKnockoutContext =
-                options.KoContext is object && adjustedExpression != jsExpression ?
+                options.KoContext is object ?
                 knockoutContext :
                 default;
 

--- a/src/Framework/Framework/Controls/TextOrContentCapability.cs
+++ b/src/Framework/Framework/Controls/TextOrContentCapability.cs
@@ -12,6 +12,20 @@ namespace DotVVM.Framework.Controls
         public ValueOrBinding<string>? Text { get; set; }
         public List<DotvvmControl>? Content { get; set; }
 
+        public TextOrContentCapability() { }
+        public TextOrContentCapability(ValueOrBinding<string> text)
+        {
+            this.Text = text;
+        }
+        public TextOrContentCapability(IEnumerable<DotvvmControl> content)
+        {
+            this.Content = content.ToList();
+        }
+        public TextOrContentCapability(params DotvvmControl[] content)
+        {
+            this.Content = content.ToList();
+        }
+
         public static TextOrContentCapability FromChildren(DotvvmControl control, DotvvmProperty textProperty)
         {
             var text = control.GetValueRaw(textProperty);

--- a/src/Framework/Testing/ControlTestHelper.cs
+++ b/src/Framework/Testing/ControlTestHelper.cs
@@ -114,7 +114,7 @@ namespace DotVVM.Framework.Testing
         {
             if (!markup.Contains("<body"))
             {
-                markup = $"<body>\n{markup}\n{(renderResources ? "" : "<tc:FakeBodyResourceLink />")}\n</body>";
+                markup = $"<body Validation.Enabled=false >\n{markup}\n{(renderResources ? "" : "<tc:FakeBodyResourceLink />")}\n</body>";
             }
             else if (!renderResources)
             {

--- a/src/Samples/Common/Views/ControlSamples/TemplateHost/CompositeListControlWithTemplate.cs
+++ b/src/Samples/Common/Views/ControlSamples/TemplateHost/CompositeListControlWithTemplate.cs
@@ -49,9 +49,8 @@ namespace DotVVM.Samples.Common.Views.ControlSamples.TemplateHost
                 .SetProperty(ItemsControl.DataSourceProperty, dataSource);
 
             yield return new HtmlGenericControl("p")
-                .AppendChildren(new Button() { Text = "Add item" }
-                    .SetProperty(
-                        ButtonBase.ClickProperty,
+                .AppendChildren(new Button(
+                    "Add item",
                     new CommandBindingExpression(bindingCompilationService, contexts => {
                                 var item = onCreateItem.BindingDelegate(this.GetDataContexts().ToArray(), this);
                                 ((dynamic)dataSource.GetBindingValue(this)).Add(((dynamic)item)());

--- a/src/Tests/ControlTests/testoutputs/CompositeControlTests.CommandDataContextChange.html
+++ b/src/Tests/ControlTests/testoutputs/CompositeControlTests.CommandDataContextChange.html
@@ -1,0 +1,21 @@
+<html>
+	<head></head>
+	<body>
+		
+		<!-- command -->
+		<div>
+			<div data-bind="foreach: { &quot;data&quot;: List }">
+				<input onclick="dotvvm.postBack(this,[&quot;List/[$index]&quot;],&quot;IYZcgJXAUDcvRzk7&quot;,&quot;&quot;,ko.contextFor(this).$parentContext,[],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="Item">
+			</div>
+			<input onclick="dotvvm.postBack(this,[],&quot;IYZcgJXAUDcvRzk7&quot;,&quot;&quot;,null,[],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="Last Item">
+		</div>
+		
+		<!-- staticCommand -->
+		<div>
+			<div data-bind="foreach: { &quot;data&quot;: List }">
+				<input onclick="dotvvm.applyPostbackHandlers((options) => options.knockoutContext.$parent.int(12).int(),this).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="Item">
+			</div>
+			<input onclick="dotvvm.applyPostbackHandlers((options) => options.viewModel.int(12).int(),this).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="Last Item">
+		</div>
+	</body>
+</html>

--- a/src/Tests/ControlTests/testoutputs/CompositeControlTests.WrappedRepeaterControl.html
+++ b/src/Tests/ControlTests/testoutputs/CompositeControlTests.WrappedRepeaterControl.html
@@ -4,7 +4,7 @@
 		
 		<!-- simple list -->
 		<p class="css-class-from-markup my-repeated-button" data-bind="foreach: { &quot;data&quot;: List }">
-			<button class="the-only-class-for-button-element" data-bind="text: $parent.Label() + $data" onclick="dotvvm.postBack(this,[&quot;List/[$index]&quot;],&quot;WHRHt9Mi4BuLdRIz&quot;,&quot;&quot;,null,[&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button"></button>
+			<button class="the-only-class-for-button-element" data-bind="text: $parent.Label() + $data" onclick="dotvvm.postBack(this,[&quot;List/[$index]&quot;],&quot;WHRHt9Mi4BuLdRIz&quot;,&quot;&quot;,null,[],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button"></button>
 		</p>
 	</body>
 </html>

--- a/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.PostbackHandlers.html
+++ b/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.PostbackHandlers.html
@@ -2,16 +2,16 @@
 	<head></head>
 	<body>
 		One handler
-		<input onclick="dotvvm.postBack(this,[],&quot;8UxwOb8axY9NSuJp&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
+		<input onclick="dotvvm.postBack(this,[],&quot;8UxwOb8axY9NSuJp&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}]],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
 		Two handlers
-		<input data-msg="ahoj" onclick="dotvvm.postBack(this,[],&quot;2suRIvLX7+StPC7x&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,{message:&quot;ahoj&quot;}],&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
+		<input data-msg="ahoj" onclick="dotvvm.postBack(this,[],&quot;2suRIvLX7+StPC7x&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,{message:&quot;ahoj&quot;}]],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
 		Two handlers, value binding message
-		<input data-bind="attr: { &quot;data-msg&quot;: Label }" onclick="dotvvm.postBack(this,[],&quot;b80b5Lh9K50jj3q2&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,(c,d)=>({message:(d).Label()})],&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
+		<input data-bind="attr: { &quot;data-msg&quot;: Label }" onclick="dotvvm.postBack(this,[],&quot;b80b5Lh9K50jj3q2&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,(c,d)=>({message:(d).Label()})]],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
 		Two handlers, resource binding message
-		<input data-msg="My Label" onclick="dotvvm.postBack(this,[],&quot;mH2HraWjqc1sx3p+&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,{message:&quot;My Label&quot;}],&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
+		<input data-msg="My Label" onclick="dotvvm.postBack(this,[],&quot;mH2HraWjqc1sx3p+&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,{message:&quot;My Label&quot;}]],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
 		Two handlers, default message
-		<input onclick="dotvvm.postBack(this,[],&quot;iA7NdAd65P3O/VQ7&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,{message:&quot;default message&quot;}],&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
+		<input onclick="dotvvm.postBack(this,[],&quot;iA7NdAd65P3O/VQ7&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,{message:&quot;default message&quot;}]],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
 		One handler, because override
-		<input data-msg="ahoj" onclick="dotvvm.postBack(this,[],&quot;RjBjjkYMn14QVrRJ&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;C&quot;}],&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
+		<input data-msg="ahoj" onclick="dotvvm.postBack(this,[],&quot;RjBjjkYMn14QVrRJ&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;C&quot;}]],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
 	</body>
 </html>


### PR DESCRIPTION
I promised to add this test for staticCommands after merging one of my PRs.
staticCommands seem to work well, commands needed slight adjustion in JavascriptTranslator