### PR TITLE
Hot reload fixes - disabled when debug=false

### DIFF
--- a/src/Tools/HotReload/AspNetCore/Configuration/DotvvmServiceCollectionExtensions.cs
+++ b/src/Tools/HotReload/AspNetCore/Configuration/DotvvmServiceCollectionExtensions.cs
@@ -26,7 +26,12 @@ namespace DotVVM.Framework.Configuration
             services.Services.AddTransient<ResourceManager>(provider =>
             {
                 var manager = new ResourceManager(provider.GetRequiredService<DotvvmResourceRepository>());
-                manager.AddRequiredResource("dotvvm-hotreload");
+                var config = provider.GetRequiredService<DotvvmConfiguration>();
+                if (config.Debug)
+                {
+                    manager.AddRequiredResource("dotvvm-hotreload");
+                }
+
                 return manager;
             });
 

--- a/src/Tools/HotReload/AspNetCore/Scripts/dotvvm.hotreload.js
+++ b/src/Tools/HotReload/AspNetCore/Scripts/dotvvm.hotreload.js
@@ -16,7 +16,7 @@
             window.location.reload();
         });
         connection.start()
-            .then(function (e) { dotvvm.log.logInfo('DotVVM view hot reload active.', e); })
+            .then(function () { dotvvm.log.logInfo('DotVVM view hot reload active.'); })
             .catch(function (e) { dotvvm.log.logWarning('DotVVM view hot reload error!', e); });
     }
 

--- a/src/Tools/HotReload/Common/HotReloadErrorPageExtension.cs
+++ b/src/Tools/HotReload/Common/HotReloadErrorPageExtension.cs
@@ -14,16 +14,23 @@ namespace DotVVM.HotReload
 
         public string GetHeadContents(IDotvvmRequestContext context, Exception ex)
         {
-            using var textWriter = new StringWriter();
-            var writer = new HtmlWriter(textWriter, context);
-            var renderedResources = new HashSet<string>();
+            if (context.Configuration.Debug)
+            {
+                using var textWriter = new StringWriter();
+                var writer = new HtmlWriter(textWriter, context);
+                var renderedResources = new HashSet<string>();
 
-            RenderResource(context, "dotvvm-hotreload", writer, renderedResources);
+                RenderResource(context, "dotvvm-hotreload", writer, renderedResources);
 
-            return textWriter.ToString();
+                return textWriter.ToString();
+            }
+            else
+            {
+                return string.Empty;
+            }
         }
 
-        private void RenderResource(IDotvvmRequestContext context, string resourceName, HtmlWriter? writer, HashSet<string> renderedResources)
+        private void RenderResource(IDotvvmRequestContext context, string resourceName, HtmlWriter writer, HashSet<string> renderedResources)
         {
             if (renderedResources.Contains(resourceName) || resourceName == "dotvvm") return;
             renderedResources.Add(resourceName);

--- a/src/Tools/HotReload/Common/HotReloadMarkupFileLoader.cs
+++ b/src/Tools/HotReload/Common/HotReloadMarkupFileLoader.cs
@@ -40,10 +40,7 @@ namespace DotVVM.HotReload
                     watcher.Changed += (s, a) => OnFileChanged(configuration, a.FullPath);
                     watcher.Renamed += (s, a) => {
                         // VS doesn't update the actual file, it writes in the temp file, moves the old file away, and then renames the temp file to the original file
-                        if (string.Equals(a.Name, watcher.Filter, Environment.OSVersion.Platform == PlatformID.Win32NT ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
-                        {
-                            OnFileChanged(configuration, a.FullPath);
-                        }
+                        OnFileChanged(configuration, a.FullPath);
                     };
                     watcher.EnableRaisingEvents = true;
                     return watcher;

--- a/src/Tools/HotReload/Owin/Configuration/DotvvmServiceCollectionExtensions.cs
+++ b/src/Tools/HotReload/Owin/Configuration/DotvvmServiceCollectionExtensions.cs
@@ -25,7 +25,12 @@ namespace DotVVM.Framework.Configuration
             services.Services.AddTransient<ResourceManager>(provider =>
             {
                 var manager = new ResourceManager(provider.GetRequiredService<DotvvmResourceRepository>());
-                manager.AddRequiredResource("dotvvm-hotreload");
+                var config = provider.GetRequiredService<DotvvmConfiguration>();
+                if (config.Debug)
+                {
+                    manager.AddRequiredResource("dotvvm-hotreload");
+                }
+
                 return manager;
             });
 

--- a/src/Tools/HotReload/Owin/Scripts/dotvvm.hotreload.js
+++ b/src/Tools/HotReload/Owin/Scripts/dotvvm.hotreload.js
@@ -13,7 +13,7 @@
             window.location.reload();
         };
         $.connection.hub.start()
-            .done(function(e) { dotvvm.log.logInfo('DotVVM view hot reload active.', e); })
+            .done(function() { dotvvm.log.logInfo('DotVVM view hot reload active.'); })
             .fail(function(e) { dotvvm.log.logWarning('DotVVM view hot reload error!', e); });
     }
 


### PR DESCRIPTION
When testing on a real project, I discovered a few issues - especially there was a problem with Visual Studio which doesn't modify the file but performs a series of operations including rename.