### PR TITLE
Improved serialization of `StaticCommandInvocationPlan`

### DIFF
--- a/src/Framework/Framework/Compilation/Binding/StaticCommandExecutionPlanSerializer.cs
+++ b/src/Framework/Framework/Compilation/Binding/StaticCommandExecutionPlanSerializer.cs
@@ -14,11 +14,13 @@ namespace DotVVM.Framework.Compilation.Binding
     {
         public static JToken SerializePlan(StaticCommandInvocationPlan plan)
         {
+            var hasOverloads = HasOverloads(plan.Method);
             var array = new JArray(
                 new JValue(GetTypeFullName(plan.Method.DeclaringType)),
                 new JValue(plan.Method.Name),
                 new JArray(plan.Method.GetGenericArguments().Select(GetTypeFullName)),
-                new JArray(plan.Method.GetParameters().Select(p => GetTypeFullName(p.ParameterType))),
+                new JValue(plan.Method.GetParameters().Length),
+                hasOverloads ? new JArray(plan.Method.GetParameters().Select(p => GetTypeFullName(p.ParameterType))) : JValue.CreateNull(),
                 JToken.FromObject(plan.Arguments.Select(a => (byte)a.Type).ToArray())
             );
             var parameters = (new ParameterInfo[plan.Method.IsStatic ? 0 : 1]).Concat(plan.Method.GetParameters()).ToArray();
@@ -57,6 +59,11 @@ namespace DotVVM.Framework.Compilation.Binding
             return array;
         }
 
+        private static bool HasOverloads(MethodInfo method)
+        {
+            return method.DeclaringType.GetMethods().Where(m => m.Name == method.Name && m.GetParameters().Length == method.GetParameters().Length).Take(2).Count() > 1;
+        }
+
         private static string GetTypeFullName(Type type) => $"{type.FullName}, {type.Assembly.GetName().Name}";
 
         public static byte[] EncryptJson(JToken json, IViewModelProtector protector)
@@ -80,11 +87,24 @@ namespace DotVVM.Framework.Compilation.Binding
             var typeName = jarray[0].Value<string>();
             var methodName = jarray[1].Value<string>();
             var genericTypeNames = jarray[2].Value<JArray>();
-            var parameterTypeNames = jarray[3].Value<JArray>();
-            var argTypes = jarray[4].ToObject<byte[]>().Select(a => (StaticCommandParameterType)a).ToArray();
+            var parametersCount = jarray[3].Value<int>();
+            var parameterTypeNames = jarray[4].Value<JArray>();
+            var hasOtherOverloads = parameterTypeNames != null;
+            var argTypes = jarray[5].ToObject<byte[]>().Select(a => (StaticCommandParameterType)a).ToArray();
 
-            var parameters = parameterTypeNames.Select(n => Type.GetType(n.Value<string>())).ToArray();
-            var method = Type.GetType(typeName).GetMethod(methodName, parameters);
+            MethodInfo method;
+            if (hasOtherOverloads)
+            {
+                // There are multiple overloads available, therefore exact parameters need to be resolved first
+                var parameters = parameterTypeNames.Select(n => Type.GetType(n.Value<string>())).ToArray();
+                method = Type.GetType(typeName).GetMethod(methodName, parameters);
+            }
+            else
+            {
+                // There are no overloads
+                method = Type.GetType(typeName).GetMethods().SingleOrDefault(m => m.Name == methodName && m.GetParameters().Length == parametersCount);
+            }
+            
             if (method == null || !method.IsDefined(typeof(AllowStaticCommandAttribute)))
                 throw new NotSupportedException("The specified method was not found or is not allowed to be used within a static command.");
 
@@ -96,7 +116,7 @@ namespace DotVVM.Framework.Compilation.Binding
 
             var methodParameters = method.GetParameters();
             var args = argTypes
-                .Select((a, i) => (type: a, arg: jarray.Count <= i + 5 ? JValue.CreateNull() : jarray[i + 5], parameter: (method.IsStatic ? methodParameters[i] : (i == 0 ? null : methodParameters[i - 1]))))
+                .Select((a, i) => (type: a, arg: jarray.Count <= i + 6 ? JValue.CreateNull() : jarray[i + 6], parameter: (method.IsStatic ? methodParameters[i] : (i == 0 ? null : methodParameters[i - 1]))))
                 .Select((a) => {
                     switch (a.type)
                     {

--- a/src/Tests/ControlTests/testoutputs/MarkupControlTests.MarkupControl_PassingStaticCommand.html
+++ b/src/Tests/ControlTests/testoutputs/MarkupControlTests.MarkupControl_PassingStaticCommand.html
@@ -4,7 +4,7 @@
 		
 		<!-- ko with: int -->
 		<div data-bind="dotvvm-with-control-properties: { &quot;Click&quot;: ()=>(dotvvm.applyPostbackHandlers(async (options) => {
-	await dotvvm.staticCommandPostback(&quot;WARNING/NOT/ENCRYPTED+++WyJEb3RWVk0uRnJhbWV3b3JrLlRlc3RzLkJpbmRpbmcuVGVzdFNlcnZpY2UsIERvdFZWTS5GcmFtZXdvcmsuVGVzdHMiLCJTYXZlIixbXSxbIlN5c3RlbS5JbnQzMiwgU3lzdGVtLlByaXZhdGUuQ29yZUxpYiJdLCJBUUE9Il0=&quot;, [options.knockoutContext.$parent.int.state], options);
+	await dotvvm.staticCommandPostback(&quot;WARNING/NOT/ENCRYPTED+++WyJEb3RWVk0uRnJhbWV3b3JrLlRlc3RzLkJpbmRpbmcuVGVzdFNlcnZpY2UsIERvdFZWTS5GcmFtZXdvcmsuVGVzdHMiLCJTYXZlIixbXSwxLG51bGwsIkFRQT0iXQ==&quot;, [options.knockoutContext.$parent.int.state], options);
 },$element)) }">
 			<input onclick="dotvvm.applyPostbackHandlers(async (options) => {
 	let a;
@@ -14,7 +14,7 @@
 		<!-- /ko -->
 		<div data-bind="foreach: { &quot;data&quot;: Collection }">
 			<div data-bind="dotvvm-with-control-properties: { &quot;Click&quot;: ()=>(dotvvm.applyPostbackHandlers(async (options) => {
-	await dotvvm.staticCommandPostback(&quot;WARNING/NOT/ENCRYPTED+++WyJEb3RWVk0uRnJhbWV3b3JrLlRlc3RzLkJpbmRpbmcuVGVzdFNlcnZpY2UsIERvdFZWTS5GcmFtZXdvcmsuVGVzdHMiLCJTYXZlIixbXSxbIlN5c3RlbS5JbnQzMiwgU3lzdGVtLlByaXZhdGUuQ29yZUxpYiJdLCJBUUE9Il0=&quot;, [options.knockoutContext.$rawData.state], options);
+	await dotvvm.staticCommandPostback(&quot;WARNING/NOT/ENCRYPTED+++WyJEb3RWVk0uRnJhbWV3b3JrLlRlc3RzLkJpbmRpbmcuVGVzdFNlcnZpY2UsIERvdFZWTS5GcmFtZXdvcmsuVGVzdHMiLCJTYXZlIixbXSwxLG51bGwsIkFRQT0iXQ==&quot;, [options.knockoutContext.$rawData.state], options);
 },$element)) }">
 				<input onclick="dotvvm.applyPostbackHandlers(async (options) => {
 	let a;


### PR DESCRIPTION
This PR further improves #1166 by implementing changes suggested by @quigamdev. In this implementation we are sending additional parameters information only when it is truly necessary (we need to distinguish between multiple overloads on server).