### PR TITLE
Improve startup and compilation performance slightly

### DIFF
--- a/src/Framework/Framework/Binding/BindingCompilationService.cs
+++ b/src/Framework/Framework/Binding/BindingCompilationService.cs
@@ -42,29 +42,13 @@ namespace DotVVM.Framework.Binding
         }
 
         BindingResolverCollection resolvers = new BindingResolverCollection(Enumerable.Empty<Delegate>());
-        [ThreadStatic]
-        private static bool LookingForResolvers = false;
-
-        private BindingResolverCollection? GetAdditionalResolvers(IBinding binding)
-        {
-            if (LookingForResolvers) return null;
-            try
-            {
-                LookingForResolvers = true;
-                return binding.GetProperty<BindingResolverCollection>(ErrorHandlingMode.ReturnNull);
-            }
-            finally
-            {
-                LookingForResolvers = false;
-            }
-        }
 
         public virtual object ComputeProperty(Type type, IBinding binding)
         {
             if (type == typeof(BindingCompilationService)) return this;
             if (type.IsAssignableFrom(binding.GetType())) return binding;
 
-            var additionalResolvers = GetAdditionalResolvers(binding);
+            var additionalResolvers = binding.GetAdditionalResolvers();
             var bindingResolvers = GetResolversForBinding(binding.GetType());
 
             var resolver = additionalResolvers?.FindResolver(type) ??

--- a/src/Framework/Framework/Binding/BindingHelper.cs
+++ b/src/Framework/Framework/Binding/BindingHelper.cs
@@ -223,6 +223,7 @@ namespace DotVVM.Framework.Binding
             var action = binding.GetCommandDelegate(control);
             if (action is Command command) return command();
             if (action is Action actionDelegate) { actionDelegate(); return null; }
+            if (action is Func<Task> command2) return command2();
 
             var parameters = action.GetType().GetMethod("Invoke")!.GetParameters();
             var evaluatedArgs = args.Zip(parameters, (a, p) => a(p.ParameterType)).ToArray();

--- a/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
+++ b/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
@@ -12,6 +12,7 @@ using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.Runtime;
 using DotVVM.Framework.Utils;
+using FastExpressionCompiler;
 
 namespace DotVVM.Framework.Binding
 {
@@ -235,8 +236,8 @@ namespace DotVVM.Framework.Binding
             }
 
             var accessors = CodeGeneration.CreateCapabilityAccessors(resultProperty);
-            resultProperty.Getter = accessors.getter.Compile();
-            resultProperty.Setter = accessors.setter.Compile();
+            resultProperty.Getter = accessors.getter.CompileFast(flags: CompilerFlags.ThrowOnNotSupportedExpression);
+            resultProperty.Setter = accessors.setter.CompileFast(flags: CompilerFlags.ThrowOnNotSupportedExpression);
         }
 
         private static readonly ParameterExpression currentControlParameter = Expression.Parameter(typeof(DotvvmBindableObject), "control");

--- a/src/Framework/Framework/Binding/DotvvmProperty.cs
+++ b/src/Framework/Framework/Binding/DotvvmProperty.cs
@@ -142,10 +142,18 @@ namespace DotVVM.Framework.Binding
             InitializeProperty(this);
         }
 
-        public IEnumerable<T> GetAttributes<T>() =>
-            AttributeProvider.GetCustomAttributes<T>().Concat(
-                PropertyInfo?.GetCustomAttributes<T>() ?? Enumerable.Empty<T>()
-            );
+        public T[] GetAttributes<T>()
+        {
+            if (PropertyInfo == null)
+                return AttributeProvider.GetCustomAttributes<T>();
+            if (object.ReferenceEquals(AttributeProvider, PropertyInfo))
+                return PropertyInfo.GetCustomAttributes<T>();
+            var attrA = AttributeProvider.GetCustomAttributes<T>();
+            var attrB = PropertyInfo.GetCustomAttributes<T>();
+            if (attrA.Length == 0) return attrB;
+            if (attrB.Length == 0) return attrA;
+            return attrA.Concat(attrB).ToArray();
+        }
 
         public bool IsOwnedByCapability(Type capability) =>
             (this is DotvvmCapabilityProperty && this.PropertyType == capability) ||

--- a/src/Framework/Framework/Binding/Expressions/IBinding.cs
+++ b/src/Framework/Framework/Binding/Expressions/IBinding.cs
@@ -12,6 +12,8 @@ namespace DotVVM.Framework.Binding.Expressions
     public interface IBinding
     {
         object? GetProperty(Type type, ErrorHandlingMode errorMode = ErrorHandlingMode.ThrowException);
+
+        BindingResolverCollection? GetAdditionalResolvers();
         //IDictionary<Type, object> Properties { get; }
         //IList<Delegate> AdditionalServices { get; }
     }

--- a/src/Framework/Framework/Binding/IExpressionToDelegateCompiler.cs
+++ b/src/Framework/Framework/Binding/IExpressionToDelegateCompiler.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Text;
+using DotVVM.Framework.Configuration;
+using FastExpressionCompiler;
+
 namespace DotVVM.Framework.Binding
 {
     public interface IExpressionToDelegateCompiler
@@ -11,6 +14,24 @@ namespace DotVVM.Framework.Binding
 
     public class DefaultExpressionToDelegateCompiler : IExpressionToDelegateCompiler
     {
-        public Delegate Compile(LambdaExpression expression) => expression.Compile();
+        readonly bool interpret;
+        public DefaultExpressionToDelegateCompiler(DotvvmConfiguration config)
+        {
+            interpret = config.Debug;
+        }
+        public Delegate Compile(LambdaExpression expression) =>
+            interpret ? expression.Compile(preferInterpretation: interpret) :
+            expression.Compile();
+        // TODO: use FastExpressionCompiler
+        // we can't do that atm since it still has some bugs, when these are fixed we should use that for all bindings
+        // {
+        //     var x = expression.CompileFast(flags: CompilerFlags.ThrowOnNotSupportedExpression | CompilerFlags.EnableDelegateDebugInfo);
+        //     var di = x.Target as IDelegateDebugInfo;
+
+        //     Console.WriteLine(di.CSharpString);
+        //     Console.WriteLine(di.ExpressionString);
+
+        //     return x;
+        // }
     }
 }

--- a/src/Framework/Framework/Compilation/Binding/BindingExpressionBuilder.cs
+++ b/src/Framework/Framework/Compilation/Binding/BindingExpressionBuilder.cs
@@ -78,14 +78,15 @@ namespace DotVVM.Framework.Compilation.Binding
         {
             var namespaces = dataContext.Enumerable().Select(t => t?.Namespace).Except(new[] { "System", null }).Distinct();
             return reg.AddSymbols(new[] {
-                // ViewModel is alias for current viewmodel type
-                new KeyValuePair<string, Expression>("ViewModel", TypeRegistry.CreateStatic(dataContext.DataContextType)),
-                // RootViewModel alias for root view model type
-                new KeyValuePair<string, Expression>("RootViewModel", TypeRegistry.CreateStatic(dataContext.Enumerable().Last())),
-            })
-            // alias for any viewModel in hierarchy :
-            .AddSymbols(dataContext.Enumerable()
-                .Select((t, i) => new KeyValuePair<string, Expression>($"Parent{i}ViewModel", TypeRegistry.CreateStatic(t))))
+                    // ViewModel is alias for current viewmodel type
+                    new KeyValuePair<string, Expression>("ViewModel", TypeRegistry.CreateStatic(dataContext.DataContextType)),
+                    // RootViewModel alias for root view model type
+                    new KeyValuePair<string, Expression>("RootViewModel", TypeRegistry.CreateStatic(dataContext.Enumerable().Last())),
+                }.Concat(
+                    // alias for any viewModel in hierarchy :
+                    dataContext.Enumerable()
+                    .Select((t, i) => new KeyValuePair<string, Expression>($"Parent{i}ViewModel", TypeRegistry.CreateStatic(t))))
+            )
             // import all viewModel namespaces
             .AddSymbols(namespaces.Select(ns => (Func<string, Expression?>)(typeName => TypeRegistry.CreateStatic(compiledAssemblyCache.FindType(ns + "." + typeName)))));
         }

--- a/src/Framework/Framework/Compilation/Binding/ExpressionBuildingVisitor.cs
+++ b/src/Framework/Framework/Compilation/Binding/ExpressionBuildingVisitor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using DotVVM.Framework.Compilation.Parser.Binding.Parser;
@@ -541,7 +541,7 @@ namespace DotVVM.Framework.Compilation.Binding
             {
                 if (Variables.TryGetValue(name, out var variable))
                     return variable;
-                if (Scope is object && memberExpressionFactory.GetMember(Scope, node.Name, typeParameters, throwExceptions: false, onlyMemberTypes: ResolveOnlyTypeName) is Expression scopeMember)
+                if (Scope is object && memberExpressionFactory.GetMember(Scope, node.Name, typeParameters, throwExceptions: false, onlyMemberTypes: ResolveOnlyTypeName, disableExtensionMethods: true) is Expression scopeMember)
                     return scopeMember;
                 return Registry.Resolve(node.Name, throwOnNotFound: false);
             }

--- a/src/Framework/Framework/Compilation/Binding/ExpressionHelper.cs
+++ b/src/Framework/Framework/Compilation/Binding/ExpressionHelper.cs
@@ -95,7 +95,7 @@ namespace DotVVM.Framework.Compilation.Binding
                 if (throwException)
                 {
                     // throw the exception
-                    Expression.Lambda(result.Expression).Compile().DynamicInvoke();
+                    Expression.Lambda(result.Expression).Compile(preferInterpretation: true).DynamicInvoke();
                 }
                 else return null;
             }

--- a/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
+++ b/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
@@ -158,18 +158,6 @@ namespace DotVVM.Framework.Compilation.Binding
             return new ExpectedTypeBindingProperty(prop.IsBindingProperty ? (prop.PropertyType.GenericTypeArguments.SingleOrDefault() ?? typeof(object)) : prop.PropertyType);
         }
 
-        public BindingResolverCollection GetAdditionalResolversFromProperty(AssignedPropertyBindingProperty? property = null, DataContextStack? stack = null)
-        {
-            var prop = property?.DotvvmProperty;
-            if (prop == null) return new BindingResolverCollection(Enumerable.Empty<Delegate>());
-
-            return new BindingResolverCollection(
-                prop.GetAttributes<BindingCompilationOptionsAttribute>()
-                .SelectMany(o => o.GetResolvers())
-                .Concat(stack?.EnumerableItems().Reverse().SelectMany(s => s.BindingPropertyResolvers) ?? Enumerable.Empty<Delegate>())
-                .ToImmutableArray());
-        }
-
         public BindingCompilationRequirementsAttribute GetAdditionalResolversFromProperty(AssignedPropertyBindingProperty property)
         {
             var prop = property?.DotvvmProperty;

--- a/src/Framework/Framework/Compilation/Binding/TypeRegistry.cs
+++ b/src/Framework/Framework/Compilation/Binding/TypeRegistry.cs
@@ -12,9 +12,9 @@ namespace DotVVM.Framework.Compilation.Binding
     {
         private readonly CompiledAssemblyCache compiledAssemblyCache;
         private readonly ImmutableDictionary<string, Expression> registry;
-        private readonly ImmutableList<Func<string, Expression?>> resolvers;
+        private readonly ImmutableArray<Func<string, Expression?>> resolvers;
 
-        public TypeRegistry(CompiledAssemblyCache compiledAssemblyCache, ImmutableDictionary<string, Expression> registry, ImmutableList<Func<string, Expression?>> resolvers)
+        public TypeRegistry(CompiledAssemblyCache compiledAssemblyCache, ImmutableDictionary<string, Expression> registry, ImmutableArray<Func<string, Expression?>> resolvers)
         {
             this.compiledAssemblyCache = compiledAssemblyCache;
             this.registry = registry;
@@ -59,7 +59,7 @@ namespace DotVVM.Framework.Compilation.Binding
             return type == null ? null : new StaticClassIdentifierExpression(type);
         }
 
-        public static TypeRegistry Default(CompiledAssemblyCache compiledAssemblyCache) => new TypeRegistry(compiledAssemblyCache,
+        private static readonly ImmutableDictionary<string, Expression> predefinedTypes =
             ImmutableDictionary<string, Expression>.Empty
                 .Add("object", CreateStatic(typeof(Object)))
                 .Add("bool", CreateStatic(typeof(Boolean)))
@@ -88,44 +88,19 @@ namespace DotVVM.Framework.Compilation.Binding
                 .Add("Decimal", CreateStatic(typeof(Decimal)))
                 .Add("Double", CreateStatic(typeof(Double)))
                 .Add("Single", CreateStatic(typeof(Single)))
-                .Add("String", CreateStatic(typeof(String))),
-            ImmutableList<Func<string, Expression?>>.Empty
-                .Add(type => CreateStatic(compiledAssemblyCache.FindType(type)))
-                .Add(type => CreateStatic(compiledAssemblyCache.FindType("System." + type)))
-            );
+                .Add("String", CreateStatic(typeof(String)));
+
+        public static TypeRegistry Default(CompiledAssemblyCache compiledAssemblyCache) => new TypeRegistry(compiledAssemblyCache,
+            predefinedTypes,
+            ImmutableArray.Create<Func<string, Expression?>>(
+                type => CreateStatic(compiledAssemblyCache.FindType(type)),
+                type => CreateStatic(compiledAssemblyCache.FindType("System." + type))
+            ));
 
         public static TypeRegistry DirectivesDefault(CompiledAssemblyCache compiledAssemblyCache, string? assemblyName = null) => new TypeRegistry(compiledAssemblyCache,
-           ImmutableDictionary<string, Expression>.Empty
-               .Add("object", CreateStatic(typeof(Object)))
-               .Add("bool", CreateStatic(typeof(Boolean)))
-               .Add("byte", CreateStatic(typeof(Byte)))
-               .Add("char", CreateStatic(typeof(Char)))
-               .Add("short", CreateStatic(typeof(Int16)))
-               .Add("int", CreateStatic(typeof(Int32)))
-               .Add("long", CreateStatic(typeof(Int64)))
-               .Add("ushort", CreateStatic(typeof(UInt16)))
-               .Add("uint", CreateStatic(typeof(UInt32)))
-               .Add("ulong", CreateStatic(typeof(UInt64)))
-               .Add("decimal", CreateStatic(typeof(Decimal)))
-               .Add("double", CreateStatic(typeof(Double)))
-               .Add("float", CreateStatic(typeof(Single)))
-               .Add("string", CreateStatic(typeof(String)))
-               .Add("Object", CreateStatic(typeof(Object)))
-               .Add("Boolean", CreateStatic(typeof(Boolean)))
-               .Add("Byte", CreateStatic(typeof(Byte)))
-               .Add("Char", CreateStatic(typeof(Char)))
-               .Add("Int16", CreateStatic(typeof(Int16)))
-               .Add("Int32", CreateStatic(typeof(Int32)))
-               .Add("Int64", CreateStatic(typeof(Int64)))
-               .Add("UInt16", CreateStatic(typeof(UInt16)))
-               .Add("UInt32", CreateStatic(typeof(UInt32)))
-               .Add("UInt64", CreateStatic(typeof(UInt64)))
-               .Add("Decimal", CreateStatic(typeof(Decimal)))
-               .Add("Double", CreateStatic(typeof(Double)))
-               .Add("Single", CreateStatic(typeof(Single)))
-               .Add("String", CreateStatic(typeof(String))),
-           ImmutableList<Func<string, Expression?>>.Empty
-               .Add(type => CreateStatic(compiledAssemblyCache.FindType(type + (assemblyName != null ? $", {assemblyName}" : ""))))
-           );
+           predefinedTypes,
+           ImmutableArray.Create<Func<string, Expression?>>(
+               type => CreateStatic(compiledAssemblyCache.FindType(type + (assemblyName != null ? $", {assemblyName}" : "")))
+           ));
     }
 }

--- a/src/Framework/Framework/Compilation/CompiledAssemblyCache.cs
+++ b/src/Framework/Framework/Compilation/CompiledAssemblyCache.cs
@@ -130,6 +130,8 @@ namespace DotVVM.Framework.Compilation
             return cachedAssemblies.Values.ToArray();
         }
 
+        private static readonly WeakReference<Assembly[]?> allAssembliesCache = new(null);
+
         public Assembly[] GetAllAssemblies()
         {
             if (configuration.ExperimentalFeatures.ExplicitAssemblyLoading.Enabled)
@@ -138,13 +140,26 @@ namespace DotVVM.Framework.Compilation
             }
             else
             {
+                if (allAssembliesCache.TryGetTarget(out var a) && a != null)
+                    return a;
+
+                // parallelism is useless in this context
+                lock (this)
+                {
+                    if (allAssembliesCache.TryGetTarget(out var a2) && a2 != null)
+                        return a2;
+                
 #if DotNetCore
-                // auto-loads all referenced assemblies recursively
-                return DependencyContext.Default.GetDefaultAssemblyNames().Select(Assembly.Load).ToArray();
+                    // auto-loads all referenced assemblies recursively
+                    var newA = DependencyContext.Default.GetDefaultAssemblyNames().Select(Assembly.Load).ToArray();
 #else
-                // this doesn't load new assemblies, but it is done in InvokeStaticConstructorsOnAllControls
-                return AppDomain.CurrentDomain.GetAssemblies();
+                    // this doesn't load new assemblies, but it is done in InvokeStaticConstructorsOnAllControls
+                    var newA = AppDomain.CurrentDomain.GetAssemblies();
 #endif
+                    allAssembliesCache.SetTarget(newA);
+                    return newA;
+                }
+
             }
         }
 
@@ -153,11 +168,21 @@ namespace DotVVM.Framework.Compilation
         public bool IsAssemblyNamespace(string fullName) => cache_AllNamespaces.Value.Contains(fullName);
 
         private HashSet<string> GetAllNamespaces()
-            => new HashSet<string>(GetAllAssemblies()
-                .SelectMany(a => a.GetLoadableTypes()
-                    .Select(t => t.Namespace!)
-                    .Where(ns => ns is object))
-                .Distinct());
+        {
+            var result = new HashSet<string>();
+            foreach (var a in GetAllAssemblies())
+            {
+                string? lastNs = null; // namespaces come in batches, usually, so no need to hash it everytime when a quick compare says it's the same as last time
+                foreach (var type in a.ExportedTypes)
+                {
+                    var ns = type.Namespace;
+                    if (ns is null || lastNs == ns)
+                        continue;
+                    result.Add(ns);                   
+                }
+            }
+            return result;
+        }
 
 
         /// <summary>

--- a/src/Framework/Framework/Compilation/ControlTree/ControlTreeResolverBase.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ControlTreeResolverBase.cs
@@ -412,7 +412,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
                 bindingOptions = controlResolver.ResolveBinding("value").NotNull(); // just try it as with value binding
             }
 
-            if (context?.NamespaceImports.Count > 0)
+            if (context?.NamespaceImports.Length > 0)
                 bindingOptions = bindingOptions.AddImports(context.NamespaceImports);
 
             return CompileBinding(node, bindingOptions, context!, property);

--- a/src/Framework/Framework/Compilation/ControlTree/IDataContextStack.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/IDataContextStack.cs
@@ -9,9 +9,9 @@ namespace DotVVM.Framework.Compilation.ControlTree
 
         IDataContextStack? Parent { get; }
 
-        IReadOnlyList<NamespaceImport> NamespaceImports { get; }
+        ImmutableArray<NamespaceImport> NamespaceImports { get; }
 
-        IReadOnlyList<BindingExtensionParameter> ExtensionParameters { get; }
+        ImmutableArray<BindingExtensionParameter> ExtensionParameters { get; }
         IEnumerable<(int dataContextLevel, BindingExtensionParameter parameter)> GetCurrentExtensionParameters();
 
     }

--- a/src/Framework/Framework/Compilation/ExtensionMethodsCache.cs
+++ b/src/Framework/Framework/Compilation/ExtensionMethodsCache.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using DotVVM.Framework.Utils;
+using DotVVM.Framework.Runtime;
+using System.Diagnostics;
 
 namespace DotVVM.Framework.Compilation
 {
@@ -22,21 +24,62 @@ namespace DotVVM.Framework.Compilation
             this.methodsCache = new ConcurrentDictionary<string, ImmutableArray<MethodInfo>>();
         }
 
-        public IEnumerable<MethodInfo> GetExtensionsForNamespace(string @namespace)
+        public IEnumerable<MethodInfo> GetExtensionsForNamespaces(string[] @namespaces)
         {
-            return methodsCache.GetOrAdd(@namespace, (ns) => CreateExtensionsForNamespace(ns));
+            var results = namespaces.Select(x => methodsCache.GetValueOrDefault(x)).ToArray();
+
+            if (!results.Any(x => x.IsDefault))
+                return results.SelectMany(x => x);
+
+
+            // the lock is there just to prevent parallel scanning of the same namespaces which is quite common with parallel compilation mode.
+            // it's most likely the same namespaces, so it won't help at all - only run into lock contention in System.Reflection
+            lock (methodsCache)
+            {
+                results = namespaces.Select(x => methodsCache.GetValueOrDefault(x)).ToArray();
+                var missingNamespaces = namespaces.Where(x => !methodsCache.ContainsKey(x)).ToArray();
+
+                var createdNamespaces = CreateExtensionsForNamespaces(missingNamespaces);
+                for (int i = 0; i < missingNamespaces.Length; i++)
+                {
+                    methodsCache.TryAdd(missingNamespaces[i], createdNamespaces[i]);
+                }
+
+                return namespaces.SelectMany(x => methodsCache.GetValue(x));
+            }
         }
 
-        private ImmutableArray<MethodInfo> CreateExtensionsForNamespace(string @namespace)
+        private ImmutableArray<MethodInfo>[] CreateExtensionsForNamespaces(string[] namespaces)
         {
-            var extensions = new List<MethodInfo>();
+            if (namespaces.Length == 0)
+                return Array.Empty<ImmutableArray<MethodInfo>>();
+            // we fetch extension methods for multiple namespaces at once for performance reasons
+            // this way we get rid of few of these "full scans"
+            var results = namespaces.Select(x => ImmutableArray.CreateBuilder<MethodInfo>()).ToArray();
+
 
             foreach (var assembly in assemblyCache.GetAllAssemblies())
-                foreach (var type in assembly.GetLoadableTypes().Where(t => t.Namespace == @namespace && t.IsClass && t.IsAbstract && t.IsSealed))
-                    foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Static).Where(m => m.GetCustomAttribute(typeof(ExtensionAttribute)) != null))
-                        extensions.Add(method);
+                foreach (var type in assembly.GetLoadableTypes())
+                {
+                    // check all flags first, these are much cheaper to get than the namespace
+                    if (!(type.IsAbstract && type.IsSealed && type.IsClass))
+                        continue;
+                    var typeNamespace = type.Namespace;
+                    for (int i = 0; i < namespaces.Length; i++)
+                    {
+                        if (!namespaces[i].Equals(typeNamespace, StringComparison.Ordinal)) continue;
 
-            return extensions.ToImmutableArray();
+                        foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Static))
+                        {
+                            if (method.IsDefined(typeof(ExtensionAttribute)))
+                                results[i].Add(method);
+                        }
+
+                        break;
+                    }
+                }
+
+            return results.Select(x => x.ToImmutableArray()).ToArray();
         }
     }
 }

--- a/src/Framework/Framework/Compilation/RoslynValueEmitter.cs
+++ b/src/Framework/Framework/Compilation/RoslynValueEmitter.cs
@@ -236,7 +236,7 @@ namespace DotVVM.Framework.Compilation
         };
         internal static bool IsImmutableObject(Type t) =>
             typeof(IBinding).IsAssignableFrom(t)
-              || t.GetCustomAttribute<HandleAsImmutableObjectInDotvvmPropertyAttribute>() is object
+              || t.IsDefined(typeof(HandleAsImmutableObjectInDotvvmPropertyAttribute), true)
               || t.IsGenericType && ImmutableContainers.Contains(t.GetGenericTypeDefinition()) && t.GenericTypeArguments.All(IsImmutableObject);
         private static int _viewObjectsCount = 0;
         private static int _viewObjectsCount_PropArray = 0;

--- a/src/Framework/Framework/Compilation/Styles/StyleMatcher.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleMatcher.cs
@@ -9,6 +9,7 @@ using DotVVM.Framework.Configuration;
 using System.Linq.Expressions;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.Utils;
+using FastExpressionCompiler;
 
 namespace DotVVM.Framework.Compilation.Styles
 {
@@ -91,7 +92,7 @@ namespace DotVVM.Framework.Compilation.Styles
                             new[] { p.ParameterType },
                             services)))
                     let expression = Expression.Lambda<Action<ResolvedControl, DotvvmConfiguration>>(invocationExpression, controlParameter, configurationParameter)
-                    select (IStyle)new GenericStyle(controlType, expression.Compile())
+                    select (IStyle)new GenericStyle(controlType, expression.CompileFast(flags: CompilerFlags.ThrowOnNotSupportedExpression))
                     ).ToImmutableArray();
             });
 

--- a/src/Framework/Framework/DotVVM.Framework.csproj
+++ b/src/Framework/Framework/DotVVM.Framework.csproj
@@ -56,10 +56,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="FastExpressionCompiler" Version="3.2.1" />
+   <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.1" />
     <PackageReference Include="RecordException" Version="0.1.2" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />

--- a/src/Framework/Framework/Runtime/AttributeViewModelParameterBinder.cs
+++ b/src/Framework/Framework/Runtime/AttributeViewModelParameterBinder.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using DotVVM.Framework.Hosting;
 using DotVVM.Framework.Utils;
 using DotVVM.Framework.ViewModel;
+using FastExpressionCompiler;
 
 namespace DotVVM.Framework.Runtime
 {
@@ -50,7 +51,7 @@ namespace DotVVM.Framework.Runtime
 
 
             var lambda = Expression.Lambda<Action<IDotvvmRequestContext, object>>(Expression.Block(statements), contextParameter, viewModelParameter);
-            return lambda.Compile();
+            return lambda.CompileFast(flags: CompilerFlags.ThrowOnNotSupportedExpression);
         }
 
         /// <summary>

--- a/src/Framework/Framework/ViewModel/Serialization/ViewModelSerializationMap.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/ViewModelSerializationMap.cs
@@ -6,6 +6,7 @@ using DotVVM.Framework.Utils;
 using Newtonsoft.Json;
 using System.Reflection;
 using DotVVM.Framework.Configuration;
+using FastExpressionCompiler;
 
 namespace DotVVM.Framework.ViewModel.Serialization
 {
@@ -67,7 +68,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
         public Func<IServiceProvider, object> CreateConstructorFactory()
         {
             var ex = Expression.Lambda<Func<IServiceProvider, object>>(Expression.New(Type), new [] { Expression.Parameter(typeof(IServiceProvider)) });
-            return ex.Compile();
+            return ex.CompileFast(flags: CompilerFlags.ThrowOnNotSupportedExpression);
         }
 
         /// <summary>
@@ -250,7 +251,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
                     Expression.Block(Type, new[] { value, currentProperty, readerTmp }, block),
                     typeof(object)).OptimizeConstants(),
                 reader, serializer, valueParam, encryptedValuesReader);
-            return ex.Compile();
+            return ex.CompileFast(flags: CompilerFlags.ThrowOnNotSupportedExpression);
             //return null;
         }
 
@@ -471,7 +472,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
             // compile the expression
             var ex = Expression.Lambda<WriterDelegate>(
                 Expression.Block(new[] { value }, block).OptimizeConstants(), writer, valueParam, serializer, encryptedValuesWriter, isPostback);
-            return ex.Compile();
+            return ex.CompileFast(flags: CompilerFlags.ThrowOnNotSupportedExpression);
         }
 
         /// <summary>

--- a/src/Framework/Framework/ViewModel/Serialization/ViewModelSerializationMapper.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/ViewModelSerializationMapper.cs
@@ -46,9 +46,11 @@ namespace DotVVM.Framework.ViewModel.Serialization
         /// </summary>
         protected virtual IEnumerable<ViewModelPropertyMap> GetProperties(Type type)
         {
-            foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance).OrderBy(p => p.Name, StringComparer.Ordinal))
+            var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            Array.Sort(properties, (a, b) => StringComparer.Ordinal.Compare(a.Name, b.Name));
+            foreach (var property in properties)
             {
-                if (property.GetCustomAttribute<JsonIgnoreAttribute>() != null) continue;
+                if (property.IsDefined(typeof(JsonIgnoreAttribute))) continue;
 
                 var propertyMap = new ViewModelPropertyMap(
                     property,

--- a/src/Framework/Testing/ControlTestHelper.cs
+++ b/src/Framework/Testing/ControlTestHelper.cs
@@ -27,27 +27,27 @@ namespace DotVVM.Framework.Testing
 {
     public class ControlTestHelper
     {
-        private readonly DotvvmConfiguration configuration;
+        public readonly DotvvmConfiguration Configuration;
         private readonly FakeMarkupFileLoader fileLoader;
         private readonly DotvvmPresenter presenter;
 
-        IControlBuilderFactory controlBuilderFactory => configuration.ServiceProvider.GetRequiredService<IControlBuilderFactory>();
+        IControlBuilderFactory controlBuilderFactory => Configuration.ServiceProvider.GetRequiredService<IControlBuilderFactory>();
 
         public ControlTestHelper(bool debug = true, Action<DotvvmConfiguration>? config = null, Action<IServiceCollection>? services = null)
         {
             fileLoader = new FakeMarkupFileLoader(null);
-            this.configuration = DotvvmTestHelper.CreateConfiguration(s => {
+            this.Configuration = DotvvmTestHelper.CreateConfiguration(s => {
                 s.AddSingleton<IMarkupFileLoader>(fileLoader);
                 services?.Invoke(s);
             });
-            this.configuration.Markup.AddCodeControls("tc", exampleControl: typeof(FakeHeadResourceLink));
-            this.configuration.ApplicationPhysicalPath = Path.GetTempPath();
-            this.configuration.Debug = debug;
-            config?.Invoke(this.configuration);
-            presenter = (DotvvmPresenter)this.configuration.ServiceProvider.GetRequiredService<IDotvvmPresenter>();
+            this.Configuration.Markup.AddCodeControls("tc", exampleControl: typeof(FakeHeadResourceLink));
+            this.Configuration.ApplicationPhysicalPath = Path.GetTempPath();
+            this.Configuration.Debug = debug;
+            config?.Invoke(this.Configuration);
+            presenter = (DotvvmPresenter)this.Configuration.ServiceProvider.GetRequiredService<IDotvvmPresenter>();
         }
 
-        private (ControlBuilderDescriptor descriptor, Lazy<IControlBuilder> builder) CompilePage(
+        public (ControlBuilderDescriptor descriptor, Lazy<IControlBuilder> builder) CompilePage(
             string markup,
             string fileName,
             Dictionary<string, string>? markupFiles = null)
@@ -70,8 +70,8 @@ namespace DotVVM.Framework.Testing
         )
         {
             var context = DotvvmTestHelper.CreateContext(
-                configuration,
-                route: new Framework.Routing.DotvvmRoute("testpage", fileName, null, _ => throw new Exception(), configuration));
+                Configuration,
+                route: new Framework.Routing.DotvvmRoute("testpage", fileName, null, _ => throw new Exception(), Configuration));
             context.CsrfToken = null;
             var httpContext = (TestHttpContext)context.HttpContext;
 
@@ -98,7 +98,7 @@ namespace DotVVM.Framework.Testing
             CultureInfo.CurrentCulture = new CultureInfo("en-US");
             CultureInfo.CurrentUICulture = new CultureInfo("en-US");
 
-            configuration.Freeze();
+            Configuration.Freeze();
             fileName = (fileName ?? "testpage") + ".dothtml";
             var (_, controlBuilder) = CompilePage(markup, fileName, markupFiles);
             return PrepareRequest(fileName);

--- a/src/Framework/Testing/DotvvmTestHelper.cs
+++ b/src/Framework/Testing/DotvvmTestHelper.cs
@@ -87,7 +87,14 @@ namespace DotVVM.Framework.Testing
             services.TryAddSingleton<IViewModelProtector, FakeProtector>();
             services.TryAddSingleton<ICsrfProtector, FakeCsrfProtector>();
             services.TryAddSingleton<IDotvvmCacheAdapter, SimpleDictionaryCacheAdapter>();
+            services.AddSingleton<CompiledAssemblyCache>(s => sharedAssemblyCache.Value);
+            services.AddSingleton<ExtensionMethodsCache>(s => sharedExtensionMethodCache.Value);
         }
+
+        private static Lazy<CompiledAssemblyCache> sharedAssemblyCache =
+            new (() => new CompiledAssemblyCache(DefaultConfig));
+        private static Lazy<ExtensionMethodsCache> sharedExtensionMethodCache =
+            new (() => new ExtensionMethodsCache(sharedAssemblyCache.Value));
 
         private static Lazy<DotvvmConfiguration> _defaultConfig = new Lazy<DotvvmConfiguration>(() => {
             var config = CreateConfiguration();

--- a/src/Framework/Testing/FakeCommandBinding.cs
+++ b/src/Framework/Testing/FakeCommandBinding.cs
@@ -3,6 +3,7 @@ using DotVVM.Framework.Binding.Expressions;
 using DotVVM.Framework.Compilation.Javascript;
 using DotVVM.Framework.Runtime.Filters;
 using System.Collections.Immutable;
+using DotVVM.Framework.Binding;
 
 namespace DotVVM.Framework.Testing
 {
@@ -21,6 +22,8 @@ namespace DotVVM.Framework.Testing
         public BindingDelegate BindingDelegate => bindingDelegate ?? throw new NotImplementedException();
 
         public ImmutableArray<IActionFilter> ActionFilters => ImmutableArray<IActionFilter>.Empty;
+
+        public BindingResolverCollection? GetAdditionalResolvers() => null;
 
         public object? GetProperty(Type type, ErrorHandlingMode errorMode = ErrorHandlingMode.ThrowException)
         {

--- a/src/Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/Tests/Binding/JavascriptCompilationTests.cs
@@ -23,15 +23,14 @@ namespace DotVVM.Framework.Tests.Binding
     [TestClass]
     public class JavascriptCompilationTests
     {
-        private DotvvmConfiguration configuration;
-        private BindingTestHelper bindingHelper;
+        private static readonly DotvvmConfiguration configuration;
+        private static readonly BindingTestHelper bindingHelper;
 
-        [TestInitialize]
-        public void Init()
+        static JavascriptCompilationTests()
         {
-            this.configuration = DotvvmTestHelper.CreateConfiguration();
+            configuration = DotvvmTestHelper.CreateConfiguration();
             configuration.RegisterApiClient(typeof(TestApiClient), "http://server/api", "./apiscript.js", "_testApi");
-            this.bindingHelper = new BindingTestHelper(configuration);
+            bindingHelper = new BindingTestHelper(configuration);
         }
         public string CompileBinding(string expression, params Type[] contexts) => CompileBinding(expression, contexts, expectedType: typeof(object));
         public string CompileBinding(string expression, NamespaceImport[] imports, params Type[] contexts) => CompileBinding(expression, contexts, expectedType: typeof(object), imports);

--- a/src/Tests/Binding/NullPropagationTests.cs
+++ b/src/Tests/Binding/NullPropagationTests.cs
@@ -171,7 +171,7 @@ namespace DotVVM.Framework.Tests.Binding
         private object EvalExpression<T>(Expression<Func<T, object>> a, T val)
         {
             var nullChecked = ExpressionNullPropagationVisitor.PropagateNulls(a.Body, _ => true);
-            var d = a.Update(body: nullChecked, a.Parameters).Compile();
+            var d = a.Update(body: nullChecked, a.Parameters).Compile(preferInterpretation: true);
             return d(val);
         }
 

--- a/src/Tests/Binding/StaticCommandCompilationTests.cs
+++ b/src/Tests/Binding/StaticCommandCompilationTests.cs
@@ -24,10 +24,7 @@ namespace DotVVM.Framework.Tests.Binding
     [TestClass]
     public class StaticCommandCompilationTests
     {
-        /// Gets translation of the specified binding expression if it would be passed in static command
-        /// For better readability, the returned code does not include null checks
-        public string CompileBinding(string expression, bool niceMode, params Type[] contexts) => CompileBinding(expression, niceMode, contexts, expectedType: typeof(Command));
-        public string CompileBinding(string expression, bool niceMode, Type[] contexts, Type expectedType, Type currentMarkupControl = null)
+        static DotvvmConfiguration MakeConfiguration()
         {
             var configuration = DotvvmTestHelper.CreateConfiguration(s => {
                 s.AddSingleton<IViewModelProtector, DotvvmTestHelper.NopProtector>();
@@ -50,7 +47,27 @@ namespace DotVVM.Framework.Tests.Binding
                                                             a[2].WithAnnotation(ShouldBeObservableAnnotation.Instance))
                                                              .WithAnnotation(new ResultIsPromiseAnnotation(e => e))
                                                        ), 2, allowMultipleMethods: true);
-            configuration.Debug = niceMode;
+            return configuration;
+        }
+
+        static readonly DotvvmConfiguration debugConfiguration;
+        static readonly DotvvmConfiguration releaseConfiguration;
+
+        static StaticCommandCompilationTests()
+        {
+            debugConfiguration = MakeConfiguration();
+            debugConfiguration.Debug = true;
+            debugConfiguration.Freeze();
+            releaseConfiguration = MakeConfiguration();
+            releaseConfiguration.Debug = false;
+            releaseConfiguration.Freeze();
+        }
+        /// Gets translation of the specified binding expression if it would be passed in static command
+        /// For better readability, the returned code does not include null checks
+        public string CompileBinding(string expression, bool niceMode, params Type[] contexts) => CompileBinding(expression, niceMode, contexts, expectedType: typeof(Command));
+        public string CompileBinding(string expression, bool niceMode, Type[] contexts, Type expectedType, Type currentMarkupControl = null)
+        {
+            var configuration = niceMode ? debugConfiguration : releaseConfiguration;
             var bindingService = configuration.ServiceProvider.GetRequiredService<BindingCompilationService>();
 
             var parameters =

--- a/src/Tests/ControlTests/CompositeControlTests.cs
+++ b/src/Tests/ControlTests/CompositeControlTests.cs
@@ -18,7 +18,7 @@ namespace DotVVM.Framework.Tests.ControlTests
     [TestClass]
     public class CompositeControlTests
     {
-        ControlTestHelper cth = new ControlTestHelper(config: config => {
+        static readonly ControlTestHelper cth = new ControlTestHelper(config: config => {
             _ = Repeater.RenderAsNamedTemplateProperty;
             config.Styles.Register<Repeater>().SetProperty(r => r.RenderAsNamedTemplate, false, StyleOverrideOptions.Ignore);
             config.Markup.AddCodeControls("cc", exampleControl: typeof(WrappedHtmlControl));

--- a/src/Tests/ControlTests/DotvvmErrorTests.cs
+++ b/src/Tests/ControlTests/DotvvmErrorTests.cs
@@ -19,7 +19,7 @@ namespace DotVVM.Framework.Tests.ControlTests
     [TestClass]
     public class DotvvmErrorTests
     {
-        ControlTestHelper cth = new ControlTestHelper(config: config => {
+        static readonly ControlTestHelper cth = new ControlTestHelper(config: config => {
         }, services: s => {
             s.AddSingleton<TestService>();
         });

--- a/src/Tests/ControlTests/IdGeneration.cs
+++ b/src/Tests/ControlTests/IdGeneration.cs
@@ -12,7 +12,7 @@ namespace DotVVM.Framework.Tests.ControlTests
     [TestClass]
     public class IdGeneration
     {
-        ControlTestHelper cth = new ControlTestHelper();
+        static readonly ControlTestHelper cth = new ControlTestHelper();
         // ControlTestHelper cth = new ControlTestHelper(config: config => {
         //     config.Markup.AddMarkupControl("cc", "CustomControl", "custom.dotcontrol");
         // });

--- a/src/Tests/ControlTests/MarkupControlTests.cs
+++ b/src/Tests/ControlTests/MarkupControlTests.cs
@@ -19,7 +19,7 @@ namespace DotVVM.Framework.Tests.ControlTests
     [TestClass]
     public class MarkupControlTests
     {
-        ControlTestHelper cth = new ControlTestHelper(config: config => {
+        static readonly ControlTestHelper cth = new ControlTestHelper(config: config => {
             config.Markup.AddMarkupControl("cc", "CustomControlWithCommand", "CustomControlWithCommand.dotcontrol");
             config.Markup.AddMarkupControl("cc", "CustomControlWithProperty", "CustomControlWithProperty.dotcontrol");
             config.Styles.Register<Repeater>().SetProperty(r => r.RenderAsNamedTemplate, false, StyleOverrideOptions.Ignore);

--- a/src/Tests/ControlTests/SimpleControlTests.cs
+++ b/src/Tests/ControlTests/SimpleControlTests.cs
@@ -16,7 +16,7 @@ namespace DotVVM.Framework.Tests.ControlTests
     [TestClass]
     public class SimpleControlTests
     {
-        ControlTestHelper cth = new ControlTestHelper(config: config => {
+        static readonly ControlTestHelper cth = new ControlTestHelper(config: config => {
             config.RouteTable.Add("WithParams", "WithParams/{A}-{B:int}/{C?}", "WithParams.dothtml", new { B = 1 });
             config.RouteTable.Add("Simple", "Simple", "Simple.dothtml");
         });

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolverTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolverTests.cs
@@ -28,13 +28,13 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
     [TestClass]
     public class DefaultControlTreeResolverTests
     {
-        private DotvvmConfiguration configuration;
+        private static readonly DotvvmConfiguration configuration;
 
-        [TestInitialize()]
-        public void TestInit()
+        static DefaultControlTreeResolverTests()
         {
             configuration = DotvvmTestHelper.CreateConfiguration();
             configuration.Markup.AddCodeControls("cc", typeof(ClassWithInnerElementProperty));
+            configuration.Freeze();
         }
 
         [TestMethod]
@@ -737,7 +737,7 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
         }
 
         private ResolvedTreeRoot ParseSource(string markup, string fileName = "default.dothtml", bool checkErrors = false) =>
-            DotvvmTestHelper.ParseResolvedTree(markup, fileName, this.configuration, checkErrors);
+            DotvvmTestHelper.ParseResolvedTree(markup, fileName, configuration, checkErrors);
 
     }
 


### PR DESCRIPTION
Added reference to FastExpressionCompiler - we'll use that for serialization, capabilities. Unfortunately, we can't use it for bindings at the moment, because there are some bugs.

We used to look for extension method even without `_this` qualifier, so this `{value: Where(x => ...)}` probably worked and now it won't (because looking for extension methods is pretty expensive). In C# this is also disabled, so I think it makes sense to have this limitation.

Other things are just optimizations of existing methods that showed up as hot during profiling startup and compilation.