### PR TITLE
Add IHeathCheck implementation to Asp.Net Core hosting

### DIFF
--- a/src/Framework/Framework/Compilation/DefaultControlBuilderFactory.cs
+++ b/src/Framework/Framework/Compilation/DefaultControlBuilderFactory.cs
@@ -60,6 +60,7 @@ namespace DotVVM.Framework.Compilation
         /// </summary>
         private (ControlBuilderDescriptor, Lazy<IControlBuilder>) CreateControlBuilder(MarkupFile file)
         {
+            var compilationService = configuration.ServiceProvider.GetService<IDotvvmViewCompilationService>();
             void editCompilationException(DotvvmCompilationException ex)
             {
                 if (ex.FileName == null)
@@ -90,11 +91,18 @@ namespace DotVVM.Framework.Compilation
                             configuration.Resources.RegisterViewModuleResources(import, init);
                         }
 
+                        compilationService.RegisterCompiledView(file.FileName, descriptor, null);
                         return result;
                     }
                     catch (DotvvmCompilationException ex)
                     {
                         editCompilationException(ex);
+                        compilationService.RegisterCompiledView(file.FileName, descriptor, ex);
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        compilationService.RegisterCompiledView(file.FileName, descriptor, ex);
                         throw;
                     }
                 });
@@ -111,6 +119,12 @@ namespace DotVVM.Framework.Compilation
             catch (DotvvmCompilationException ex)
             {
                 editCompilationException(ex);
+                compilationService.RegisterCompiledView(file.FileName, null, ex);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                compilationService.RegisterCompiledView(file.FileName, null, ex);
                 throw;
             }
         }

--- a/src/Framework/Framework/Compilation/IDotvvmViewCompilationService.cs
+++ b/src/Framework/Framework/Compilation/IDotvvmViewCompilationService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
@@ -43,5 +44,7 @@ namespace DotVVM.Framework.Compilation
         /// <param name="forceRecompile">If set, than everything will be recompiled.</param>
         /// <returns>Returns whether compilation was successful.</returns>
         Task<bool> CompileAll(bool buildInParallel=true, bool forceRecompile = false);
+
+        void RegisterCompiledView(string filePath, ViewCompiler.ControlBuilderDescriptor? descriptor, Exception? exception);
     }
 }

--- a/src/Framework/Hosting.AspNetCore/DotVVM.Framework.Hosting.AspNetCore.csproj
+++ b/src/Framework/Hosting.AspNetCore/DotVVM.Framework.Hosting.AspNetCore.csproj
@@ -32,5 +32,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Localization" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Localization" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/src/Framework/Hosting.AspNetCore/Hosting/DotvvmHealthCheck.cs
+++ b/src/Framework/Hosting.AspNetCore/Hosting/DotvvmHealthCheck.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DotVVM.Framework.Compilation;
+using DotVVM.Framework.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace DotVVM.Framework.Hosting
+{
+    public class DotvvmHealthCheck : IHealthCheck
+    {
+        private readonly IDotvvmViewCompilationService compilationService;
+
+        public DotvvmHealthCheck(IDotvvmViewCompilationService compilationService)
+        {
+            this.compilationService = compilationService;
+        }
+
+        public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            var c = compilationService.GetRoutes().AddRange(compilationService.GetControls().AddRange(compilationService.GetMasterPages()));
+
+            if (!c.Any(p => p.Status == CompilationState.CompilationFailed))
+            {
+                return Task.FromResult(new HealthCheckResult(HealthStatus.Healthy));
+            }
+
+            // if nothing compiles, we say unhealthy. If at least something works, we say only degraded
+            var state =
+                c.Any(p => p.Status is CompilationState.CompletedSuccessfully or CompilationState.CompilationWarning)
+                    ? HealthStatus.Degraded
+                    : HealthStatus.Unhealthy;
+            
+            var views = c.Where(p => p.Status == CompilationState.CompilationFailed)
+                         .Select(c => c.VirtualPath);
+            return Task.FromResult(new HealthCheckResult(state, $"Dothtml pages can not be compiled: {views.Take(10).StringJoin(", ")}. See /_dotvvm/diagnostics/compilation for more information."));
+        }
+
+        public static void RegisterHealthCheck(IServiceCollection services)
+        {
+            services.ConfigureWithServices<HealthCheckServiceOptions>((options, s) => {
+                if (options.Registrations.Any(c => c.Name == "DotVVM"))
+                    return;
+
+                options.Registrations.Add(
+                    new HealthCheckRegistration(
+                        "DotVVM",
+                        ActivatorUtilities.CreateInstance<DotvvmHealthCheck>(s),
+                        null,
+                        new [] { "dotvvm" }
+                    )
+                );
+            });
+        }
+    }
+}

--- a/src/Framework/Hosting.AspNetCore/ServiceCollectionExtensions.cs
+++ b/src/Framework/Hosting.AspNetCore/ServiceCollectionExtensions.cs
@@ -88,6 +88,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddTransient<IDotvvmWarningSink, AspNetCoreLoggerWarningSink>();
 
             services.TryAddSingleton<IStartupTracer>(startupTracer);
+
+            DotvvmHealthCheck.RegisterHealthCheck(services);
         }
     }
 }

--- a/src/Samples/AspNetCoreLatest/Startup.cs
+++ b/src/Samples/AspNetCoreLatest/Startup.cs
@@ -50,6 +50,8 @@ namespace DotVVM.Samples.BasicSamples
             services.AddAuthentication("Scheme3")
                 .AddCookie("Scheme3");
 
+            services.AddHealthChecks();
+
             services.AddLocalization(o => o.ResourcesPath = "Resources");
 
             services.AddDotVVM<DotvvmServiceConfigurator>();
@@ -78,11 +80,14 @@ namespace DotVVM.Samples.BasicSamples
                 }
             });
 
-
 #if AssertConfiguration
             // this compilation symbol is set by CI server
             config.AssertConfigurationIsValid();
 #endif
+            app.UseRouting();
+            app.UseEndpoints(endpoints => {
+                endpoints.MapHealthChecks("/health");
+            });
             app.UseStaticFiles();
 
             app.UseEndpoints(endpoints => {


### PR DESCRIPTION
The healthcheck just checks if dotvvm pages can be compiled.

resolves #1205 