### PR TITLE
Add Save & Share button to error page, redact cookies

### DIFF
--- a/src/Framework/Framework/DotVVM.Framework.csproj
+++ b/src/Framework/Framework/DotVVM.Framework.csproj
@@ -35,6 +35,7 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\Scripts\DotVVM.Debug.js" />
+    <EmbeddedResource Include="Resources\Scripts\DotVVM.ErrorPage.js" />
     <EmbeddedResource Include="obj/javascript/root-only/dotvvm-root.js" />
     <EmbeddedResource Include="obj/javascript/root-only-debug/dotvvm-root.js" />
     <EmbeddedResource Include="obj/javascript/root-spa/dotvvm-root.js" />

--- a/src/Framework/Framework/Hosting/ErrorPages/CookiesSection.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/CookiesSection.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DotVVM.Framework.Hosting.ErrorPages
+{
+    public class CookiesSection : IErrorSectionFormatter
+    {
+        public string DisplayName => "Cookies";
+
+        public string Id => "cookies";
+
+        public ICookieCollection Cookies { get; }
+
+        public CookiesSection(ICookieCollection cookies)
+        {
+            this.Cookies = cookies;
+        }
+
+        public void WriteBody(IErrorWriter writer)
+        {
+            // it's not a very great idea to copy all cookie values into the output,
+            // since some of them might be HTTP only - so there should not be a way to read
+            // them using Javascript. However, if error pages would be enabled in production,
+            // this would allow it.
+            // We will thus fill the cookie table with "redacted" values and then fill it in JS.
+            var table = Cookies.Select(c => new KeyValuePair<string, string>(c.Key, "redacted value of HTTP only cookie"));
+            writer.WriteKVTable(table, "cookie-table");
+
+            writer.WriteUnencoded(@"
+            <script>
+            (function () {
+                var cookies = {}
+                document.cookie.split(';').forEach(function(c) {
+                    let split = c.split('=', 2);
+                    cookies[split[0].trim()] = split[1];
+                })
+                var table = document.querySelector('.cookie-table');
+                var rows = table.tBodies[0].rows;
+                for (var i = 0; i < rows.length; i++) {
+                    var cookieName = rows[i].cells[0].textContent.trim();
+                    if (cookieName in cookies) {
+                        rows[i].cells[1].textContent = cookies[cookieName]
+                    } else {
+                        rows[i].cells[1].classList.add('hint-text')
+                    }
+                }
+            }())
+            </script>
+            ");
+        }
+        public void WriteStyle(IErrorWriter writer)
+        {
+        }
+    }
+}

--- a/src/Framework/Framework/Hosting/ErrorPages/DictionarySection.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/DictionarySection.cs
@@ -5,34 +5,26 @@ using System.Linq;
 
 namespace DotVVM.Framework.Hosting.ErrorPages
 {
-    public class DictionarySection : IErrorSectionFormatter
+    public class DictionarySection<K, V> : IErrorSectionFormatter
     {
         public string DisplayName { get; set; }
 
         public string Id { get; set; }
-        public IEnumerable Keys { get; set; }
-        public IEnumerable Values { get; set; }
+        public KeyValuePair<K, V>[] Table { get; set; }
 
-        public DictionarySection(string name, string id, IEnumerable keys, IEnumerable values)
+        public DictionarySection(string name, string id, IEnumerable<KeyValuePair<K, V>> table)
         {
             DisplayName = name;
             Id = id;
-            Keys = keys;
-            Values = values;
+            Table = table.ToArray();
         }
-
-        public static DictionarySection Create(string name, string id, IDictionary dictionary)
-            => new DictionarySection(name, id, dictionary.Keys, dictionary.Values);
-
-        public static DictionarySection Create<TKey, TValue>(string name, string id, IEnumerable<KeyValuePair<TKey, TValue>> kvps)
-            => new DictionarySection(name, id, kvps.Select(kvp => kvp.Key), kvps.Select(kvp => kvp.Value));
 
         public void WriteBody(IErrorWriter writer)
         {
-            writer.WriteKVTable(Keys, Values);
+            writer.WriteKVTable(Table);
         }
 
-        public void WriteHead(IErrorWriter writer)
+        public void WriteStyle(IErrorWriter writer)
         {
         }
     }

--- a/src/Framework/Framework/Hosting/ErrorPages/DotvvmMarkupErrorSection.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/DotvvmMarkupErrorSection.cs
@@ -140,7 +140,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
             };
         }
 
-        public void WriteHead(IErrorWriter w)
+        public void WriteStyle(IErrorWriter w)
         { }
 
         public static DotvvmMarkupErrorSection? Create(Exception ex)

--- a/src/Framework/Framework/Hosting/ErrorPages/ErrorFormatter.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/ErrorFormatter.cs
@@ -304,7 +304,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
             var template = new ErrorPageTemplate(
                 formatters: Formatters
                     .Select(f => f(exception, context))
-                    .Concat(context.GetEnvironmentTabs().Select(o => DictionarySection.Create(o.Item1, "env_" + o.Item1.GetHashCode(), o.Item2)))
+                    .Concat(context.GetEnvironmentTabs().Select(o => new DictionarySection<string, object>(o.Item1, "env_" + o.Item1.GetHashCode(), o.Item2)))
                     .Where(t => t != null)
                     .ToArray()!,
                 errorCode: context.Response.StatusCode,
@@ -330,12 +330,10 @@ namespace DotVVM.Framework.Hosting.ErrorPages
             var f = new ErrorFormatter();
             f.Formatters.Add((e, o) => DotvvmMarkupErrorSection.Create(e));
             f.Formatters.Add((e, o) => new ExceptionSectionFormatter(f.LoadException(e), "Raw Stack Trace", "raw_stack_trace"));
-            f.Formatters.Add((e, o) => DictionarySection.Create("Cookies", "cookies", o.Request.Cookies));
-            f.Formatters.Add((e, o) => DictionarySection.Create("Request Headers", "reqHeaders", o.Request.Headers));
             f.Formatters.Add((e, o) => {
                 var b = e.AllInnerExceptions().OfType<BindingPropertyException>().Select(a => a.Binding).OfType<ICloneableBinding>().FirstOrDefault();
                 if (b == null) return null;
-                return DictionarySection.Create("Binding", "binding",
+                return new DictionarySection<object, object>("Binding", "binding",
                     new []{ new KeyValuePair<object, object>("Type", b.GetType().FullName) }
                     .Concat(
                         b.GetAllComputedProperties()
@@ -343,6 +341,15 @@ namespace DotVVM.Framework.Hosting.ErrorPages
                         .Select(a => new KeyValuePair<object, object>(a.name, a.value))
                     ).ToArray());
             });
+            f.Formatters.Add((e, o) => new CookiesSection(o.Request.Cookies));
+            f.Formatters.Add((e, o) => new DictionarySection<string, string[]>(
+                "Request Headers",
+                "reqHeaders",
+                o.Request.Headers.Select(h =>
+                    h.Key.Equals("Cookie", StringComparison.OrdinalIgnoreCase) ?
+                        new ("Cookie", new [] {"<redacted, see Cookies tab or devtools>"}) :
+                        h)
+            ));
             f.AddInfoLoader<ReflectionTypeLoadException>(e => new ExceptionAdditionalInfo(
                 "Loader Exceptions",
                 e.LoaderExceptions.Select(lde => lde.GetType().Name + ": " + lde.Message).ToArray(),

--- a/src/Framework/Framework/Hosting/ErrorPages/ExceptionSectionFormatter.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/ExceptionSectionFormatter.cs
@@ -127,7 +127,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
             return sb.ToString();
         }
 
-        public void WriteHead(IErrorWriter w)
+        public void WriteStyle(IErrorWriter w)
         {
             w.WriteUnencoded(@"
 .exception .exceptionType:after { content: ': '; }

--- a/src/Framework/Framework/Hosting/ErrorPages/IErrorSectionFormatter.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/IErrorSectionFormatter.cs
@@ -8,7 +8,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
 {
     public interface IErrorSectionFormatter
     {
-        void WriteHead(IErrorWriter writer);
+        void WriteStyle(IErrorWriter writer);
         void WriteBody(IErrorWriter writer);
         string DisplayName { get; }
         string Id { get; }

--- a/src/Framework/Framework/Hosting/ErrorPages/IErrorWriter.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/IErrorWriter.cs
@@ -12,7 +12,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
         void WriteUnencoded(string str);
         void WriteText(string str);
         void ObjectBrowser(object? obj);
-        void WriteKVTable(IEnumerable keys, IEnumerable values);
+        void WriteKVTable<K, V>(IEnumerable<KeyValuePair<K, V>> table, string className = "");
         void WriteSourceCode(SourceModel source, bool collapse = true);
     }
 }

--- a/src/Framework/Framework/Resources/Scripts/DotVVM.ErrorPage.js
+++ b/src/Framework/Framework/Resources/Scripts/DotVVM.ErrorPage.js
@@ -1,0 +1,40 @@
+// script which makes error page a bit better, but it also works without JS
+
+fillCookieTable()
+
+document.getElementById("save-and-share-button").addEventListener("click", saveAndShare)
+
+function fillCookieTable() {
+	// fill in cookie values, since we can not place them from the server for security reasons
+	var cookies = {}
+	document.cookie.split(';').forEach(function(c) {
+		let split = c.split('=', 2);
+		cookies[split[0].trim()] = split[1];
+	})
+	var table = document.querySelector('.cookie-table');
+	var rows = table.tBodies[0].rows;
+	for (var i = 0; i < rows.length; i++) {
+		var cookieName = rows[i].cells[0].textContent.trim();
+		if (cookieName in cookies) {
+			rows[i].cells[1].textContent = cookies[cookieName]
+		} else {
+			rows[i].cells[1].classList.add('hint-text')
+		}
+	}
+}
+
+function saveAndShare() {
+	// saves the page as HTML
+	var pageAsHtml = document.documentElement.outerHTML;
+    var blob = new Blob([pageAsHtml], {type:'text/html'});
+    var downloadLink = document.createElement("a");
+	var exceptionName = document.querySelector(".exceptionType")
+	if (exceptionName) {
+		exceptionName = exceptionName.textContent.replace(/^.*\./, "")
+		downloadLink.download = "dotvvm-error-" + exceptionName + ".html";
+	} else {
+		downloadLink.download = "dotvvm-error.html";
+	}
+    downloadLink.href = window.URL.createObjectURL(blob);
+    downloadLink.click();
+}

--- a/src/Framework/Framework/Resources/Styles/DotVVM.Internal.css
+++ b/src/Framework/Framework/Resources/Styles/DotVVM.Internal.css
@@ -80,6 +80,10 @@ h3 {
     margin: 1.5rem 0;
 }
 
+.hint-text {
+    color: var(--hint-color)
+}
+
 
 /* Tables */
 table {
@@ -237,7 +241,7 @@ nav {
 }
 
 /* Interaction */
-input.execute {
+input.execute, button.execute {
     background-color: var(--hint-color);
     padding: 0.4rem 2rem;
     color: white;
@@ -245,7 +249,7 @@ input.execute {
     border: none;
 }
 
-    input.execute:hover {
+    input.execute:hover, button.execute:hover {
         background-color: var(--activate-color);
     }
 
@@ -258,6 +262,10 @@ a.execute {
     a.execute:hover {
         color: var(--activate-color);
     }
+
+.header-toolbox {
+    float: right;
+}
 
 /* Decoration */
 hr {


### PR DESCRIPTION
Since we don't know on server which cookies are HttpOnly, we
don't render anything (only the cookie names).
I have added a piece of JS code which fills in the cookies which
can be found in document.cookie

Added button that saves the error page as one Html file, so it can be
easily shared.

This is good, because people don't have to send screenshot. Here is a screenshot of how it looks now:

![image](https://user-images.githubusercontent.com/7894687/138097405-908b513e-eb5c-46a1-8feb-c4b2b9ee9860.png)
