### PR TITLE
Fix isViewModelUpdating with ko.delaySync

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/state-manager.ts
+++ b/src/Framework/Framework/Resources/Scripts/state-manager.ts
@@ -81,20 +81,22 @@ export class StateManager<TViewModel extends { $type?: TypeDefinition }> {
         this.rerender(performance.now());
     }
 
-    private startTime: number | null = null
     private rerender(time: number) {
-        if (this.startTime === null) this.startTime = time
-        const realStart = performance.now()
         this._isDirty = false
 
-        this.stateUpdateEvent.trigger(this._state)
-        isViewModelUpdating = true
-        ko.delaySync.pause()
         try {
+            isViewModelUpdating = true
+            ko.delaySync.pause()
+
+            this.stateUpdateEvent.trigger(this._state)
+
             this.stateObservable[notifySymbol as any](this._state)
         } finally {
-            isViewModelUpdating = false
-            ko.delaySync.resume()
+            try {
+                ko.delaySync.resume()
+            } finally {
+                isViewModelUpdating = false
+            }
         }
         //logInfoVerbose("New state dispatched, t = ", performance.now() - time, "; t_cpu = ", performance.now() - realStart);
     }


### PR DESCRIPTION
The problem is that we used to set isViewModelUpdating to false before
we invoked ko.delaySync.resume(). This lead to actually updating the controls
after when isViewModelUpdating was already false.

I also moved invocation of the newState event into this isViewModelUpdating=true
block, since it's also used for updating controls