### PR TITLE
Fix ContentPlaceHolder in head element

### DIFF
--- a/src/Framework/Framework/Controls/Content.cs
+++ b/src/Framework/Framework/Controls/Content.cs
@@ -38,13 +38,19 @@ namespace DotVVM.Framework.Controls
             }
         }
 
+        bool hasViewModule = false;
+
         protected override void RenderBeginTag(IHtmlWriter writer, IDotvvmRequestContext context)
         {
             base.RenderBeginTag(writer, context);
 
             var viewModule = this.GetValue<ViewModuleReferenceInfo>(Internal.ReferencedViewModuleInfoProperty);
-            if (viewModule is object)
+            // some users put ContentPlaceHolder into the <head> element, but knockout comments maybe cause problems in there
+            // we rather check if we are in head and ignore the @js directive there 
+            var isInHead = this.GetAllAncestors().OfType<HtmlGenericControl>().Any(c => "head".Equals(c.TagName,StringComparison.OrdinalIgnoreCase));
+            if (viewModule is object && !isInHead)
             {
+                hasViewModule = true;
                 var settings = DefaultSerializerSettingsProvider.Instance.GetSettingsCopy();
                 settings.StringEscapeHandling = StringEscapeHandling.EscapeHtml;
 
@@ -56,8 +62,7 @@ namespace DotVVM.Framework.Controls
 
         protected override void RenderEndTag(IHtmlWriter writer, IDotvvmRequestContext context)
         {
-            var viewModule = this.GetValue<ViewModuleReferenceInfo>(Internal.ReferencedViewModuleInfoProperty);
-            if (viewModule is object)
+            if (hasViewModule)
             {
                 writer.WriteKnockoutDataBindEndComment();
             }

--- a/src/Samples/Common/Views/FeatureSamples/ViewModules/ModuleInPageMasterPage.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/ViewModules/ModuleInPageMasterPage.dothtml
@@ -2,6 +2,9 @@
 @masterPage Views/FeatureSamples/ViewModules/ModuleMasterPage.dotmaster
 @js FeatureSamples_Resources_TestViewModule2
 
+<dot:Content ContentPlaceHolderID="TitleContent">
+    Test title
+</dot:Content>
 <dot:Content ContentPlaceHolderID="MainContent">
 
     <div DataContext="{value: Page2}" class="page">

--- a/src/Samples/Common/Views/FeatureSamples/ViewModules/ModuleMasterPage.dotmaster
+++ b/src/Samples/Common/Views/FeatureSamples/ViewModules/ModuleMasterPage.dotmaster
@@ -7,7 +7,7 @@
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <meta charset="utf-8" />
-    <title></title>
+    <title><dot:ContentPlaceHolder ID="TitleContent" /></title>
 </head>
 <body>
 

--- a/src/Samples/Tests/Tests/Feature/ViewModuleTests.cs
+++ b/src/Samples/Tests/Tests/Feature/ViewModuleTests.cs
@@ -120,6 +120,8 @@ namespace DotVVM.Samples.Tests.Feature
             RunInAllBrowsers(browser => {
                 browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_ViewModules_ModuleInPageMasterPage);
 
+                Assert.Equal("Test title", browser.GetTitle());
+
                 var log = browser.Single("#log");
                 AssertLogEntry(log, "testViewModule: init");
                 AssertLogEntry(log, "testViewModule2: init");


### PR DESCRIPTION
We simply don't render the knockout comments for initializing JS modules
when the ContentPlaceholder is in <head> element.
We don't initialize knockout bindings in head, so it does not make sense to render them.

resolves  #1152