### PR TITLE
markup controls: Don't render unused properties

### DIFF
--- a/src/Framework/Framework/Compilation/ControlTree/UsedPropertiesFindingVisitor.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/UsedPropertiesFindingVisitor.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Compilation.ControlTree.Resolved;
+using DotVVM.Framework.Controls;
+
+namespace DotVVM.Framework.Compilation
+{
+    /// <summary> Tracks which control properties are used in this markup control and stores that in <see cref="Internal.UsedPropertiesInfoProperty" /> </summary>
+    class UsedPropertiesFindingVisitor : ResolvedControlTreeVisitor
+    {
+
+        class ExpressionInspectingVisitor: ExpressionVisitor
+        {
+            public List<DotvvmProperty> UsedProperties { get; } = new();
+            public bool UsesViewModel { get; set; }
+            protected override Expression VisitConstant(ConstantExpression node)
+            {
+                if (node.Value is DotvvmProperty property)
+                    UsedProperties.Add(property);
+                return base.VisitConstant(node);
+            }
+            protected override Expression VisitMember(MemberExpression node)
+            {
+                if (typeof(DotvvmProperty).IsAssignableFrom(node.Type) && node.Member is FieldInfo { IsStatic: true } field)
+                    UsedProperties.Add((DotvvmProperty)field.GetValue(null));
+                return base.VisitMember(node);
+            }
+
+            protected override Expression VisitParameter(ParameterExpression node)
+            {
+                if (node.GetParameterAnnotation() is { DataContext: { Parent: null } } annotation)
+                    UsesViewModel = true;
+                return base.VisitParameter(node);
+            }
+        }
+
+        ExpressionInspectingVisitor exprVisitor = new();
+
+        public override void VisitBinding(ResolvedBinding binding)
+        {
+            base.VisitBinding(binding);
+
+            var type = binding.BindingType;
+            if (typeof(IValueBinding).IsAssignableFrom(type) || typeof(IStaticCommandBinding).IsAssignableFrom(type))
+            {
+                exprVisitor.Visit(binding.Expression);
+            }
+        }
+
+        public override void VisitView(ResolvedTreeRoot view)
+        {
+            if (!typeof(DotvvmMarkupControl).IsAssignableFrom(view.Metadata.Type))
+                return;
+
+            base.VisitView(view);
+
+            var info = new ControlUsedPropertiesInfo(exprVisitor.UsedProperties.ToArray(), exprVisitor.UsesViewModel);
+
+            view.SetProperty(new ResolvedPropertyValue(Internal.UsedPropertiesInfoProperty, info));
+        }
+    }
+
+    [HandleAsImmutableObjectInDotvvmPropertyAttribute]
+    sealed record ControlUsedPropertiesInfo(
+        DotvvmProperty[] ClientSideUsedProperties,
+        bool UsesViewModelClientSide
+    );
+}

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlParser.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlParser.cs
@@ -159,7 +159,7 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
             // check element hierarchy
             if (ElementHierarchy.Count > 1)
             {
-                ElementHierarchy.Peek().AddError($"Unexpected end of file! The tag '<{ElementHierarchy.Peek().CastTo<DothtmlElementNode>().TagName}>' was not closed!");
+                ElementHierarchy.Peek().AddError($"Unexpected end of file! The tag '<{ElementHierarchy.Peek().CastTo<DothtmlElementNode>().FullTagName}>' was not closed!");
             }
 
             ResolveParents(root);

--- a/src/Framework/Framework/Controls/DotvvmMarkupControl.cs
+++ b/src/Framework/Framework/Controls/DotvvmMarkupControl.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Linq;
 using DotVVM.Framework.Binding;
 using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Compilation;
 using DotVVM.Framework.Compilation.Javascript;
 using DotVVM.Framework.Compilation.Parser;
 using DotVVM.Framework.Configuration;
@@ -73,7 +74,10 @@ namespace DotVVM.Framework.Controls
         protected override void AddAttributesToRender(IHtmlWriter writer, IDotvvmRequestContext context)
         {
             var properties = new KnockoutBindingGroup();
-            foreach (var p in GetDeclaredProperties())
+            var usedProperties =
+                GetValue<ControlUsedPropertiesInfo>(Internal.UsedPropertiesInfoProperty)?.ClientSideUsedProperties
+                    ?? GetDeclaredProperties();
+            foreach (var p in usedProperties)
             {
                 if (p.DeclaringType.IsAssignableFrom(typeof(DotvvmMarkupControl)))
                     continue;

--- a/src/Framework/Framework/Controls/Internal.cs
+++ b/src/Framework/Framework/Controls/Internal.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using DotVVM.Framework.Binding;
 using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Compilation;
 using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Compilation.ControlTree.Resolved;
 using DotVVM.Framework.Hosting;
@@ -60,6 +61,9 @@ namespace DotVVM.Framework.Controls
 
         public static DotvvmProperty ReferencedViewModuleInfoProperty =
             DotvvmProperty.Register<ViewModuleReferenceInfo, Internal>(() => ReferencedViewModuleInfoProperty);
+
+        public static DotvvmProperty UsedPropertiesInfoProperty =
+            DotvvmProperty.Register<ControlUsedPropertiesInfo, Internal>(() => UsedPropertiesInfoProperty);
 
         public static bool IsViewCompilerProperty(DotvvmProperty property)
         {

--- a/src/Framework/Framework/DependencyInjection/DotVVMServiceCollectionExtensions.cs
+++ b/src/Framework/Framework/DependencyInjection/DotVVMServiceCollectionExtensions.cs
@@ -104,6 +104,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 var requiredGlobalizeControl = controlResolver.ResolveControl(new ResolvedTypeDescriptor(typeof(GlobalizeResource)));
                 o.TreeVisitors.Add(() => new GlobalizeResourceVisitor((ControlResolverMetadata)requiredGlobalizeControl));
                 o.TreeVisitors.Add(() => ActivatorUtilities.CreateInstance<DataContextPropertyAssigningVisitor>(s));
+                o.TreeVisitors.Add(() => new UsedPropertiesFindingVisitor());
                 o.TreeVisitors.Add(() => new LifecycleRequirementsAssigningVisitor());
             });
 

--- a/src/Tests/ControlTests/MarkupControlTests.cs
+++ b/src/Tests/ControlTests/MarkupControlTests.cs
@@ -34,9 +34,9 @@ namespace DotVVM.Framework.Tests.ControlTests
         {
             var r = await cth.RunPage(typeof(BasicTestViewModel), @"
 
-                <cc:CustomControlWithCommand DataContext={value: Integer} Click={staticCommand: s.Save(_parent.Integer)} />
+                <cc:CustomControlWithCommand DataContext={value: Integer} Click={staticCommand: s.Save(_parent.Integer)} Another={value: _this} />
                 <dot:Repeater DataSource={value: Collection}>
-                    <cc:CustomControlWithCommand Click={staticCommand: s.Save(_this)} />
+                    <cc:CustomControlWithCommand Click={staticCommand: s.Save(_this)} Another={value: _root.Integer} />
                 </dot:Repeater>
                 ",
                 directives: $"@service s = {typeof(TestService)}",
@@ -45,7 +45,7 @@ namespace DotVVM.Framework.Tests.ControlTests
                         @viewModel int
                         @baseType DotVVM.Framework.Tests.ControlTests.CustomControlWithCommand
                         @wrapperTag div
-                        <dot:Button Click={staticCommand: _control.Click()} />"
+                        <dot:Button Click={staticCommand: _control.Click()} Text={resource: $'Button with number = {_control.Another}'} />"
                 }
             );
 
@@ -119,6 +119,9 @@ namespace DotVVM.Framework.Tests.ControlTests
     {
         public static readonly DotvvmProperty ClickProperty =
             DotvvmProperty.Register<Command, CustomControlWithCommand>("Click");
+
+        public static readonly DotvvmProperty AnotherProperty =
+            DotvvmProperty.Register<int, CustomControlWithCommand>("Another");
     }
 
     public class CustomControlWithProperty : DotvvmMarkupControl

--- a/src/Tests/ControlTests/testoutputs/MarkupControlTests.MarkupControl_PassingStaticCommand.html
+++ b/src/Tests/ControlTests/testoutputs/MarkupControlTests.MarkupControl_PassingStaticCommand.html
@@ -9,7 +9,7 @@
 			<input onclick="dotvvm.applyPostbackHandlers(async (options) => {
 	let a;
 	return await((a = options.knockoutContext.$control.Click.state) &amp;&amp; a());
-},this).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
+},this).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="Button with number = 10000000">
 		</div>
 		<!-- /ko -->
 		<div data-bind="foreach: { data: Collection }">
@@ -19,7 +19,7 @@
 				<input onclick="dotvvm.applyPostbackHandlers(async (options) => {
 	let a;
 	return await((a = options.knockoutContext.$control.Click.state) &amp;&amp; a());
-},this).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
+},this).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="Button with number = 10000000">
 			</div>
 		</div>
 	</body>

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -661,6 +661,9 @@
       "UniqueID": {
         "type": "System.String"
       },
+      "UsedPropertiesInfo": {
+        "type": "DotVVM.Framework.Compilation.ControlUsedPropertiesInfo, DotVVM.Framework"
+      },
       "UseHistoryApiSpaNavigation": {
         "type": "System.Boolean",
         "isValueInherited": true


### PR DESCRIPTION
Another crack at reducing the amount of bullshit HTML we produce...
Just added a visitor which goes through all client-side bindings
and checks which properties are actually used.
Then, when rendering a markup control, only those will be included.

It also reduces the possibility of invoking arbitrary commands bound to
the markup control.
And it will stop exposing objects which may not be intended for the user.

It is technically a breaking change for people accessing the $control field
manually, but I hope there is not that many of them.