### PR TITLE
Remove obsolete control properties

### DIFF
--- a/src/Framework/Framework/Configuration/DotvvmConfiguration.cs
+++ b/src/Framework/Framework/Configuration/DotvvmConfiguration.cs
@@ -106,17 +106,11 @@ namespace DotVVM.Framework.Configuration
         private bool _clientSideValidation = true;
 
         /// <summary>
-        /// Gets or sets whether navigation in the SPA pages should use History API. Default value is <c>true</c>.
+        /// Gets or sets whether navigation in the SPA pages should use History API. Always true
         /// </summary>
-        [JsonProperty("useHistoryApiSpaNavigation", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        [DefaultValue(true)]
+        [JsonIgnore]
         [Obsolete("The UseHistoryApiSpaNavigation property is not supported - the classic SPA mode (URLs with #/) was removed from DotVVM, and the History API is the default and only option now. See https://www.dotvvm.com/docs/3.0/pages/concepts/layout/single-page-applications-spa#changes-to-spas-in-dotvvm-30 for more details.")]
-        public bool UseHistoryApiSpaNavigation
-        {
-            get { return _useHistoryApiSpaNavigation; }
-            set { ThrowIfFrozen(); _useHistoryApiSpaNavigation = value; }
-        }
-        private bool _useHistoryApiSpaNavigation = true;
+        public bool UseHistoryApiSpaNavigation => true;
 
         /// <summary>
         /// Gets or sets the configuration for experimental features.

--- a/src/Framework/Framework/Controls/GridViewTextColumn.cs
+++ b/src/Framework/Framework/Controls/GridViewTextColumn.cs
@@ -40,20 +40,6 @@ namespace DotVVM.Framework.Controls
             DotvvmProperty.Register<ICommandBinding?, GridViewTextColumn>(t => t.ChangedBinding, null);
 
         /// <summary>
-        /// Gets or sets the type of value being formatted - Number or DateTime.
-        /// </summary>
-        [MarkupOptions(AllowBinding = false)]
-        [Obsolete("ValueType property is no longer required, it is automatically inferred from compile-time type of ValueBinding")]
-        public FormatValueType ValueType
-        {
-            get { return (FormatValueType)GetValue(ValueTypeProperty)!; }
-            set { SetValue(ValueTypeProperty, value); }
-        }
-        [Obsolete("ValueType property is no longer required, it is automatically inferred from compile-time type of ValueBinding")]
-        public static readonly DotvvmProperty ValueTypeProperty =
-            DotvvmProperty.Register<FormatValueType, GridViewTextColumn>(t => t.ValueType);
-
-        /// <summary>
         /// Gets or sets a binding which retrieves the value to display from the current data item.
         /// </summary>
         [MarkupOptions(Required = true)]
@@ -91,9 +77,6 @@ namespace DotVVM.Framework.Controls
         {
             var literal = new Literal();
             literal.FormatString = FormatString;
-            #pragma warning disable
-            literal.ValueType = ValueType;
-            #pragma warning restore
 
             CopyProperty(UITests.NameProperty, literal, UITests.NameProperty);
 
@@ -106,9 +89,6 @@ namespace DotVVM.Framework.Controls
         {
             var textBox = new TextBox();
             textBox.FormatString = FormatString;
-            #pragma warning disable
-            textBox.ValueType = ValueType;
-            #pragma warning restore
 
             textBox.SetBinding(TextBox.TextProperty, ValueBinding);
             textBox.SetBinding(TextBox.ChangedProperty, ChangedBinding);

--- a/src/Framework/Framework/Controls/Literal.cs
+++ b/src/Framework/Framework/Controls/Literal.cs
@@ -44,21 +44,6 @@ namespace DotVVM.Framework.Controls
             DotvvmProperty.Register<string, Literal>(c => c.FormatString, "");
 
         /// <summary>
-        /// Gets or sets the type of value being formatted - Number or DateTime.
-        /// </summary>
-        [MarkupOptions(AllowBinding = false)]
-        [Obsolete("ValueType property is no longer required, it is automatically inferred from compile-time type of Text binding")]
-        public FormatValueType ValueType
-        {
-            get { return (FormatValueType)GetValue(ValueTypeProperty)!; }
-            set { SetValue(ValueTypeProperty, value); }
-        }
-
-        [Obsolete("ValueType property is no longer required, it is automatically inferred from compile-time type of Text binding")]
-        public static readonly DotvvmProperty ValueTypeProperty =
-            DotvvmProperty.Register<FormatValueType, Literal>(t => t.ValueType);
-
-        /// <summary>
         /// Gets or sets whether the literal should render the wrapper span HTML element.
         /// </summary>
         [MarkupOptions(AllowBinding = false)]
@@ -115,9 +100,6 @@ namespace DotVVM.Framework.Controls
 
         public bool IsFormattingRequired =>
             !string.IsNullOrEmpty(FormatString) ||
-#pragma warning disable
-            ValueType != FormatValueType.Text ||
-#pragma warning restore
             NeedsFormatting(GetValueBinding(TextProperty));
 
         private new struct RenderState
@@ -136,9 +118,7 @@ namespace DotVVM.Framework.Controls
                 r.Text = value;
             else if (prop == RenderSpanElementProperty)
                 r.RenderSpanElement = (bool)EvalPropertyValue(RenderSpanElementProperty, value)!;
-#pragma warning disable CS0618
-            else if (prop == FormatStringProperty || prop == ValueTypeProperty)
-#pragma warning restore CS0618
+            else if (prop == FormatStringProperty)
                 r.HasFormattingStuff = true;
             else if (base.TouchProperty(prop, value, ref r.HtmlState)) { }
             else if (DotvvmControl.TouchProperty(prop, value, ref r.BaseState)) { }

--- a/src/Framework/Framework/Controls/SelectorBase.cs
+++ b/src/Framework/Framework/Controls/SelectorBase.cs
@@ -32,32 +32,6 @@ namespace DotVVM.Framework.Controls
             DotvvmPropertyWithFallback.Register<bool, SelectorBase>(nameof(Enabled), FormControls.EnabledProperty);
 
         /// <summary>
-        /// Gets or sets the name of property in the DataSource collection that will be displayed in the control.
-        /// </summary>
-        [Obsolete("Use ItemTextBinding property instead", true)]
-        public string? DisplayMember
-        {
-            get { return (string?)GetValue(DisplayMemberProperty); }
-            set { SetValue(DisplayMemberProperty, value); }
-        }
-        [Obsolete("Use ItemTextBinding property instead", true)]
-        public static readonly DotvvmProperty DisplayMemberProperty =
-            DotvvmProperty.Register<string?, SelectorBase>(t => t.DisplayMember, "");
-
-        /// <summary>
-        /// Gets or sets the name of property in the DataSource collection that will be passed to the SelectedValue property when the item is selected.
-        /// </summary>
-        [Obsolete("Use ItemValueBinding property instead", true)]
-        public string? ValueMember
-        {
-            get { return (string?)GetValue(ValueMemberProperty); }
-            set { SetValue(ValueMemberProperty, value); }
-        }
-        [Obsolete("Use ItemValueBinding property instead", true)]
-        public static readonly DotvvmProperty ValueMemberProperty =
-            DotvvmProperty.Register<string?, SelectorBase>(t => t.ValueMember, "");
-
-        /// <summary>
         /// The expression of DataSource item that will be displayed in the control.
         /// </summary>
         [ControlPropertyBindingDataContextChange(nameof(DataSource))]
@@ -121,21 +95,6 @@ namespace DotVVM.Framework.Controls
                 {
                     yield return new ControlUsageError("Return type of ItemValueBinding has to be a primitive type!", valueBinding.DothtmlNode);
                 }
-            }
-        }
-
-        [ControlUsageValidator]
-        [Obsolete("This must be obsolete to compile...")]
-        public static IEnumerable<ControlUsageError> ValidateObsoleteProperties(ResolvedControl control)
-        {
-            // validate usage of obsolete properties
-            if (control.Properties.GetValueOrDefault(DisplayMemberProperty) is ResolvedPropertySetter displayMember)
-            {
-                yield return new ControlUsageError("Property DisplayMemberProperty is obsolete. Please use ItemTextBinding instead.", displayMember.DothtmlNode);
-            }
-            if (control.Properties.GetValueOrDefault(ValueMemberProperty) is ResolvedPropertySetter valueMember)
-            {
-                yield return new ControlUsageError("Property DisplayMemberProperty is obsolete. Please use ItemValueBinding instead.", valueMember.DothtmlNode);
             }
         }
     }

--- a/src/Framework/Framework/Controls/TextBox.cs
+++ b/src/Framework/Framework/Controls/TextBox.cs
@@ -107,15 +107,6 @@ namespace DotVVM.Framework.Controls
             DotvvmProperty.Register<TextBoxType, TextBox>(c => c.Type, TextBoxType.Normal);
 
         /// <summary>
-        /// Gets or sets whether the viewmodel property will be updated after the key is pressed. 
-        /// By default, the viewmodel is updated after the control loses its focus.
-        /// </summary>
-        [MarkupOptions(AllowBinding = false)]
-        [Obsolete("Use `UpdateTextOnInput` instead.")]
-        public static readonly DotvvmProperty UpdateTextAfterKeydownProperty =
-            DotvvmProperty.Register<bool, TextBox>("UpdateTextAfterKeydown", false);
-        
-        /// <summary>
         /// Gets or sets whether the viewmodel property will be updated immediately after change. 
         /// By default, the viewmodel is updated after the control loses its focus.
         /// </summary>
@@ -126,27 +117,9 @@ namespace DotVVM.Framework.Controls
             set { SetValue(UpdateTextOnInputProperty, value); }
         }
         public static readonly DotvvmProperty UpdateTextOnInputProperty =
-            DotvvmPropertyWithFallback.Register<bool, TextBox>(
+            DotvvmProperty.Register<bool, TextBox>(
                 nameof(UpdateTextOnInput),
-#pragma warning disable CS0618
-                UpdateTextAfterKeydownProperty,
-#pragma warning restore CS0618
                 isValueInherited: true);
-
-        /// <summary>
-        /// Gets or sets the type of value being formatted - Number or DateTime.
-        /// </summary>
-        [MarkupOptions(AllowBinding = false)]
-        [Obsolete("ValueType property is no longer required, it is automatically inferred from compile-time type of Text binding")]
-        public FormatValueType ValueType
-        {
-            get { return (FormatValueType)GetValue(ValueTypeProperty)!; }
-            set { SetValue(ValueTypeProperty, value); }
-        }
-
-        [Obsolete("ValueType property is no longer required, it is automatically inferred from compile-time type of Text binding")]
-        public static readonly DotvvmProperty ValueTypeProperty =
-            DotvvmProperty.Register<FormatValueType, TextBox>(t => t.ValueType);
 
         public static FormatValueType ResolveValueType(IValueBinding? binding)
         {
@@ -172,16 +145,7 @@ namespace DotVVM.Framework.Controls
 
             if (!isTypeImplicitlyFormatted || implicitFormatString != null)
             {
-#pragma warning disable
-                if (ValueType != FormatValueType.Text)
-                {
-                    resolvedValueType = ValueType;
-                }
-#pragma warning restore
-                else
-                {
-                    resolvedValueType = ResolveValueType(GetValueBinding(TextProperty));
-                }
+                resolvedValueType = ResolveValueType(GetValueBinding(TextProperty));
             }
 
             if (resolvedValueType != FormatValueType.Text)

--- a/src/Framework/Framework/ResourceManagement/FileResourceLocation.cs
+++ b/src/Framework/Framework/ResourceManagement/FileResourceLocation.cs
@@ -31,16 +31,4 @@ namespace DotVVM.Framework.ResourceManagement
 
         public string GetFilePath(IDotvvmRequestContext context) => FilePath;
     }
-
-    /// <summary>
-    /// Compatibility alias for FileResourceLocation.
-    /// Represents a resource located in a file in filesystem.
-    /// </summary>
-    [Obsolete("Use FileResourceLocation instead.")]
-    public class LocalFileResourceLocation : FileResourceLocation
-    {
-        public LocalFileResourceLocation(string filePath) : base(filePath)
-        {
-        }
-    }
 }

--- a/src/Framework/Framework/ResourceManagement/UrlResourceLocation.cs
+++ b/src/Framework/Framework/ResourceManagement/UrlResourceLocation.cs
@@ -24,16 +24,4 @@ namespace DotVVM.Framework.ResourceManagement
             return context.TranslateVirtualPath(context.Configuration.Debug ? DebugUrl : Url);
         }
     }
-
-    /// <summary>
-    /// Compatibility alias for UrlResourceLocation.
-    /// Represents a resource located at remote server identified by a url.
-    /// </summary> 
-    [Obsolete("Use UrlResourceLocation instead.")]
-    public class RemoteResourceLocation : UrlResourceLocation
-    {
-        public RemoteResourceLocation(string url) : base(url)
-        {
-        }
-    }
 }

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -587,9 +587,6 @@
       "ValueBinding": {
         "type": "DotVVM.Framework.Binding.Expressions.IValueBinding, DotVVM.Framework",
         "required": true
-      },
-      "ValueType": {
-        "type": "DotVVM.Framework.Controls.FormatValueType, DotVVM.Framework"
       }
     },
     "DotVVM.Framework.Controls.HtmlGenericControl": {
@@ -700,9 +697,6 @@
       },
       "Text": {
         "type": "System.Object"
-      },
-      "ValueType": {
-        "type": "DotVVM.Framework.Controls.FormatValueType, DotVVM.Framework"
       }
     },
     "DotVVM.Framework.Controls.MultiSelector": {
@@ -851,9 +845,6 @@
       }
     },
     "DotVVM.Framework.Controls.SelectorBase": {
-      "DisplayMember": {
-        "type": "System.String"
-      },
       "Enabled": {
         "type": "System.Boolean"
       },
@@ -913,9 +904,6 @@
       },
       "SelectionChanged": {
         "type": "DotVVM.Framework.Binding.Expressions.Command, DotVVM.Framework"
-      },
-      "ValueMember": {
-        "type": "System.String"
       }
     },
     "DotVVM.Framework.Controls.SelectorItem": {
@@ -1012,15 +1000,9 @@
       "Type": {
         "type": "DotVVM.Framework.Controls.TextBoxType, DotVVM.Framework"
       },
-      "UpdateTextAfterKeydown": {
-        "type": "System.Boolean"
-      },
       "UpdateTextOnInput": {
         "type": "System.Boolean",
         "isValueInherited": true
-      },
-      "ValueType": {
-        "type": "DotVVM.Framework.Controls.FormatValueType, DotVVM.Framework"
       }
     },
     "DotVVM.Framework.Controls.UITests": {


### PR DESCRIPTION
Most of these are obsolete for many years now (from DotVVM 2).
Selector.*Member did not work at all,
TextBox.ValueType will basically work even when removed.