### PR TITLE
Dictionary[X] translation should not return observable

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/collections/dictionaryHelper.ts
+++ b/src/Framework/Framework/Resources/Scripts/collections/dictionaryHelper.ts
@@ -14,7 +14,7 @@ export function getItem<Key, Value>(dictionary: Dictionary<Key, Value>, identifi
         throw Error("Provided key \"" + identifier + "\" is not present in the dictionary!");
     }
 
-    return ko.unwrap(dictionary[index]).Value;
+    return ko.unwrap(ko.unwrap(dictionary[index]).Value);
 }
 
 export function remove<Key, Value>(observable: any, identifier: Key): boolean {


### PR DESCRIPTION
We generally return unwrapped objects from the translations,
but here it was missing. The translated JS assumed that it was
not observable, so it led to bugs.

resolves #1221