### PR TITLE
file upload: Don't put multiple files in collection when AllowMultipleFiles = false

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/controls/fileUpload.ts
+++ b/src/Framework/Framework/Resources/Scripts/controls/fileUpload.ts
@@ -21,9 +21,12 @@ export function reportProgress(inputControl: HTMLInputElement, isBusy: boolean, 
         // files were uploaded successfully
         viewModel.Error("");
         updateTypeInfo(result.typeMetadata);
-        for (let i = 0; i < result.result.length; i++) {
-            viewModel.Files.push(wrapObservable(deserialize(result.result[i])));
-        }
+
+        // if multiple files are allowed, we append to the collection
+        // if it's not, we replace the collection with the one new file
+        const allowMultiple = inputControl.multiple
+        const newFiles = allowMultiple ? [...viewModel.Files.state, ...result.result] : result.result
+        viewModel.Files.setState(newFiles)
 
         // call the handler
         if (((<any> targetControl.attributes)["data-dotvvm-upload-completed"] || { value: null }).value) {


### PR DESCRIPTION
We instead replace the collection with the new file. If you don't like
it and want to allow users upload multiple files, then please
enable the `AllowMultipleFiles` option - it will also allow multiselect
in the dialog.

resolves #985