### PR TITLE
Add basic support for capabilities in server-side styles

### DIFF
--- a/src/Framework/Framework/Binding/DotvvmPropertyUtils.cs
+++ b/src/Framework/Framework/Binding/DotvvmPropertyUtils.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using DotVVM.Framework.Compilation.ControlTree;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Utils;
+
+namespace DotVVM.Framework.Binding
+{
+
+using static DotvvmPropertyUtils.ReferenceType;
+public static class DotvvmPropertyUtils
+{
+    public static DotvvmProperty GetDotvvmPropertyFromExpression(LambdaExpression lambda) =>
+        GetDotvvmPropertyFromExpression(lambda.Body);
+    public static DotvvmProperty GetDotvvmPropertyFromExpression(Expression expression)
+    {
+        var (t, p) = ParsePropReference(expression);
+        if (t == Property)
+            return p!;
+        else
+            throw new NotSupportedException($"Expression {expression} of type {expression.NodeType} is not supported.");
+    }
+
+    internal enum ReferenceType { This, Property }
+
+    static (ReferenceType type, DotvvmProperty? property) ParsePropReference(Expression expression)
+    {
+        switch (expression.NodeType)
+        {
+            case ExpressionType.Convert:
+                // ignore conversions
+                return ParsePropReference(((UnaryExpression)expression).Operand);
+            case ExpressionType.Parameter:
+                return (This, null);
+            case ExpressionType.MemberAccess: {
+                var me = (MemberExpression)expression;
+                var prop = me.Member;
+                // just skip ValueOrBinding unwrapping
+                if (prop.Name is nameof(ValueOrBinding<int>.ValueOrDefault) or nameof(ValueOrBinding<int>.BindingOrDefault) && 
+                    prop.DeclaringType.IsGenericType && prop.DeclaringType.GetGenericTypeDefinition() == typeof(ValueOrBinding<>))
+                    return ParsePropReference(me.Expression);
+                return ParseProperty(me.Expression, prop);
+            }
+            case ExpressionType.Index: {
+                // this may be property group access .SetProperty(a => a.Attributes["class"], class)
+                var ie = (IndexExpression)expression;
+                return ParseIndexer(ie.Object, ie.Arguments.Single());
+            }
+            case ExpressionType.Call: {
+                var ce = (MethodCallExpression)expression;
+                var m = ce.Method;
+                // control.GetCapability<HtmlCapability>()
+                if (m.DeclaringType == typeof(DotvvmBindableObjectHelper) && m.Name == "GetCapability")
+                    return ParseGetCapability(ce);
+                else if (m.Name == "get_Item" && m.GetParameters().Length == 1)
+                    return ParseIndexer(ce.Object, ce.Arguments[0]);
+
+                goto default;
+            }
+            case ExpressionType.New: {
+                var ne = (NewExpression)expression;
+
+                // skip new ValueOrBinding(myProperty)
+                if (ne.Constructor.DeclaringType.IsGenericType && ne.Constructor.DeclaringType.GetGenericTypeDefinition() == typeof(ValueOrBinding<>))
+                    return ParsePropReference(ne.Arguments.Single());
+
+                goto default;
+            }
+            default:
+                throw new NotSupportedException($"Expression {expression} is not supported.");
+        }
+    }
+
+    static (ReferenceType, DotvvmProperty?) ParseGetCapability(MethodCallExpression ce)
+    {
+        var targetExpr = ce.Arguments.First();
+        var target = ParsePropReference(targetExpr);
+        if (target.type != This)
+            throw new Exception($"Can not get capability from {ce.Object}");
+        var capabilityType = ce.Method.GetGenericArguments().Single();
+        var prefix = ce.Arguments.ElementAtOrDefault(1)?.Apply(GetConstant<string>);
+        var capprop = DotvvmCapabilityProperty.Find(targetExpr.Type, capabilityType, prefix);
+        return (Property, capprop);
+    }
+
+    static (ReferenceType, DotvvmProperty?) ParseProperty(Expression targetExpr, MemberInfo prop)
+    {
+        var target = ParsePropReference(targetExpr);
+        if (target.type == This)
+        {
+            // normal dotvvm property
+            var dotprop =
+                DotvvmProperty.ResolveProperty(prop.DeclaringType!, prop.Name) ??
+                throw new Exception($"Property '{prop.DeclaringType!.Name}.{prop.Name}' is not a registered DotvvmProperty.");
+            return (Property, dotprop);
+        }
+        else if (target.type == Property)
+        {
+            // dotvvm property inside a capability
+            if (target.property is not DotvvmCapabilityProperty capprop)
+                throw new NotSupportedException($"Can not access property on another dotvvm property: {targetExpr}");
+            var mapping = capprop.PropertyMapping ??
+                throw new Exception($"Capability property {capprop} does not have a property mapping, thus can not be used in this helper method.");
+            var p = mapping.SingleOrDefault(p => p.prop == prop);
+            if (p.dotvvmProperty is null)
+                throw new Exception($"Capability property {capprop} does not contain property {prop.Name}.");
+            return (Property, p.dotvvmProperty);
+        }
+        else throw null!;
+    }
+
+    static (ReferenceType, DotvvmProperty) ParseIndexer(Expression targetExpr, Expression index)
+    {
+        var me = targetExpr as MemberExpression ?? throw new NotSupportedException($"Can not parse property from {targetExpr}[{index}]");
+        var prop = me.Member;
+        var name = GetConstant<string>(index);
+        var target = ParsePropReference(me.Expression);
+        if (target.type == This)
+        {
+            // normal property group
+            var pgroup =
+                DotvvmPropertyGroup.ResolvePropertyGroup(prop.DeclaringType!, prop.Name) ??
+                throw new Exception($"'{prop.DeclaringType!.Name}.{prop.Name}' is not a registered property group.");
+            return (Property, pgroup.GetDotvvmProperty(name));
+        }
+        else if (target.type == Property)
+        {
+            // property group inside a capability
+            if (target.property is not DotvvmCapabilityProperty capprop)
+                throw new Exception($"Can not access property group on another dotvvm property: {targetExpr}");
+            var mapping = capprop.PropertyGroupMapping ??
+                throw new Exception($"Capability property {capprop} does not have a property group mapping, thus can not be used in this helper method.");
+            var p = mapping.SingleOrDefault(p => p.prop == prop);
+            if (p.dotvvmPropertyGroup is null)
+                throw new Exception($"Capability property {capprop} does not contain property group {prop.Name}.");
+            return (Property, p.dotvvmPropertyGroup.GetDotvvmProperty(name));
+        }
+        else throw null!;
+    }
+
+    /// <summary> Gets a constant from the expression or throws if it's not possible </summary>
+    static T GetConstant<T>(Expression expression)
+    {
+        while (expression.NodeType == ExpressionType.Convert)
+            expression = ((UnaryExpression)expression).Operand;
+
+        if (expression.NodeType != ExpressionType.Constant)
+            expression = expression.OptimizeConstants();
+
+        if (expression.NodeType == ExpressionType.Constant)
+            return ((ConstantExpression)expression).Value switch {
+                T x => x,
+                null => default!,
+                var x => throw new NotSupportedException($"{expression} was expected to be of type {typeof(T).Name}")
+            };
+        throw new NotSupportedException($"Cannot get constant from {expression}");
+    }
+}
+}

--- a/src/Framework/Framework/Compilation/ControlTree/DotvvmPropertyGroup.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/DotvvmPropertyGroup.cs
@@ -126,6 +126,11 @@ namespace DotVVM.Framework.Compilation.ControlTree
 
         public static IEnumerable<DotvvmPropertyGroup> AllGroups => descriptorDictionary.Values;
 
+        public static DotvvmPropertyGroup? ResolvePropertyGroup(Type declaringType, string name)
+        {
+            return descriptorDictionary.TryGetValue((declaringType, name), out var group) ? group : null;
+        }
+
         public static IPropertyDescriptor? ResolvePropertyGroup(string name, bool caseSensitive, MappingMode requiredMode = default)
         {
             var nameParts = name.Split('.');

--- a/src/Framework/Framework/Compilation/Styles/StyleBuilderMethods.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleBuilderMethods.cs
@@ -24,7 +24,17 @@ public static partial class StyleBuilderExtensionMethods
         ValueOrBinding<TProperty> value,
         StyleOverrideOptions options = StyleOverrideOptions.Overwrite)
     {
-        var dotprop = ReflectionUtils.GetDotvvmPropertyFromExpression(property);
+        var dotprop = DotvvmPropertyUtils.GetDotvvmPropertyFromExpression(property);
+        return sb.SetDotvvmProperty(dotprop, value, options);
+    }
+    /// <summary> Sets a specified property on the matching controls. The referenced property must be a wrapper around a DotvvmProperty. </summary>
+    public static IStyleBuilder<TControl> SetProperty<TControl, TProperty>(
+        this IStyleBuilder<TControl> sb,
+        Expression<Func<TControl, ValueOrBinding<TProperty>>> property,
+        ValueOrBinding<TProperty> value,
+        StyleOverrideOptions options = StyleOverrideOptions.Overwrite)
+    {
+        var dotprop = DotvvmPropertyUtils.GetDotvvmPropertyFromExpression(property);
         return sb.SetDotvvmProperty(dotprop, value, options);
     }
 
@@ -57,7 +67,7 @@ public static partial class StyleBuilderExtensionMethods
         StyleOverrideOptions options = StyleOverrideOptions.Overwrite)
         where TInnerControl: DotvvmBindableObject
     {
-        var dotprop = ReflectionUtils.GetDotvvmPropertyFromExpression(property);
+        var dotprop = DotvvmPropertyUtils.GetDotvvmPropertyFromExpression(property);
         return sb.SetControlProperty<IStyleBuilder<TControl>, TInnerControl>(
             dotprop, prototypeControl, styleBuilder, options);
     }
@@ -150,7 +160,7 @@ public static partial class StyleBuilderExtensionMethods
         Func<IStyleMatchContext<TControl>, TProperty> value,
         StyleOverrideOptions options = StyleOverrideOptions.Overwrite)
     {
-        var dotprop = ReflectionUtils.GetDotvvmPropertyFromExpression(property);
+        var dotprop = DotvvmPropertyUtils.GetDotvvmPropertyFromExpression(property);
         return sb.SetDotvvmProperty(dotprop, c => (object?)value(c), options);
     }
 
@@ -165,7 +175,7 @@ public static partial class StyleBuilderExtensionMethods
         BindingParserOptions? bindingOptions = null)
         where T: IStyleBuilder
     {
-        var dotprop = ReflectionUtils.GetDotvvmPropertyFromExpression(property);
+        var dotprop = DotvvmPropertyUtils.GetDotvvmPropertyFromExpression(property);
         return sb.AddApplicator(new PropertyStyleBindingApplicator(
             dotprop,
             binding,
@@ -217,7 +227,7 @@ public static partial class StyleBuilderExtensionMethods
         StyleOverrideOptions options = StyleOverrideOptions.Overwrite,
         BindingParserOptions? bindingOptions = null)
     {
-        var dotprop = ReflectionUtils.GetDotvvmPropertyFromExpression(property);
+        var dotprop = DotvvmPropertyUtils.GetDotvvmPropertyFromExpression(property);
         return sb.SetDotvvmPropertyBinding(dotprop, binding, options, bindingOptions);
     }
 

--- a/src/Framework/Framework/Compilation/Styles/StyleMatchContextMethods.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleMatchContextMethods.cs
@@ -156,7 +156,7 @@ public static class StyleMatchContextExtensionMethods
     /// </summary>
     public static bool HasProperty<TControl>(this IStyleMatchContext<TControl> c, Expression<Func<TControl, object>> property)
     {
-        var prop = ReflectionUtils.GetDotvvmPropertyFromExpression(property);
+        var prop = DotvvmPropertyUtils.GetDotvvmPropertyFromExpression(property);
         return c.HasProperty(prop);
     }
 
@@ -173,7 +173,7 @@ public static class StyleMatchContextExtensionMethods
     /// </summary>
     public static bool HasBinding<TControl>(this IStyleMatchContext<TControl> c, Expression<Func<TControl, object>> property)
     {
-        var prop = ReflectionUtils.GetDotvvmPropertyFromExpression(property);
+        var prop = DotvvmPropertyUtils.GetDotvvmPropertyFromExpression(property);
         return c.HasBinding(prop);
     }
 
@@ -260,7 +260,15 @@ public static class StyleMatchContextExtensionMethods
     [return: MaybeNull]
     public static TProp PropertyValue<TControl, TProp>(this IStyleMatchContext<TControl> c, Expression<Func<TControl, TProp>> pp)
     {
-        var property = ReflectionUtils.GetDotvvmPropertyFromExpression(pp);
+        var property = DotvvmPropertyUtils.GetDotvvmPropertyFromExpression(pp);
+        return c.PropertyValue<TProp>(property);
+    }
+
+    /// <summary> Gets the property value or null if it's not defined. </summary>
+    [return: MaybeNull]
+    public static TProp PropertyValue<TControl, TProp>(this IStyleMatchContext<TControl> c, Expression<Func<TControl, ValueOrBinding<TProp>>> pp)
+    {
+        var property = DotvvmPropertyUtils.GetDotvvmPropertyFromExpression(pp);
         return c.PropertyValue<TProp>(property);
     }
 
@@ -288,7 +296,14 @@ public static class StyleMatchContextExtensionMethods
     /// <summary> Gets the property value or null if it's not defined. </summary>
     public static ValueOrBinding<TProp> Property<TControl, TProp>(this IStyleMatchContext<TControl> c, Expression<Func<TControl, TProp>> pp)
     {
-        var property = ReflectionUtils.GetDotvvmPropertyFromExpression(pp);
+        var property = DotvvmPropertyUtils.GetDotvvmPropertyFromExpression(pp);
+        return c.Property<TProp>(property);
+    }
+
+    /// <summary> Gets the property value or null if it's not defined. </summary>
+    public static ValueOrBinding<TProp> Property<TControl, TProp>(this IStyleMatchContext<TControl> c, Expression<Func<TControl, ValueOrBinding<TProp>>> pp)
+    {
+        var property = DotvvmPropertyUtils.GetDotvvmPropertyFromExpression(pp);
         return c.Property<TProp>(property);
     }
 

--- a/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
+++ b/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
@@ -18,7 +18,7 @@ namespace DotVVM.Framework.Controls
         /// <summary> Gets the DotvvmProperty referenced by the lambda expression. </summary>
         public static DotvvmProperty GetDotvvmProperty<TControl, TProperty>(this TControl control, Expression<Func<TControl, TProperty>> prop)
             where TControl : DotvvmBindableObject =>
-            ReflectionUtils.GetDotvvmPropertyFromExpression(prop);
+            DotvvmPropertyUtils.GetDotvvmPropertyFromExpression(prop);
         /// <summary> Gets the DotvvmProperty with the specified name.  </summary>
         public static DotvvmProperty GetDotvvmProperty<TControl>(this TControl control, string propName)
             where TControl : DotvvmBindableObject
@@ -282,7 +282,16 @@ namespace DotVVM.Framework.Controls
             => control.GetValueOrBinding<TProperty>(control.GetDotvvmProperty(prop));
 
         /// <summary> Gets the specified control capability - reads all the properties in the capability at once. Throws if this control does not support the capability. </summary>
-        public static TCapability GetCapability<TCapability>(this DotvvmBindableObject control, string prefix = "")
+        public static TCapability GetCapability<TCapability>(this DotvvmBindableObject control)
+        {
+            var c = DotvvmCapabilityProperty.Find(control.GetType(), typeof(TCapability));
+            if (c is null)
+                throw new Exception($"Capability {typeof(TCapability)} is not defined on {control.GetType()}, or it's not uniquely determined");
+            return (TCapability)c.GetValue(control)!;
+        }
+
+        /// <summary> Gets the specified control capability - reads all the properties in the capability at once. Throws if this control does not support the capability. </summary>
+        public static TCapability GetCapability<TCapability>(this DotvvmBindableObject control, string prefix)
         {
             var c = DotvvmCapabilityProperty.Find(control.GetType(), typeof(TCapability), prefix);
             if (c is null)

--- a/src/Framework/Framework/Utils/ReflectionUtils.cs
+++ b/src/Framework/Framework/Utils/ReflectionUtils.cs
@@ -20,6 +20,7 @@ using DotVVM.Framework.Binding;
 
 namespace DotVVM.Framework.Utils
 {
+
     public static class ReflectionUtils
     {
         /// <summary>
@@ -28,8 +29,9 @@ namespace DotVVM.Framework.Utils
         public static MemberInfo GetMemberFromExpression(Expression expression)
         {
             var originalExpression = expression;
-            if (expression is LambdaExpression lambda)
-                expression = lambda.Body;
+            if (expression.NodeType == ExpressionType.Lambda)
+                expression = ((LambdaExpression)expression).Body;
+
             while (expression is UnaryExpression unary)
                 expression = unary.Operand;
 
@@ -39,14 +41,6 @@ namespace DotVVM.Framework.Utils
                 throw new NotSupportedException($"Cannot get member from {originalExpression}");
 
             return body.Member;
-        }
-
-        public static DotvvmProperty GetDotvvmPropertyFromExpression(Expression expression)
-        {
-            var prop = GetMemberFromExpression(expression);
-            return DotvvmProperty.ResolveProperty(prop.DeclaringType!, prop.Name) ??
-                throw new Exception($"Property '{prop.DeclaringType!.Name}.{prop.Name}' is not a registered DotvvmProperty.");
-
         }
 
         // http://haacked.com/archive/2012/07/23/get-all-types-in-an-assembly.aspx/

--- a/src/Tests/ControlTests/ServerSideStyleTests.cs
+++ b/src/Tests/ControlTests/ServerSideStyleTests.cs
@@ -209,6 +209,31 @@ namespace DotVVM.Framework.Tests.ControlTests
         }
 
         [TestMethod]
+        public async Task CapabilitySetting()
+        {
+            var cth = createHelper(c => {
+                var dataAttributeName = "data-test2";
+                c.Styles.Register<HtmlGenericControl>(c =>
+                    c.PropertyValue(x => x.GetCapability<HtmlCapability>().Attributes["class"]) as string == "test")
+                    .SetProperty(x => x.Attributes["data-test1"], "true")
+                    .SetProperty(x => x.HtmlCapability.Attributes[dataAttributeName], "also true");
+                // test conversion to/from ValueOrBinding
+                // this is not needed in this case, but might be useful for workarounding some type-parameter magic rough edges
+                c.Styles.Register<HtmlGenericControl>(c =>
+                    c.PropertyValue(x => new ValueOrBinding<object>(x.Attributes["class"])) as string == "test2")
+                    .SetProperty(x => (ValueOrBinding<object>)x.Attributes["data-test1"], "true")
+                    .SetProperty(x => x.HtmlCapability.Attributes[dataAttributeName].ValueOrDefault, "also true");
+            });
+
+            var r = await cth.RunPage(typeof(BasicTestViewModel), @"
+                <div class=test />
+                <div class=test2 />
+            ");
+            check.CheckString(r.FormattedHtml, fileExtension: "html");
+        }
+
+
+        [TestMethod]
         public async Task StyleBindingMapping()
         {
             var cth = createHelper(c => {

--- a/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.CapabilitySetting.html
+++ b/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.CapabilitySetting.html
@@ -1,0 +1,7 @@
+<html>
+	<head></head>
+	<body>
+		<div class="test" data-test1="true" data-test2="also true"></div>
+		<div class="test2" data-test1="true" data-test2="also true"></div>
+	</body>
+</html>


### PR DESCRIPTION
Just basic support to be able to at least get/set properties
only available through capabilities. The API is fairly simple -
it's just an extension of the existing parser from Linq.Expression:
`GetProperty(c => c.Prop)`. Now it allows more complex expressions:

* c => c.Capability.Property
* c => c.PropertyGroup["constant"]
* c => c.PropertyGroup[localVariable]
* c => c.Capability.PropertyGroup["x"]

Note that the same parser is used for the control.SetProperty(..., ...) which
available at runtime, so I tried to not make it very slow.
It might be convenient to use it there as well, but it's not
recommended in performance sensitive scenarios (like in dotvvm controls)