### PR TITLE
Add translations for Convert.ToX for numeric types

### DIFF
--- a/src/Framework/Framework/Compilation/Binding/MemberExpressionFactory.cs
+++ b/src/Framework/Framework/Compilation/Binding/MemberExpressionFactory.cs
@@ -254,7 +254,8 @@ namespace DotVVM.Framework.Compilation.Binding
             if (method.AutomaticTypeArgCount == method2.AutomaticTypeArgCount && method.CastCount == method2.CastCount && method.HasParamsAttribute == method2.HasParamsAttribute)
             {
                 // TODO: this behavior is not completed. Implement the same behavior as in roslyn.
-                throw new InvalidOperationException($"Found ambiguous overloads of method '{name}'.");
+                var foundOverloads = $"{method.Method}, {method2.Method}";
+                throw new InvalidOperationException($"Found ambiguous overloads of method '{name}'. The following overloads were found: {foundOverloads}.");
             }
             return method;
         }

--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -189,6 +189,7 @@ namespace DotVVM.Framework.Compilation.Javascript
             AddDefaultListTranslations();
             AddDefaultMathTranslations();
             AddDefaultDateTimeTranslations();
+            AddDefaultConvertTranslations();
         }
 
         private void AddDefaultToStringTranslations()
@@ -595,6 +596,50 @@ namespace DotVVM.Framework.Compilation.Javascript
                 new JsNewExpression(new JsIdentifierExpression("Date"), args[0]).Member("getMilliseconds").Invoke()));
         }
 
+        private void AddDefaultConvertTranslations()
+        {
+            // Convert.ToDouble, ToSingle, ToDecimal - all of these are represented as double in JS, we only sometimes need them for correct overload resolution
+
+            // for integer types, we do the same, but also call Math.round
+
+            foreach (var m in typeof(Convert)
+                .GetMethods(BindingFlags.Static | BindingFlags.Public)
+                .Where(m => m.Name is "ToDouble" or "ToSingle" or "ToDecimal" or "ToInt32" or "ToUInt32" or "ToInt16" or "ToUInt16" or "ToByte" or "ToSByte" or "ToInt64" or "ToUInt64"))
+            {
+                var p = m.GetParameters();
+                if (p.Length != 1)
+                    continue;
+                var isFloating = m.Name is "ToDouble" or "ToSingle" or "ToDecimal";
+                JsExpression wrapInRound(JsExpression a) =>
+                    isFloating ? a : new JsIdentifierExpression("Math").Member("round").Invoke(a);
+                if (p[0].ParameterType == typeof(char))
+                {
+                    // Convert char to number
+                    AddMethodTranslator(m, translator: new GenericMethodCompiler(args => args[1].Member("charCodeAt").Invoke(new JsLiteral(0))));
+                }
+                else if (p[0].ParameterType.IsNumericType())
+                {
+                    AddMethodTranslator(m, translator: new GenericMethodCompiler(args => wrapInRound(args[1])));
+                }
+                else if (p[0].ParameterType == typeof(string) || p[0].ParameterType == typeof(bool))
+                {
+                    AddMethodTranslator(m, translator: new GenericMethodCompiler(args => wrapInRound(new JsIdentifierExpression("Number").Invoke(args[1]))));
+                }
+            }
+
+            foreach (var m in typeof(Convert)
+                .GetMethods(BindingFlags.Static | BindingFlags.Public)
+                .Where(m => m.Name == "ToBoolean"))
+            {
+                var p = m.GetParameters();
+                if (p.Length != 1)
+                    continue;
+                if (p[0].ParameterType.IsNumericType() && p[0].ParameterType != typeof(char))
+                {
+                    AddMethodTranslator(m, translator: new GenericMethodCompiler(args => new JsIdentifierExpression("Boolean").Invoke(args[1])));
+                }
+            }
+        }
         public JsExpression? TryTranslateCall(LazyTranslatedExpression? context, LazyTranslatedExpression[] args, MethodInfo method)
         {
             {

--- a/src/Tests/Binding/BindingCompilationTests.cs
+++ b/src/Tests/Binding/BindingCompilationTests.cs
@@ -1008,6 +1008,7 @@ namespace DotVVM.Framework.Tests.Binding
         public Dictionary<int?, TestViewModel2> NullableIntVmDictionary = new() { { 0, new TestViewModel2() }, { 1, new TestViewModel2() } };
         public TestViewModel2[] VmArray => new TestViewModel2[] { new TestViewModel2() };
         public int[] IntArray { get; set; }
+        public decimal DecimalProp { get; set; }
 
         public string SetStringProp(string a, int b)
         {

--- a/src/Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/Tests/Binding/JavascriptCompilationTests.cs
@@ -813,6 +813,20 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        [DataRow("Convert.ToBoolean(IntProp)", "Boolean(IntProp())")]
+        [DataRow("Convert.ToBoolean(DoubleProp)", "Boolean(DoubleProp())")]
+        [DataRow("Convert.ToDecimal(DoubleProp)", "DoubleProp")]
+        [DataRow("Convert.ToInt32(DoubleProp)", "Math.round(DoubleProp())")]
+        [DataRow("Convert.ToByte(DoubleProp)", "Math.round(DoubleProp())")]
+        [DataRow("Convert.ToDouble(IntProp)", "IntProp")]
+        [DataRow("Convert.ToDouble(DecimalProp)", "DecimalProp")]
+        public void JsTranslator_ConvertNumeric(string binding, string expected)
+        {
+            var result = CompileBinding(binding, new[] { typeof(TestViewModel) });
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
         [DataRow("StringProp.Split('c')", "c", "None")]
         [DataRow("StringProp.Split(\"str\")", "str", "None")]
         [DataRow("StringProp.Split('c', StringSplitOptions.None)", "c", "None")]


### PR DESCRIPTION
This is useful for invoking a specific overload of a method (for example Math.Round),
only conversions which do basically nothing are implemented.

We don't support casting syntax, and this is easier to implement :sweat_smile: 