### PR TITLE
Working with bindings in server-side styles and CompositeControls

### DIFF
--- a/src/Framework/Framework/Binding/BindingCombinator.cs
+++ b/src/Framework/Framework/Binding/BindingCombinator.cs
@@ -32,6 +32,16 @@ namespace DotVVM.Framework.Binding
                     )
                 )
             );
+        static IBinding CreateOrElseCombination(IBinding a, IBinding b) =>
+            a.DeriveBinding(
+                new ParsedExpressionBindingProperty(
+                    Expression.OrElse(
+                        a.GetProperty<ParsedExpressionBindingProperty>().Expression,
+                        b.GetProperty<ParsedExpressionBindingProperty>().Expression
+                    )
+                )
+            );
+        public static readonly BindingCombinatorDescriptor OrElseCombination = new BindingCombinatorDescriptor(CreateOrElseCombination);
         public static readonly BindingCombinatorDescriptor AndAlsoCombination = new BindingCombinatorDescriptor(CreateAndAlsoCombination);
         public static void AndAssignProperty(this DotvvmBindableObject obj, DotvvmProperty property, object value)
         {

--- a/src/Framework/Framework/Binding/BindingCompilationService.cs
+++ b/src/Framework/Framework/Binding/BindingCompilationService.cs
@@ -34,7 +34,7 @@ namespace DotVVM.Framework.Binding
         {
             this.expressionCompiler = expressionCompiler;
             this.noInitService = 
-                this is NoInitService ? new(this)
+                this is NoInitService ? new(() => this)
                                       : new(() => new NoInitService(options, expressionCompiler, cache));
             foreach (var p in GetDelegates(options.Value.TransformerClasses))
                 resolvers.AddDelegate(p);

--- a/src/Framework/Framework/Binding/BindingCompilationService.cs
+++ b/src/Framework/Framework/Binding/BindingCompilationService.cs
@@ -33,7 +33,9 @@ namespace DotVVM.Framework.Binding
         public BindingCompilationService(IOptions<BindingCompilationOptions> options, IExpressionToDelegateCompiler expressionCompiler, IDotvvmCacheAdapter cache)
         {
             this.expressionCompiler = expressionCompiler;
-            this.noInitService = new Lazy<BindingCompilationService>(() => new NoInitService(options, expressionCompiler, cache));
+            this.noInitService = 
+                this is NoInitService ? new(this)
+                                      : new(() => new NoInitService(options, expressionCompiler, cache));
             foreach (var p in GetDelegates(options.Value.TransformerClasses))
                 resolvers.AddDelegate(p);
             this.Cache = new DotvvmBindingCacheHelper(cache, this);

--- a/src/Framework/Framework/Binding/BindingHelper.cs
+++ b/src/Framework/Framework/Binding/BindingHelper.cs
@@ -276,7 +276,10 @@ namespace DotVVM.Framework.Binding
                     b.GetProperty<LocationInfoBindingProperty>(ErrorHandlingMode.ReturnNull)
                 };
             var service = binding.GetProperty<BindingCompilationService>();
-            return (TBinding)service.CreateBinding(binding.GetType(), getContextProperties(binding).Concat(properties).ToArray());
+            var bindingType = binding.GetType();
+            if (bindingType.IsGenericType)
+                bindingType = bindingType.GetGenericTypeDefinition();
+            return (TBinding)service.CreateBinding(bindingType, getContextProperties(binding).Concat(properties).ToArray());
         }
 
         /// <summary>

--- a/src/Framework/Framework/Binding/BindingProperties.cs
+++ b/src/Framework/Framework/Binding/BindingProperties.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Linq;

--- a/src/Framework/Framework/Binding/BindingProperties.cs
+++ b/src/Framework/Framework/Binding/BindingProperties.cs
@@ -334,6 +334,30 @@ namespace DotVVM.Framework.Binding.Properties
             this.Binding = binding;
         }
     }
+    public sealed class IsNullBindingExpression
+    {
+        public readonly IBinding Binding;
+        public IsNullBindingExpression(IBinding binding)
+        {
+            this.Binding = binding;
+        }
+    }
+    public sealed class IsNullOrWhitespaceBindingExpression
+    {
+        public readonly IBinding Binding;
+        public IsNullOrWhitespaceBindingExpression(IBinding binding)
+        {
+            this.Binding = binding;
+        }
+    }
+    public sealed class IsNullOrEmptyBindingExpression
+    {
+        public readonly IBinding Binding;
+        public IsNullOrEmptyBindingExpression(IBinding binding)
+        {
+            this.Binding = binding;
+        }
+    }
     public sealed class ExpectedAsStringBindingExpression
     {
         public readonly IBinding Binding;

--- a/src/Framework/Framework/Binding/DotvvmCapabilityProperty.Helpers.cs
+++ b/src/Framework/Framework/Binding/DotvvmCapabilityProperty.Helpers.cs
@@ -29,8 +29,7 @@ namespace DotVVM.Framework.Binding
                 if (val.HasValue)
                 {
                     var v = val.GetValueOrDefault();
-                    var boxedVal = v.BindingOrDefault ?? v.BoxedValue;
-                    c.properties.Set(p, boxedVal);
+                    c.properties.Set(p, v.UnwrapToObject());
                 }
                 else
                 {
@@ -40,7 +39,7 @@ namespace DotVVM.Framework.Binding
             public static void SetValueOrBinding<T>(DotvvmBindableObject c, DotvvmProperty p, ValueOrBinding<T> val)
             {
                 // TODO: remove the property in case of default value?
-                var boxedVal = val.BindingOrDefault ?? val.BoxedValue;
+                var boxedVal = val.UnwrapToObject();
                 c.properties.Set(p, boxedVal);
             }
 

--- a/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
+++ b/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
@@ -197,7 +197,7 @@ namespace DotVVM.Framework.Binding
             {
                 defaultValue = ValueOrBinding<object>.FromBoxedValue(defaultAttribute.Value);
             }
-            var boxedDefaultValue = defaultValue?.BindingOrDefault ?? defaultValue?.BoxedValue;
+            var boxedDefaultValue = defaultValue?.UnwrapToObject();
 
             var valueParameter = Expression.Parameter(propertyType, "value");
 

--- a/src/Framework/Framework/Binding/ValueOrBinding.cs
+++ b/src/Framework/Framework/Binding/ValueOrBinding.cs
@@ -65,6 +65,7 @@ namespace DotVVM.Framework.Binding
         public IBinding? BindingOrDefault => binding;
         public object? BoxedValue => (object?)value;
 
+        [MemberNotNullWhenAttribute(false, "BindingOrDefault", "binding")]
         public bool HasValue => binding is null;
 
         [MemberNotNullWhenAttribute(true, "BindingOrDefault", "binding")]

--- a/src/Framework/Framework/Binding/ValueOrBinding.cs
+++ b/src/Framework/Framework/Binding/ValueOrBinding.cs
@@ -10,12 +10,14 @@ using Newtonsoft.Json;
 
 namespace DotVVM.Framework.Binding
 {
+    /// <summary> Non-generic variant of <see cref="ValueOrBinding{T}" />. Represents either a binding or a constant value. In TypeScript this would be object | <see cref="IBinding"/>  </summary>
     public interface ValueOrBinding
     {
         IBinding? BindingOrDefault { get; }
         object? BoxedValue { get; }
     }
 
+    /// <summary> Represents either a binding or a constant value. In TypeScript this would be <typeparamref name="T"/> | <see cref="IBinding"/>. Note that `default(<see cref="ValueOrBinding{T}" />)` is the same as `new <see cref="ValueOrBinding{T}" />(default(T))` </summary>
     public struct ValueOrBinding<T> : ValueOrBinding
     {
         private readonly IBinding? binding;
@@ -28,6 +30,7 @@ namespace DotVVM.Framework.Binding
             this.value = value;
         }
 
+        /// <summary> Creates new ValueOrBinding which contains the specified binding. Will throw an exception if the binding's result type is not assignable to <typeparamref name="T"/> </summary>
         public ValueOrBinding(IBinding binding)
         {
             if (binding == null) throw new ArgumentNullException(nameof(binding));
@@ -38,6 +41,7 @@ namespace DotVVM.Framework.Binding
             this.value = default;
         }
 
+        /// <summary> Creates new ValueOrBinding which contains the specified binding. </summary>
         public ValueOrBinding(IStaticValueBinding<T> binding)
         {
             if (binding == null) throw new ArgumentNullException(nameof(binding));
@@ -46,66 +50,66 @@ namespace DotVVM.Framework.Binding
             this.value = default;
         }
 
+        /// <summary> Creates new ValueOrBinding which contains the specified value. Note that there is an implicit conversion for this, so calling the constructor explicitly may be unnecessary. </summary>
         public ValueOrBinding(T value)
         {
             this.value = value;
             this.binding = default;
         }
 
+        /// <summary> Creates a ValueOrBinding from raw object. If the object is IBinding, the ValueOrBinding will <see cref="HasBinding"/> == true, otherwise it will <see cref="HasValue" /> == true. </summary>
         public static ValueOrBinding<T> FromBoxedValue(object? value) =>
+            value is IStaticValueBinding<T> bindingS ? new ValueOrBinding<T>(bindingS) :
             value is IBinding binding ? new ValueOrBinding<T>(binding) :
             value is ValueOrBinding vob ? new ValueOrBinding<T>(vob.BindingOrDefault, (T)vob.BoxedValue!) :
             new ValueOrBinding<T>((T)value!);
 
+        /// <summary> If the binding <see cref="HasValue" />, returns it. If it <see cref="HasBinding" />, evaluates it on the <paramref name="control"/> and returns the result. </summary>
         [return: MaybeNull]
         public T Evaluate(DotvvmBindableObject control) =>
             binding is object ? (T)binding.GetBindingValue(control)! : value;
 
+        /// <summary> Returns the value as object if this <see cref="HasValue"/> or `default(T)` if this <see cref="HasBinding"/>. </summary>
         public T ValueOrDefault => value;
+        /// <summary> Returns the binding if this <see cref="HasBinding"/>, or null if this <see cref="HasValue"/> or `default(T)`. </summary>
         public IBinding? BindingOrDefault => binding;
-        public object? BoxedValue => (object?)value;
+        /// <summary> Returns the value as object if this <see cref="HasValue"/> or null if this <see cref="HasBinding"/>. </summary>
+        public object? BoxedValue => HasValue ? (object?)value : null;
 
+        /// <summary> If this ValueOrBinding contains value. </summary>
         [MemberNotNullWhenAttribute(false, "BindingOrDefault", "binding")]
         public bool HasValue => binding is null;
 
+        /// <summary> If this ValueOrBinding contains binding. </summary>
         [MemberNotNullWhenAttribute(true, "BindingOrDefault", "binding")]
         public bool HasBinding => binding is object;
 
+        /// <summary> Returns a ValueOrBinding with new type T which is a base type of the old T2 </summary>
         public static ValueOrBinding<T> DownCast<T2>(ValueOrBinding<T2> createFrom)
             where T2 : T => new ValueOrBinding<T>(createFrom.binding, createFrom.value!);
 
-
+        /// <summary> Returns a ValueOrBinding with new type T2 which is a derived type of the old T. Will throw an exception if the conversion is not possible. </summary>
         public ValueOrBinding<T2> UpCast<T2>()
             where T2 : T =>
             this.binding != null ?
             new ValueOrBinding<T2>(this.binding) :
             new ValueOrBinding<T2>((T2)this.value!);
 
+        /// <summary> Returns a Javascript (knockout) expression representing this value or this binding. </summary>
         public ParametrizedCode GetParametrizedJsExpression(DotvvmBindableObject control, bool unwrapped = false) =>
             ProcessValueBinding(control,
                 value => new ParametrizedCode(JsonConvert.SerializeObject(value, DefaultSerializerSettingsProvider.Instance.Settings), OperatorPrecedence.Max),
                 binding => binding.GetParametrizedKnockoutExpression(control, unwrapped)
             );
 
+        /// <summary> Returns a Javascript (knockout) expression representing this value or this binding. The parameters are set to defaults, so knockout context is $context, view model is $data and both are available as global. </summary>
         public string GetJsExpression(DotvvmBindableObject control, bool unwrapped = false) =>
             ProcessValueBinding(control,
                 value => JsonConvert.SerializeObject(value, DefaultSerializerSettingsProvider.Instance.Settings),
                 binding => binding.GetKnockoutBindingExpression(control, unwrapped)
             );
 
-
-        // TODO: proper mapping operators
-
-        // public ValueOrBinding<TNew> Map<TNew>(Func<T, TNew> valueMap, Func<IBinding, IBinding>? bindingMap = null) =>
-        //     binding != null ?
-        //     new ValueOrBinding<TNew>(bindingMap == null ? binding : bindingMap.Invoke(binding)) :
-        //     new ValueOrBinding<TNew>(valueMap(value));
-
-        // public ValueOrBinding<TNew> Bind<TNew>(Func<T, ValueOrBinding<TNew>> valueMap, Func<IBinding, ValueOrBinding<TNew>>? bindingMap = null) =>
-        //     binding != null ?
-        //     (bindingMap == null ? new ValueOrBinding<TNew>(binding) : bindingMap.Invoke(binding)) :
-        //     valueMap(value);
-
+        /// <summary> Simple helper which invokes <paramref name="processValue"/> if this HasValue and <paramref name="processBinding"/> if it HasBinding. </summary>
         public void Process(Action<T> processValue, Action<IBinding> processBinding)
         {
             if (binding != null)
@@ -113,6 +117,7 @@ namespace DotVVM.Framework.Binding
             else processValue?.Invoke(value);
         }
 
+        /// <summary> Simple helper which invokes <paramref name="processValue"/> if this HasValue and <paramref name="processBinding"/> if it HasBinding. </summary>
         public TResult Process<TResult>(Func<T, TResult> processValue, Func<IBinding, TResult> processBinding)
         {
             if (binding != null)
@@ -120,6 +125,7 @@ namespace DotVVM.Framework.Binding
             else return processValue(value);
         }
 
+        /// <summary> Simple helper which invokes <paramref name="processValue"/> if this HasValue or if the binding is a resource binding. Invokes <paramref name="processBinding"/> if it HasBinding and the binding is <see cref="IValueBinding" />. </summary>
         public void ProcessValueBinding(DotvvmBindableObject control, Action<T> processValue, Action<IValueBinding> processBinding)
         {
             if (binding == null)
@@ -130,6 +136,7 @@ namespace DotVVM.Framework.Binding
                 processValue?.Invoke(this.Evaluate(control)!);
         }
 
+        /// <summary> Simple helper which invokes <paramref name="processValue"/> if this HasValue or if the binding is a resource binding. Invokes <paramref name="processBinding"/> if it HasBinding and the binding is <see cref="IValueBinding" />. </summary>
         public TResult ProcessValueBinding<TResult>(DotvvmBindableObject control, Func<T, TResult> processValue, Func<IValueBinding, TResult> processBinding)
         {
             if (binding == null)
@@ -142,7 +149,7 @@ namespace DotVVM.Framework.Binding
 
         public static implicit operator ValueOrBinding<T>(T val) => new ValueOrBinding<T>(val);
 
-        public const string EqualsDisabledReason = "Equals is disabled on ValueOrBinding<T> as it may lead to unexpected behavior. Please use object.ReferenceEquals for reference comparison or evalate the ValueOrBinding<T> and compare the value.";
+        public const string EqualsDisabledReason = "Equals is disabled on ValueOrBinding<T> as it may lead to unexpected behavior. Please use object.ReferenceEquals for reference comparison or evalate the ValueOrBinding<T> and compare the value. Or use IsNull/NotNull for nullchecks on bindings.";
         [Obsolete(EqualsDisabledReason, error: true)]
         public static bool operator ==(ValueOrBinding<T> a, ValueOrBinding<T> b) =>
             throw new NotSupportedException(EqualsDisabledReason);

--- a/src/Framework/Framework/Binding/ValueOrBindingExtensions.cs
+++ b/src/Framework/Framework/Binding/ValueOrBindingExtensions.cs
@@ -1,15 +1,25 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using DotVVM.Framework.Binding;
 using DotVVM.Framework.Binding.Expressions;
 using DotVVM.Framework.Binding.Properties;
+using DotVVM.Framework.Compilation;
+using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Compilation.Javascript;
 using DotVVM.Framework.Controls;
+using DotVVM.Framework.Utils;
 using Newtonsoft.Json;
 
 public static class ValueOrBindingExtensions
 {
+    public static object? UnwrapToObject(this ValueOrBinding vob) =>
+        vob.BindingOrDefault ?? vob.BoxedValue;
+    public static object? UnwrapToObject(object? obj) =>
+        obj is ValueOrBinding vob ? vob.UnwrapToObject() : obj;
     public static ValueOrBinding<bool> Negate(this ValueOrBinding<bool> v)
     {
         if (v.BindingOrDefault is IBinding binding)
@@ -60,4 +70,88 @@ public static class ValueOrBindingExtensions
         else
             return new ValueOrBinding<string>("" + v.ValueOrDefault);
     }
+
+    public static ValueOrBinding<bool> And(this ValueOrBinding<bool> a, ValueOrBinding<bool> b)
+    {
+        if (a.HasValue)
+            return a.ValueOrDefault ? b : false;
+        if (b.HasValue)
+            return b.ValueOrDefault ? a : false;
+        return new(BindingCombinator.GetCombination(
+            BindingCombinator.AndAlsoCombination,
+            a.BindingOrDefault,
+            b.BindingOrDefault));
+    }
+
+    public static ValueOrBinding<bool> Or(this ValueOrBinding<bool> a, ValueOrBinding<bool> b)
+    {
+        if (a.HasValue)
+            return a.ValueOrDefault ? true : b;
+        if (b.HasValue)
+            return b.ValueOrDefault ? true : a;
+        return new(BindingCombinator.GetCombination(
+            BindingCombinator.OrElseCombination,
+            a.BindingOrDefault,
+            b.BindingOrDefault));
+    }
+
+    internal static IBinding CreateConstantBinding(
+        object constant,
+        Type type,
+        BindingCompilationService service,
+        BindingParserOptions bpo) =>
+        service.Cache.CreateCachedBinding(
+            "dotvvm-ConstantBinding",
+            new object [] { type, constant, bpo },
+            () => {
+                var expr = Expression.Constant(constant, type);
+                return service.CreateBinding(bpo.BindingType, new object[] {
+                    bpo,
+                    new ExpectedTypeBindingProperty(type),
+                    new ResultTypeBindingProperty(type),
+                    new ParsedExpressionBindingProperty(expr),
+                    new CastedExpressionBindingProperty(expr),
+                    new KnockoutJsExpressionBindingProperty(JavascriptTranslationVisitor.TranslateConstant(expr)),
+                    new BindingDelegate((_, _) => constant)
+                });
+            });
+
+    internal static IBinding SelectImpl(IBinding binding, LambdaExpression mapping)
+    {
+        var service = binding.GetProperty<BindingCompilationService>();
+        var parserOptions = binding.GetProperty<BindingParserOptions>();
+        // get reasonable hash key by captured variables into constants
+        var optimizedExpr = (LambdaExpression)mapping.OptimizeConstants();
+
+        if (optimizedExpr.Body is ConstantExpression constantBody)
+            return CreateConstantBinding(constantBody.Value, mapping.ReturnType, service, parserOptions);
+
+        return service.Cache.CreateCachedBinding(
+                "Dotvvm-BindingSelect",
+                new object[] {
+                    new Tuple<IBinding>(binding),
+                    new ObjectWithComparer<Expression>(optimizedExpr, ExpressionComparer.Instance)
+                },
+                () => binding.DeriveBinding(new object?[] {
+                    new ExpectedTypeBindingProperty(mapping.ReturnType),
+                    new ResultTypeBindingProperty(mapping.ReturnType),
+                    new ParsedExpressionBindingProperty(
+                        ExpressionUtils.Replace(
+                            optimizedExpr,
+                            Expression.Convert(
+                                binding.GetProperty<ParsedExpressionBindingProperty>().Expression,
+                                optimizedExpr.Parameters[0].Type
+                            )
+                        )
+                    )
+                })
+            );
+    }
+    public static IValueBinding<U> Select<T, U>(this IValueBinding<T> binding, Expression<Func<T, U>> mapping) =>
+        (IValueBinding<U>)SelectImpl(binding, mapping);
+    public static IStaticValueBinding<U> Select<T, U>(this IStaticValueBinding<T> binding, Expression<Func<T, U>> mapping) =>
+        (IStaticValueBinding<U>)SelectImpl(binding, mapping);
+    public static ValueOrBinding<U> Select<T, U>(this ValueOrBinding<T> vob, Expression<Func<T, U>> mapping) =>
+        vob.HasBinding ? new(SelectImpl(vob.BindingOrDefault, mapping))
+                       : new(mapping.Compile(preferInterpretation: true).Invoke(vob.ValueOrDefault));
 }

--- a/src/Framework/Framework/Binding/ValueOrBindingExtensions.cs
+++ b/src/Framework/Framework/Binding/ValueOrBindingExtensions.cs
@@ -70,6 +70,33 @@ public static class ValueOrBindingExtensions
         else
             return new ValueOrBinding<string>("" + v.ValueOrDefault);
     }
+    public static ValueOrBinding<bool> NotNull<T>(this ValueOrBinding<T> v) =>
+        v.IsNull().Negate();
+    public static ValueOrBinding<bool> IsNull<T>(this ValueOrBinding<T> v)
+    {
+        if (v.HasBinding)
+            return new(v.BindingOrDefault.GetProperty<IsNullBindingExpression>().Binding);
+        else
+            return new(v.ValueOrDefault is null);
+    }
+    public static ValueOrBinding<bool> NotNullOrEmpty(this ValueOrBinding<string> v) =>
+        v.IsNullOrEmpty().Negate();
+    public static ValueOrBinding<bool> IsNullOrEmpty(this ValueOrBinding<string> v)
+    {
+        if (v.HasBinding)
+            return new(v.BindingOrDefault.GetProperty<IsNullOrEmptyBindingExpression>().Binding);
+        else
+            return new(string.IsNullOrEmpty(v.ValueOrDefault));
+    }
+    public static ValueOrBinding<bool> NotNullOrWhitespace(this ValueOrBinding<string> v) =>
+        v.IsNullOrWhitespace().Negate();
+    public static ValueOrBinding<bool> IsNullOrWhitespace(this ValueOrBinding<string> v)
+    {
+        if (v.HasBinding)
+            return new(v.BindingOrDefault.GetProperty<IsNullOrWhitespaceBindingExpression>().Binding);
+        else
+            return new(string.IsNullOrWhiteSpace(v.ValueOrDefault));
+    }
 
     public static ValueOrBinding<bool> And(this ValueOrBinding<bool> a, ValueOrBinding<bool> b)
     {

--- a/src/Framework/Framework/Binding/ValueOrBindingExtensions.cs
+++ b/src/Framework/Framework/Binding/ValueOrBindingExtensions.cs
@@ -16,10 +16,15 @@ using Newtonsoft.Json;
 
 public static class ValueOrBindingExtensions
 {
+    /// <summary> Returns the value or the binding from the ValueOrBinding container. Equivalent to calling <code>vob.BindingOrDefault ?? vob.BoxedValue</code> </summary>
     public static object? UnwrapToObject(this ValueOrBinding vob) =>
         vob.BindingOrDefault ?? vob.BoxedValue;
+
+    /// <summary> If the obj is ValueOrBinding, returns the binding or the value from the container. Equivalent to <code>obj is ValueOrBinding vob ? vob.UnwrapToObject() : obj</code> </summary>
     public static object? UnwrapToObject(object? obj) =>
         obj is ValueOrBinding vob ? vob.UnwrapToObject() : obj;
+
+    /// <summary> Returns ValueOrBinding with the value of `!a`. The resulting binding is cached, so it's safe to use this method at runtime. </summary>
     public static ValueOrBinding<bool> Negate(this ValueOrBinding<bool> v)
     {
         if (v.BindingOrDefault is IBinding binding)
@@ -29,6 +34,7 @@ public static class ValueOrBindingExtensions
         else
             return !v.ValueOrDefault;
     }
+    /// <summary> Returns ValueOrBinding with the value of `!a`. The resulting binding is cached, so it's safe to use this method at runtime. </summary>
     public static ValueOrBinding<bool?> Negate(this ValueOrBinding<bool?> v)
     {
         if (v.BindingOrDefault is IBinding binding)
@@ -38,11 +44,13 @@ public static class ValueOrBindingExtensions
         else
             return !v.ValueOrDefault;
     }
+    /// <summary> Returns a binding with the value of `!bindingValue`. The resulting binding is cached, so it's safe to use this method at runtime. </summary>
     public static T Negate<T>(this T binding)
         where T: IStaticValueBinding<bool>
     {
         return (T)binding.GetProperty<NegatedBindingExpression>().Binding;
     }
+    /// <summary> Returns ValueOrBinding with the value of `a > 0`. The resulting binding is cached, so it's safe to use this method at runtime. </summary>
     public static ValueOrBinding<bool> IsMoreThanZero(this ValueOrBinding<int> v)
     {
         if (v.BindingOrDefault is IBinding binding)
@@ -52,6 +60,7 @@ public static class ValueOrBindingExtensions
         else
             return v.ValueOrDefault > 0;
     }
+    /// <summary> Returns ValueOrBinding with the value of `a.Items` where a is grid view dataset. The resulting binding is cached, so it's safe to use this method at runtime. </summary>
     public static ValueOrBinding<IList<T>> GetItems<T>(this ValueOrBinding<IBaseGridViewDataSet<T>> v)
     {
         if (v.BindingOrDefault is IBinding binding)
@@ -61,6 +70,7 @@ public static class ValueOrBindingExtensions
         else
             return new ValueOrBinding<IList<T>>(v.ValueOrDefault.Items);
     }
+    /// <summary> Returns ValueOrBinding with the value of `a?.ToString() ?? ""`. The resulting binding is cached, so it's safe to use this method at runtime. </summary>
     public static ValueOrBinding<string> AsString<T>(this ValueOrBinding<T> v)
     {
         if (v.BindingOrDefault is IBinding binding)
@@ -70,8 +80,10 @@ public static class ValueOrBindingExtensions
         else
             return new ValueOrBinding<string>("" + v.ValueOrDefault);
     }
+    /// <summary> Returns ValueOrBinding with the value of `a is object`. The resulting binding is cached, so it's safe to use this method at runtime. </summary>
     public static ValueOrBinding<bool> NotNull<T>(this ValueOrBinding<T> v) =>
         v.IsNull().Negate();
+    /// <summary> Returns ValueOrBinding with the value of `a is null`. The resulting binding is cached, so it should be safe to use this method at runtime. </summary>
     public static ValueOrBinding<bool> IsNull<T>(this ValueOrBinding<T> v)
     {
         if (v.HasBinding)
@@ -79,8 +91,10 @@ public static class ValueOrBindingExtensions
         else
             return new(v.ValueOrDefault is null);
     }
+    /// <summary> Returns ValueOrBinding with the value of `!string.IsNullOrEmpty(a)`. The resulting binding is cached, so it should be safe to use this method at runtime. </summary>
     public static ValueOrBinding<bool> NotNullOrEmpty(this ValueOrBinding<string> v) =>
         v.IsNullOrEmpty().Negate();
+    /// <summary> Returns ValueOrBinding with the value of `string.IsNullOrEmpty(a)`. The resulting binding is cached, so it's safe to use this method at runtime. </summary>
     public static ValueOrBinding<bool> IsNullOrEmpty(this ValueOrBinding<string> v)
     {
         if (v.HasBinding)
@@ -88,8 +102,11 @@ public static class ValueOrBindingExtensions
         else
             return new(string.IsNullOrEmpty(v.ValueOrDefault));
     }
+    /// <summary> Returns ValueOrBinding with the value of `!string.IsNullOrWhitespace(a)`. The resulting binding is cached, so it's safe to use this method at runtime. </summary>
     public static ValueOrBinding<bool> NotNullOrWhitespace(this ValueOrBinding<string> v) =>
         v.IsNullOrWhitespace().Negate();
+
+    /// <summary> Returns ValueOrBinding with the value of `string.IsNullOrWhitespace(a)`. The resulting binding is cached, so it's safe to use this method at runtime. </summary>
     public static ValueOrBinding<bool> IsNullOrWhitespace(this ValueOrBinding<string> v)
     {
         if (v.HasBinding)
@@ -98,6 +115,7 @@ public static class ValueOrBindingExtensions
             return new(string.IsNullOrWhiteSpace(v.ValueOrDefault));
     }
 
+    /// <summary> Returns ValueOrBinding with the value of `a &amp;&amp; b`. If both a and b contain a binding, they are combined together. The result is cached, so it's safe to use this method at runtime. </summary>
     public static ValueOrBinding<bool> And(this ValueOrBinding<bool> a, ValueOrBinding<bool> b)
     {
         if (a.HasValue)
@@ -110,6 +128,7 @@ public static class ValueOrBindingExtensions
             b.BindingOrDefault));
     }
 
+    /// <summary> Returns ValueOrBinding with the value of `a || b`. If both a and b contain a binding, they are combined together. The result is cached, so it's safe to use this method at runtime. </summary>
     public static ValueOrBinding<bool> Or(this ValueOrBinding<bool> a, ValueOrBinding<bool> b)
     {
         if (a.HasValue)
@@ -174,10 +193,17 @@ public static class ValueOrBindingExtensions
                 })
             );
     }
+
+    /// <summary> Maps the result of this binding with another expression. The expression is also translated to Javascript, so only translatable methods may be used.
+    /// Note that this method is very fast, so use it carefully. Usage is server-side styles should be preferred over usage at runtime in custom controls. </summary>
     public static IValueBinding<U> Select<T, U>(this IValueBinding<T> binding, Expression<Func<T, U>> mapping) =>
         (IValueBinding<U>)SelectImpl(binding, mapping);
+    /// <summary> Maps the result of this binding with another expression. The expression is also translated to Javascript, so only translatable methods may be used.
+    /// Note that this method is very fast, so use it carefully. Usage is server-side styles should be preferred over usage at runtime in custom controls. </summary>
     public static IStaticValueBinding<U> Select<T, U>(this IStaticValueBinding<T> binding, Expression<Func<T, U>> mapping) =>
         (IStaticValueBinding<U>)SelectImpl(binding, mapping);
+    /// <summary> Maps the result of this binding with another expression. The expression is also translated to Javascript, so only translatable methods may be used.
+    /// Note that this method is very fast, so use it carefully. Usage is server-side styles should be preferred over usage at runtime in custom controls. </summary>
     public static ValueOrBinding<U> Select<T, U>(this ValueOrBinding<T> vob, Expression<Func<T, U>> mapping) =>
         vob.HasBinding ? new(SelectImpl(vob.BindingOrDefault, mapping))
                        : new(mapping.Compile(preferInterpretation: true).Invoke(vob.ValueOrDefault));

--- a/src/Framework/Framework/Binding/VirtualPropertyGroupDictionary.cs
+++ b/src/Framework/Framework/Binding/VirtualPropertyGroupDictionary.cs
@@ -135,8 +135,7 @@ namespace DotVVM.Framework.Binding
 
         public void Set(string key, ValueOrBinding<TValue> value)
         {
-            var val = value.BindingOrDefault ?? value.BoxedValue;
-            control.properties.Set(group.GetDotvvmProperty(key), val);
+            control.properties.Set(group.GetDotvvmProperty(key), value.UnwrapToObject());
         }
 
         public bool ContainsKey(string key)
@@ -156,7 +155,7 @@ namespace DotVVM.Framework.Binding
         public void Add(string key, ValueOrBinding<TValue> value)
         {
             var prop = group.GetDotvvmProperty(key);
-            object? val = value.BindingOrDefault ?? (object?)value.ValueOrDefault;
+            object? val = value.UnwrapToObject();
             if (!control.properties.TryAdd(prop, val))
                 AddOnConflict(prop, val);
         }

--- a/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
+++ b/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
+++ b/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
@@ -258,7 +258,39 @@ namespace DotVVM.Framework.Compilation.Binding
         {
             return new ExpectedAsStringBindingExpression(binding.DeriveBinding(new ExpectedTypeBindingProperty(typeof(string)), e));
         }
-
+        public IsNullBindingExpression IsNull(ParsedExpressionBindingProperty eprop, IBinding binding)
+        {
+            var e = eprop.Expression;
+            return new IsNullBindingExpression(binding.DeriveBinding(
+                new ParsedExpressionBindingProperty(
+                    e.Type.IsNullable() ? Expression.Not(Expression.Property(e, "HasValue")) :
+                    e.Type.IsValueType ? Expression.Constant(false) :
+                    Expression.ReferenceEqual(e, Expression.Constant(null, e.Type))
+                )
+            ));
+        }
+        public IsNullOrEmptyBindingExpression IsNullOrEmpty(ParsedExpressionBindingProperty eprop, IBinding binding)
+        {
+            var e = eprop.Expression;
+            if (e.Type != typeof(string))
+                throw new NotSupportedException($"{e} was not of type string, but {e.Type}");
+            return new IsNullOrEmptyBindingExpression(binding.DeriveBinding(
+                new ParsedExpressionBindingProperty(
+                    Expression.Call(typeof(string), "IsNullOrEmpty", Type.EmptyTypes, e)
+                )
+            ));
+        }
+        public IsNullOrWhitespaceBindingExpression IsNullOrWhitespace(ParsedExpressionBindingProperty eprop, IBinding binding)
+        {
+            var e = eprop.Expression;
+            if (e.Type != typeof(string))
+                throw new NotSupportedException($"{e} was not of type string, but {e.Type}");
+            return new IsNullOrWhitespaceBindingExpression(binding.DeriveBinding(
+                new ParsedExpressionBindingProperty(
+                    Expression.Call(typeof(string), "IsNullOrWhitespace", Type.EmptyTypes, e)
+                )
+            ));
+        }
 
         public DataSourceAccessBinding GetDataSourceAccess(ParsedExpressionBindingProperty expression, IBinding binding)
         {

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedBinding.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedBinding.cs
@@ -54,6 +54,12 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
             this.Binding = bindingService.CreateBinding(bindingType, properties.ToArray());
         }
 
+        public ResolvedBinding(IBinding binding)
+        {
+            this.Binding = binding;
+            this.BindingService = binding.GetProperty<BindingCompilationService>();
+        }
+
         public Expression GetExpression() => Binding.GetProperty<ParsedExpressionBindingProperty>().Expression;
 
         public override void Accept(IResolvedControlTreeVisitor visitor)

--- a/src/Framework/Framework/Compilation/ControlTree/ResolvedTreeHelpers.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ResolvedTreeHelpers.cs
@@ -29,6 +29,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
         public static object? GetValue(this ResolvedPropertySetter setter) =>
             setter switch {
                 ResolvedPropertyValue value => value.Value,
+                ResolvedPropertyBinding binding => binding.Binding.Binding,
                 ResolvedPropertyTemplate value => value.Content,
                 ResolvedPropertyControl value => value.Control,
                 ResolvedPropertyControlCollection value => value.Controls,

--- a/src/Framework/Framework/Compilation/HtmlAttributeValueMerger.cs
+++ b/src/Framework/Framework/Compilation/HtmlAttributeValueMerger.cs
@@ -22,8 +22,19 @@ namespace DotVVM.Framework.Compilation
             // return Expression.Call(typeof(string).GetMethod("Concat", new[] { typeof(string), typeof(string), typeof(string) }), a, Expression.Constant(separator), b);
         }
 
-        public static string? MergeValues(GroupedDotvvmProperty property, string? a, string? b) =>
-            HtmlWriter.JoinAttributeValues(property.GroupMemberName, a, b);
+        public static string? MergeValues(GroupedDotvvmProperty property, string? a, string? b)
+        {
+            // for perf reasons only do this compile time - we'll deduplicate the attribute if it's a CSS class
+            if (property.GroupMemberName == "class" && a is string && b is string)
+            {
+                var classesA = a.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+                var classesB = b.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)
+                    .Where(c => !classesA.Contains(c));
+                b = string.Join(" ", classesB);
+            }
+
+            return HtmlWriter.JoinAttributeValues(property.GroupMemberName, a, b);
+        }
 
 
         public override object? MergePlainValues(DotvvmProperty prop, object? a, object? b)

--- a/src/Framework/Framework/Compilation/Javascript/Ast/JsAstHelpers.cs
+++ b/src/Framework/Framework/Compilation/Javascript/Ast/JsAstHelpers.cs
@@ -6,10 +6,10 @@ namespace DotVVM.Framework.Compilation.Javascript.Ast
 {
     public static class JsAstHelpers
     {
-        public static JsExpression Member(this JsExpression target, string memberName)
+        public static JsExpression Member(this JsExpression target, string memberName, bool optional = false)
         {
             if (target == null) return new JsIdentifierExpression(memberName);
-            else return new JsMemberAccessExpression(target, memberName);
+            else return new JsMemberAccessExpression(target, memberName) { IsOptional = optional };
         }
 
         public static JsExpression Invoke(this JsExpression target, IEnumerable<JsExpression> arguments) =>

--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -266,15 +266,10 @@ namespace DotVVM.Framework.Compilation.Javascript
             AddMethodTranslator(typeof(string), nameof(string.EndsWith), parameters: new[] { typeof(string), typeof(StringComparison) }, translator: new GenericMethodCompiler(
                 a => new JsIdentifierExpression("dotvvm").Member("translations").Member("string").Member("endsWith").Invoke(a[0], a[1], a[2])));
             AddMethodTranslator(typeof(string), nameof(string.IsNullOrEmpty), parameters: new[] { typeof(string) }, translator: new GenericMethodCompiler(
-                a => new JsBinaryExpression(
-                    new JsBinaryExpression(a[1], BinaryOperatorType.Equal, new JsLiteral(null)),
-                    BinaryOperatorType.ConditionalOr,
-                    new JsBinaryExpression(a[1].Clone(), BinaryOperatorType.StrictlyEqual, new JsLiteral("")))));
+                a => new JsBinaryExpression(a[1].Member("length", optional: true), BinaryOperatorType.Greater, new JsLiteral(0)).Unary(UnaryOperatorType.LogicalNot)
+            ));
             AddMethodTranslator(typeof(string), nameof(string.IsNullOrWhiteSpace), parameters: new[] { typeof(string) }, translator: new GenericMethodCompiler(
-                a => new JsBinaryExpression(
-                    new JsBinaryExpression(a[1], BinaryOperatorType.Equal, new JsLiteral(null)),
-                    BinaryOperatorType.ConditionalOr,
-                    new JsBinaryExpression(a[1].Clone().Member("trim").Invoke(), BinaryOperatorType.StrictlyEqual, new JsLiteral("")))));
+                a => new JsBinaryExpression(a[1].Member("trim", optional: true).Invoke().Member("length"), BinaryOperatorType.Greater, new JsLiteral(0)).Unary(UnaryOperatorType.LogicalNot)));
 
             var joinStringArrayMethod = typeof(string).GetMethods(BindingFlags.Public | BindingFlags.Static)
                 .Where(m => m.Name == nameof(string.Join) && m.GetParameters().Length == 2 && m.GetParameters().Last().ParameterType == typeof(string[]) && m.GetParameters().First().ParameterType == typeof(string)).Single();

--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslationVisitor.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslationVisitor.cs
@@ -226,7 +226,7 @@ namespace DotVVM.Framework.Compilation.Javascript
                           null)
             .WithAnnotation(new ViewModelInfoAnnotation(expression.Type, containsObservables: false));
 
-        public JsLiteral TranslateConstant(ConstantExpression expression) =>
+        public static JsLiteral TranslateConstant(ConstantExpression expression) =>
             new JsLiteral(expression.Value).WithAnnotation(new ViewModelInfoAnnotation(expression.Type, containsObservables: false));
 
         public JsExpression TranslateMethodCall(MethodCallExpression expression)

--- a/src/Framework/Framework/Compilation/Styles/ResolvedControlHelper.cs
+++ b/src/Framework/Framework/Compilation/Styles/ResolvedControlHelper.cs
@@ -57,6 +57,7 @@ namespace DotVVM.Framework.Compilation.Styles
         }
 
         public static bool IsAllowedPropertyValue([NotNullWhen(false)] object? value) =>
+            value is ValueOrBinding vob && IsAllowedPropertyValue(vob.UnwrapToObject()) ||
             value is null ||
             ReflectionUtils.IsPrimitiveType(value.GetType()) ||
             RoslynValueEmitter.IsImmutableObject(value.GetType()) ||
@@ -68,6 +69,8 @@ namespace DotVVM.Framework.Compilation.Styles
             {
                 value = resolvedSetter.GetValue();
             }
+
+            value = ValueOrBindingExtensions.UnwrapToObject(value);
 
             if (value is DotvvmBindableObject valueControl)
             {
@@ -103,9 +106,9 @@ namespace DotVVM.Framework.Compilation.Styles
                 else
                     return new ResolvedPropertyControlCollection(property, cs.ToList());
             }
-            else if (value is IBinding)
+            else if (value is IBinding binding)
             {
-                return new ResolvedPropertyValue(property, value);
+                return new ResolvedPropertyBinding(property, new ResolvedBinding(binding));
             }
             else if (IsAllowedPropertyValue(value))
             {

--- a/src/Framework/Framework/Compilation/Styles/StyleApplicator.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleApplicator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using DotVVM.Framework.Binding;
@@ -213,6 +213,8 @@ namespace DotVVM.Framework.Compilation.Styles
                 .ToArray();
             foreach (var c in innerControls)
             {
+                if (c is null)
+                    continue;
                 c.Parent = control;
                 innerControlsStyle.Applicator.ApplyStyle(c, new StyleMatchContext<DotvvmBindableObject>(context, c, context.Configuration));
             }

--- a/src/Framework/Framework/Compilation/Styles/StyleBuilder.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleBuilder.cs
@@ -68,7 +68,7 @@ namespace DotVVM.Framework.Compilation.Styles
 
             public override bool Matches(IStyleMatchContext context)
             {
-                if (context.PropertyS<bool>(Controls.Styles.ExcludeProperty) == true)
+                if (context.PropertyValue<bool>(Controls.Styles.ExcludeProperty))
                     return false;
 
                 return Matcher != null ? Matcher(new StyleMatchContext<T>(context.Parent, context.Control, context.Configuration)) : true;

--- a/src/Framework/Framework/Compilation/Styles/StyleBuilderMethods.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleBuilderMethods.cs
@@ -277,6 +277,16 @@ public static partial class StyleBuilderExtensionMethods
 
         sb.AppendAttribute("class", className);
 
+    /// <summary> Appends a css class (or multiple of them) with the condition. </summary>
+    public static IStyleBuilder<T> AddClass<T>(this IStyleBuilder<T> sb, string className, Func<IStyleMatchContext<T>, ValueOrBinding<bool>> condition) =>
+
+        sb.SetPropertyGroupMember("Class-", className, c => condition(c), StyleOverrideOptions.Append);
+
+    /// <summary> Appends a css class (or multiple of them) with the condition. </summary>
+    public static IStyleBuilder<T> AddClassBinding<T>(this IStyleBuilder<T> sb, string className, string conditionBinding, BindingParserOptions? bindingOptions = null) =>
+
+        sb.SetPropertyGroupMemberBinding("Class-", className, conditionBinding, StyleOverrideOptions.Append);
+
     /// <summary> Appends value to the specified attribute. </summary>
     public static T AppendAttribute<T>(this T sb, string attribute, ValueOrBinding<string> value)
         where T: IStyleBuilder =>

--- a/src/Framework/Framework/Compilation/Styles/StyleBuilderMethods.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleBuilderMethods.cs
@@ -17,23 +17,15 @@ using DotVVM.Framework.Binding.Properties;
 
 public static partial class StyleBuilderExtensionMethods
 {
-    private static DotvvmProperty GetProperty(this IStyleBuilder sb, string name)
-    {
-        var field = sb.ControlType.GetField(name + "Property", BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy) ??
-            throw new ArgumentException($"DotVVM Property {name} does not exist on control {sb.ControlType}", nameof(name));
-        return field.GetValue(null) as DotvvmProperty ??
-            throw new Exception($"Property {name} has an invalid backing field. It was expected to contain DotvvmProperty.");
-    }
-
     /// <summary> Sets a specified property on the matching controls. The referenced property must be a wrapper around a DotvvmProperty. </summary>
     public static IStyleBuilder<TControl> SetProperty<TControl, TProperty>(
         this IStyleBuilder<TControl> sb,
         Expression<Func<TControl, TProperty>> property,
-        TProperty value,
+        ValueOrBinding<TProperty> value,
         StyleOverrideOptions options = StyleOverrideOptions.Overwrite)
     {
-        var propertyName = ReflectionUtils.GetMemberFromExpression(property).Name;
-        return sb.SetDotvvmProperty(sb.GetProperty(propertyName), value, options);
+        var dotprop = ReflectionUtils.GetDotvvmPropertyFromExpression(property);
+        return sb.SetDotvvmProperty(dotprop, value, options);
     }
 
     /// <summary> Sets a control to the specified property on the matching controls. </summary>
@@ -65,9 +57,9 @@ public static partial class StyleBuilderExtensionMethods
         StyleOverrideOptions options = StyleOverrideOptions.Overwrite)
         where TInnerControl: DotvvmBindableObject
     {
-        var propertyName = ReflectionUtils.GetMemberFromExpression(property).Name;
+        var dotprop = ReflectionUtils.GetDotvvmPropertyFromExpression(property);
         return sb.SetControlProperty<IStyleBuilder<TControl>, TInnerControl>(
-            sb.GetProperty(propertyName), prototypeControl, styleBuilder, options);
+            dotprop, prototypeControl, styleBuilder, options);
     }
 
     /// <summary> Adds a control to the specified property on the matching controls. </summary>
@@ -109,11 +101,11 @@ public static partial class StyleBuilderExtensionMethods
     public static T SetLiteralControlProperty<T>(
         this T sb,
         DotvvmProperty property,
-        string text,
+        ValueOrBinding<string> text,
         StyleOverrideOptions options = StyleOverrideOptions.Overwrite)
         where T: IStyleBuilder =>
 
-        sb.SetControlProperty(property, RawLiteral.Create(text), options: options);
+        sb.SetControlProperty(property, text.Process<DotvvmControl>(RawLiteral.Create, _ => new Literal(text)), options: options);
 
     /// <summary> Sets a specified property on the matching controls </summary>
     public static T SetDotvvmProperty<T>(
@@ -123,6 +115,7 @@ public static partial class StyleBuilderExtensionMethods
         StyleOverrideOptions options = StyleOverrideOptions.Overwrite)
         where T: IStyleBuilder
     {
+        value = ValueOrBindingExtensions.UnwrapToObject(value);
         if (value is DotvvmBindableObject || value is IEnumerable<DotvvmBindableObject>)
             throw new ArgumentException($"For setting controls into properties please use the SetControlProperty or AppendControlProperty functions.", nameof(value));
         if (!ResolvedControlHelper.IsAllowedPropertyValue(value))
@@ -157,8 +150,8 @@ public static partial class StyleBuilderExtensionMethods
         Func<IStyleMatchContext<TControl>, TProperty> value,
         StyleOverrideOptions options = StyleOverrideOptions.Overwrite)
     {
-        var propertyName = ReflectionUtils.GetMemberFromExpression(property).Name;
-        return sb.SetDotvvmProperty(sb.GetProperty(propertyName), c => (object?)value(c), options);
+        var dotprop = ReflectionUtils.GetDotvvmPropertyFromExpression(property);
+        return sb.SetDotvvmProperty(dotprop, c => (object?)value(c), options);
     }
 
     /// <summary> Sets the specified property to a binding.
@@ -172,8 +165,7 @@ public static partial class StyleBuilderExtensionMethods
         BindingParserOptions? bindingOptions = null)
         where T: IStyleBuilder
     {
-        var propertyName = ReflectionUtils.GetMemberFromExpression(property).Name;
-        var dotprop = GetProperty(sb, propertyName);
+        var dotprop = ReflectionUtils.GetDotvvmPropertyFromExpression(property);
         return sb.AddApplicator(new PropertyStyleBindingApplicator(
             dotprop,
             binding,
@@ -225,8 +217,8 @@ public static partial class StyleBuilderExtensionMethods
         StyleOverrideOptions options = StyleOverrideOptions.Overwrite,
         BindingParserOptions? bindingOptions = null)
     {
-        var propertyName = ReflectionUtils.GetMemberFromExpression(property).Name;
-        return sb.SetDotvvmPropertyBinding(sb.GetProperty(propertyName), binding, options, bindingOptions);
+        var dotprop = ReflectionUtils.GetDotvvmPropertyFromExpression(property);
+        return sb.SetDotvvmPropertyBinding(dotprop, binding, options, bindingOptions);
     }
 
     /// <summary> Adds a Class-className binding to the control </summary>
@@ -246,7 +238,7 @@ public static partial class StyleBuilderExtensionMethods
         BindingParserOptions? bindingOptions = null)
         where T: IStyleBuilder =>
 
-        sb.SetPropertyGroupMemberBinding("", attribute, binding, StyleOverrideOptions.Append, bindingOptions);
+        sb.SetPropertyGroupMemberBinding("html:", attribute, binding, StyleOverrideOptions.Append, bindingOptions);
 
     /// <summary> Sets HTML attribute of the control.
     /// Value binding is used by default, alternative binding types can be set using the bindingOptions parameter.
@@ -259,7 +251,7 @@ public static partial class StyleBuilderExtensionMethods
         BindingParserOptions? bindingOptions = null)
         where T: IStyleBuilder =>
 
-        sb.SetPropertyGroupMemberBinding("", attribute, binding, options, bindingOptions);
+        sb.SetPropertyGroupMemberBinding("html:", attribute, binding, options, bindingOptions);
 
     /// <summary> Sets property group member of the control. For example SetPropertyGroupMember("Param-", "Abcd", "_root.DefaultAbcd") would set the Abcd parameter on RouteLink.
     /// Value binding is used by default, alternative binding types can be set using the bindingOptions parameter.
@@ -281,38 +273,38 @@ public static partial class StyleBuilderExtensionMethods
         sb.AppendAttribute("class", className);
 
     /// <summary> Appends a css class (or multiple of them) to the control. </summary>
-    public static IStyleBuilder<T> AddClass<T>(this IStyleBuilder<T> sb, Func<IStyleMatchContext<T>, string> className) =>
+    public static IStyleBuilder<T> AddClass<T>(this IStyleBuilder<T> sb, Func<IStyleMatchContext<T>, ValueOrBinding<string>> className) =>
 
         sb.AppendAttribute("class", className);
 
     /// <summary> Appends value to the specified attribute. </summary>
-    public static T AppendAttribute<T>(this T sb, string attribute, string value)
+    public static T AppendAttribute<T>(this T sb, string attribute, ValueOrBinding<string> value)
         where T: IStyleBuilder =>
 
-        sb.SetPropertyGroupMember("", attribute, value, StyleOverrideOptions.Append);
+        sb.SetPropertyGroupMember("html:", attribute, value, StyleOverrideOptions.Append);
 
     /// <summary> Appends value to the specified attribute. </summary>
-    public static IStyleBuilder<T> AppendAttribute<T>(this IStyleBuilder<T> sb, string attribute, Func<IStyleMatchContext<T>, string> value) =>
+    public static IStyleBuilder<T> AppendAttribute<T>(this IStyleBuilder<T> sb, string attribute, Func<IStyleMatchContext<T>, ValueOrBinding<string>> value) =>
 
-        sb.SetPropertyGroupMember("", attribute, value, StyleOverrideOptions.Append);
+        sb.SetPropertyGroupMember("html:", attribute, c => value(c), StyleOverrideOptions.Append);
 
     /// <summary> Sets HTML attribute of the control. </summary>
     public static T SetAttribute<T>(this T sb, string attribute, object value, StyleOverrideOptions options = StyleOverrideOptions.Ignore)
         where T: IStyleBuilder =>
 
-        sb.SetPropertyGroupMember("", attribute, value, options);
+        sb.SetPropertyGroupMember("html:", attribute, value, options);
 
     /// <summary> Sets HTML attribute of the control. </summary>
-    public static IStyleBuilder<T> SetAttribute<T>(this IStyleBuilder<T> sb, string attribute, Func<IStyleMatchContext<T>, string> value, StyleOverrideOptions options = StyleOverrideOptions.Ignore) =>
+    public static IStyleBuilder<T> SetAttribute<T>(this IStyleBuilder<T> sb, string attribute, Func<IStyleMatchContext<T>, object> value, StyleOverrideOptions options = StyleOverrideOptions.Ignore) =>
 
-        sb.SetPropertyGroupMember("", attribute, value, options);
+        sb.SetPropertyGroupMember("html:", attribute, value, options);
 
     public static DotvvmProperty GetPropertyGroup(this IStyleBuilder sb, string prefix, string member)
     {
         var group = DotvvmPropertyGroup.GetPropertyGroups(sb.ControlType).Where(p => p.Prefixes.Contains(prefix)).ToArray();
         if (group.Length == 0)
         {
-            var attributesHelp = prefix == "" ? " If you want to set html attributes make sure to register the style for control that supports them, for example using Styles.Register<HtmlGenericControl>(...)..." : "";
+            var attributesHelp = prefix == "html:" ? " If you want to set html attributes make sure to register the style for control that supports them, for example using Styles.Register<HtmlGenericControl>(...)..." : "";
             throw new Exception($"Control {sb.ControlType.Name} does not have any property group with prefix '{prefix}'." + attributesHelp);
         }
         if (group.Length > 1)

--- a/src/Framework/Framework/Compilation/Styles/StyleBuilderMethods.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleBuilderMethods.cs
@@ -351,6 +351,7 @@ public static partial class StyleBuilderExtensionMethods
         where T: IStyleBuilder<DotvvmControl>
         where TControl: DotvvmBindableObject
     {
+        if (prototypeControl is null) throw new ArgumentNullException(nameof(prototypeControl));
         var innerControlStyleBuilder = new StyleBuilder<TControl>(null, false);
         styleBuilder?.Invoke(innerControlStyleBuilder);
 

--- a/src/Framework/Framework/Compilation/Styles/StyleMatchContextMethods.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleMatchContextMethods.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using DotVVM.Framework.Binding;

--- a/src/Framework/Framework/Compilation/Styles/StyleMatchContextMethods.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleMatchContextMethods.cs
@@ -157,7 +157,24 @@ public static class StyleMatchContextExtensionMethods
     public static bool HasProperty<TControl>(this IStyleMatchContext<TControl> c, Expression<Func<TControl, object>> property)
     {
         var prop = ReflectionUtils.GetDotvvmPropertyFromExpression(property);
-        return c.Control.Properties.ContainsKey(prop);
+        return c.HasProperty(prop);
+    }
+
+    /// <summary>
+    /// Determines whether the control has the given <see cref="DotvvmProperty"/>.
+    /// </summary>
+    public static bool HasBinding(this IStyleMatchContext c, DotvvmProperty property)
+    {
+        return c.Control.Properties.TryGetValue(property, out var r) && r.GetValue() is IBinding;
+    }
+
+    /// <summary>
+    /// Determines whether the control has the given <see cref="DotvvmProperty"/>.
+    /// </summary>
+    public static bool HasBinding<TControl>(this IStyleMatchContext<TControl> c, Expression<Func<TControl, object>> property)
+    {
+        var prop = ReflectionUtils.GetDotvvmPropertyFromExpression(property);
+        return c.HasBinding(prop);
     }
 
     /// <summary>

--- a/src/Framework/Framework/Compilation/Styles/StyleMatchContextMethods.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleMatchContextMethods.cs
@@ -156,8 +156,8 @@ public static class StyleMatchContextExtensionMethods
     /// </summary>
     public static bool HasProperty<TControl>(this IStyleMatchContext<TControl> c, Expression<Func<TControl, object>> property)
     {
-        var member = ReflectionUtils.GetMemberFromExpression(property);
-        return c.Control.Properties.Any(p => p.Key.PropertyInfo == member);
+        var prop = ReflectionUtils.GetDotvvmPropertyFromExpression(property);
+        return c.Control.Properties.ContainsKey(prop);
     }
 
     /// <summary>
@@ -165,15 +165,23 @@ public static class StyleMatchContextExtensionMethods
     /// </summary>
     public static bool HasHtmlAttribute(this IStyleMatchContext c, string attributeName)
     {
-        return c.HasPropertyGroupMember("", attributeName);
+        return c.HasPropertyGroupMember("html:", attributeName);
     }
 
     /// <summary>
     /// Determines whether the control has an HTML attribute of the specified name.
     /// </summary>
-    public static string? GetHtmlAttribute(this IStyleMatchContext c, string attributeName)
+    public static ValueOrBinding<string>? GetHtmlAttribute(this IStyleMatchContext c, string attributeName)
     {
-        return c.GetPropertyGroupMember("", attributeName)?.ToString();
+        return c.GetPropertyGroupMember<object>("html:", attributeName)?.UpCast<string>();
+    }
+
+    /// <summary>
+    /// Determines whether the control has an HTML attribute of the specified name.
+    /// </summary>
+    public static string? GetHtmlAttributeValue(this IStyleMatchContext c, string attributeName)
+    {
+        return c.GetPropertyGroupMember<object>("html:", attributeName)?.ValueOrDefault?.ToString();
     }
 
     public static bool HasPropertyGroupMember(this IStyleMatchContext c, string prefix, string memberName)
@@ -182,10 +190,15 @@ public static class StyleMatchContextExtensionMethods
         return prop != null && c.HasProperty((DotvvmProperty)prop.GetDotvvmProperty(memberName));
     }
     
-    public static object? GetPropertyGroupMember(this IStyleMatchContext c, string prefix, string memberName)
+    public static ValueOrBinding<T>? GetPropertyGroupMember<T>(this IStyleMatchContext c, string prefix, string memberName)
     {
-        var prop = c.Control.Metadata.PropertyGroups.FirstOrDefault(p => p.Prefix == prefix).PropertyGroup;
-        return prop is null ? null : c.Property<object>((DotvvmProperty)prop.GetDotvvmProperty(memberName));
+        var propGroup = c.Control.Metadata.PropertyGroups.FirstOrDefault(p => p.Prefix == prefix).PropertyGroup;
+        if (propGroup is null)
+            return null;
+        var prop = (DotvvmProperty)propGroup.GetDotvvmProperty(memberName);
+        if (!c.HasProperty(prop))
+            return null;
+        else return c.Property<T>(prop);
     }
 
     /// <summary>
@@ -194,7 +207,7 @@ public static class StyleMatchContextExtensionMethods
     /// </summary>
     public static bool HasClass(this IStyleMatchContext c, params string[] classes)
     {
-        var attr = c.GetHtmlAttribute("class")?.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        var attr = c.GetHtmlAttributeValue("class")?.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
         if (attr is object)
         {
             return classes.All(c => attr.Contains(c));
@@ -208,50 +221,51 @@ public static class StyleMatchContextExtensionMethods
     /// <summary> Returns tag name, if the current control is HtmlGenericControl. If the type is unknown, returns null. </summary>
     public static string? TagName(this IStyleMatchContext c) =>
         c.ControlType() == typeof(HtmlGenericControl) ? c.Control.ConstructorParameters![0] as string :
-        c.IsType<ConfigurableHtmlControl>() ? c.Property<string>(ConfigurableHtmlControl.WrapperTagNameProperty) :
-        c.IsType<Repeater>() ? c.Property<string>(Repeater.WrapperTagNameProperty) :
+        c.IsType<ConfigurableHtmlControl>() ? c.PropertyValue<string>(ConfigurableHtmlControl.WrapperTagNameProperty) :
+        c.IsType<Repeater>() ? c.PropertyValue<string>(Repeater.WrapperTagNameProperty) :
         null;
 
     /// <summary> Gets the property value or null if it's not defined. </summary>
-    public static T? Property<T>(this IStyleMatchContext c, DotvvmProperty property)
-        where T : class
+    [return: MaybeNull]
+    public static T PropertyValue<T>(this IStyleMatchContext c, DotvvmProperty property)
     {
         ResolvedPropertySetter s;
         if (c.Control.Properties.TryGetValue(property, out s))
         {
-            return (s as ResolvedPropertyValue)?.Value as T;
+            var value = s.GetValue();
+            if (value is T or null)
+                return (T?)value;
         }
-        return null;
+        return (T?)property.DefaultValue;
     }
 
     /// <summary> Gets the property value or null if it's not defined. </summary>
-    public static T? PropertyS<T>(this IStyleMatchContext c, DotvvmProperty property)
-        where T : struct
+    [return: MaybeNull]
+    public static TProp PropertyValue<TControl, TProp>(this IStyleMatchContext<TControl> c, Expression<Func<TControl, TProp>> pp)
     {
-        ResolvedPropertySetter s;
-        if (c.Control.Properties.TryGetValue(property, out s))
+        var property = ReflectionUtils.GetDotvvmPropertyFromExpression(pp);
+        return c.PropertyValue<TProp>(property);
+    }
+
+    /// <summary> Gets the property value or null if it's not defined. </summary>
+    public static ValueOrBinding<T> Property<T>(this IStyleMatchContext c, DotvvmProperty property)
+    {
+        if (c.Control.Properties.TryGetValue(property, out var s))
         {
-            return (s as ResolvedPropertyValue)?.Value as T?;
+            var value = s.GetValue();
+            if (value is IBinding binding)
+                return new ValueOrBinding<T>(binding);
+            if (value is T or null)
+                return new ValueOrBinding<T>((T)value!);
         }
-        return null;
+        return new ValueOrBinding<T>((T)property.DefaultValue!);
     }
 
     /// <summary> Gets the property value or null if it's not defined. </summary>
-    public static TProp? PropertyS<TControl, TProp>(this IStyleMatchContext<TControl> c, Expression<Func<TControl, TProp>> pp)
-        where TProp : struct
+    public static ValueOrBinding<TProp> Property<TControl, TProp>(this IStyleMatchContext<TControl> c, Expression<Func<TControl, TProp>> pp)
     {
-        var member = ReflectionUtils.GetMemberFromExpression(pp);
-        ResolvedPropertySetter s = c.Control.Properties.FirstOrDefault(p => p.Key.PropertyInfo == member).Value;
-        return (s as ResolvedPropertyValue)?.Value as TProp?;
-    }
-
-    /// <summary> Gets the property value or null if it's not defined. </summary>
-    public static TProp? Property<TControl, TProp>(this IStyleMatchContext<TControl> c, Expression<Func<TControl, TProp>> pp)
-        where TProp : class
-    {
-        var member = ReflectionUtils.GetMemberFromExpression(pp);
-        ResolvedPropertySetter s = c.Control.Properties.FirstOrDefault(p => p.Key.PropertyInfo == member).Value;
-        return (s as ResolvedPropertyValue)?.Value as TProp;
+        var property = ReflectionUtils.GetDotvvmPropertyFromExpression(pp);
+        return c.Property<TProp>(property);
     }
 
     private static IStyleMatchContext ChildContext(this IStyleMatchContext c, ResolvedControl control) =>

--- a/src/Framework/Framework/Compilation/Styles/StyleMatchContextMethods.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleMatchContextMethods.cs
@@ -253,7 +253,7 @@ public static class StyleMatchContextExtensionMethods
             if (value is T or null)
                 return (T?)value;
         }
-        return (T?)property.DefaultValue;
+        return GetDefault<T>(property);
     }
 
     /// <summary> Gets the property value or null if it's not defined. </summary>
@@ -275,7 +275,14 @@ public static class StyleMatchContextExtensionMethods
             if (value is T or null)
                 return new ValueOrBinding<T>((T)value!);
         }
-        return new ValueOrBinding<T>((T)property.DefaultValue!);
+        return new ValueOrBinding<T>(GetDefault<T>(property));
+    }
+
+    private static T GetDefault<T>(DotvvmProperty p)
+    {
+        if (p.DefaultValue is T d) return d;
+        if (p.DefaultValue is null && !typeof(T).IsValueType) return default!;
+        throw new Exception($"Property {p} is probably not of type {typeof(T).Name}, its default value {p.DefaultValue ?? "null"} is not assignable to the requested type.");
     }
 
     /// <summary> Gets the property value or null if it's not defined. </summary>

--- a/src/Framework/Framework/Compilation/Styles/StyleRepository.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleRepository.cs
@@ -102,6 +102,16 @@ namespace DotVVM.Framework.Compilation.Styles
         public StyleBuilder<DotvvmBindableObject> RegisterAnyObject(Func<StyleMatchContext<DotvvmBindableObject>, bool>? matcher = null) =>
             Register<DotvvmBindableObject>(matcher);
 
+        /// <summary>
+        /// Registers a server-side style for any component that have specified Styles.Tag (including special objects like GridViewColumn)
+        /// </summary>
+        /// <returns>A <see cref="StyleBuilder{T}"/> that can be used to style the control.</returns>
+        public StyleBuilder<DotvvmBindableObject> RegisterForTag(string tag, Func<StyleMatchContext<DotvvmBindableObject>, bool>? matcher = null) =>
+            Register<DotvvmBindableObject>(m => m.HasTag(tag) && matcher?.Invoke(m) != false);
+
+        
+        
+
         private bool isFrozen = false;
         private void ThrowIfFrozen()
         {

--- a/src/Framework/Framework/Controls/ConfirmPostBackHandler.cs
+++ b/src/Framework/Framework/Controls/ConfirmPostBackHandler.cs
@@ -29,9 +29,9 @@ namespace DotVVM.Framework.Controls
             = DotvvmProperty.Register<string?, ConfirmPostBackHandler>(c => c.Message, null);
 
         public ConfirmPostBackHandler() { }
-        public ConfirmPostBackHandler(string message)
+        public ConfirmPostBackHandler(ValueOrBinding<string> message)
         {
-            this.Message = message;
+            this.SetValue(MessageProperty, message);
         }
     }
 }

--- a/src/Framework/Framework/Controls/DotvvmBindableObject.cs
+++ b/src/Framework/Framework/Controls/DotvvmBindableObject.cs
@@ -151,8 +151,7 @@ namespace DotVVM.Framework.Controls
         public virtual void SetValue(DotvvmProperty property, object? value)
         {
             // "unbox" ValueOrBinding instances
-            if (value is ValueOrBinding valueOrBinding)
-                value = valueOrBinding.BindingOrDefault ?? valueOrBinding.BoxedValue;
+            value = ValueOrBindingExtensions.UnwrapToObject(value);
 
             var originalValue = GetValueRaw(property, false);
             // TODO: really do we want to update the value binding only if it's not a binding

--- a/src/Framework/Framework/Controls/DotvvmBindableObject.cs
+++ b/src/Framework/Framework/Controls/DotvvmBindableObject.cs
@@ -78,12 +78,14 @@ namespace DotVVM.Framework.Controls
         public static readonly DotvvmProperty DataContextProperty =
             DotvvmProperty.Register<object, DotvvmBindableObject>(c => c.DataContext, isValueInherited: true);
 
+        /// <summary> Returns the value of the specified property. If the property contains a binding, it is evaluted. </summary>
         [return: MaybeNull]
         public T GetValue<T>(DotvvmProperty property, bool inherit = true)
         {
             return (T)GetValue(property, inherit)!;
         }
 
+        /// <summary> If the object is IBinding and the property is not of type IBinding, it is evaluated. </summary>
         internal object? EvalPropertyValue(DotvvmProperty property, object? value)
         {
             if (property.IsBindingProperty) return value;
@@ -111,7 +113,7 @@ namespace DotVVM.Framework.Controls
         }
 
         /// <summary>
-        /// Gets the value of a specified property.
+        /// Gets the value of a specified property. If the property contains a binding, it is evaluted.
         /// </summary>
         public virtual object? GetValue(DotvvmProperty property, bool inherit = true) =>
             EvalPropertyValue(property, GetValueRaw(property, inherit));
@@ -124,11 +126,13 @@ namespace DotVVM.Framework.Controls
             return property.GetValue(this, inherit);
         }
 
+        /// <summary> For internal use, public because it's used from our generated code. If want to use it, create the arguments using <see cref="PropertyImmutableHashtable.CreateTableWithValues{T}(DotvvmProperty[], T[])" /> </summary>
         public void MagicSetValue(DotvvmProperty[] keys, object[] values, int hashSeed)
         {
             this.properties.AssignBulk(keys, values, hashSeed);
         }
 
+        /// <summary> Sets the value of a specified property. </summary>
         public void SetValue<T>(DotvvmProperty property, ValueOrBinding<T> valueOrBinding)
         {
             if (valueOrBinding.BindingOrDefault == null)
@@ -137,6 +141,7 @@ namespace DotVVM.Framework.Controls
                 this.SetBinding(property, valueOrBinding.BindingOrDefault);
         }
 
+        /// <summary> Gets the value of a specified property. Bindings are always returned, not evaluated. </summary>
         public ValueOrBinding<T> GetValueOrBinding<T>(DotvvmProperty property, bool inherit = true)
         {
             var value = this.GetValueRaw(property, inherit);
@@ -181,7 +186,7 @@ namespace DotVVM.Framework.Controls
             => GetValueRaw(property, inherit) as IBinding;
 
         /// <summary>
-        /// Gets the value binding set to a specified property. Returns null if the property is not a binding.
+        /// Gets the value binding set to a specified property. Returns null if the property is not a binding, throws if the binding some kind of command.
         /// </summary>
         public IValueBinding? GetValueBinding(DotvvmProperty property, bool inherit = true)
         {
@@ -193,12 +198,12 @@ namespace DotVVM.Framework.Controls
             return binding as IValueBinding;
         }
 
+        /// <summary> Returns a Javascript (knockout) expression representing value or binding of this property. </summary>
         public ParametrizedCode GetJavascriptValue(DotvvmProperty property, bool inherit = true) =>
-            GetValueBinding(property, inherit)?.KnockoutExpression ??
-            new ParametrizedCode(JavascriptCompilationHelper.CompileConstant(GetValue(property)), OperatorPrecedence.Max);
+            GetValueOrBinding<object>(property, inherit).GetParametrizedJsExpression(this);
 
         /// <summary>
-        /// Gets the command binding set to a specified property. Returns null if the property is not a binding.
+        /// Gets the command binding set to a specified property. Returns null if the property is not a binding, throws if the binding is not command, controlCommand or staticCommand.
         /// </summary>
         public ICommandBinding? GetCommandBinding(DotvvmProperty property, bool inherit = true)
         {
@@ -293,15 +298,18 @@ namespace DotVVM.Framework.Controls
             return current;
         }
 
+        /// <summary> if this property contains any kind of binding. Note that the property value is not inherited. </summary>
         public bool HasBinding(DotvvmProperty property)
         {
             return properties.TryGet(property, out var value) && value is IBinding;
         }
+        /// <summary> if this property contains value binding. Note that the property value is not inherited. </summary>
         public bool HasValueBinding(DotvvmProperty property)
         {
             return properties.TryGet(property, out var value) && value is IValueBinding;
         }
 
+        /// <summary> if this property contains binding of the specified type. Note that the property value is not inherited. </summary>
         public bool HasBinding<TBinding>(DotvvmProperty property)
             where TBinding : IBinding
         {
@@ -338,7 +346,7 @@ namespace DotVVM.Framework.Controls
         }
 
         /// <summary>
-        /// Gets the root of the control tree.
+        /// Gets the root of the control tree. The the control is properly rooted, the result value will be of type <see cref="Infrastructure.DotvvmView" />
         /// </summary>
         public DotvvmBindableObject GetRoot()
         {

--- a/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
+++ b/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
@@ -15,15 +15,18 @@ namespace DotVVM.Framework.Controls
 {
     public static class DotvvmBindableObjectHelper
     {
+        /// <summary> Gets the DotvvmProperty referenced by the lambda expression. </summary>
         public static DotvvmProperty GetDotvvmProperty<TControl, TProperty>(this TControl control, Expression<Func<TControl, TProperty>> prop)
             where TControl : DotvvmBindableObject =>
             ReflectionUtils.GetDotvvmPropertyFromExpression(prop);
+        /// <summary> Gets the DotvvmProperty with the specified name.  </summary>
         public static DotvvmProperty GetDotvvmProperty<TControl>(this TControl control, string propName)
             where TControl : DotvvmBindableObject
         {
             return DotvvmProperty.ResolveProperty(typeof(TControl), propName) ?? throw new Exception($"Property '{typeof(TControl)}.{propName}' is not a registered DotvvmProperty.");
         }
 
+        /// <summary> Sets binding into the DotvvmProperty referenced in the lambda expression. Returns <paramref name="control"/> for fluent API usage. </summary>
         public static TControl SetProperty<TControl, TProperty>(this TControl control, Expression<Func<TControl, TProperty>> prop, IBinding? binding)
             where TControl : DotvvmBindableObject
         {
@@ -31,12 +34,14 @@ namespace DotVVM.Framework.Controls
             return control;
         }
 
-        public static TControl SetProperty<TControl, TProperty>(this TControl control, DotvvmProperty prop, IBinding? binding)
+        /// <summary> Sets binding into the DotvvmProperty. Returns <paramref name="control"/> for fluent API usage. </summary>
+        public static TControl SetProperty<TControl>(this TControl control, DotvvmProperty prop, IBinding? binding)
             where TControl : DotvvmBindableObject
         {
             control.SetBinding(prop, binding);
             return control;
         }
+        /// <summary> Sets binding into the DotvvmProperty with specified name. Returns <paramref name="control"/> for fluent API usage. </summary>
         public static TControl SetProperty<TControl>(this TControl control, string propName, IBinding? binding)
             where TControl : DotvvmBindableObject
         {
@@ -44,19 +49,14 @@ namespace DotVVM.Framework.Controls
             return control;
         }
 
-        public static TControl SetProperty<TControl, TProperty>(this TControl control, Expression<Func<TControl, TProperty>> prop, TProperty value)
-            where TControl : DotvvmBindableObject
-        {
-            control.SetValue(control.GetDotvvmProperty(prop), value);
-            return control;
-        }
-
+        /// <summary> Sets value or binding into the DotvvmProperty referenced in the lambda expression. Returns <paramref name="control"/> for fluent API usage. </summary>
         public static TControl SetProperty<TControl, TProperty>(this TControl control, Expression<Func<TControl, TProperty>> prop, ValueOrBinding<TProperty> value)
             where TControl : DotvvmBindableObject
         {
             control.SetValue(control.GetDotvvmProperty(prop), value);
             return control;
         }
+        /// <summary> Sets value or binding into the DotvvmProperty with specified name. Returns <paramref name="control"/> for fluent API usage. </summary>
         public static TControl SetProperty<TControl, TProperty>(this TControl control, string propName, ValueOrBinding<TProperty> valueOrBinding)
             where TControl : DotvvmBindableObject
         {
@@ -64,6 +64,7 @@ namespace DotVVM.Framework.Controls
             return control;
         }
 
+        /// <summary> Sets value or binding into the DotvvmProperty. Returns <paramref name="control"/> for fluent API usage. </summary>
         public static TControl SetProperty<TControl, TProperty>(this TControl control, DotvvmProperty property, ValueOrBinding<TProperty> valueOrBinding)
             where TControl: DotvvmBindableObject
         {
@@ -74,6 +75,7 @@ namespace DotVVM.Framework.Controls
             return control;
         }
 
+        /// <summary> Sets value or binding into the DotvvmProperty. If the <paramref name="valueOrBinding"/> is null, the property is removed. Returns <paramref name="control"/> for fluent API usage. </summary>
         public static TControl SetProperty<TControl, TProperty>(this TControl control, DotvvmProperty property, ValueOrBinding<TProperty>? valueOrBinding)
             where TControl: DotvvmBindableObject
         {
@@ -81,19 +83,6 @@ namespace DotVVM.Framework.Controls
                 control.SetProperty(property, valueOrBinding.GetValueOrDefault());
             else
                 control.Properties.Remove(property);
-            return control;
-        }
-
-        public static TControl SetProperty<TControl>(this TControl control, DotvvmProperty property, object value)
-            where TControl: DotvvmBindableObject
-        {
-            control.SetValue(property, value);
-            return control;
-        }
-        public static TControl SetProperty<TControl, TProperty>(this TControl control, string propName, object value)
-            where TControl : DotvvmBindableObject
-        {
-            control.SetValue(control.GetDotvvmProperty(propName), value);
             return control;
         }
 
@@ -106,6 +95,7 @@ namespace DotVVM.Framework.Controls
             where TControl : DotvvmBindableObject =>
             control.SetProperty(prop, value);
 
+        /// <summary> Sets a binding into member of the specified property group. Returns <paramref name="control"/> for fluent API usage. </summary>
         public static TControl SetProperty<TControl, TProperty>(this TControl control, Func<TControl, VirtualPropertyGroupDictionary<TProperty>> prop, string key, IBinding? binding)
             where TControl : DotvvmBindableObject
         {
@@ -114,6 +104,7 @@ namespace DotVVM.Framework.Controls
             return control;
         }
 
+        /// <summary> Sets a value into member of the specified property group. Returns <paramref name="control"/> for fluent API usage. </summary>
         public static TControl SetProperty<TControl, TProperty>(this TControl control, Func<TControl, VirtualPropertyGroupDictionary<TProperty>> prop, string key, TProperty value)
             where TControl : DotvvmBindableObject
         {
@@ -122,6 +113,7 @@ namespace DotVVM.Framework.Controls
             return control;
         }
 
+        /// <summary> Sets a value or a binding into member of the specified property group. Returns <paramref name="control"/> for fluent API usage. </summary>
         public static TControl SetProperty<TControl, TProperty>(this TControl control, Func<TControl, VirtualPropertyGroupDictionary<TProperty>> prop, string key, ValueOrBinding<TProperty> value)
             where TControl : DotvvmBindableObject
         {
@@ -130,6 +122,7 @@ namespace DotVVM.Framework.Controls
             return control;
         }
 
+        /// <summary> Sets a value (or a binding) into the specified html attribute. If the value is null, the attribute is removed. Returns <paramref name="control"/> for fluent API usage. </summary>
         public static TControl SetAttribute<TControl>(this TControl control, string attribute, object? value)
             where TControl : IControlWithHtmlAttributes
         {
@@ -146,18 +139,21 @@ namespace DotVVM.Framework.Controls
             return control;
         }
 
+        /// <summary> Sets a value or a binding into the specified html attribute. If the value is null, the attribute is removed. Returns <paramref name="control"/> for fluent API usage. </summary>
         public static TControl SetAttribute<TControl, TValue>(this TControl control, string attribute, ValueOrBinding<TValue> value)
             where TControl : IControlWithHtmlAttributes
         {
             return SetAttribute(control, attribute, value.UnwrapToObject());
         }
 
+        /// <summary> Sets a value or a binding into the specified html attribute. If the value is null, the attribute is removed. Returns <paramref name="control"/> for fluent API usage. </summary>
         public static TControl SetAttribute<TControl, TValue>(this TControl control, string attribute, ValueOrBinding<TValue>? value)
             where TControl : IControlWithHtmlAttributes
         {
             return SetAttribute(control, attribute, value?.UnwrapToObject());
         }
 
+        /// <summary> Sets all properties from the capability into this control. If the control does not support the capability, exception is thrown. Returns <paramref name="control"/> for fluent API usage. </summary>
         public static TControl SetCapability<TControl, TCapability>(this TControl control, [AllowNull] TCapability capability, string prefix = "")
             where TControl: DotvvmBindableObject
         {
@@ -171,6 +167,7 @@ namespace DotVVM.Framework.Controls
             return control;
         }
 
+        /// <summary> Adds all <paramref name="children"/> into control.Children (nulls are skipped). Returns <paramref name="control"/> for fluent API usage. </summary>
         public static T AppendChildren<T>(this T control, params DotvvmControl?[]? children)
             where T : DotvvmControl
         {
@@ -187,6 +184,7 @@ namespace DotVVM.Framework.Controls
 
         }
 
+        /// <summary> Adds all <paramref name="children"/> into control.Children (nulls are skipped). Returns <paramref name="control"/> for fluent API usage. </summary>
         public static T AppendChildren<T>(this T control, IEnumerable<DotvvmControl?>? children)
             where T : DotvvmControl 
         {
@@ -202,23 +200,32 @@ namespace DotVVM.Framework.Controls
             return control;
         }
 
+        /// <summary>
+        /// Gets the value binding set to the DotvvmProperty referenced in the lambda expression. Returns null if the property is not a binding, throws if the binding some kind of command.
+        /// </summary>
         public static IValueBinding<TProperty>? GetValueBinding<TControl, TProperty>(this TControl control, Expression<Func<TControl, TProperty>> prop)
             where TControl : DotvvmBindableObject
             => (IValueBinding<TProperty>?)control.GetValueBinding(control.GetDotvvmProperty(prop));
 
+        /// <summary>
+        /// Gets the command binding set to the DotvvmProperty referenced in the lambda expression. Returns null if the property is not a binding, throws if the binding is not command, controlCommand or staticCommand.
+        /// </summary>
         public static ICommandBinding<TProperty>? GetCommandBinding<TControl, TProperty>(this TControl control, Expression<Func<TControl, TProperty>> prop)
             where TControl : DotvvmBindableObject
             => (ICommandBinding<TProperty>?)control.GetCommandBinding(control.GetDotvvmProperty(prop));
 
+        /// <summary> Returns the value of the DotvvmProperty referenced in the lambda expression. If the property contains a binding, it is evaluted. </summary>
         [return: MaybeNull]
         public static TProperty GetValue<TControl, TProperty>(this TControl control, Expression<Func<TControl, TProperty>> prop)
             where TControl : DotvvmBindableObject
             => control.GetValue<TProperty>(control.GetDotvvmProperty(prop));
 
+        /// <summary> Gets the value of the DotvvmProperty referenced in the lambda expression. Bindings are always returned, not evaluated. </summary>
         public static ValueOrBinding<TProperty> GetValueOrBinding<TControl, TProperty>(this TControl control, Expression<Func<TControl, TProperty>> prop)
             where TControl : DotvvmBindableObject
             => control.GetValueOrBinding<TProperty>(control.GetDotvvmProperty(prop));
 
+        /// <summary> Gets the specified control capability - reads all the properties in the capability at once. Throws if this control does not support the capability. </summary>
         public static TCapability GetCapability<TCapability>(this DotvvmBindableObject control, string prefix = "")
         {
             var c = DotvvmCapabilityProperty.Find(control.GetType(), typeof(TCapability), prefix);
@@ -239,6 +246,7 @@ namespace DotVVM.Framework.Controls
             }
         }
 
+        /// <summary> Returns somewhat readable string representing this dotvvm control. </summary>
         public static string DebugString(this DotvvmBindableObject control, DotvvmConfiguration? config = null, bool multiline = true)
         {
             if (control == null) return "null";

--- a/src/Framework/Framework/Utils/ExpressionUtils.cs
+++ b/src/Framework/Framework/Utils/ExpressionUtils.cs
@@ -251,7 +251,7 @@ namespace DotVVM.Framework.Utils
                 if (lc != null && rc != null)
                 {
                     if (node.Method != null)
-                        return Expression.Constant(node.Method.Invoke(null, new object[] { lc.Value, rc.Value }));
+                        return Expression.Constant(node.Method.Invoke(null, new object[] { lc.Value, rc.Value }), node.Type);
                     else return node;
                 }
                 else return base.VisitBinary(node);
@@ -260,7 +260,7 @@ namespace DotVVM.Framework.Utils
             protected override Expression VisitUnary(UnaryExpression node)
             {
                 var op = Visit(node.Operand);
-                if (op is ConstantExpression constantExpression)
+                if (op is ConstantExpression constantExpression && node.Method != null)
                 {
                     return Expression.Constant(
                         node.Method.Invoke(null, new object[] { constantExpression.Value }), node.Type);

--- a/src/Framework/Framework/Utils/FunctionalExtensions.cs
+++ b/src/Framework/Framework/Utils/FunctionalExtensions.cs
@@ -89,4 +89,26 @@ namespace DotVVM.Framework.Utils
             where T : class =>
             target ?? throw new Exception(message);
     }
+
+    sealed class ObjectWithComparer<T> : IEquatable<ObjectWithComparer<T>>, IEquatable<T>
+    {
+        public ObjectWithComparer(T @object, IEqualityComparer<T> comparer)
+        {
+            Object = @object;
+            Comparer = comparer;
+        }
+
+        public IEqualityComparer<T> Comparer { get; }
+        public T Object { get; }
+
+        public bool Equals(ObjectWithComparer<T> other) => Comparer.Equals(Object, other.Object);
+
+        public bool Equals(T other) => Comparer.Equals(Object, other);
+
+        public override bool Equals(object obj) =>
+            obj is ObjectWithComparer<T> objC ? Equals(objC) :
+            obj is T objT ? Equals(objT) :
+            false;
+        public override int GetHashCode() => Comparer.GetHashCode(Object);
+    }
 }

--- a/src/Framework/Framework/Utils/ReflectionUtils.cs
+++ b/src/Framework/Framework/Utils/ReflectionUtils.cs
@@ -30,7 +30,7 @@ namespace DotVVM.Framework.Utils
             var originalExpression = expression;
             if (expression is LambdaExpression lambda)
                 expression = lambda.Body;
-            if (expression is UnaryExpression unary)
+            while (expression is UnaryExpression unary)
                 expression = unary.Operand;
 
             var body = expression as MemberExpression;
@@ -39,6 +39,14 @@ namespace DotVVM.Framework.Utils
                 throw new NotSupportedException($"Can not get member from {originalExpression}");
 
             return body.Member;
+        }
+
+        public static DotvvmProperty GetDotvvmPropertyFromExpression(Expression expression)
+        {
+            var prop = GetMemberFromExpression(expression);
+            return DotvvmProperty.ResolveProperty(prop.DeclaringType!, prop.Name) ??
+                throw new Exception($"Property '{prop.DeclaringType!.Name}.{prop.Name}' is not a registered DotvvmProperty.");
+
         }
 
         // http://haacked.com/archive/2012/07/23/get-all-types-in-an-assembly.aspx/

--- a/src/Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/Tests/Binding/JavascriptCompilationTests.cs
@@ -1040,8 +1040,8 @@ namespace DotVVM.Framework.Tests.Binding
         [DataRow("StringProp.PadRight(2)", "StringProp().padEnd(2)")]
         [DataRow("StringProp.PadLeft(1,'#')", "StringProp().padStart(1,\"#\")")]
         [DataRow("StringProp.PadRight(2,'#')", "StringProp().padEnd(2,\"#\")")]
-        [DataRow("string.IsNullOrEmpty(StringProp)", "StringProp()==null||StringProp()===\"\"")]
-        [DataRow("string.IsNullOrWhiteSpace(StringProp)", "StringProp()==null||StringProp().trim()===\"\"")]
+        [DataRow("string.IsNullOrEmpty(StringProp)", "!(StringProp()?.length>0)")]
+        [DataRow("string.IsNullOrWhiteSpace(StringProp)", "!(StringProp()?.trim().length>0)")]
         public void JavascriptCompilation_StringFunctions(string input, string expected)
         {
             var result = CompileBinding(input, typeof(TestViewModel));

--- a/src/Tests/ControlTests/CompositeControlTests.cs
+++ b/src/Tests/ControlTests/CompositeControlTests.cs
@@ -74,7 +74,7 @@ namespace DotVVM.Framework.Tests.ControlTests
         {
             var r = await cth.RunPage(typeof(BasicTestViewModel), @"
                 <cc:BindingMappingControl Str={value: Label} IntBinding={value: Integer}/>
-                <cc:BindingMappingControl Str=Bazmek IntBinding={value: 0}/>
+                <cc:BindingMappingControl Str=TtTt IntBinding={value: 0}/>
                 "
             );
 

--- a/src/Tests/ControlTests/CompositeControlTests.cs
+++ b/src/Tests/ControlTests/CompositeControlTests.cs
@@ -7,6 +7,7 @@ using DotVVM.Framework.Binding;
 using DotVVM.Framework.Binding.Expressions;
 using DotVVM.Framework.Compilation.Styles;
 using DotVVM.Framework.Controls;
+using DotVVM.Framework.Controls.Infrastructure;
 using DotVVM.Framework.Testing;
 using DotVVM.Framework.Tests.Binding;
 using DotVVM.Framework.ViewModel;
@@ -62,6 +63,18 @@ namespace DotVVM.Framework.Tests.ControlTests
                                    Text={value: _parent.Label + _this}
                                    ItemClick={command: _parent.Integer = _index}
                                    />
+                "
+            );
+
+            check.CheckString(r.FormattedHtml, fileExtension: "html");
+        }
+
+        [TestMethod]
+        public async Task BindingMapping()
+        {
+            var r = await cth.RunPage(typeof(BasicTestViewModel), @"
+                <cc:BindingMappingControl Str={value: Label} IntBinding={value: Integer}/>
+                <cc:BindingMappingControl Str=Bazmek IntBinding={value: 0}/>
                 "
             );
 
@@ -165,6 +178,26 @@ namespace DotVVM.Framework.Tests.ControlTests
         {
             return new HtmlGenericControl(TagName);
         }
+    }
 
+    public class BindingMappingControl: CompositeControl
+    {
+        public static DotvvmControl GetContents(
+            ValueOrBinding<string> str,
+            IValueBinding<int> intBinding
+        )
+        {
+            return new HtmlGenericControl("div") {
+                Children = {
+                    RawLiteral.Create("\ntext length: "),
+                    new Literal(str.Select(s => s.Length), renderSpan: true),
+                    RawLiteral.Create("\ntext to lower"),
+                    new Literal(str.Select(s => s.ToLowerInvariant()), renderSpan: true),
+                    RawLiteral.Create("\nint times 2"),
+                    new Literal(intBinding.Select(s => s * 2), renderSpan: true)
+                        .SetProperty(c => c.Visible, intBinding.Select(s => s > 10)),
+                }
+            };
+        }
     }
 }

--- a/src/Tests/ControlTests/testoutputs/CompositeControlTests.BindingMapping.html
+++ b/src/Tests/ControlTests/testoutputs/CompositeControlTests.BindingMapping.html
@@ -1,0 +1,17 @@
+<html>
+	<head></head>
+	<body>
+		<div>
+			text length:
+			<span data-bind="text: Label()?.length"></span>
+			text to lower<span data-bind="text: Label()?.toLowerCase()"></span>
+			int times 2<span data-bind="visible: int() > 10, text: int() * 2"></span>
+		</div>
+		<div>
+			text length:
+			<span>6</span>
+			text to lower<span>bazmek</span>
+			int times 2<span data-bind="visible: 0 > 10, text: 0 * 2" style="display:none"></span>
+		</div>
+	</body>
+</html>

--- a/src/Tests/ControlTests/testoutputs/CompositeControlTests.BindingMapping.html
+++ b/src/Tests/ControlTests/testoutputs/CompositeControlTests.BindingMapping.html
@@ -9,8 +9,8 @@
 		</div>
 		<div>
 			text length:
-			<span>6</span>
-			text to lower<span>bazmek</span>
+			<span>4</span>
+			text to lower<span>tttt</span>
 			int times 2<span data-bind="visible: 0 > 10, text: 0 * 2" style="display:none"></span>
 		</div>
 	</body>

--- a/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.PostbackHandlers.html
+++ b/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.PostbackHandlers.html
@@ -5,7 +5,13 @@
 		<input onclick="dotvvm.postBack(this,[],&quot;8UxwOb8axY9NSuJp&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
 		Two handlers
 		<input data-msg="ahoj" onclick="dotvvm.postBack(this,[],&quot;2suRIvLX7+StPC7x&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,{message:&quot;ahoj&quot;}],&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
+		Two handlers, value binding message
+		<input data-bind="attr: { &quot;data-msg&quot;: Label }" onclick="dotvvm.postBack(this,[],&quot;b80b5Lh9K50jj3q2&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,(c,d)=>({message:(d).Label()})],&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
+		Two handlers, resource binding message
+		<input data-msg="My Label" onclick="dotvvm.postBack(this,[],&quot;mH2HraWjqc1sx3p+&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,{message:&quot;My Label&quot;}],&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
+		Two handlers, default message
+		<input onclick="dotvvm.postBack(this,[],&quot;iA7NdAd65P3O/VQ7&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,{message:&quot;default message&quot;}],&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
 		One handler, because override
-		<input data-msg="ahoj" onclick="dotvvm.postBack(this,[],&quot;b80b5Lh9K50jj3q2&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;C&quot;}],&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
+		<input data-msg="ahoj" onclick="dotvvm.postBack(this,[],&quot;RjBjjkYMn14QVrRJ&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;C&quot;}],&quot;validate-root&quot;],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
 	</body>
 </html>

--- a/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.StyleBindingMapping.html
+++ b/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.StyleBindingMapping.html
@@ -1,0 +1,17 @@
+<html>
+	<head></head>
+	<body>
+		static value
+		<div class="a class123-x" data-custom-class-attr="x"></div>
+		resource binding
+		<div class="a class123-some-class" data-custom-class-attr="some-class"></div>
+		value binding
+		<div data-bind="class: &quot;a class123-&quot; + SomeClass(), attr: { &quot;data-custom-class-attr&quot;: SomeClass }"></div>
+		checkbox with checkbox-checked class
+		<input data-bind="class: int() > 10 == true ? &quot;checkbox-checked&quot; : &quot;&quot;, dotvvm-CheckState: int() > 10" type="checkbox">
+		<input data-bind="class: Boolean() == true ? &quot;checkbox-checked&quot; : &quot;&quot;, dotvvm-CheckState: Boolean" type="checkbox">
+		a div with visible class
+		<div class="hide" data-bind="css: { &quot;hide&quot;: !Boolean() }"></div>
+		<input data-bind="css: { &quot;hide&quot;: Label() == &quot;hidden&quot; }, dotvvm-textbox-text: Label" type="text">
+	</body>
+</html>


### PR DESCRIPTION
* Added x.Select(x => ...) method to ValueOrBinding and bindings
   - this method will still be quite slow, but it should not be terrible, so it should be safe to use even in runtime controls
   - obviously, usage in server-side style is preferred
* Added .And and .Or extension methods to ValueOrBinding.
   - useful for setting Visible when it's already set to something - in that case we can use the And method to have both conditions
* Added support for ValueOrBinding to styles
* Asking for c.Property(...) in styles will return the default value, if the property does not exist on this element.
* Deduplicate css `class`es in attributes when set using styles.
* Added helpers like IsNull, IsNullOrEmpty, ... to ValueOrBinding. Includes helpers NotNull, NotNullOrEmpty, since negating a ValueOrBinding is bit more annoying
   - also, the IsNullOrEmpty JS translation is now more concise (most importantly does not duplicate the expression)