### PR TITLE
Make it possible to access entire capability in server-side styles

### DIFF
--- a/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
+++ b/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
@@ -9,6 +9,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using DotVVM.Framework.Binding.Expressions;
 using DotVVM.Framework.Compilation.ControlTree;
+using DotVVM.Framework.Compilation.ControlTree.Resolved;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.Runtime;
 using DotVVM.Framework.Utils;
@@ -21,7 +22,11 @@ namespace DotVVM.Framework.Binding
     public partial class DotvvmCapabilityProperty : DotvvmProperty
     {
         internal Func<DotvvmBindableObject, object> Getter { get; private set; } = null!;
-        internal Action<DotvvmBindableObject, object?> Setter { get; private set; } = null!;
+        internal Action<DotvvmBindableObject, object> Setter { get; private set; } = null!;
+        internal Func<ResolvedControl, ResolvedPropertyCapability>? ResolvedControlGetter { get; private set; } = null;
+        internal Action<ResolvedControl, ResolvedPropertyCapability>? ResolvedControlSetter { get; private set; } = null;
+
+
         /// <summary> List of properties that this capability contains. Note that this may contain nested capabilities. </summary>
         public ImmutableArray<(PropertyInfo prop, DotvvmProperty dotvvmProperty)>? PropertyMapping { get; private set; }
         /// <summary> List of property groups that this capability contains. Note that other property groups may be in nested capabilities (see the <see cref="PropertyMapping" /> array). </summary>
@@ -69,7 +74,11 @@ namespace DotVVM.Framework.Binding
 
         public override object GetValue(DotvvmBindableObject control, bool inherit = true) => Getter(control);
 
-        public override void SetValue(DotvvmBindableObject control, object? value) => Setter(control, value);
+        public override void SetValue(DotvvmBindableObject control, object? value)
+        {
+            _ = value ?? throw new DotvvmControlException($"Capability can not be set to null") { RelatedProperty = this };
+            Setter(control, value);
+        }
         
         /// <summary> Looks up a capability on the specified control (<paramref name="declaringType"/>).
         /// If multiple capabilities of this type are registered, <see cref="Find(Type, Type, string)" /> method must be used to retrieve the one with specified prefix. </summary>

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedControl.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedControl.cs
@@ -93,7 +93,7 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
         {
             if (property is DotvvmCapabilityProperty capability)
                 return GetCapabilityProperty(capability);
-            return Properties.GetValueOrDefault(property);
+            return Properties.TryGetValue(property, out var result) ? result : default;
         }
 
         public ResolvedPropertyCapability? GetCapabilityProperty(DotvvmCapabilityProperty capability)
@@ -111,10 +111,10 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
             if (!groupMapping.IsEmpty)
             {
                 var groups = groupMapping.Select(g => g.dotvvmPropertyGroup).ToHashSet();
-                foreach (var (p, propValue) in Properties)
+                foreach (var item in Properties)
                 {
-                    if (p is GroupedDotvvmProperty pg && groups.Contains(pg.PropertyGroup))
-                        properties.Add(p, propValue);
+                    if (item.Key is GroupedDotvvmProperty pg && groups.Contains(pg.PropertyGroup))
+                        properties.Add(item.Key, item.Value);
                 }
             }
 

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedPropertyCapability.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedPropertyCapability.cs
@@ -91,14 +91,14 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
                 var properties = propertyGroupLookup[pgroup].ToArray();
 
                 var propertyOriginalValue = prop.GetValue(obj);
+                var dictionaryElementType = DotvvmCapabilityProperty.Helpers.GetDictionaryElement(prop.PropertyType);
                 var dictionary = (System.Collections.IDictionary)(
                     propertyOriginalValue ??
-                    Activator.CreateInstance(prop.PropertyType)
+                    Activator.CreateInstance(typeof(Dictionary<,>).MakeGenericType(typeof(string), dictionaryElementType))
                 );
 
                 if (properties.Length > 0)
                 {
-                    var dictionaryElementType = DotvvmCapabilityProperty.Helpers.GetDictionaryElement(prop.PropertyType);
 
                     foreach (var p in properties)
                         dictionary.Add(p.GroupMemberName, convertValue(this.Values[p].GetValue(), dictionaryElementType));

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedPropertyCapability.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedPropertyCapability.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Utils;
+
+namespace DotVVM.Framework.Compilation.ControlTree.Resolved
+{
+    public class ResolvedPropertyCapability : ResolvedPropertySetter
+    {
+        public new DotvvmCapabilityProperty Property
+        {
+            get => (DotvvmCapabilityProperty)base.Property;
+            set => base.Property = value;
+        }
+
+        public Type Type => Property.PropertyType;
+
+        public Dictionary<DotvvmProperty, ResolvedPropertySetter> Values { get; set; }
+        public ImmutableArray<(PropertyInfo, DotvvmProperty)>? Mapping { get; set; }
+
+        public ResolvedPropertyCapability(
+            DotvvmCapabilityProperty property,
+            Dictionary<DotvvmProperty, ResolvedPropertySetter> values,
+            ImmutableArray<(PropertyInfo, DotvvmProperty)>? mapping = null) : base(property)
+        {
+            this.Values = values;
+            Mapping = mapping;
+        }
+
+        public override void Accept(IResolvedControlTreeVisitor visitor)
+        {
+            // not really needed, this does not occur in the tree so it does not make sense to add this to the visitor
+            foreach (var v in Values.Values)
+            {
+                v.Accept(visitor);
+            }
+        }
+
+        public override void AcceptChildren(IResolvedControlTreeVisitor visitor) { }
+
+        public object ToCapabilityObject(bool throwExceptions = false)
+        {
+            var c = this.Property;
+            var obj = Activator.CreateInstance(c.PropertyType);
+
+            if ((this.Mapping ?? c.PropertyMapping) is not {} mapping)
+                if (throwExceptions)
+                    throw new NotSupportedException($"Capability {c} does not have property mapping.");
+
+            object? convertValue(object? value, Type t)
+            {
+                t = t.UnwrapNullableType();
+                if (t.IsInstanceOfType(value) || value is null)
+                    return value;
+                if (t.IsValueOrBinding(out var elementType))
+                {
+                    value = value as IBinding ?? convertValue(value, elementType);
+                    if (value is IBinding)
+                        return t.GetConstructor(new [] { typeof(IBinding) }).Invoke(new [] { value });
+                    else
+                        return t.GetConstructor(new [] { elementType }).Invoke(new [] { value });
+                }
+                // TODO: controls and templates
+                if (throwExceptions)
+                    throw new NotSupportedException($"Can not convert {value} to {t}");
+                return null;
+            }
+
+
+            foreach (var (p, dotprop) in mapping)
+            {
+                if (this.Values.TryGetValue(dotprop, out var value))
+                    p.SetValue(obj, convertValue(value.GetValue(), p.PropertyType));
+            }
+
+            if (c.PropertyGroupMapping is not { Length: > 0 } groupMappingList)
+                return obj;
+
+            var propertyGroupLookup =
+                this.Values.Keys
+                    .OfType<GroupedDotvvmProperty>()
+                    .ToLookup(gp => gp.PropertyGroup);
+
+            foreach (var (prop, pgroup) in groupMappingList)
+            {
+                var properties = propertyGroupLookup[pgroup].ToArray();
+
+                var propertyOriginalValue = prop.GetValue(obj);
+                var dictionary = (System.Collections.IDictionary)(
+                    propertyOriginalValue ??
+                    Activator.CreateInstance(prop.PropertyType)
+                );
+
+                if (properties.Length > 0)
+                {
+                    var dictionaryElementType = DotvvmCapabilityProperty.Helpers.GetDictionaryElement(prop.PropertyType);
+
+                    foreach (var p in properties)
+                        dictionary.Add(p.GroupMemberName, convertValue(this.Values[p].GetValue(), dictionaryElementType));
+                }
+                if (propertyOriginalValue is null)
+                    prop.SetValue(obj, dictionary);
+            }
+
+            return obj;
+        }
+
+        private static string DebugFormatValue(object? v) =>
+            v is null ? "null" :
+            v is IEnumerable<object> vs ? $"[{string.Join(", ", vs.Select(DebugFormatValue))}]" :
+            v.ToString();
+
+        public override string ToString() =>
+            $"{{{string.Join(", ", Values.Select(x => x.Key.Name + "." + DebugFormatValue(x.Value)))}}}";
+    }
+}

--- a/src/Framework/Framework/Compilation/ControlTree/ResolvedTreeHelpers.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ResolvedTreeHelpers.cs
@@ -33,6 +33,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
                 ResolvedPropertyTemplate value => value.Content,
                 ResolvedPropertyControl value => value.Control,
                 ResolvedPropertyControlCollection value => value.Controls,
+                ResolvedPropertyCapability value => value.ToCapabilityObject(throwExceptions: false),
                 _ => throw new NotSupportedException()
             };
 

--- a/src/Framework/Framework/Utils/ReflectionUtils.cs
+++ b/src/Framework/Framework/Utils/ReflectionUtils.cs
@@ -378,16 +378,28 @@ namespace DotVVM.Framework.Utils
                 return type;
         }
 
-        public static Type UnwrapValueOrBinding(this Type type)
+        public static bool IsValueOrBinding(this Type type, [NotNullWhen(true)] out Type? elementType)
         {
             type = type.UnwrapNullableType();
             if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ValueOrBinding<>))
-                return type.GenericTypeArguments.Single();
+            {
+                elementType = type.GenericTypeArguments.Single();
+                return true;
+            }
             else if (typeof(ValueOrBinding).IsAssignableFrom(type))
-                return typeof(object);
+            {
+                elementType = typeof(object);
+                return true;
+            }
             else
-                return type;
+            {
+                elementType = null;
+                return false;
+            }
         }
+
+        public static Type UnwrapValueOrBinding(this Type type) =>
+            type.IsValueOrBinding(out var x) ? x : type;
 
         public static T GetCustomAttribute<T>(this ICustomAttributeProvider attributeProvider, bool inherit = true) =>
             (T)attributeProvider.GetCustomAttributes(typeof(T), inherit).FirstOrDefault();

--- a/src/Tests/ControlTests/ServerSideStyleTests.cs
+++ b/src/Tests/ControlTests/ServerSideStyleTests.cs
@@ -232,6 +232,26 @@ namespace DotVVM.Framework.Tests.ControlTests
             check.CheckString(r.FormattedHtml, fileExtension: "html");
         }
 
+        [TestMethod]
+        public async Task CapabilityReads()
+        {
+            var cth = createHelper(c => {
+                c.Styles.Register<HtmlGenericControl>(c =>
+                    c.PropertyValue(x => x.HtmlCapability).CssClasses.ContainsKey("z"))
+                    .SetAttribute("data-test1", c => c.PropertyValue(c => c.HtmlCapability).CssClasses["z"].Select(z => z ? "has-z-class" : "no-z-class"));
+                c.Styles.Register<HtmlGenericControl>(c => c.HasTag("t"))
+                    .SetAttribute("data-visible-copy", c => c.PropertyValue(c => c.HtmlCapability).Visible.Select(z => z ? "yes" : "no"));
+            });
+
+            var r = await cth.RunPage(typeof(BasicTestViewModel), @"
+                <div class-z />
+                <div class-z={value: Integer > 1} />
+                <div class-z={resource: Integer > 1} />
+                <div Styles.Tag=t Visible={value: Integer > 1} />
+                <div Styles.Tag=t Visible={resource: Integer > 1} />
+            ");
+            check.CheckString(r.FormattedHtml, fileExtension: "html");
+        }
 
         [TestMethod]
         public async Task StyleBindingMapping()

--- a/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.CapabilityReads.html
+++ b/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.CapabilityReads.html
@@ -1,0 +1,10 @@
+<html>
+	<head></head>
+	<body>
+		<div class="z" data-test1="has-z-class"></div>
+		<div class="z" data-bind="css: { z: int() > 1 }, attr: { &quot;data-test1&quot;: int() > 1 ? &quot;has-z-class&quot; : &quot;no-z-class&quot; }"></div>
+		<div class="z" data-test1="has-z-class"></div>
+		<div data-bind="visible: int() > 1, attr: { &quot;data-visible-copy&quot;: int() > 1 ? &quot;yes&quot; : &quot;no&quot; }"></div>
+		<div data-visible-copy="yes"></div>
+	</body>
+</html>


### PR DESCRIPTION
For example, this makes it possible to write a common function for a style
and for a control.

Potentially, this infrastucture could be used to execute
entire composite controls at compile-time. This makes is a bit more
limiting, since it's only executed once, but if you wish
to create data bindings in the control, it's the only option
that will not make the page super slow just by putting
the control in a Repeater