### PR TITLE
Added missing `MaybeNullAnnotation` to some JS translations

### DIFF
--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -476,13 +476,13 @@ namespace DotVVM.Framework.Compilation.Javascript
 
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.FirstOrDefault), parameterCount: 1, translator: new GenericMethodCompiler((args, m) =>
                 new JsIndexerExpression(args[1], new JsLiteral(0))
-                    .WithAnnotation(new VMPropertyInfoAnnotation(m.ReturnType))));
+                    .WithAnnotation(new VMPropertyInfoAnnotation(m.ReturnType)).WithAnnotation(MayBeNullAnnotation.Instance)));
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.FirstOrDefault), parameterCount: 2, parameterFilter: p => p[1].ParameterType.IsGenericType && p[1].ParameterType.GetGenericTypeDefinition() == typeof(Func<,>), translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("firstOrDefault").Invoke(args[1], args[2])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("firstOrDefault").Invoke(args[1], args[2]).WithAnnotation(MayBeNullAnnotation.Instance)));
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.LastOrDefault), parameterCount: 1, translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("lastOrDefault").Invoke(args[1], returnTrueFunc.Clone())));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("lastOrDefault").Invoke(args[1], returnTrueFunc.Clone()).WithAnnotation(MayBeNullAnnotation.Instance)));
             AddMethodTranslator(typeof(Enumerable), nameof(Enumerable.LastOrDefault), parameterCount: 2, parameterFilter: p => p[1].ParameterType.IsGenericType && p[1].ParameterType.GetGenericTypeDefinition() == typeof(Func<,>), translator: new GenericMethodCompiler(args =>
-                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("lastOrDefault").Invoke(args[1], args[2])));
+                new JsIdentifierExpression("dotvvm").Member("translations").Member("array").Member("lastOrDefault").Invoke(args[1], args[2]).WithAnnotation(MayBeNullAnnotation.Instance)));
 
             foreach (var type in new[] { typeof(int), typeof(long), typeof(float), typeof(double), typeof(decimal), typeof(int?), typeof(long?), typeof(float?), typeof(double?), typeof(decimal?) })
             {


### PR DESCRIPTION
This PR fixes JS translations (`FirstOrDefault` and `LastOrDefault` overloads) that may return `null`. Previously, null propagation was not applied to these return values which caused issues in javascript. Consider the following example:

- `staticCommand: MyCollection.FirstOrDefault(e => e.Id == 123).Name`
  - collection does not contain an element with Id equal to 123
  - user is accessing `Name` property on `null`

This patch ensures that null propagation is applied. Therefore no errors are produced and result of these expressions is always `null`