### PR TITLE
Use http security headers by default

### DIFF
--- a/src/Framework/Framework/Configuration/DotvvmCompilationPageConfiguration.cs
+++ b/src/Framework/Framework/Configuration/DotvvmCompilationPageConfiguration.cs
@@ -124,6 +124,8 @@ namespace DotVVM.Framework.Configuration
                     routeName: RouteName,
                     url: Url,
                     virtualPath: "embedded://DotVVM.Framework/Diagnostics/CompilationPage.dothtml");
+
+                config.Security.RequireSecFetchHeaders.EnableForRoutes(RouteName);
             }
 
             if (IsApiEnabled)

--- a/src/Framework/Framework/Configuration/DotvvmConfigurationSerializationResolver.cs
+++ b/src/Framework/Framework/Configuration/DotvvmConfigurationSerializationResolver.cs
@@ -19,17 +19,17 @@ namespace DotVVM.Framework.Configuration
             var prop = member as PropertyInfo;
             var property = base.CreateProperty(member, memberSerialization);
 
-            if (property.PropertyType == typeof(DotvvmExperimentalFeatureFlag) && prop is object)
+            if (property.PropertyType == typeof(DotvvmFeatureFlag) && prop is object)
             {
                 // ignore defaults for brevity
                 property.ShouldSerialize = o =>
-                    !(prop.GetValue(o) is DotvvmExperimentalFeatureFlag flag) || flag.IsEnabledForAnyRoute();
+                    !(prop.GetValue(o) is DotvvmFeatureFlag flag) || flag.IsEnabledForAnyRoute();
             }
-            if (property.PropertyType == typeof(DotvvmGlobalExperimentalFeatureFlag) && prop is object)
+            if (property.PropertyType == typeof(DotvvmGlobalFeatureFlag) && prop is object)
             {
                 // ignore defaults for brevity
                 property.ShouldSerialize = o =>
-                    !(prop.GetValue(o) is DotvvmGlobalExperimentalFeatureFlag flag) || flag.Enabled;
+                    !(prop.GetValue(o) is DotvvmGlobalFeatureFlag flag) || flag.Enabled;
             }
 
             if (typeof(IEnumerable).IsAssignableFrom(property.PropertyType) && property.PropertyType != typeof(string) && prop is object)

--- a/src/Framework/Framework/Configuration/DotvvmExperimentalFeaturesConfiguration.cs
+++ b/src/Framework/Framework/Configuration/DotvvmExperimentalFeaturesConfiguration.cs
@@ -9,13 +9,13 @@ namespace DotVVM.Framework.Configuration
 
         // Add a DotvvmExperimentalFeatureFlag property for each experimental feature here
         [JsonProperty("lazyCsrfToken")]
-        public DotvvmExperimentalFeatureFlag LazyCsrfToken { get; private set; } = new DotvvmExperimentalFeatureFlag();
+        public DotvvmFeatureFlag LazyCsrfToken { get; private set; } = new DotvvmFeatureFlag();
 
         [JsonProperty("serverSideViewModelCache")]
-        public DotvvmExperimentalFeatureFlag ServerSideViewModelCache { get; private set; } = new DotvvmExperimentalFeatureFlag();
+        public DotvvmFeatureFlag ServerSideViewModelCache { get; private set; } = new DotvvmFeatureFlag();
 
         [JsonProperty("explicitAssemblyLoading")]
-        public DotvvmGlobalExperimentalFeatureFlag ExplicitAssemblyLoading { get; private set; } = new DotvvmGlobalExperimentalFeatureFlag();
+        public DotvvmGlobalFeatureFlag ExplicitAssemblyLoading { get; private set; } = new DotvvmGlobalFeatureFlag();
 
         public void Freeze()
         {

--- a/src/Framework/Framework/Configuration/DotvvmFeatureFlag.cs
+++ b/src/Framework/Framework/Configuration/DotvvmFeatureFlag.cs
@@ -5,7 +5,8 @@ using Newtonsoft.Json;
 
 namespace DotVVM.Framework.Configuration
 {
-    public class DotvvmExperimentalFeatureFlag
+    /// <summary> Enables certain DotVVM feature for the entire application or only for certain routes. </summary>
+    public class DotvvmFeatureFlag
     {
 
         [JsonProperty("enabled")]
@@ -92,7 +93,7 @@ namespace DotVVM.Framework.Configuration
         private void ThrowIfFrozen()
         {
             if (isFrozen)
-                FreezableUtils.Error(nameof(DotvvmExperimentalFeatureFlag));
+                FreezableUtils.Error(nameof(DotvvmFeatureFlag));
         }
         public void Freeze()
         {

--- a/src/Framework/Framework/Configuration/DotvvmGlobalFeatureFlag.cs
+++ b/src/Framework/Framework/Configuration/DotvvmGlobalFeatureFlag.cs
@@ -2,7 +2,7 @@
 
 namespace DotVVM.Framework.Configuration
 {
-    public class DotvvmGlobalExperimentalFeatureFlag
+    public class DotvvmGlobalFeatureFlag
     {
 
         [JsonProperty("enabled")]
@@ -22,12 +22,17 @@ namespace DotVVM.Framework.Configuration
             ThrowIfFrozen();
             Enabled = true;
         }
+        public void Disable()
+        {
+            ThrowIfFrozen();
+            Enabled = false;
+        }
 
         private bool isFrozen = false;
         private void ThrowIfFrozen()
         {
             if (isFrozen)
-                FreezableUtils.Error(nameof(DotvvmExperimentalFeatureFlag));
+                FreezableUtils.Error(nameof(DotvvmFeatureFlag));
         }
 
         public void Freeze()

--- a/src/Framework/Framework/Configuration/DotvvmSecurityConfiguration.cs
+++ b/src/Framework/Framework/Configuration/DotvvmSecurityConfiguration.cs
@@ -11,21 +11,6 @@ namespace DotVVM.Framework.Configuration
     /// </summary>
     public class DotvvmSecurityConfiguration
     {
-
-        /// <summary>
-        /// Gets or sets base-64 encoded key for signing (128 bytes recommended - for HMACSHA512, long is hashed or short is padded).
-        /// </summary>
-        [JsonProperty("signingKey")]
-        [Obsolete("This property is not used at all. DotVVM derives the keys from ASP.NET Core.")]
-        public byte[]? SigningKey { get; set; }
-
-        /// <summary>
-        /// Gets or sets base-64 encoded key for encryption (128, 192 or 256 key - used for AES).
-        /// </summary>
-        [JsonProperty("encryptionKey")]
-        [Obsolete("This property is not used at all. DotVVM derives the keys from ASP.NET Core.")]
-        public byte[]? EncryptionKey { get; set; }
-
         /// <summary>
         /// Gets or sets name of HTTP cookie used for Session ID
         /// </summary>
@@ -37,8 +22,50 @@ namespace DotVVM.Framework.Configuration
             set { ThrowIfFrozen(); sessionIdCookieName = value; }
         }
         private string sessionIdCookieName = "dotvvm_sid_{0}";
-        private bool isFrozen = false;
 
+        /// <summary>
+        /// When enabled, uses `X-Frame-Options: SAMEORIGIN` instead of DENY
+        /// </summary>
+        [JsonProperty("frameOptionsSameOrigin", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public DotvvmFeatureFlag FrameOptionsSameOrigin { get; } = new();
+
+        /// <summary>
+        /// When enabled, does not add `X-Frame-Options: DENY` header. Enabling will force DotVVM to use SameSite=None on the session cookie
+        /// </summary>
+        [JsonProperty("frameOptionsCrossOrigin", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public DotvvmFeatureFlag FrameOptionsCrossOrigin { get; } = new();
+
+        /// <summary>
+        /// When enabled, adds the `X-XSS-Protection: 1; mode=block` header, which enables some basic XSS filtering in browsers. This is enabled by default.
+        /// </summary>
+        [JsonProperty("xssProtectionHeader", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public DotvvmFeatureFlag XssProtectionHeader { get; } = new() { Enabled = true };
+
+        /// <summary>
+        /// When enabled, adds the `X-Content-Type-Options: nosniff` header, which prevents browsers from incorrectly detecting non-scripts as scripts. This is enabled by default.
+        /// </summary>
+        [JsonProperty("contentTypeOptionsHeader", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public DotvvmFeatureFlag ContentTypeOptionsHeader { get; } = new() { Enabled = true };
+
+        /// <summary>
+        /// Verifies Sec-Fetch headers on the GET request coming to dothtml pages. The request must have `Sec-Fetch-Dest: document` or `Sec-Fetch-Site: same-origin` if the request is for SPA. If the FrameOptionsSameOrigin is enabled, DotVVM will also allow `Sec-Fetch-Dest: document` and if FrameOptionsSameOrigin is enabled, DotVVM will also allow iframe from an cross-site request. This protects agains cross-site page scraping. Also prevents potential XSS bug to scrape the non-SPA pages.
+        /// </summary>
+        [JsonProperty("verifySecFetchForPages", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public DotvvmFeatureFlag VerifySecFetchForPages { get; } = new() { Enabled = true };
+
+        /// <summary>
+        /// Verifies Sec-Fetch headers on the POST request executing staticCommands and commands. The request must have `Sec-Fetch-Site: same-origin`. This protects again cross-site malicious requests even if SameSite cookies and CSRF tokens would fail. It also prevents websites on a subdomain to perform postbacks.
+        /// </summary>
+        [JsonProperty("verifySecFetchForCommands", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public DotvvmFeatureFlag VerifySecFetchForCommands { get; } = new() { Enabled = true };
+
+        /// <summary>
+        /// Requires that requests to dotvvm pages always have the Sec-Fetch-* headers. This may offer a slight protection against server-side request forgery attacks and against attacks exploiting obsolete web browsers (MS IE and Apple IE)
+        /// </summary>
+        [JsonProperty("requireSecFetchHeaders", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public DotvvmFeatureFlag RequireSecFetchHeaders { get; } = new();
+
+        private bool isFrozen = false;
         private void ThrowIfFrozen()
         {
             if (isFrozen)
@@ -47,6 +74,7 @@ namespace DotVVM.Framework.Configuration
         public void Freeze()
         {
             this.isFrozen = true;
+            this.FrameOptionsSameOrigin.Freeze();
         }
     }
 }

--- a/src/Framework/Framework/Diagnostics/CompilationPageViewModel.cs
+++ b/src/Framework/Framework/Diagnostics/CompilationPageViewModel.cs
@@ -26,8 +26,7 @@ namespace DotVVM.Framework.Diagnostics
             var isAuthorized = await Context.Configuration.Diagnostics.CompilationPage.AuthorizationPredicate(Context);
             if (!isAuthorized)
             {
-                Context.HttpContext.Response.StatusCode = 403;
-                Context.InterruptRequest();
+                await Context.RejectRequest("Unauthorized access to compilation page");
                 return;
             }
 

--- a/src/Framework/Framework/Hosting/DotvvmPresenter.cs
+++ b/src/Framework/Framework/Hosting/DotvvmPresenter.cs
@@ -482,7 +482,7 @@ namespace DotVVM.Framework.Hosting
                 }
             }
 
-            if (!checksAllowed || string.IsNullOrEmpty(dest))
+            if (!checksAllowed || string.IsNullOrEmpty(dest) || string.IsNullOrEmpty(site))
                 return;
 
             if (isPost)

--- a/src/Framework/Framework/Hosting/DotvvmRequestContextExtensions.cs
+++ b/src/Framework/Framework/Hosting/DotvvmRequestContextExtensions.cs
@@ -251,6 +251,19 @@ public static class DotvvmRequestContextExtensions
         throw new DotvvmInterruptRequestExecutionException(InterruptReason.ReturnFile, fileName);
     }
 
+    internal static async Task RejectRequest(this IDotvvmRequestContext context, string message, int statusCode = 403)
+    {
+        // push it as a warning to ILogger
+        var msg = "request rejected: " + message;
+        context.Services
+            .GetRequiredService<RuntimeWarningCollector>()
+            .Warn(new DotvvmRuntimeWarning(msg));
+        context.HttpContext.Response.StatusCode = statusCode;
+        context.HttpContext.Response.ContentType = "text/plain";
+        await context.HttpContext.Response.WriteAsync(msg);
+        throw new DotvvmInterruptRequestExecutionException(InterruptReason.RequestRejected, msg);
+    }
+
     public static void DebugWarning(this IDotvvmRequestContext context, string message, Exception? relatedException = null, DotvvmBindableObject? relatedControl = null)
     {
         if (context.Configuration.Debug)

--- a/src/Framework/Framework/Hosting/InterruptReason.cs
+++ b/src/Framework/Framework/Hosting/InterruptReason.cs
@@ -8,6 +8,8 @@ namespace DotVVM.Framework.Hosting
         RedirectPermanent,
         ReturnFile,
         ModelValidationFailed,
-        CachedViewModelMissing
+        CachedViewModelMissing,
+        /// <summary> The request was rejected, most likely for security reasons. </summary>
+        RequestRejected
     }
 }

--- a/src/Framework/Framework/Hosting/Middlewares/DotvvmRoutingMiddleware.cs
+++ b/src/Framework/Framework/Hosting/Middlewares/DotvvmRoutingMiddleware.cs
@@ -112,20 +112,21 @@ namespace DotVVM.Framework.Hosting.Middlewares
         {
             var config = context.Configuration.Security;
             var route = context.Route?.RouteName;
-            if (config.ContentTypeOptionsHeader.IsEnabledForRoute(route))
-                context.HttpContext.Response.Headers.Add("X-Content-Type-Options", new [] { "nosniff" });
+            var headers = context.HttpContext.Response.Headers;
+            if (config.ContentTypeOptionsHeader.IsEnabledForRoute(route) && !headers.ContainsKey("X-Content-Type-Options"))
+                headers.Add("X-Content-Type-Options", new [] { "nosniff" });
 
-            if (config.XssProtectionHeader.IsEnabledForRoute(route))
-                context.HttpContext.Response.Headers.Add("X-XSS-Protection", new [] { "1; mode=block" });
+            if (config.XssProtectionHeader.IsEnabledForRoute(route) && !headers.ContainsKey("X-XSS-Protection"))
+                headers.Add("X-XSS-Protection", new [] { "1; mode=block" });
 
-            if (config.FrameOptionsCrossOrigin.IsEnabledForRoute(route))
+            if (config.FrameOptionsCrossOrigin.IsEnabledForRoute(route) || headers.ContainsKey("X-Frame-Options"))
             {
                 // nothing
             }
             else if (config.FrameOptionsSameOrigin.IsEnabledForRoute(route))
-                context.HttpContext.Response.Headers.Add("X-Frame-Options", new [] { "SAMEORIGIN" });
+                headers.Add("X-Frame-Options", new [] { "SAMEORIGIN" });
             else
-                context.HttpContext.Response.Headers.Add("X-Frame-Options", new [] { "DENY" });
+                headers.Add("X-Frame-Options", new [] { "DENY" });
 
 
         }

--- a/src/Framework/Hosting.AspNetCore/Security/DefaultCsrfProtector.cs
+++ b/src/Framework/Hosting.AspNetCore/Security/DefaultCsrfProtector.cs
@@ -83,6 +83,8 @@ namespace DotVVM.Framework.Security
             var originalHttpContext = context.GetAspNetCoreContext();
             var sessionIdCookieName = GetSessionIdCookieName(context);
             if (string.IsNullOrWhiteSpace(sessionIdCookieName)) throw new FormatException("Configured SessionIdCookieName is missing or empty.");
+            if (context.HttpContext.Request.IsHttps)
+                sessionIdCookieName = "__Host-" + sessionIdCookieName;
             
             // Construct protector with purposes
             var protector = this.protectionProvider.CreateProtector(PURPOSE_SID);
@@ -109,6 +111,8 @@ namespace DotVVM.Framework.Security
                 }
             }
 
+            var canUseSameSite = !context.Configuration.Security.FrameOptionsCrossOrigin.IsEnabledForAnyRoute();
+
             // No SID - generate and protect new one
 
             if(canGenerate)
@@ -128,7 +132,8 @@ namespace DotVVM.Framework.Security
                     {
                         HttpOnly = true,                                // Don't allow client script access
                         Secure = context.HttpContext.Request.IsHttps,   // If request goes trough HTTPS, mark as secure only
-                        SameSite = SameSiteMode.Lax
+                        SameSite = canUseSameSite ? SameSiteMode.Lax : SameSiteMode.None,
+                        Domain = context.HttpContext.Request.Url.Host
                     });
 
                 // Return newly generated SID

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.AuxOptions.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.AuxOptions.json
@@ -15,7 +15,20 @@
       }
     },
     "resources": {},
-    "security": {},
+    "security": {
+      "xssProtectionHeader": {
+        "enabled": true
+      },
+      "contentTypeOptionsHeader": {
+        "enabled": true
+      },
+      "verifySecFetchForPages": {
+        "enabled": true
+      },
+      "verifySecFetchForCommands": {
+        "enabled": true
+      }
+    },
     "runtime": {},
     "defaultCulture": "cs-CZ",
     "clientSideValidation": false,

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.ExperimentalFeatures.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.ExperimentalFeatures.json
@@ -14,7 +14,20 @@
       }
     },
     "resources": {},
-    "security": {},
+    "security": {
+      "xssProtectionHeader": {
+        "enabled": true
+      },
+      "contentTypeOptionsHeader": {
+        "enabled": true
+      },
+      "verifySecFetchForPages": {
+        "enabled": true
+      },
+      "verifySecFetchForCommands": {
+        "enabled": true
+      }
+    },
     "runtime": {},
     "defaultCulture": "en-US",
     "experimentalFeatures": {

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.Markup.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.Markup.json
@@ -70,7 +70,20 @@
       }
     },
     "resources": {},
-    "security": {},
+    "security": {
+      "xssProtectionHeader": {
+        "enabled": true
+      },
+      "contentTypeOptionsHeader": {
+        "enabled": true
+      },
+      "verifySecFetchForPages": {
+        "enabled": true
+      },
+      "verifySecFetchForCommands": {
+        "enabled": true
+      }
+    },
     "runtime": {},
     "defaultCulture": "en-US",
     "experimentalFeatures": {},

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.RestAPI.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.RestAPI.json
@@ -53,7 +53,20 @@
         }
       }
     },
-    "security": {},
+    "security": {
+      "xssProtectionHeader": {
+        "enabled": true
+      },
+      "contentTypeOptionsHeader": {
+        "enabled": true
+      },
+      "verifySecFetchForPages": {
+        "enabled": true
+      },
+      "verifySecFetchForCommands": {
+        "enabled": true
+      }
+    },
     "runtime": {},
     "defaultCulture": "en-US",
     "experimentalFeatures": {},

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -120,7 +120,20 @@
         }
       }
     },
-    "security": {},
+    "security": {
+      "xssProtectionHeader": {
+        "enabled": true
+      },
+      "contentTypeOptionsHeader": {
+        "enabled": true
+      },
+      "verifySecFetchForPages": {
+        "enabled": true
+      },
+      "verifySecFetchForCommands": {
+        "enabled": true
+      }
+    },
     "runtime": {},
     "defaultCulture": "en-US",
     "experimentalFeatures": {},

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeEmptyConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeEmptyConfig.json
@@ -14,7 +14,20 @@
       }
     },
     "resources": {},
-    "security": {},
+    "security": {
+      "xssProtectionHeader": {
+        "enabled": true
+      },
+      "contentTypeOptionsHeader": {
+        "enabled": true
+      },
+      "verifySecFetchForPages": {
+        "enabled": true
+      },
+      "verifySecFetchForCommands": {
+        "enabled": true
+      }
+    },
     "runtime": {},
     "defaultCulture": "en-US",
     "experimentalFeatures": {},

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeResources.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeResources.json
@@ -97,7 +97,20 @@
         }
       }
     },
-    "security": {},
+    "security": {
+      "xssProtectionHeader": {
+        "enabled": true
+      },
+      "contentTypeOptionsHeader": {
+        "enabled": true
+      },
+      "verifySecFetchForPages": {
+        "enabled": true
+      },
+      "verifySecFetchForCommands": {
+        "enabled": true
+      }
+    },
     "runtime": {},
     "defaultCulture": "en-US",
     "experimentalFeatures": {},

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeRoutes.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeRoutes.json
@@ -45,7 +45,20 @@
       }
     },
     "resources": {},
-    "security": {},
+    "security": {
+      "xssProtectionHeader": {
+        "enabled": true
+      },
+      "contentTypeOptionsHeader": {
+        "enabled": true
+      },
+      "verifySecFetchForPages": {
+        "enabled": true
+      },
+      "verifySecFetchForCommands": {
+        "enabled": true
+      }
+    },
     "runtime": {},
     "defaultCulture": "en-US",
     "experimentalFeatures": {},


### PR DESCRIPTION
Switches were added to DotvvmSecurityConfiguration, so the behavior
can be configured.

* X-Frame-Options: DENY is used by default. It should pose no problem,
 since DotVVM did not work with iframes anyway due to cookie
  SameSite policy. When CrossSite frames are enabled, the cookie will
  have SameSite=None
* we also check Sec-Fetch-Dest - if it's an iframe, we validate on server that iframes are allowed.
   This mostly allows us to print a nicer error message, but may also in theory prevent some iframe timing attacks
* X-XSS-Protection: 1; mode=block
   probably not super useful, but also not harmful
* X-Content-Type-Options: nosniff
   - disable inference of content-type based on content, this could prevent some XSS attacks.
   probably also not super useful, but very unlikely to cause any problems.

* When on https, we set the session cookie with __Host- prefix. This prevents
 it being used by subdomains. Can help only in obscure cases -
 but for example when a system on the subdomain is compromised,
 the attacked can not pivot to the parent domain so easily.

We also check Sec-Fetch-* headers - that tells us what the browsers intends
to do with the page and if it's cross-origin or same-origin request.
Basically, we don't allow cross-origin POST and SPA requests. We also
don't allow JS initiated GET requests to dotvvm pages, but this may
be disabled, as someone could rely on it.

If the browser does not send these Sec-Fetch-* headers, we don't check
anything. You can enable strict checking by Security.RequireSecFetchHeaders option.
By default it's enabled on compilation page to prevent SSRF
and it does not matter too much if it does not work for someone.

Importantly, we don't set Strict-Transport-Security, since it's quite hard
to undo if it's unwanted and should be set on all requests coming from the server,
not only from requests handled by dotvvm.

I basically went through this guide and implemented what makes sense in our context:
https://infosec.mozilla.org/guidelines/web_security#web-security-cheat-sheet