### PR TITLE
Make view precompilation the default in production mode

### DIFF
--- a/src/Framework/Framework/Compilation/DotvvmViewCompilationServiceExtensions.cs
+++ b/src/Framework/Framework/Compilation/DotvvmViewCompilationServiceExtensions.cs
@@ -29,6 +29,8 @@ namespace DotVVM.Framework.Compilation
         {
             if (compilationConfiguration.Mode == ViewCompilationMode.Lazy)
                 return;
+            if (!compilationConfiguration.PrecompileEvenInDebug && config.Debug)
+                return;
 
             var getCompilationTask = compilationConfiguration.Precompile(config, startupTracer);
             if (compilationConfiguration.Mode == ViewCompilationMode.DuringApplicationStart)

--- a/src/Framework/Framework/Configuration/ViewCompilationConfiguration.cs
+++ b/src/Framework/Framework/Configuration/ViewCompilationConfiguration.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using DotVVM.Framework.Compilation;
 using Newtonsoft.Json;
 
@@ -7,11 +8,12 @@ namespace DotVVM.Framework.Configuration
     public sealed class ViewCompilationConfiguration
     {
         private bool isFrozen = false;
-        private ViewCompilationMode mode;
+        private ViewCompilationMode mode = ViewCompilationMode.AfterApplicationStart;
         /// <summary>
-        /// Gets or sets the mode under which the view compilation (pages, controls, ... ) is done.
+        /// Gets or sets the mode under which the view compilation (pages, controls, ... ) is done. By default, view are precompiled asynchronously after the application starts.
         /// </summary>
         [JsonProperty("mode")]
+        [DefaultValue(ViewCompilationMode.AfterApplicationStart)]
         public ViewCompilationMode Mode
         {
             get => mode;
@@ -47,6 +49,21 @@ namespace DotVVM.Framework.Configuration
             {
                 ThrowIfFrozen();
                 compileInParallel = value;
+            }
+        }
+
+        private bool precompileEvenInDebug = false;
+        /// <summary>
+        /// By default, view precompilation is disabled in Debug mode, to make startup time faster. This options controls this behavior.
+        /// </summary>
+        [JsonProperty("precompileEvenInDebug")]
+        public bool PrecompileEvenInDebug
+        {
+            get => precompileEvenInDebug;
+            set
+            {
+                ThrowIfFrozen();
+                precompileEvenInDebug = value;
             }
         }
 


### PR DESCRIPTION
This helps the healthcheck to make more sense by default. Should also help with user facing latency after the app is restarted