### PR TITLE
Add net6.0 target and hot reload handler that flushes various caches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,26 +20,23 @@ jobs:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget
     - uses: actions/checkout@v2
-    - name: Setup .NET Core  5.0.300
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 5.0.300
-    - name: Build Hosting.AspNetCore
-      run: dotnet build src/Framework/Hosting.AspNetCore --no-incremental /WarnAsError --framework net5.0
     - name: Setup .NET Core  ${{ env.DOTNET_VERSION }}
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
+
     - name: Install dependencies
       run: dotnet restore ci/linux/Linux.sln
     - name: Build (without warnings)
       run: dotnet build src/Framework/Framework --configuration Release --no-restore --no-incremental /property:WarningLevel=0
     - name: Build
-      run: dotnet build src/Framework/Framework --configuration Release --no-restore --no-incremental /WarnAsError
+      run: dotnet build src/Framework/Framework --configuration Release --no-restore --no-incremental --framework netstandard2.1 /WarnAsError
     - name: Build (Debug)
-      run: dotnet build src/Framework/Framework --configuration Debug --no-restore --no-incremental /WarnAsError
+      run: dotnet build src/Framework/Framework --configuration Debug --no-restore --no-incremental --framework netstandard2.1 /WarnAsError
     - name: Build Testing
-      run: dotnet build src/Framework/Testing --no-incremental /WarnAsError
+      run: dotnet build src/Framework/Testing --no-incremental --framework netstandard2.1 /WarnAsError
+    - name: Build Hosting.AspNetCore
+      run: dotnet build src/Framework/Hosting.AspNetCore --no-incremental /WarnAsError --framework net5.0
     - name: Build Tracing.MiniProfiler
       run: dotnet build src/Tracing/MiniProfiler.AspNetCore --no-incremental /WarnAsError
     - name: Build Tracing.ApplicationInsights

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Build Tracing.ApplicationInsights
       run: dotnet build src/Tracing/ApplicationInsights.AspNetCore --no-incremental /WarnAsError
     - name: Build Dynamic Data
-      run: dotnet build src/DynamicData/DynamicData --no-incremental /WarnAsError
+      run: dotnet build src/DynamicData/DynamicData --no-incremental --framework netstandard2.1 /WarnAsError
     - name: Build Compiler
       run: dotnet build src/Tools/Compiler --no-incremental /WarnAsError
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,8 +5,8 @@
     <!-- Disable warning for missing XML doc comments. -->
     <NoWarn>$(NoWarn);CS1591;CS1573</NoWarn>
     <LangVersion>9.0</LangVersion>
-    <DefaultTargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.1;net472</DefaultTargetFrameworks>
-    <DefaultTargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.1</DefaultTargetFrameworks>
+    <DefaultTargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.1;net6.0;net472</DefaultTargetFrameworks>
+    <DefaultTargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.1;net6.0</DefaultTargetFrameworks>
     <Version>4.0.0-preview01-122136</Version>
   </PropertyGroup>
 

--- a/src/Framework/Core/DotVVM.Core.csproj
+++ b/src/Framework/Core/DotVVM.Core.csproj
@@ -32,7 +32,6 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
-    <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="System" />

--- a/src/Framework/Framework/Binding/DotvvmProperty.cs
+++ b/src/Framework/Framework/Binding/DotvvmProperty.cs
@@ -426,6 +426,7 @@ namespace DotVVM.Framework.Binding
             }
         }
 
+        // TODO: figure out how to refresh on hot reload
         private static readonly ConcurrentDictionary<(Type, string), DotvvmProperty> registeredProperties = new();
         private static readonly ConcurrentDictionary<(Type, string), DotvvmPropertyAlias> registeredAliases = new();
 

--- a/src/Framework/Framework/Binding/ValueOrBinding.cs
+++ b/src/Framework/Framework/Binding/ValueOrBinding.cs
@@ -82,6 +82,14 @@ namespace DotVVM.Framework.Binding
         [MemberNotNullWhenAttribute(true, "BindingOrDefault", "binding")]
         public bool HasBinding => binding is object;
 
+        /// <summary> Gets a binding or throws an exception if the ValueOrBinding contains a value. </summary>
+        public IBinding GetBinding() =>
+            HasBinding ? binding : throw new DotvvmControlException($"Binding was expected but ValueOrBinding<{typeof(T).Name}> contains a value: {value}.");
+
+        /// <summary> Gets a value from ValueOrBinding or throws an exception if the it contains a binding. To evaluate the binding use the <see cref="Evaluate(DotvvmBindableObject)" /> method. </summary>
+        public T GetValue() =>
+            HasValue ? value : throw new DotvvmControlException($"Value was expected but ValueOrBinding<{typeof(T).Name}> contains a binding: {binding}.") { RelatedBinding = binding };
+
         /// <summary> Returns a ValueOrBinding with new type T which is a base type of the old T2 </summary>
         public static ValueOrBinding<T> DownCast<T2>(ValueOrBinding<T2> createFrom)
             where T2 : T => new ValueOrBinding<T>(createFrom.binding, createFrom.value!);
@@ -147,7 +155,7 @@ namespace DotVVM.Framework.Binding
 
         public static implicit operator ValueOrBinding<T>(T val) => new ValueOrBinding<T>(val);
 
-        public const string EqualsDisabledReason = "Equals is disabled on ValueOrBinding<T> as it may lead to unexpected behavior. Please use object.ReferenceEquals for reference comparison or evalate the ValueOrBinding<T> and compare the value. Or use IsNull/NotNull for nullchecks on bindings.";
+        public const string EqualsDisabledReason = "Equals is disabled on ValueOrBinding<T> as it may lead to unexpected behavior. Please use object.ReferenceEquals for reference comparison or evaluate the ValueOrBinding<T> and compare the value. Or use IsNull/NotNull for nullchecks on bindings.";
         [Obsolete(EqualsDisabledReason, error: true)]
         public static bool operator ==(ValueOrBinding<T> a, ValueOrBinding<T> b) =>
             throw new NotSupportedException(EqualsDisabledReason);

--- a/src/Framework/Framework/Compilation/ControlTree/LifecycleRequirementsAssigningVisitor.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/LifecycleRequirementsAssigningVisitor.cs
@@ -47,5 +47,12 @@ namespace DotVVM.Framework.Compilation.ControlTree
                     control.SetProperty(new ResolvedPropertyValue(CompileTimeLifecycleRequirementsProperty, value));
             }
         }
+
+        /// <summary> Clear cache when hot reload happens </summary>
+        internal static void ClearCaches(Type[] types)
+        {
+            foreach (var t in types)
+                requirementsCache.TryRemove(t, out _);
+        }
     }
 }

--- a/src/Framework/Framework/Compilation/ExtensionMethodsCache.cs
+++ b/src/Framework/Framework/Compilation/ExtensionMethodsCache.cs
@@ -22,6 +22,8 @@ namespace DotVVM.Framework.Compilation
         {
             this.assemblyCache = assemblyCache;
             this.methodsCache = new ConcurrentDictionary<string, ImmutableArray<MethodInfo>>();
+
+            HotReloadMetadataUpdateHandler.ExtensionMethodsCaches.Add(new(this));
         }
 
         public IEnumerable<MethodInfo> GetExtensionsForNamespaces(string[] @namespaces)
@@ -81,5 +83,13 @@ namespace DotVVM.Framework.Compilation
 
             return results.Select(x => x.ToImmutableArray()).ToArray();
         }
+
+        /// <summary> Clear cache when hot reload happens </summary>
+        internal void ClearCaches(Type[] types)
+        {
+            foreach (var t in types)
+                methodsCache.TryRemove(t.Namespace, out _);
+        }
+
     }
 }

--- a/src/Framework/Framework/Compilation/Styles/StyleMatcher.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleMatcher.cs
@@ -96,6 +96,14 @@ namespace DotVVM.Framework.Compilation.Styles
                     ).ToImmutableArray();
             });
 
+        /// <summary> Clear cache when hot reload happens </summary>
+        internal static void ClearCaches(Type[] types)
+        {
+            foreach (var t in types)
+                implicitStyles.TryRemove(t, out _);
+        }
+
+
         class GenericStyle : IStyle
         {
             public Type ControlType { get; }

--- a/src/Framework/Framework/Compilation/Validation/DefaultControlUsageValidator.cs
+++ b/src/Framework/Framework/Compilation/Validation/DefaultControlUsageValidator.cs
@@ -121,5 +121,12 @@ namespace DotVVM.Framework.Compilation.Validation
             var type = metadata.Type as ResolvedTypeDescriptor;
             return type?.Type;
         }
+
+        /// <summary> Clear cache when hot reload happens </summary>
+        internal static void ClearCaches(Type[] types)
+        {
+            foreach (var t in types)
+                cache.TryRemove(t, out _);
+        }
     }
 }

--- a/src/Framework/Framework/Configuration/UserColumnMappingCache.cs
+++ b/src/Framework/Framework/Configuration/UserColumnMappingCache.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using DotVVM.Framework.Controls;
+using DotVVM.Framework.Runtime;
 using DotVVM.Framework.ViewModel;
 using DotVVM.Framework.ViewModel.Serialization;
 
@@ -18,7 +19,9 @@ namespace DotVVM.Framework.Configuration
         public UserColumnMappingCache(IViewModelSerializationMapper serializationMapper)
         {
             this.serializationMapper = serializationMapper;
-            this.mappingCache = new ConcurrentDictionary<Type, Dictionary<string, string>>();       
+            this.mappingCache = new ConcurrentDictionary<Type, Dictionary<string, string>>();    
+
+            HotReloadMetadataUpdateHandler.UserColumnMappingCaches.Add(new(this));
         }
 
         public IReadOnlyDictionary<string, string> GetMapping(Type type)
@@ -40,6 +43,13 @@ namespace DotVVM.Framework.Configuration
             }
             mappingCache.TryAdd(type, columnsMapping);
             return columnsMapping;
+        }
+
+        /// <summary> Clear cache when hot reload happens </summary>
+        internal void ClearCaches(Type[] types)
+        {
+            foreach (var t in types)
+                mappingCache.TryRemove(t, out _);
         }
     }
 }

--- a/src/Framework/Framework/Controls/CompositeControl.cs
+++ b/src/Framework/Framework/Controls/CompositeControl.cs
@@ -35,6 +35,8 @@ namespace DotVVM.Framework.Controls
                 Properties = properties;
             }
         }
+
+        // TODO: clear on hot reload
         private static ConcurrentDictionary<Type, ControlInfo> controlInfoCache = new ConcurrentDictionary<Type, ControlInfo>();
 
         private static object registrationLock = new object();

--- a/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
+++ b/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
@@ -23,7 +23,8 @@ namespace DotVVM.Framework.Controls
         public static DotvvmProperty GetDotvvmProperty<TControl>(this TControl control, string propName)
             where TControl : DotvvmBindableObject
         {
-            return DotvvmProperty.ResolveProperty(typeof(TControl), propName) ?? throw new Exception($"Property '{typeof(TControl)}.{propName}' is not a registered DotvvmProperty.");
+            var type = control.GetType();
+            return DotvvmProperty.ResolveProperty(type, propName) ?? throw new Exception($"Property '{type}.{propName}' is not a registered DotvvmProperty.");
         }
 
         /// <summary> Sets binding into the DotvvmProperty referenced in the lambda expression. Returns <paramref name="control"/> for fluent API usage. </summary>
@@ -280,6 +281,28 @@ namespace DotVVM.Framework.Controls
         public static ValueOrBinding<TProperty> GetValueOrBinding<TControl, TProperty>(this TControl control, Expression<Func<TControl, TProperty>> prop)
             where TControl : DotvvmBindableObject
             => control.GetValueOrBinding<TProperty>(control.GetDotvvmProperty(prop));
+
+        /// <summary> Returns the value of dotvvm with the specified name. If the property contains a binding, it is evaluted. </summary>
+        [return: MaybeNull]
+        public static TProperty GetValue<TProperty>(this DotvvmBindableObject control, string propName)
+            => control.GetValue<TProperty>(control.GetDotvvmProperty(propName));
+
+        /// <summary> Returns the value of dotvvm with the specified name. If the property contains a binding, it is evaluted. </summary>
+        [return: MaybeNull]
+        public static ValueOrBinding<TProperty> GetValueOrBinding<TProperty>(this DotvvmBindableObject control, string propName)
+            => control.GetValueOrBinding<TProperty>(control.GetDotvvmProperty(propName));
+            
+        /// <summary>
+        /// Gets the value binding set to dotvvm property of the specified <paramref name="propName" />. Returns null if the property is not a binding, throws if the binding some kind of command.
+        /// </summary>
+        public static IValueBinding<TProperty>? GetValueBinding<TProperty>(this DotvvmBindableObject control, string propName)
+            => (IValueBinding<TProperty>?)control.GetValueBinding(control.GetDotvvmProperty(propName));
+
+        /// <summary>
+        /// Gets the command binding set to the dotvvm property of the specified <paramref name="propName" />. Returns null if the property is not a binding, throws if the binding is not command, controlCommand or staticCommand.
+        /// </summary>
+        public static ICommandBinding<TProperty>? GetCommandBinding<TProperty>(this DotvvmBindableObject control, string propName)
+            => (ICommandBinding<TProperty>?)control.GetCommandBinding(control.GetDotvvmProperty(propName));
 
         /// <summary> Gets the specified control capability - reads all the properties in the capability at once. Throws if this control does not support the capability. </summary>
         public static TCapability GetCapability<TCapability>(this DotvvmBindableObject control)

--- a/src/Framework/Framework/DotVVM.Framework.csproj
+++ b/src/Framework/Framework/DotVVM.Framework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>DotVVM</AssemblyTitle>
-    <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultTargetFrameworks);net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>dotvvmwizard.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -57,18 +57,12 @@
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
     <PackageReference Include="FastExpressionCompiler" Version="3.2.1" />
-   <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.1" />
     <PackageReference Include="RecordException" Version="0.1.2" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
     <PackageReference Include="System.CodeDom" Version="4.4.0" />
-    <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="System.Security.Claims" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
@@ -76,6 +70,7 @@
     <PackageReference Include="DotNext.Metaprogramming" Version="1.2.9" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <Reference Include="System" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.Net.Http" />
@@ -83,9 +78,6 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
-    <None Update="Controls\DelegateTemplate.d.ts">
-      <DependentUpon>DelegateTemplate.cs</DependentUpon>
-    </None>
     <None Update="ResourceManagement\ClientGlobalize\JQueryGlobalizeRegisterTemplate.tt">
       <Generator>TextTemplatingFilePreprocessor</Generator>
       <LastGenOutput>JQueryGlobalizeRegisterTemplate.cs</LastGenOutput>

--- a/src/Framework/Framework/DotVVM.Framework.csproj
+++ b/src/Framework/Framework/DotVVM.Framework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>DotVVM</AssemblyTitle>
-    <TargetFrameworks>$(DefaultTargetFrameworks);net6.0</TargetFrameworks>
+    <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>dotvvmwizard.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/src/Framework/Framework/NullableAttributes.cs
+++ b/src/Framework/Framework/NullableAttributes.cs
@@ -144,7 +144,8 @@ namespace System.Diagnostics.CodeAnalysis
     }
 
 #endif
- 
+
+#if !NET5_0_OR_GREATER
     /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
     internal sealed class MemberNotNullWhenAttribute : Attribute
@@ -181,9 +182,12 @@ namespace System.Diagnostics.CodeAnalysis
         /// <summary>Gets field or property member names.</summary>
         public string[] Members { get; }
     }
+#endif
 }
 
+#if !NET5_0_OR_GREATER
 namespace System.Runtime.CompilerServices
 {
     internal class IsExternalInit: Attribute { }
 }
+#endif

--- a/src/Framework/Framework/Runtime/AttributeViewModelParameterBinder.cs
+++ b/src/Framework/Framework/Runtime/AttributeViewModelParameterBinder.cs
@@ -17,13 +17,8 @@ namespace DotVVM.Framework.Runtime
     public class AttributeViewModelParameterBinder : IViewModelParameterBinder
     {
 
-        private readonly ConcurrentDictionary<Type, Action<IDotvvmRequestContext, object>?> cache = new ConcurrentDictionary<Type, Action<IDotvvmRequestContext, object>?>();
-        private readonly MethodInfo setPropertyMethod;
-
-        public AttributeViewModelParameterBinder()
-        {
-            setPropertyMethod = typeof(AttributeViewModelParameterBinder).GetMethod(nameof(SetProperty), BindingFlags.NonPublic | BindingFlags.Static).NotNull();
-        }
+        private static readonly ConcurrentDictionary<Type, Action<IDotvvmRequestContext, object>?> cache = new ConcurrentDictionary<Type, Action<IDotvvmRequestContext, object>?>();
+        private static readonly MethodInfo setPropertyMethod = typeof(AttributeViewModelParameterBinder).GetMethod(nameof(SetProperty), BindingFlags.NonPublic | BindingFlags.Static).NotNull();
 
         /// <summary>
         /// Performs the parameter binding.
@@ -37,7 +32,7 @@ namespace DotVVM.Framework.Runtime
         /// <summary>
         /// Builds a lambda expression which performs the parameter binding for a specified viewmodel type.
         /// </summary>
-        private Action<IDotvvmRequestContext, object>? BuildParameterBindingMethod(Type type)
+        private static Action<IDotvvmRequestContext, object>? BuildParameterBindingMethod(Type type)
         {
             var properties = FindPropertiesWithParameterBinding(type).ToList();
             if (!properties.Any())
@@ -57,7 +52,7 @@ namespace DotVVM.Framework.Runtime
         /// <summary>
         /// Looks up for all properties to be bound.
         /// </summary>
-        private Dictionary<PropertyInfo, ParameterBindingAttribute> FindPropertiesWithParameterBinding(Type type)
+        private static Dictionary<PropertyInfo, ParameterBindingAttribute> FindPropertiesWithParameterBinding(Type type)
         {
             return (from prop in type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
                     let attribute = prop.GetCustomAttribute<ParameterBindingAttribute>()
@@ -68,7 +63,7 @@ namespace DotVVM.Framework.Runtime
                     .ToDictionary(p => p.writableProp, p => p.attribute);
         }
 
-        private PropertyInfo TryFindWritableSetter(PropertyInfo propertyInfo)
+        private static PropertyInfo TryFindWritableSetter(PropertyInfo propertyInfo)
         {
             // when the property is declared in the base class and has private set, we need to find the property on the base class to see the SetMethod
             if (propertyInfo.CanWrite)
@@ -85,7 +80,7 @@ namespace DotVVM.Framework.Runtime
         /// <summary>
         /// Generates an expression which calls the <see cref="SetProperty{T}"/> method to perform the parameter binding.
         /// </summary>
-        private Expression GenerateParameterBindStatement(Type viewModelType, Expression viewModelParameter, Expression contextParameter, KeyValuePair<PropertyInfo, ParameterBindingAttribute> property)
+        private static Expression GenerateParameterBindStatement(Type viewModelType, Expression viewModelParameter, Expression contextParameter, KeyValuePair<PropertyInfo, ParameterBindingAttribute> property)
         {
             var propAccess = Expression.Property(Expression.Convert(viewModelParameter, viewModelType), property.Key);
             var methodCall = Expression.Call(null, setPropertyMethod.MakeGenericMethod(property.Key.PropertyType), contextParameter, Expression.Constant(property.Value), propAccess);
@@ -102,6 +97,15 @@ namespace DotVVM.Framework.Runtime
                 return result;
             }
             return defaultValue;
+        }
+
+        /// <summary> Clear cache when hot reload happens </summary>
+        internal static void ClearCaches(Type[] types)
+        {
+            foreach (var t in types)
+            {
+                cache.TryRemove(t, out _);
+            }
         }
     }
 }

--- a/src/Framework/Framework/Runtime/Filters/ActionFilterHelper.cs
+++ b/src/Framework/Framework/Runtime/Filters/ActionFilterHelper.cs
@@ -25,5 +25,12 @@ namespace DotVVM.Framework.Runtime.Filters
                 return result.ToArray();
             });
         }
+
+        /// <summary> Clear cache when hot reload happens </summary>
+        internal static void ClearCaches(Type[] types)
+        {
+            // this cache is cheap enough to regenerate, so we won't bother too much
+            cache_GetActionFilters.Clear();
+        }
     }
 }

--- a/src/Framework/Framework/Runtime/HotReloadMetadataUpdateHandler.cs
+++ b/src/Framework/Framework/Runtime/HotReloadMetadataUpdateHandler.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using DotVVM.Framework.Compilation;
+using DotVVM.Framework.Compilation.ControlTree;
+using DotVVM.Framework.Compilation.Styles;
+using DotVVM.Framework.Compilation.Validation;
+using DotVVM.Framework.Configuration;
+using DotVVM.Framework.Runtime.Filters;
+using DotVVM.Framework.Utils;
+using DotVVM.Framework.ViewModel;
+using DotVVM.Framework.ViewModel.Serialization;
+#if NET6_0_OR_GREATER
+[assembly: System.Reflection.Metadata.MetadataUpdateHandler(typeof(DotVVM.Framework.Runtime.HotReloadMetadataUpdateHandler))]
+#endif
+namespace DotVVM.Framework.Runtime
+{
+    public static class HotReloadMetadataUpdateHandler
+    {
+        internal static readonly ConcurrentBag<WeakReference<ViewModelSerializationMapper>> SerializationMappers = new();
+        internal static readonly ConcurrentBag<WeakReference<UserColumnMappingCache>> UserColumnMappingCaches = new();
+        internal static readonly ConcurrentBag<WeakReference<ExtensionMethodsCache>> ExtensionMethodsCaches = new();
+        public static void ClearCache(Type[]? updatedTypes)
+        {
+            if (updatedTypes is null or { Length: 0})
+                return;
+
+            var problematicTypes = new HashSet<Type>();
+            foreach (var sRef in SerializationMappers)
+            {
+                if (sRef.TryGetTarget(out var s))
+                    foreach (var u in updatedTypes)
+                    {
+                        if (!s.ClearCache(u))
+                            problematicTypes.Add(u);
+                    }
+            }
+            foreach (var cRef in UserColumnMappingCaches)
+            {
+                if (cRef.TryGetTarget(out var c))
+                    c.ClearCaches(updatedTypes);
+            }
+            foreach (var eRef in UserColumnMappingCaches)
+            {
+                if (eRef.TryGetTarget(out var e))
+                    e.ClearCaches(updatedTypes);
+            }
+
+            ViewModelTypeMetadataSerializer.ClearCaches(updatedTypes);
+            DefaultViewModelLoader.ClearCaches(updatedTypes);
+            AttributeViewModelParameterBinder.ClearCaches(updatedTypes);
+            ChildViewModelsCache.ClearCaches(updatedTypes);
+            ActionFilterHelper.ClearCaches(updatedTypes);
+            AttributeViewModelParameterBinder.ClearCaches(updatedTypes);
+            DefaultControlUsageValidator.ClearCaches(updatedTypes);
+            StyleMatcher.ClearCaches(updatedTypes);
+            LifecycleRequirementsAssigningVisitor.ClearCaches(updatedTypes);
+            ReflectionUtils.ClearCaches(updatedTypes);
+
+            if (problematicTypes.Count > 0)
+            {
+                // yea, Console.WriteLine is the only way how to let the developer know AFAIK
+                Console.WriteLine("DotVVM Hot Reload has a problem, we could not refresh metadata for these types: " + string.Join(", ", problematicTypes.Select(t => t.FullName)));
+            }
+        }
+        // public static void UpdateApplication(Type[]? updatedTypes)
+        // {
+        //     if (updatedTypes is null or { Length: 0})
+        //         return;
+        // }
+    }
+}

--- a/src/Framework/Framework/Utils/ReflectionUtils.cs
+++ b/src/Framework/Framework/Utils/ReflectionUtils.cs
@@ -370,7 +370,7 @@ namespace DotVVM.Framework.Utils
                 return type.GetGenericArguments()[0];
             else if (typeof(Task).IsAssignableFrom(type))
                 return typeof(void);
-#if NETSTANDARD2_1
+#if DotNetCore
             else if (type.IsGenericType && typeof(ValueTask<>).IsAssignableFrom(type.GetGenericTypeDefinition()))
                 return type.GetGenericArguments()[0];
 #endif
@@ -453,6 +453,16 @@ namespace DotVVM.Framework.Utils
                 }
             }
             return name;
+        }
+
+        /// <summary> Clear cache when hot reload happens </summary>
+        internal static void ClearCaches(Type[] types)
+        {
+            foreach (var t in types)
+            {
+                delegateInvokeCache.TryRemove(t, out _);
+                cache_GetTypeHash.TryRemove(t, out _);
+            }
         }
     }
 }

--- a/src/Framework/Framework/ViewModel/ChildViewModelsCache.cs
+++ b/src/Framework/Framework/ViewModel/ChildViewModelsCache.cs
@@ -52,5 +52,15 @@ namespace DotVVM.Framework.ViewModel
 
         public static ParametrizedCode GetViewModelClientPath(IDotvvmViewModel viewModel) =>
             viewModelPaths.TryGetValue(viewModel, out var p) ? p : p;
+
+        /// <summary> Clear cache when hot reload happens </summary>
+        internal static void ClearCaches(Type[] types)
+        {
+            foreach (var t in types)
+            {
+                childViewModelsCollectionCache.TryRemove(t, out _);
+                childViewModelsPropertiesCache.TryRemove(t, out _);
+            }
+        }
     }
 }

--- a/src/Framework/Framework/ViewModel/Serialization/DefaultViewModelLoader.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/DefaultViewModelLoader.cs
@@ -40,5 +40,12 @@ namespace DotVVM.Framework.ViewModel.Serialization
         {
             (instance as IDisposable)?.Dispose();
         }
+
+        /// <summary> Clear cache when hot reload happens </summary>
+        internal static void ClearCaches(Type[] types)
+        {
+            foreach (var t in types)
+                factoryCache.TryRemove(t, out _);
+        }
     }
 }

--- a/src/Framework/Framework/ViewModel/Serialization/ViewModelSerializationMap.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/ViewModelSerializationMap.cs
@@ -28,6 +28,9 @@ namespace DotVVM.Framework.ViewModel.Serialization
         public IEnumerable<ViewModelPropertyMap> Properties { get; private set; }
 
 
+        /// <summary> Rough structure of Properties when the object was initialized. This is used for hot reload to judge if it can be flushed from the cache. </summary>
+        internal (string name, Type t, Direction direction, ProtectMode protection)[] OriginalProperties { get; private set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ViewModelSerializationMap"/> class.
         /// </summary>
@@ -36,6 +39,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
             this.configuration = configuration;
             Type = type;
             Properties = properties.ToList();
+            OriginalProperties = Properties.Select(p => (p.Name, p.Type, p.BindDirection, p.ViewModelProtection)).ToArray();
         }
 
         public void ResetFunctions()

--- a/src/Framework/Framework/ViewModel/Serialization/ViewModelTypeMetadataSerializer.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/ViewModelTypeMetadataSerializer.cs
@@ -274,6 +274,15 @@ namespace DotVVM.Framework.ViewModel.Serialization
             public static bool operator ==(ViewModelSerializationMapWithCulture left, ViewModelSerializationMapWithCulture right) => left.Equals(right);
             public static bool operator !=(ViewModelSerializationMapWithCulture left, ViewModelSerializationMapWithCulture right) => !(left == right);
         }
+
+        /// <summary> Clear caches for the specified types </summary>
+        internal static void ClearCaches(Type[] types)
+        {
+            foreach (var t in types)
+                cachedEnumMetadata.TryRemove(t, out _);
+            
+            // metadata does not have to be cleared, since it will get regenerated in the ViewModelSerializationMapper
+        }
     }
 
 }

--- a/src/Samples/Common/Views/ControlSamples/TemplateHost/CompositeControlWithTemplate.cs
+++ b/src/Samples/Common/Views/ControlSamples/TemplateHost/CompositeControlWithTemplate.cs
@@ -15,7 +15,7 @@ namespace DotVVM.Samples.Common.Views.ControlSamples.TemplateHost
         {
             return new HtmlGenericControl("fieldset")
                 .AppendChildren(
-                    new HtmlGenericControl("legend", new TextOrContentCapability() { Text = headerText }),
+                    new HtmlGenericControl("legend", new TextOrContentCapability(headerText)),
                     new Framework.Controls.TemplateHost() { Template = contentTemplate }
                 );
         }

--- a/src/Tests/Runtime/CapabilityPropertyTests.cs
+++ b/src/Tests/Runtime/CapabilityPropertyTests.cs
@@ -60,6 +60,34 @@ namespace DotVVM.Framework.Tests.Runtime
             );
         }
 
+
+        [TestMethod]
+        public void CapabilityGetterAndSetter1()
+        {
+            var control = new TestControl1 { Something = "X" };
+            Assert.AreEqual(
+                new TestCapability { Something = "X" },
+                control.GetCapability<TestCapability>()
+            );
+            control.SetCapability(new TestCapability { Something = "Y", SomethingElse = "Z" });
+            Assert.AreEqual(
+                new TestCapability { Something = "Y", SomethingElse = "Z" },
+                control.GetCapability<TestCapability>()
+            );
+            Assert.AreEqual("Y", control.Something);
+            Assert.AreEqual("Z", control.GetValue<string>("SomethingElse"));
+            Assert.AreEqual("Z", control.GetValue(c => c.GetCapability<TestCapability>().SomethingElse));
+
+            control.SetCapability(new HtmlCapability { Attributes = { ["attr"] = "a" } });
+            Assert.AreEqual("a", control.Attributes["attr"]);
+            control.AddAttribute("class", "x");
+            control.AddAttribute("class", "y");
+            var attrs = control.GetValue(c => c.GetCapability<HtmlCapability>()).Attributes;
+            Assert.AreEqual("x y", attrs["class"].GetValue());
+            Assert.AreEqual("a", attrs["attr"].GetValue());
+            Assert.AreEqual("x y", control.GetValue(c => c.GetCapability<HtmlCapability>().Attributes["class"].ValueOrDefault));
+        }
+
         public class TestControl1:
             HtmlGenericControl,
             IObjectWithCapability<HtmlCapability>,
@@ -106,16 +134,16 @@ namespace DotVVM.Framework.Tests.Runtime
         [DotvvmControlCapability]
         public sealed record TestCapability
         {
-            public string Something { get; set; } = "kokosovina";
-            public string SomethingElse { get; set; } = "baf";
+            public string Something { get; init; } = "kokosovina";
+            public string SomethingElse { get; init; } = "baf";
         }
 
         [DotvvmControlCapability]
-        public sealed class TestNestedCapability
+        public sealed record TestNestedCapability
         {
-            public string Something { get; set; } = "abc";
-            public TestCapability Test { get; set; }
-            public HtmlCapability Html { get; set; }
+            public string Something { get; init; } = "abc";
+            public TestCapability Test { get; init; }
+            public HtmlCapability Html { get; init; }
         }
 
     }


### PR DESCRIPTION
It's by no means bullet-proof, but it's most likely going to fail in .NET
sooner than in DotVVM, so we are fine.

It enables adding properties to viewmodel and then using them in
a dothtml page. Everything else I tried lead to .NET saying "rude edit"