### PR TITLE
Optimize memory a bit

### DIFF
--- a/src/Framework/Framework/Binding/BindingCompilationRequirementsAttribute.cs
+++ b/src/Framework/Framework/Binding/BindingCompilationRequirementsAttribute.cs
@@ -26,6 +26,10 @@ namespace DotVVM.Framework.Binding
         /// </summary>
         public readonly ImmutableArray<Type> Excluded;
 
+        public static readonly BindingCompilationRequirementsAttribute Empty = new();
+
+        public bool IsEmpty => Required.IsEmpty && Optional.IsEmpty && Excluded.IsEmpty;
+
         public BindingCompilationRequirementsAttribute(Type[]? required = null, Type[]? optional = null, Type[]? excluded = null)
         {
             this.Required = required?.ToImmutableArray() ?? ImmutableArray<Type>.Empty;
@@ -42,19 +46,24 @@ namespace DotVVM.Framework.Binding
 
         public BindingCompilationRequirementsAttribute ApplySecond(BindingCompilationRequirementsAttribute attr)
         {
-            return new BindingCompilationRequirementsAttribute(
+            if (attr.IsEmpty) return this;
+            if (this.IsEmpty) return attr;
+            var result = new BindingCompilationRequirementsAttribute(
                 required: Required.Concat(attr.Required).Except(attr.Excluded).Distinct().ToImmutableArray(),
                 optional: Optional.Concat(attr.Optional).Distinct().ToImmutableArray(),
                 excluded: Excluded.Concat(attr.Excluded).Distinct().ToImmutableArray());
+            if (result.IsEmpty)
+                return Empty;
+            return result;
         }
 
 
         public BindingCompilationRequirementsAttribute ClearRequirements()
         {
-            if (Required.Length == 0) return this;
+            if (Required.Length + Optional.Length == 0) return this;
             return new BindingCompilationRequirementsAttribute(
                 required: ImmutableArray<Type>.Empty,
-                optional: Optional,
+                optional: ImmutableArray<Type>.Empty,
                 excluded: Excluded
             );
         }

--- a/src/Framework/Framework/Binding/BindingCompilationService.cs
+++ b/src/Framework/Framework/Binding/BindingCompilationService.cs
@@ -230,9 +230,9 @@ namespace DotVVM.Framework.Binding
         }
 
         public IEnumerable<Delegate> GetPostProcessors(Type type) =>
-            postProcs?.TryGetValue(type, out var result) == true ? result : Enumerable.Empty<Delegate>();
+            postProcs is {} && postProcs.TryGetValue(type, out var result) ? result : Enumerable.Empty<Delegate>();
 
         public Delegate? FindResolver(Type type) =>
-            resolvers?.TryGetValue(type, out var result) == true ? result : null;
+            resolvers is {} && resolvers.TryGetValue(type, out var result) ? result : null;
     }
 }

--- a/src/Framework/Framework/Binding/BindingCompilationService.cs
+++ b/src/Framework/Framework/Binding/BindingCompilationService.cs
@@ -45,11 +45,8 @@ namespace DotVVM.Framework.Binding
 
         BindingResolverCollection resolvers = new BindingResolverCollection(Enumerable.Empty<Delegate>());
 
-        public virtual object ComputeProperty(Type type, IBinding binding)
+        public virtual object? ComputeProperty(Type type, IBinding binding)
         {
-            if (type == typeof(BindingCompilationService)) return this;
-            if (type.IsAssignableFrom(binding.GetType())) return binding;
-
             var additionalResolvers = binding.GetAdditionalResolvers();
             var bindingResolvers = GetResolversForBinding(binding.GetType());
 
@@ -88,7 +85,10 @@ namespace DotVVM.Framework.Binding
                     return expressionCompiler.Compile(lambda);
                 else return result;
             }
-            else return new BindingPropertyException(binding, type, "resolver not found"); // don't throw the exception, since it creates noise for debugger
+            // instead of returning exception we return null since this is the most common exception
+            // and whatever we return will probably stay in RAM forever.
+            else return null;
+            //; // don't throw the exception, since it creates noise for debugger
         }
 
         protected Exception GetException(IBinding binding, string message) =>

--- a/src/Framework/Framework/Binding/BindingHelper.cs
+++ b/src/Framework/Framework/Binding/BindingHelper.cs
@@ -301,7 +301,7 @@ namespace DotVVM.Framework.Binding
             var bindingType = binding.GetType();
             if (bindingType.IsGenericType)
                 bindingType = bindingType.GetGenericTypeDefinition();
-            return (TBinding)service.CreateBinding(bindingType, getContextProperties(binding).Concat(properties).ToArray());
+            return (TBinding)service.CreateBinding(bindingType, properties.Concat(getContextProperties(binding)).ToArray());
         }
 
         /// <summary>

--- a/src/Framework/Framework/Binding/BindingHelper.cs
+++ b/src/Framework/Framework/Binding/BindingHelper.cs
@@ -73,7 +73,7 @@ namespace DotVVM.Framework.Binding
         public static (int stepsUp, DotvvmBindableObject target) FindDataContextTarget(this IBinding binding, DotvvmBindableObject control)
         {
             if (control == null) throw new ArgumentNullException(nameof(control), $"Cannot evaluate binding without any dataContext.");
-            var bindingContext = binding.GetProperty<DataContextStack>(ErrorHandlingMode.ReturnNull);
+            var bindingContext = binding.DataContext;
             return FindDataContextTarget(control, bindingContext, binding);
         }
 
@@ -291,7 +291,7 @@ namespace DotVVM.Framework.Binding
         {
             object?[] getContextProperties(IBinding b) =>
                 new object?[] {
-                    b.GetProperty<DataContextStack>(ErrorHandlingMode.ReturnNull),
+                    b.DataContext,
                     b.GetProperty<BindingResolverCollection>(ErrorHandlingMode.ReturnNull),
                     b.GetProperty<BindingCompilationRequirementsAttribute>(ErrorHandlingMode.ReturnNull)?.ClearRequirements(),
                     b.GetProperty<BindingErrorReporterProperty>(ErrorHandlingMode.ReturnNull),

--- a/src/Framework/Framework/Binding/BindingPropertyException.cs
+++ b/src/Framework/Framework/Binding/BindingPropertyException.cs
@@ -49,7 +49,14 @@ namespace DotVVM.Framework.Binding
                 pathMsg += ".";
             }
 
-            var bindingMsg = binding is null ? "" : $" Binding: {binding}.";
+            var bindingMsg = "";
+            if (binding is {})
+                try
+                {
+                    // IBinding.ToString may fail in weird cases
+                    bindingMsg = $" Binding: {binding.ToString()}.";
+                }
+                catch { }
             return introMsg + coreMsg + bindingMsg + pathMsg;
         }
 

--- a/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
+++ b/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
@@ -254,7 +254,9 @@ namespace DotVVM.Framework.Binding
         internal static object InitializeArgument(ICustomAttributeProvider attributeProvider, string propertyName, Type propertyType, Type declaringType, DotvvmCapabilityProperty? declaringCapability, ValueOrBinding<object>? defaultValue)
         {
             var capabilityType = declaringCapability?.PropertyType;
-            propertyName = char.ToUpperInvariant(propertyName[0]) + propertyName.Substring(1);
+            if (char.IsLower(propertyName[0]))
+                propertyName = char.ToUpperInvariant(propertyName[0]) + propertyName.Substring(1);
+            propertyName = propertyName.DotvvmInternString(trySystemIntern: true);
 
             if (attributeProvider.GetCustomAttribute<DefaultValueAttribute>() is DefaultValueAttribute defaultAttribute)
             {

--- a/src/Framework/Framework/Binding/DotvvmProperty.cs
+++ b/src/Framework/Framework/Binding/DotvvmProperty.cs
@@ -215,7 +215,7 @@ namespace DotVVM.Framework.Binding
             var field = ReflectionUtils.GetMemberFromExpression(fieldAccessor) as FieldInfo;
             if (field == null || !field.IsStatic) throw new ArgumentException("The expression should be simple static field access", nameof(fieldAccessor));
             if (!field.Name.EndsWith("Property", StringComparison.Ordinal)) throw new ArgumentException($"DotVVM property backing field's '{field.Name}' name should end with 'Property'");
-            return Register<TPropertyType, TDeclaringType>(field.Name.Remove(field.Name.Length - "Property".Length), defaultValue, isValueInherited);
+            return Register<TPropertyType, TDeclaringType>(field.Name.Remove(field.Name.Length - "Property".Length).DotvvmInternString(trySystemIntern: true), defaultValue, isValueInherited);
         }
 
         /// <summary>
@@ -225,7 +225,7 @@ namespace DotVVM.Framework.Binding
         {
             var property = ReflectionUtils.GetMemberFromExpression(propertyAccessor) as PropertyInfo;
             if (property == null) throw new ArgumentException("The expression should be simple property access", nameof(propertyAccessor));
-            return Register<TPropertyType, TDeclaringType>(property.Name, defaultValue, isValueInherited);
+            return Register<TPropertyType, TDeclaringType>(property.Name.DotvvmInternString(trySystemIntern: true), defaultValue, isValueInherited);
         }
 
         /// <summary>

--- a/src/Framework/Framework/Binding/Expressions/BindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/BindingExpression.cs
@@ -36,7 +36,8 @@ namespace DotVVM.Framework.Binding.Expressions
             }
         }
 
-        private readonly ConcurrentDictionary<Type, PropValue> properties = new ConcurrentDictionary<Type, PropValue>();
+        // concurrencyLevel: 1, we don't need super high parallel performance, it better to save memory on all those locks
+        private readonly ConcurrentDictionary<Type, PropValue> properties = new ConcurrentDictionary<Type, PropValue>(concurrencyLevel: 1, capacity: 8);
         protected readonly BindingCompilationService bindingService;
 
 

--- a/src/Framework/Framework/Binding/Expressions/BindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/BindingExpression.cs
@@ -4,9 +4,12 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using DotVVM.Framework.Binding.Properties;
+using DotVVM.Framework.Compilation;
 using DotVVM.Framework.Compilation.ControlTree;
+using DotVVM.Framework.Compilation.ControlTree.Resolved;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.Runtime.Filters;
 using DotVVM.Framework.Utils;
@@ -17,29 +20,118 @@ namespace DotVVM.Framework.Binding.Expressions
     [Newtonsoft.Json.JsonConverter(typeof(BindingDebugJsonConverter))]
     public abstract class BindingExpression : IBinding, ICloneableBinding
     {
-        struct PropValue
+        private protected struct PropValue<TValue> where TValue : class
         {
-            public readonly object? Value;
-            public readonly Exception? Error;
+            public TValue? Value;
+            public Exception? Error;
 
-            public object? GetValue(ErrorHandlingMode errorMode, Func<Exception, Exception> exceptionFactory) =>
-                Error == null ? Value :
-                errorMode == ErrorHandlingMode.ReturnNull ? null :
-                errorMode == ErrorHandlingMode.ReturnException ? Error :
-                throw exceptionFactory(Error);
-
-            public PropValue(object? value, Exception? error = null)
+            public object? GetValue(ErrorHandlingMode errorMode, IBinding contextBinding, Type propType)
             {
-                if (value == null && error == null) throw new ArgumentNullException();
+                if (Value is null && errorMode != ErrorHandlingMode.ReturnNull)
+                {
+                    var err = Error ?? new BindingPropertyException(contextBinding, propType, "resolver not found");
+                    if (errorMode == ErrorHandlingMode.ReturnException)
+                        return err;
+                    ThrowException(err, contextBinding, propType);
+                }
+                return Value;
+            }
+
+            public static void ThrowException(Exception err, IBinding contextBinding, Type propType)
+            {
+                if (err is BindingPropertyException bpe && bpe.Binding == contextBinding)
+                
+                    throw bpe.Nest(propType);
+                else
+                    throw new BindingPropertyException(contextBinding, propType, err);
+            }
+
+            public PropValue<object> AsObject() => new PropValue<object>(Value, Error);
+
+
+            public PropValue(TValue? value, Exception? error = null)
+            {
                 this.Value = value;
                 this.Error = error;
             }
         }
 
+        private protected struct MaybePropValue<TValue> where TValue : class
+        {
+            public PropValue<TValue> Value;
+            public bool HasValue;
+
+            public void SetValue(PropValue<TValue> r)
+            {
+                // we need to use Volatile, otherwise there is risk of setting HasValue before the actual error/value
+                if (r.Error != null)
+                {
+                    // we can overwrite errors
+                    // in case the Value already contains a value, this will not have any effect
+                    Volatile.Write(ref Value.Error, r.Error);
+                }
+                else
+                {
+                    // value must not be overwritten
+                    // if there was an error, we "overwrite" it, but that is not a problem
+                    Interlocked.CompareExchange(ref Value.Value, r.Value, null);
+                }
+                Volatile.Write(ref HasValue, true);
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            void ComputeValue(BindingExpression @this)
+            {
+                SetValue(@this.ComputeProperty<TValue>(null));
+                Unsafe.Unbox
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public PropValue<TValue> GetValue(BindingExpression @this)
+            {
+                if (!HasValue)
+                    ComputeValue(@this);
+                return Value;
+            }
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public TValue? GetValueOrNull(BindingExpression @this) => GetValue(@this).Value;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public TValue GetValueOrThrow(BindingExpression @this)
+            {
+                var x = GetValue(@this);
+                if (x.Value is {})
+                    return x.Value;
+                ThrowError(x.Error, @this);
+                return null!;
+            }
+            
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            void ThrowError(Exception? exception, BindingExpression @this) =>
+                PropValue<TValue>.ThrowException(exception ?? new BindingPropertyException(@this, typeof(TValue), "resolver not found"), @this, typeof(TValue));
+
+        }
+
         // concurrencyLevel: 1, we don't need super high parallel performance, it better to save memory on all those locks
-        private readonly ConcurrentDictionary<Type, PropValue> properties = new ConcurrentDictionary<Type, PropValue>(concurrencyLevel: 1, capacity: 8);
+        private readonly ConcurrentDictionary<Type, PropValue<object>> properties = new(concurrencyLevel: 1, capacity: 8);
         protected readonly BindingCompilationService bindingService;
 
+        // well, ConcurrentDictionary is pretty slow and takes a ton of memory, so we just do this for the most common properties
+        private protected MaybePropValue<DataContextStack> dataContextStack;
+        private protected MaybePropValue<BindingErrorReporterProperty> errorReporter;
+        private protected MaybePropValue<BindingResolverCollection> resolverCollection;
+        private protected MaybePropValue<ResolvedBinding> resolvedBinding;
+        private protected MaybePropValue<KnockoutExpressionBindingProperty> knockoutExpressions;
+        private protected MaybePropValue<ParsedExpressionBindingProperty> parsedExpression;
+        private protected MaybePropValue<ResultTypeBindingProperty> resultType;
+        private protected MaybePropValue<BindingParserOptions> parserOptions;
+        private protected MaybePropValue<BindingDelegate> bindingDelegate;
+        private protected MaybePropValue<AssignedPropertyBindingProperty> assignedProperty;
+        private protected MaybePropValue<BindingCompilationRequirementsAttribute> compilationRequirements;
+        private protected MaybePropValue<DotvvmLocationInfo> locationInfo;
+        private protected MaybePropValue<BindingUpdateDelegate> updateDelegate;
+        private protected MaybePropValue<OriginalStringBindingProperty> originalString;
+        private protected MaybePropValue<ExpectedTypeBindingProperty> expectedType;
 
         public BindingExpression(BindingCompilationService service, IEnumerable<object?> properties)
         {
@@ -49,9 +141,9 @@ namespace DotVVM.Framework.Binding.Expressions
                 try
                 {
                     value =
-                        this.GetProperty<OriginalStringBindingProperty>(ErrorHandlingMode.ReturnNull)?.Code ??
-                        this.GetProperty<ParsedExpressionBindingProperty>(ErrorHandlingMode.ReturnNull)?.Expression?.ToString() ??
-                        this.GetProperty<KnockoutExpressionBindingProperty>(ErrorHandlingMode.ReturnNull)?.Code?.ToString(o => new Compilation.Javascript.CodeParameterAssignment($"${o.GetHashCode()}", Compilation.Javascript.OperatorPrecedence.Max)) ??
+                        originalString.GetValueOrNull(this)?.Code ??
+                        parsedExpression.GetValueOrNull(this)?.Expression?.ToString() ??
+                        knockoutExpressions.GetValueOrNull(this)?.Code?.ToString(o => new Compilation.Javascript.CodeParameterAssignment($"${o.GetHashCode()}", Compilation.Javascript.OperatorPrecedence.Max)) ??
                         this.GetProperty<KnockoutJsExpressionBindingProperty>(ErrorHandlingMode.ReturnNull)?.Expression?.ToString() ??
                         "... unrepresentable binding content ...";
                 }
@@ -73,22 +165,86 @@ namespace DotVVM.Framework.Binding.Expressions
             });
 
             foreach (var prop in properties)
-                if (prop != null) this.properties[prop.GetType()] = new PropValue(prop);
+                if (prop != null) this.StoreProperty(prop);
             this.bindingService = service;
             service.InitializeBinding(this);
         }
 
-        PropValue ComputeProperty(Type propertyType)
+        PropValue<object> GetPropertyNotInCache(Type propertyType)
+        {
+            // these really don't need to be stored in properties...
+            // multiple different binding types (IBinding, IValueBinding, ValueBindingExpression) would be just polluting the concurrent dictionary
+            if (propertyType == typeof(BindingCompilationService)) 
+                return new(bindingService);
+            if (propertyType.IsAssignableFrom(this.GetType()))
+                return new(this);
+
+            return StorePropertyInCache(propertyType, ComputeProperty<object>(propertyType));
+        }
+
+        PropValue<T> ComputeProperty<T>(Type? propertyType) where T : class
         {
             try
             {
+                propertyType ??= typeof(T);
                 var value = bindingService.ComputeProperty(propertyType, this);
-                return value is Exception error ? new PropValue(null, error) : new PropValue(value);
+                return value is Exception error ? new(null, error) : new((T?)value);
             }
             catch (Exception ex)
             {
-                return new PropValue(null, ex);
+                return new(null, ex);
             }
+        }
+
+        PropValue<object> StorePropertyInCache(Type propertyType, PropValue<object> r)
+        {
+            if (r.Error != null)
+            {
+                // overwrite previous error, this has a chance of being more descriptive (due to blocked recursion)
+                return properties[propertyType] = r;
+            }
+            else
+            {
+                // don't overwrite value, it has to be singleton
+                return properties.GetOrAdd(propertyType, r);
+            }
+        }
+
+        void StoreProperty(object p)
+        {
+            if (p is DataContextStack dataContextStack)
+                this.dataContextStack.SetValue(new(dataContextStack));
+            else if (p is BindingErrorReporterProperty errorReporter)
+                this.errorReporter.SetValue(new(errorReporter));
+            else if (p is BindingResolverCollection resolverCollection)
+                this.resolverCollection.SetValue(new(resolverCollection));
+            else if (p is ResolvedBinding resolvedBinding)
+                this.resolvedBinding.SetValue(new(resolvedBinding));
+            else if (p is KnockoutExpressionBindingProperty knockoutExpressions)
+                this.knockoutExpressions.SetValue(new(knockoutExpressions));
+            else if (p is ParsedExpressionBindingProperty parsedExpression)
+                this.parsedExpression.SetValue(new(parsedExpression));
+            else if (p is ResultTypeBindingProperty resultType)
+                this.resultType.SetValue(new(resultType));
+            else if (p is BindingParserOptions parserOptions)
+                this.parserOptions.SetValue(new(parserOptions));
+            else if (p is BindingDelegate bindingDelegate)
+                this.bindingDelegate.SetValue(new(bindingDelegate));
+            else if (p is AssignedPropertyBindingProperty assignedProperty)
+                this.assignedProperty.SetValue(new(assignedProperty));
+            else if (p is BindingCompilationRequirementsAttribute compilationRequirements)
+                this.compilationRequirements.SetValue(new(compilationRequirements));
+            else if (p is DotvvmLocationInfo locationInfo)
+                this.locationInfo.SetValue(new(locationInfo));
+            else if (p is BindingUpdateDelegate updateDelegate)
+                this.updateDelegate.SetValue(new(updateDelegate));
+            else if (p is OriginalStringBindingProperty originalString)
+                this.originalString.SetValue(new(originalString));
+            else if (p is ExpectedTypeBindingProperty expectedType)
+                this.expectedType.SetValue(new(expectedType));
+            
+            else
+                StorePropertyInCache(p.GetType(), new(p));
         }
 
         private static Exception noResolversException = new Exception("There are no additional resolvers for this binding.");
@@ -97,33 +253,33 @@ namespace DotVVM.Framework.Binding.Expressions
         /// </summary>
         protected void AddNullResolvers()
         {
-            this.properties.TryAdd(typeof(BindingResolverCollection), new PropValue(null, noResolversException));
+            this.resolverCollection.SetValue(new(null, noResolversException));
         }
 
-        static Func<Exception, Exception> GetExceptionFactory(IBinding contextBinding, Type propType) =>
-            innerException =>
-            innerException is BindingPropertyException bpe && bpe.Binding == contextBinding ?
-            bpe.Nest(propType) :
-            new BindingPropertyException(contextBinding, propType, innerException);
+        public DataContextStack? DataContext => this.dataContextStack.GetValueOrNull(this);
 
         public object? GetProperty(Type type, ErrorHandlingMode errorMode = ErrorHandlingMode.ThrowException)
         {
-            if (!properties.TryGetValue(type, out var result))
-            {
-                var r = ComputeProperty(type);
-                if (r.Error != null)
-                {
-                    // overwrite previous error, this has a chance of being more descriptive (due to blocked recursion)
-                    properties[type] = r;
-                    result = r;
-                }
-                else
-                {
-                    // don't overwrite value, it has to be singleton
-                    result = properties.GetOrAdd(type, r);
-                }
-            }
-            return result.GetValue(errorMode, GetExceptionFactory(this, type));
+            var propValue =
+                type == typeof(DataContextStack) ? dataContextStack.GetValue(this).AsObject() :
+                type == typeof(BindingErrorReporterProperty) ? errorReporter.GetValue(this).AsObject() :
+                type == typeof(BindingResolverCollection) ? resolverCollection.GetValue(this).AsObject() :
+                type == typeof(ResolvedBinding) ? resolvedBinding.GetValue(this).AsObject() :
+                type == typeof(KnockoutExpressionBindingProperty) ? knockoutExpressions.GetValue(this).AsObject() :
+                type == typeof(ParsedExpressionBindingProperty) ? parsedExpression.GetValue(this).AsObject() :
+                type == typeof(ResultTypeBindingProperty) ? resultType.GetValue(this).AsObject() :
+                type == typeof(BindingParserOptions) ? parserOptions.GetValue(this).AsObject() :
+                type == typeof(BindingDelegate) ? bindingDelegate.GetValue(this).AsObject() :
+                type == typeof(AssignedPropertyBindingProperty) ? assignedProperty.GetValue(this).AsObject() :
+                type == typeof(BindingCompilationRequirementsAttribute) ? compilationRequirements.GetValue(this).AsObject() :
+                type == typeof(DotvvmLocationInfo) ? locationInfo.GetValue(this).AsObject() :
+                type == typeof(BindingUpdateDelegate) ? updateDelegate.GetValue(this).AsObject() :
+                type == typeof(OriginalStringBindingProperty) ? originalString.GetValue(this).AsObject() :
+                type == typeof(ExpectedTypeBindingProperty) ? expectedType.GetValue(this).AsObject() :
+
+                properties.TryGetValue(type, out var result) ? result : GetPropertyNotInCache(type);
+
+            return propValue.GetValue(errorMode, this, type);
         }
 
 
@@ -133,9 +289,24 @@ namespace DotVVM.Framework.Binding.Expressions
 
         IEnumerable<object> ICloneableBinding.GetAllComputedProperties()
         {
-            return properties.Values
-                .Where(p => p.Error == null)
-                .Select(p => p.Value ?? throw null!);
+            return properties.Values.Select(p => p.Value).Concat(new object?[] {
+                dataContextStack.GetValueOrNull(this),
+                errorReporter.GetValueOrNull(this),
+                resolverCollection.GetValueOrNull(this),
+                resolvedBinding.GetValueOrNull(this),
+                knockoutExpressions.GetValueOrNull(this),
+                parsedExpression.GetValueOrNull(this),
+                resultType.GetValueOrNull(this),
+                parserOptions.GetValueOrNull(this),
+                bindingDelegate.GetValueOrNull(this),
+                assignedProperty.GetValueOrNull(this),
+                compilationRequirements.GetValueOrNull(this),
+                locationInfo.GetValueOrNull(this),
+                updateDelegate.GetValueOrNull(this),
+                originalString.GetValueOrNull(this),
+                expectedType.GetValueOrNull(this),
+
+            }).Where(p => p != null)!;
         }
 
         BindingResolverCollection? cachedAdditionalResolvers;
@@ -145,8 +316,8 @@ namespace DotVVM.Framework.Binding.Expressions
             if (cachedAdditionalResolvers is {})
                 return cachedAdditionalResolvers;
 
-            var prop = ((AssignedPropertyBindingProperty?)properties.GetValueOrDefault(typeof(AssignedPropertyBindingProperty)).Value)?.DotvvmProperty;
-            var stack = (DataContextStack?)properties.GetValueOrDefault(typeof(DataContextStack)).Value;
+            var prop = assignedProperty.Value.Value?.DotvvmProperty;
+            var stack = dataContextStack.Value.Value;
 
             var attributes = prop?.GetAttributes<BindingCompilationOptionsAttribute>();
             var fromDataContext = stack?.GetAllBindingPropertyResolvers() ?? ImmutableArray<Delegate>.Empty;

--- a/src/Framework/Framework/Binding/Expressions/CommandBindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/CommandBindingExpression.cs
@@ -41,7 +41,7 @@ namespace DotVVM.Framework.Binding.Expressions
 
         public string BindingId => this.GetProperty<IdBindingProperty>().Id;
 
-        public BindingDelegate BindingDelegate => this.GetProperty<BindingDelegate>();
+        public BindingDelegate BindingDelegate => this.bindingDelegate.GetValueOrThrow(this);
 
         public class OptionsAttribute : BindingCompilationOptionsAttribute
         {

--- a/src/Framework/Framework/Binding/Expressions/CommandBindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/CommandBindingExpression.cs
@@ -34,12 +34,47 @@ namespace DotVVM.Framework.Binding.Expressions
             AddNullResolvers();
         }
 
+        private protected MaybePropValue<CommandJavascriptBindingProperty> commandJs;
+        private protected MaybePropValue<IdBindingProperty> id;
+        private protected MaybePropValue<ActionFiltersBindingProperty> actionFilters;
+
+        private protected override void StoreProperty(object p)
+        {
+            if (p is CommandJavascriptBindingProperty commandJs)
+                this.commandJs.SetValue(new(commandJs));
+            if (p is IdBindingProperty id)
+                this.id.SetValue(new(id));
+            if (p is ActionFiltersBindingProperty actionFilters)
+                this.actionFilters.SetValue(new(actionFilters));
+            else
+                base.StoreProperty(p);
+        }
+
+        public override object? GetProperty(Type type, ErrorHandlingMode errorMode = ErrorHandlingMode.ThrowException)
+        {
+            if (type == typeof(CommandJavascriptBindingProperty))
+                return commandJs.GetValue(this).GetValue(errorMode, this, type);
+            if (type == typeof(IdBindingProperty))
+                return id.GetValue(this).GetValue(errorMode, this, type);
+            if (type == typeof(ActionFiltersBindingProperty))
+                return actionFilters.GetValue(this).GetValue(errorMode, this, type);
+            return base.GetProperty(type, errorMode);
+        }
+
+        private protected override IEnumerable<object?> GetOutOfDictionaryProperties() =>
+            base.GetOutOfDictionaryProperties().Concat(new object?[] {
+                commandJs.Value.Value,
+                id.Value.Value,
+                actionFilters.Value.Value,
+            });
+
+
         public ImmutableArray<IActionFilter> ActionFilters =>
-            this.GetProperty<ActionFiltersBindingProperty>(ErrorHandlingMode.ReturnNull)?.Filters ?? ImmutableArray<IActionFilter>.Empty;
+            actionFilters.GetValueOrNull(this)?.Filters ?? ImmutableArray<IActionFilter>.Empty;
 
-        public ParametrizedCode CommandJavascript => this.GetProperty<CommandJavascriptBindingProperty>().Code;
+        public ParametrizedCode CommandJavascript => commandJs.GetValueOrThrow(this).Code;
 
-        public string BindingId => this.GetProperty<IdBindingProperty>().Id;
+        public string BindingId => id.GetValueOrThrow(this).Id;
 
         public BindingDelegate BindingDelegate => this.bindingDelegate.GetValueOrThrow(this);
 

--- a/src/Framework/Framework/Binding/Expressions/IBinding.cs
+++ b/src/Framework/Framework/Binding/Expressions/IBinding.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using DotVVM.Framework.Compilation.ControlTree;
 
 namespace DotVVM.Framework.Binding.Expressions
 {
@@ -12,6 +13,8 @@ namespace DotVVM.Framework.Binding.Expressions
     public interface IBinding
     {
         object? GetProperty(Type type, ErrorHandlingMode errorMode = ErrorHandlingMode.ThrowException);
+
+        DataContextStack? DataContext { get; }
 
         BindingResolverCollection? GetAdditionalResolvers();
         //IDictionary<Type, object> Properties { get; }

--- a/src/Framework/Framework/Binding/Expressions/ResourceBindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/ResourceBindingExpression.cs
@@ -20,9 +20,9 @@ namespace DotVVM.Framework.Binding.Expressions
     {
         public ResourceBindingExpression(BindingCompilationService service, IEnumerable<object> properties) : base(service, properties) { }
 
-        public BindingDelegate BindingDelegate => this.GetProperty<BindingDelegate>();
+        public BindingDelegate BindingDelegate => this.bindingDelegate.GetValueOrThrow(this);
 
-        public Type ResultType => this.GetProperty<ResultTypeBindingProperty>().Type;
+        public Type ResultType => this.resultType.GetValueOrThrow(this).Type;
 
         public class OptionsAttribute : BindingCompilationOptionsAttribute
         {

--- a/src/Framework/Framework/Binding/Expressions/StaticCommandBindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/StaticCommandBindingExpression.cs
@@ -20,7 +20,7 @@ namespace DotVVM.Framework.Binding.Expressions
 
         public ImmutableArray<IActionFilter> ActionFilters => this.GetProperty<ActionFiltersBindingProperty>(ErrorHandlingMode.ReturnNull)?.Filters ?? ImmutableArray<IActionFilter>.Empty;
 
-        public BindingDelegate BindingDelegate => this.GetProperty<BindingDelegate>();
+        public BindingDelegate BindingDelegate => this.bindingDelegate.GetValueOrThrow(this);
 
         public ParametrizedCode CommandJavascript => this.GetProperty<StaticCommandJavascriptProperty>().Code;
 

--- a/src/Framework/Framework/Binding/Expressions/ValueBindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/ValueBindingExpression.cs
@@ -34,15 +34,17 @@ namespace DotVVM.Framework.Binding.Expressions
             AddNullResolvers();
         }
 
-        public BindingDelegate BindingDelegate => this.GetProperty<BindingDelegate>();
+        public BindingDelegate BindingDelegate => this.bindingDelegate.GetValueOrThrow(this);
 
-        public BindingUpdateDelegate UpdateDelegate => this.GetProperty<BindingUpdateDelegate>();
+        public BindingUpdateDelegate UpdateDelegate => this.updateDelegate.GetValueOrThrow(this);
 
-        public ParametrizedCode KnockoutExpression => this.GetProperty<KnockoutExpressionBindingProperty>().Code;
-        public ParametrizedCode UnwrappedKnockoutExpression => this.GetProperty<KnockoutExpressionBindingProperty>().UnwrappedCode;
-        public ParametrizedCode WrappedKnockoutExpression => this.GetProperty<KnockoutExpressionBindingProperty>().WrappedCode;
+        public KnockoutExpressionBindingProperty KnockoutExpressionBindingProperty => this.knockoutExpressions.GetValueOrThrow(this);
 
-        public Type ResultType => this.GetProperty<ResultTypeBindingProperty>().Type;
+        public ParametrizedCode KnockoutExpression => KnockoutExpressionBindingProperty.Code;
+        public ParametrizedCode UnwrappedKnockoutExpression => KnockoutExpressionBindingProperty.UnwrappedCode;
+        public ParametrizedCode WrappedKnockoutExpression => KnockoutExpressionBindingProperty.WrappedCode;
+
+        public Type ResultType => this.resultType.GetValueOrThrow(this).Type;
 
         public class OptionsAttribute : BindingCompilationOptionsAttribute
         {

--- a/src/Framework/Framework/Binding/Expressions/ValueBindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/ValueBindingExpression.cs
@@ -34,6 +34,28 @@ namespace DotVVM.Framework.Binding.Expressions
             AddNullResolvers();
         }
 
+        private protected MaybePropValue<KnockoutExpressionBindingProperty> knockoutExpressions;
+
+        private protected override void StoreProperty(object p)
+        {
+            if (p is KnockoutExpressionBindingProperty knockoutExpressions)
+                this.knockoutExpressions.SetValue(new(knockoutExpressions));
+            else
+                base.StoreProperty(p);
+        }
+
+        public override object? GetProperty(Type type, ErrorHandlingMode errorMode = ErrorHandlingMode.ThrowException)
+        {
+            if (type == typeof(KnockoutExpressionBindingProperty))
+                return knockoutExpressions.GetValue(this).GetValue(errorMode, this, type);
+            return base.GetProperty(type, errorMode);
+        }
+
+        private protected override IEnumerable<object?> GetOutOfDictionaryProperties() =>
+            base.GetOutOfDictionaryProperties().Concat(new object?[] {
+                knockoutExpressions.Value.Value
+            });
+
         public BindingDelegate BindingDelegate => this.bindingDelegate.GetValueOrThrow(this);
 
         public BindingUpdateDelegate UpdateDelegate => this.updateDelegate.GetValueOrThrow(this);

--- a/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
+++ b/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
@@ -91,6 +91,19 @@ namespace DotVVM.Framework.Compilation.Binding
 
         public BindingParserOptions GetDefaultBindingParserOptions(IBinding binding)
         {
+            if (binding is ResourceBindingExpression)
+                return BindingParserOptions.Resource;
+            if (binding is StaticCommandBindingExpression)
+                return BindingParserOptions.StaticCommand;
+            if (binding is ControlPropertyBindingExpression)
+                return BindingParserOptions.ControlProperty;
+            if (binding is ValueBindingExpression)
+                return BindingParserOptions.Value;
+            if (binding is ControlCommandBindingExpression)
+                return BindingParserOptions.ControlCommand;
+            if (binding is CommandBindingExpression)
+                return BindingParserOptions.Command;
+
             return new BindingParserOptions(binding.GetType());
         }
 
@@ -161,10 +174,10 @@ namespace DotVVM.Framework.Compilation.Binding
         public BindingCompilationRequirementsAttribute GetAdditionalResolversFromProperty(AssignedPropertyBindingProperty property)
         {
             var prop = property?.DotvvmProperty;
-            if (prop == null) return new BindingCompilationRequirementsAttribute();
+            if (prop == null) return BindingCompilationRequirementsAttribute.Empty;
 
             return
-                new[] { new BindingCompilationRequirementsAttribute() }
+                new[] { BindingCompilationRequirementsAttribute.Empty }
                 .Concat(prop.GetAttributes<BindingCompilationRequirementsAttribute>())
                 .Aggregate((a, b) => a.ApplySecond(b));
         }
@@ -365,7 +378,8 @@ namespace DotVVM.Framework.Compilation.Binding
                 p
             ));
             // does not matter that this is slow, there is quite a lot of bindings and all the filenames take space
-            fileName = string.Intern(fileName);
+            if (fileName is {})
+                fileName = string.Intern(fileName);
             return new DotvvmLocationInfo(
                 fileName,
                 resolvedBinding.DothtmlNode?.Tokens?.Select(t => (t.ColumnNumber, t.ColumnNumber + t.Length)).ToArray(),

--- a/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
+++ b/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
@@ -364,6 +364,8 @@ namespace DotVVM.Framework.Compilation.Binding
                 configuration.ApplicationPhysicalPath,
                 p
             ));
+            // does not matter that this is slow, there is quite a lot of bindings and all the filenames take space
+            fileName = string.Intern(fileName);
             return new DotvvmLocationInfo(
                 fileName,
                 resolvedBinding.DothtmlNode?.Tokens?.Select(t => (t.ColumnNumber, t.ColumnNumber + t.Length)).ToArray(),

--- a/src/Framework/Framework/Compilation/BindingCompiler.cs
+++ b/src/Framework/Framework/Compilation/BindingCompiler.cs
@@ -130,9 +130,9 @@ namespace DotVVM.Framework.Compilation
                 if (p is DataSourceCurrentElementBinding collectionElement)
                     properties[i] = cloneNestedBinding(collectionElement.Binding)?.Apply(b => new DataSourceCurrentElementBinding(b));
                 if (p is SelectorItemBindingProperty selectorItem)
-                    properties[i] = cloneNestedBinding(selectorItem.Expression)?.Apply(b => new SelectorItemBindingProperty((IValueBinding)b));
+                    properties[i] = cloneNestedBinding(selectorItem.Expression)?.Apply(b => new SelectorItemBindingProperty(b));
                 if (p is ThisBindingProperty thisBinding)
-                    properties[i] = cloneNestedBinding(thisBinding.binding)?.Apply(b => new ThisBindingProperty((IValueBinding)b));
+                    properties[i] = cloneNestedBinding(thisBinding.binding)?.Apply(b => new ThisBindingProperty(b));
             }
 
             return (IBinding)Activator.CreateInstance(binding.GetType(), new object[] {
@@ -140,9 +140,10 @@ namespace DotVVM.Framework.Compilation
                 properties
             });
 
-            IBinding? cloneNestedBinding(IBinding b) =>
+            T? cloneNestedBinding<T>(T b)
+                where T: class, IBinding =>
                 b == binding ? null : // it it's self, then we can just recreate it at runtime
-                CreateMinimalClone(b);
+                (T)CreateMinimalClone(b);
         }
 
         public IEnumerable<object> GetMinimalCloneProperties(IBinding binding)

--- a/src/Framework/Framework/Compilation/ControlTree/ControlResolverBase.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ControlResolverBase.cs
@@ -127,7 +127,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
 				rule.Validate();
 				if (!string.IsNullOrEmpty(rule.TagName))
 				{
-					return FindMarkupControl(rule.Src.NotNull());
+					return FindMarkupControl(string.Intern(rule.Src.NotNull()));
 				}
 			}
 			// then code only control

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedBinding.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedBinding.cs
@@ -8,6 +8,7 @@ using DotVVM.Framework.Binding.Expressions;
 using DotVVM.Framework.Binding.Properties;
 using DotVVM.Framework.Compilation.Parser.Dothtml.Parser;
 using DotVVM.Framework.Controls;
+using DotVVM.Framework.Utils;
 using Microsoft.CodeAnalysis;
 
 namespace DotVVM.Framework.Compilation.ControlTree.Resolved
@@ -28,7 +29,7 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
 
         public Expression? Expression => Binding.GetProperty<ParsedExpressionBindingProperty>(ErrorHandlingMode.ReturnNull)?.Expression;
 
-        public DataContextStack DataContextTypeStack => Binding.GetProperty<DataContextStack>();
+        public DataContextStack DataContextTypeStack => Binding.DataContext.NotNull();
 
         public BindingErrorReporterProperty Errors => Binding.GetProperty<BindingErrorReporterProperty>();
 

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedPropertyCapability.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedPropertyCapability.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using DotVVM.Framework.Binding;

--- a/src/Framework/Framework/Compilation/Javascript/JsFormattingVisitor.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JsFormattingVisitor.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using DotVVM.Framework.Compilation.Javascript.Ast;
+using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Compilation.Javascript
 {
@@ -130,14 +131,14 @@ namespace DotVVM.Framework.Compilation.Javascript
         {
             if (parameters == null || parameters.Count == 0) return new ParametrizedCode(result.ToString(), operatorPrecedence);
             var parts = new string[parameters.Count + 1];
-            parts[0] = result.ToString(0, parameters[0].index);
+            parts[0] = result.ToString(0, parameters[0].index).DotvvmInternString();
             for (int i = 1; i < parameters.Count; i++)
             {
                 var from = parameters[i - 1].index;
-                parts[i] = result.ToString(from, parameters[i].index - from);
+                parts[i] = result.ToString(from, parameters[i].index - from).DotvvmInternString();
             }
             int lastFrom = parameters[parameters.Count - 1].index;
-            parts[parts.Length - 1] = result.ToString(lastFrom, result.Length - lastFrom);
+            parts[parts.Length - 1] = result.ToString(lastFrom, result.Length - lastFrom).DotvvmInternString();
             return new ParametrizedCode(parts, parameters.Select(p => p.parameter).ToArray(), operatorPrecedence);
         }
 

--- a/src/Framework/Framework/Compilation/Javascript/ParametrizedCode.cs
+++ b/src/Framework/Framework/Compilation/Javascript/ParametrizedCode.cs
@@ -8,6 +8,7 @@ using DotVVM.Framework.Binding.Properties;
 using DotVVM.Framework.Binding.Expressions;
 using Newtonsoft.Json;
 using System.Diagnostics;
+using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Compilation.Javascript
 {
@@ -88,7 +89,7 @@ namespace DotVVM.Framework.Compilation.Javascript
             }
             var result = sb.ToString();
             if (allIsDefault)
-                this.evaluatedDefault = result;
+                this.evaluatedDefault = result.DotvvmInternString();
             return result;
         }
 
@@ -150,7 +151,7 @@ namespace DotVVM.Framework.Compilation.Javascript
                     var isGlobalContext = a.IsGlobalContext && parameters![i].IsSafeMemberAccess;
 
                     if (isGlobalContext)
-                        builder.Add(stringParts[1 + i].Substring(1, stringParts[i].Length - 1)); // skip `.`
+                        builder.Add(stringParts[1 + i].AsSpan(1, stringParts[i].Length - 1).DotvvmInternString()); // skip `.`
                     else
                     {
                         builder.Add(a.Code, parameters![i].OperatorPrecedence);
@@ -246,7 +247,7 @@ namespace DotVVM.Framework.Compilation.Javascript
 
             public void Add(CodeParameterInfo parameter)
             {
-                stringParts.Add(lastPart.ToString());
+                stringParts.Add(lastPart.ToString().DotvvmInternString());
                 lastPart.Clear();
                 parameters.Add(parameter);
             }
@@ -261,7 +262,7 @@ namespace DotVVM.Framework.Compilation.Javascript
 
             public ParametrizedCode Build(OperatorPrecedence operatorPrecedence)
             {
-                stringParts.Add(lastPart.ToString());
+                stringParts.Add(lastPart.ToString().DotvvmInternString());
                 return new ParametrizedCode(stringParts.ToArray(), parameters.ToArray(), operatorPrecedence);
             }
 

--- a/src/Framework/Framework/Compilation/Parser/AggregateList.cs
+++ b/src/Framework/Framework/Compilation/Parser/AggregateList.cs
@@ -16,9 +16,13 @@ namespace DotVVM.Framework.Compilation.Parser
         public void Add(Part p)
         {
             if (p.len == 0) return;
+            if (firstPart.len == 0)
+            {
+                firstPart = p;
+                return;
+            }
             var last = (parts == null ? firstPart : parts[parts.Count - 1]);
-            if (firstPart.len == 0) firstPart = p;
-            else if (last.list == p.list && last.from + last.len == p.from)
+            if (last.list == p.list && last.from + last.len == p.from)
             {
                 if (parts == null) firstPart = firstPart.AddLen(p.len);
                 else
@@ -182,6 +186,8 @@ namespace DotVVM.Framework.Compilation.Parser
             public IEnumerator<T> GetEnumerator() => new AggregateList<T>.Enumerator(this, null);
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            public bool Any => len > 0;
 
             public T Last() => len > 0 ? list[from + len - 1] : throw new InvalidOperationException("AggregateList does not contain any element.");
             [return: MaybeNull]

--- a/src/Framework/Framework/Compilation/Parser/Binding/Parser/BindingParser.cs
+++ b/src/Framework/Framework/Compilation/Parser/Binding/Parser/BindingParser.cs
@@ -13,7 +13,9 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
 {
     public class BindingParser : ParserBase<BindingToken, BindingTokenType>
     {
-        protected override bool IsWhiteSpace(BindingToken t) => t.Type == BindingTokenType.WhiteSpace;
+        public BindingParser() : base(BindingTokenType.WhiteSpace)
+        {
+        }
 
         public BindingParserNode ReadDirectiveValue()
         {
@@ -49,7 +51,7 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
         {
             var startIndex = CurrentIndex;
             var typeName = ReadNamespaceOrTypeName();
-            if (Peek()?.Type == BindingTokenType.Comma)
+            if (PeekType() == BindingTokenType.Comma)
             {
                 Read();
                 var assemblyName = ReadNamespaceOrTypeName();
@@ -373,7 +375,7 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
             SetRestorePoint();
 
             // Try to read lambda parameters
-            if (!TryReadLambdaParametersExpression(out var parameters) || Peek()?.Type != BindingTokenType.LambdaOperator)
+            if (!TryReadLambdaParametersExpression(out var parameters) || PeekType() != BindingTokenType.LambdaOperator)
             {
                 // Fail - we should try to parse as an expression
                 Restore();
@@ -395,13 +397,13 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
             var startIndex = CurrentIndex;
             var waitingForParameter = false;
             parameters = new List<LambdaParameterBindingParserNode>();
-            if (Peek()?.Type == BindingTokenType.OpenParenthesis)
+            if (PeekType() == BindingTokenType.OpenParenthesis)
             {
                 // Begin parameters parsing - read opening parenthesis
                 Read();
                 SkipWhiteSpace();
 
-                while (Peek()?.Type != BindingTokenType.CloseParenthesis)
+                while (PeekType() != BindingTokenType.CloseParenthesis)
                 {
                     // Try read parameter definition (either implicitly defined type or explicitly)
                     if (!TryReadLambdaParameterDefinition(out var typeDef, out var nameDef))
@@ -409,7 +411,7 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
                     parameters.Add(new LambdaParameterBindingParserNode(typeDef, nameDef!));
                     waitingForParameter = false;
 
-                    if (Peek()?.Type == BindingTokenType.Comma)
+                    if (PeekType() == BindingTokenType.Comma)
                     {
                         Read();
                         SkipWhiteSpace();
@@ -423,7 +425,7 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
                 }
 
                 // End parameters parsing - read closing parenthesis
-                if (Peek()?.Type != BindingTokenType.CloseParenthesis)
+                if (PeekType() != BindingTokenType.CloseParenthesis)
                     return false;
                 Read();
                 SkipWhiteSpace();
@@ -448,14 +450,14 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
         {
             name = null;
             type = null;
-            if (Peek()?.Type != BindingTokenType.Identifier)
+            if (PeekType() != BindingTokenType.Identifier)
                 return false;
 
             if (!TryReadTypeReference(out type))
                 return false;
             SkipWhiteSpace();
 
-            if (Peek()?.Type != BindingTokenType.Identifier)
+            if (PeekType() != BindingTokenType.Identifier)
             {
                 name = type;
                 type = null;
@@ -804,11 +806,11 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
                     arguments.Add(argument);
                 SkipWhiteSpace();
 
-                if (Peek()?.Type != BindingTokenType.Comma) { break; }
+                if (PeekType() != BindingTokenType.Comma) { break; }
                 Read();
             }
 
-            failure |= Peek()?.Type != BindingTokenType.GreaterThanOperator;
+            failure |= PeekType() != BindingTokenType.GreaterThanOperator;
 
             if (!failure)
             {

--- a/src/Framework/Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenizer.cs
+++ b/src/Framework/Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenizer.cs
@@ -9,9 +9,9 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Tokenizer
     {
         private readonly ISet<char> operatorCharacters = new HashSet<char> { '+', '-', '*', '/', '^', '\\', '%', '<', '>', '=', '&', '|', '~', '!', ';' };
 
-        protected override BindingTokenType TextTokenType => BindingTokenType.Identifier;
-
-        protected override BindingTokenType WhiteSpaceTokenType => BindingTokenType.WhiteSpace;
+        public BindingTokenizer() : base(BindingTokenType.Identifier, BindingTokenType.WhiteSpace)
+        {
+        }
 
         public bool IsOperator(char c) => operatorCharacters.Contains(c);
 
@@ -30,52 +30,52 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Tokenizer
                 switch (ch)
                 {
                     case '.':
-                        if (CurrentTokenChars.Length > 0 && Enumerable.Range(0, CurrentTokenChars.Length).All(i => Char.IsDigit(CurrentTokenChars[i])))
+                        if (DistanceSinceLastToken > 0 && GetCurrentTokenText().All(c => Char.IsDigit(c)))
                         {
                             // treat dot in a number as part of the number
                             Read();
                             if (!char.IsDigit(Peek()))
                             {
                                 CreateToken(BindingTokenType.Identifier, 1);
-                                CreateToken(BindingTokenType.Dot);
+                                CreateToken(BindingTokenType.Dot, ".");
                             }
                         }
                         else
                         {
                             FinishIncompleteIdentifier();
                             Read();
-                            CreateToken(BindingTokenType.Dot);
+                            CreateToken(BindingTokenType.Dot, ".");
                         }
                         break;
 
                     case ',':
                         FinishIncompleteIdentifier();
                         Read();
-                        CreateToken(BindingTokenType.Comma);
+                        CreateToken(BindingTokenType.Comma, ",");
                         break;
 
                     case '(':
                         FinishIncompleteIdentifier();
                         Read();
-                        CreateToken(BindingTokenType.OpenParenthesis);
+                        CreateToken(BindingTokenType.OpenParenthesis, "(");
                         break;
 
                     case ')':
                         FinishIncompleteIdentifier();
                         Read();
-                        CreateToken(BindingTokenType.CloseParenthesis);
+                        CreateToken(BindingTokenType.CloseParenthesis, ")");
                         break;
 
                     case '[':
                         FinishIncompleteIdentifier();
                         Read();
-                        CreateToken(BindingTokenType.OpenArrayBrace);
+                        CreateToken(BindingTokenType.OpenArrayBrace, "[");
                         break;
 
                     case ']':
                         FinishIncompleteIdentifier();
                         Read();
-                        CreateToken(BindingTokenType.CloseArrayBrace);
+                        CreateToken(BindingTokenType.CloseArrayBrace, "]");
                         break;
 
                     case '+':
@@ -116,7 +116,7 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Tokenizer
                     case ':':
                         FinishIncompleteIdentifier();
                         Read();
-                        CreateToken(BindingTokenType.ColonOperator);
+                        CreateToken(BindingTokenType.ColonOperator, ":");
                         break;
 
                     case '=':
@@ -247,7 +247,7 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Tokenizer
                     case ';':
                         FinishIncompleteIdentifier();
                         Read();
-                        CreateToken(BindingTokenType.Semicolon);
+                        CreateToken(BindingTokenType.Semicolon, ";");
                         break;
 
                     default:

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DotHtmlCommentNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DotHtmlCommentNode.cs
@@ -23,21 +23,16 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
         {
             if (ValueNode != null)
             {
-                yield return ValueNode;
+                return new DothtmlNode[] { ValueNode };
             }
+            return Enumerable.Empty<DothtmlNode>();
         }
 
         public override void Accept(IDothtmlSyntaxTreeVisitor visitor)
         {
             visitor.Visit(this);
 
-            foreach (var node in EnumerateChildNodes())
-            {
-                if (visitor.Condition(node))
-                {
-                    node.Accept(visitor);
-                }
-            }
+            ValueNode?.AcceptIfCondition(visitor);
         }
 
         public override IEnumerable<DothtmlNode> EnumerateNodes()

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlAttributeNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlAttributeNode.cs
@@ -6,7 +6,7 @@ using DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer;
 namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
 {
     [DebuggerDisplay("{debuggerDisplay,nq}{ValueNode}")]
-    public class DothtmlAttributeNode : DothtmlNode
+    public sealed class DothtmlAttributeNode : DothtmlNode
     {
         #region debugger display
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -56,13 +56,15 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
         {
             visitor.Visit(this);
 
-            foreach (var node in EnumerateChildNodes())
-            {
-                if (visitor.Condition(node))
-                {
-                    node.Accept(visitor);
-                }
-            }
+            AttributePrefixNode?.AcceptIfCondition(visitor);
+            AttributeNameNode.AcceptIfCondition(visitor);
+            ValueNode?.AcceptIfCondition(visitor);
+        }
+
+        internal new void AcceptIfCondition(IDothtmlSyntaxTreeVisitor visitor)
+        {
+            if (visitor.Condition(this))
+                this.Accept(visitor);
         }
 
         public override IEnumerable<DothtmlNode> EnumerateNodes()

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlBindingNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlBindingNode.cs
@@ -57,13 +57,8 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
         {
             visitor.Visit(this);
 
-            foreach (var node in EnumerateChildNodes())
-            {
-                if (visitor.Condition(node))
-                {
-                    node.Accept(visitor);
-                }
-            }
+            NameNode?.AcceptIfCondition(visitor);
+            ValueNode?.AcceptIfCondition(visitor);
         }
 
         public override IEnumerable<DothtmlNode> EnumerateNodes()

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlDirectiveNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlDirectiveNode.cs
@@ -31,14 +31,8 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
         public override void Accept(IDothtmlSyntaxTreeVisitor visitor)
         {
             visitor.Visit(this);
-
-            foreach (var node in EnumerateChildNodes())
-            {
-                if (visitor.Condition(node))
-                {
-                    node.Accept(visitor);
-                }
-            }
+            NameNode.AcceptIfCondition(visitor);
+            ValueNode?.AcceptIfCondition(visitor);
         }
 
         public override IEnumerable<DothtmlNode> EnumerateNodes()

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlNameNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlNameNode.cs
@@ -4,7 +4,7 @@ using DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer;
 
 namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
 {
-    public class DothtmlNameNode :DothtmlNode
+    public sealed class DothtmlNameNode :DothtmlNode
     {
         public DothtmlNameNode(DothtmlToken nameToken)
         {
@@ -24,6 +24,12 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
         public override void Accept(IDothtmlSyntaxTreeVisitor visitor)
         {
             visitor.Visit(this);
+        }
+
+        internal new void AcceptIfCondition(IDothtmlSyntaxTreeVisitor visitor)
+        {
+            if (visitor.Condition(this))
+                visitor.Visit(this);
         }
     }
 }

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlNode.cs
@@ -40,6 +40,12 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
 
         public abstract void Accept(IDothtmlSyntaxTreeVisitor visitor);
 
+        internal void AcceptIfCondition(IDothtmlSyntaxTreeVisitor visitor)
+        {
+            if (visitor.Condition(this))
+                this.Accept(visitor);
+        }
+
         public abstract IEnumerable<DothtmlNode> EnumerateChildNodes();
 
         public DothtmlNode FindNodeByPosition(int position)

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlValueNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlValueNode.cs
@@ -8,5 +8,6 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
     {
         public IEnumerable<DothtmlToken> WhitespacesBefore { get; set; } = Enumerable.Empty<DothtmlToken>();
         public IEnumerable<DothtmlToken> WhitespacesAfter { get; set; } = Enumerable.Empty<DothtmlToken>();
+        
     }
 }

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/ParserBase.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/ParserBase.cs
@@ -7,7 +7,7 @@ using DotVVM.Framework.Utils;
 namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
 {
     public abstract class ParserBase<TToken, TTokenType> where TToken : TokenBase<TTokenType>
-                                                         where TTokenType : notnull, IEquatable<TTokenType>
+                                                         where TTokenType : notnull
     {
         public TTokenType WhiteSpaceTokenType { get; }
 
@@ -24,7 +24,8 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
             return new AggregateList<TToken>.Part(Tokens, startIndex, CurrentIndex - startIndex); // Enumerable.Skip<TToken>(Tokens, startIndex).Take(CurrentIndex - startIndex);
         }
 
-        protected bool IsWhiteSpace(TToken token) => this.WhiteSpaceTokenType.Equals(token.Type);
+        protected bool IsWhiteSpace(TToken token) =>
+            EqualityComparer<TTokenType>.Default.Equals(this.WhiteSpaceTokenType, token.Type);
 
         public List<TToken> Tokens { get; set; } = new List<TToken>();
         protected int CurrentIndex { get; set; }

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/ParserBase.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/ParserBase.cs
@@ -7,7 +7,15 @@ using DotVVM.Framework.Utils;
 namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
 {
     public abstract class ParserBase<TToken, TTokenType> where TToken : TokenBase<TTokenType>
+                                                         where TTokenType : notnull, IEquatable<TTokenType>
     {
+        public TTokenType WhiteSpaceTokenType { get; }
+
+        protected ParserBase(TTokenType whiteSpaceTokenType)
+        {
+            WhiteSpaceTokenType = whiteSpaceTokenType;
+        }
+
         /// <summary>
         /// Gets the tokens from.
         /// </summary>
@@ -16,7 +24,7 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
             return new AggregateList<TToken>.Part(Tokens, startIndex, CurrentIndex - startIndex); // Enumerable.Skip<TToken>(Tokens, startIndex).Take(CurrentIndex - startIndex);
         }
 
-        protected abstract bool IsWhiteSpace(TToken token);
+        protected bool IsWhiteSpace(TToken token) => this.WhiteSpaceTokenType.Equals(token.Type);
 
         public List<TToken> Tokens { get; set; } = new List<TToken>();
         protected int CurrentIndex { get; set; }
@@ -43,9 +51,18 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
         {
             if (CurrentIndex < Tokens.Count)
             {
-                return Tokens[CurrentIndex].NotNull();
+                return Tokens[CurrentIndex];
             }
-            return null!;
+            return null;
+        }
+
+        public TTokenType PeekType()
+        {
+            if (CurrentIndex < Tokens.Count)
+            {
+                return Tokens[CurrentIndex].Type;
+            }
+            return default!;
         }
 
         /// <summary>
@@ -105,9 +122,9 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
         {
             if (CurrentIndex < Tokens.Count)
             {
-                return Tokens[CurrentIndex++].NotNull();
+                return Tokens[CurrentIndex++];
             }
-            return null!;
+            return null;
         }
 
         /// <summary>

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Tokenizer/DothtmlTokenizer.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Tokenizer/DothtmlTokenizer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using DotVVM.Framework.Compilation.Parser.Binding.Tokenizer;
@@ -12,21 +13,36 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
     /// </summary>
     public class DothtmlTokenizer : TokenizerBase<DothtmlToken, DothtmlTokenType>
     {
-
-        private static readonly HashSet<char> AllowedAttributeFirstChars = new HashSet<char>()
+        public DothtmlTokenizer() : base(DothtmlTokenType.Text, DothtmlTokenType.WhiteSpace)
         {
-            '_', '[', '('
-        };
+        }
 
-        private static readonly HashSet<char> AllowedAttributeChars = new HashSet<char>()
+        private static bool IsAllowedAttributeFirstChar(char ch)
         {
-            ':', '_', '-', '.', '[', ']', '(', ')'
-        };
+            return ch == '_' | ch == '[' | ch == '(';
+        }
 
-        private static readonly HashSet<char> AllowedIdentifierChars = new HashSet<char>()
+        private static bool IsAllowedAttributeChar(char ch)
         {
-            ':', '_', '-', '.'
-        };
+            // codegolfing at this point... nvm, this is a fast way to check if small (< 64) integer is in a set
+            // * create a bit mask for the target set
+            //     - when needed, shift the integer by an offset to make it fit into the 64 bits
+            // ...would be nice if C# did this optimization automatically, but it doesn't
+            const int shift = '('; // 40
+            Debug.Assert(shift - '_' < 64);
+            const ulong magicBitMask = (1L << ':' - shift | 1L << '_' - shift | 1L << '-' - shift | 1L << '.' - shift | 1L << '[' - shift | 1L << ']' - shift | 1L << '(' - shift | 1L << ')' - shift);
+            uint c = (uint)ch - shift;
+            return c < 63 & 0 != ((1UL << (int)c) & magicBitMask);
+        }
+
+        private static bool IsAllowedIdentifierChar(char ch)
+        {
+            const int shift = '('; // 40
+            Debug.Assert(shift - '_' < 64);
+            const ulong magicBitMask = (1L << ':' - shift | 1L << '_' - shift | 1L << '-' - shift | 1 << '.' - shift);
+            uint c = (uint)ch - shift;
+            return c < 63 & 0 != ((1UL << (int)c) & magicBitMask);
+        }
 
 
         public override void Tokenize(string sourceText)
@@ -45,22 +61,6 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
                 Assert((Tokens.LastOrDefault()?.Length ?? 0) > 0);
                 return true;
             });
-        }
-
-        /// <summary>
-        /// Gets the type of the text token.
-        /// </summary>
-        protected override DothtmlTokenType TextTokenType
-        {
-            get { return DothtmlTokenType.Text; }
-        }
-
-        /// <summary>
-        /// Gets the type of the white space token.
-        /// </summary>
-        protected override DothtmlTokenType WhiteSpaceTokenType
-        {
-            get { return DothtmlTokenType.WhiteSpace; }
         }
 
         /// <summary>
@@ -136,10 +136,10 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
 
             // the directive started
             Read();
-            CreateToken(DothtmlTokenType.DirectiveStart);
+            CreateToken(DothtmlTokenType.DirectiveStart, "@");
 
             // identifier
-            if (!ReadIdentifier(DothtmlTokenType.DirectiveName, '\r', '\n'))
+            if (!ReadIdentifier(DothtmlTokenType.DirectiveName))
             {
                 CreateToken(DothtmlTokenType.DirectiveName, errorProvider: t => CreateTokenError(t, DothtmlTokenType.DirectiveStart, DothtmlTokenizerErrors.DirectiveNameExpected));
             }
@@ -166,16 +166,18 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
         /// <summary>
         /// Reads the identifier.
         /// </summary>
-        private bool ReadIdentifier(DothtmlTokenType tokenType, params char[] stopChars)
+        private bool ReadIdentifier(DothtmlTokenType tokenType, char stopChar = '\0')
         {
+            var ch = Peek();
             // read first character
-            if ((!char.IsLetter(Peek()) && Peek() != '_') || stopChars.Contains(Peek()))
+            if ((!char.IsLetter(ch) && ch != '_') | stopChar == ch)
                 return false;
 
             // read identifier
-            while ((Char.IsLetterOrDigit(Peek()) || AllowedIdentifierChars.Contains(Peek())) && !stopChars.Contains(Peek()))
+            while ((Char.IsLetterOrDigit(ch) | IsAllowedIdentifierChar(ch)) & stopChar != ch)
             {
                 Read();
+                ch = Peek();
             }
             CreateToken(tokenType);
             return true;
@@ -184,16 +186,18 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
         /// <summary>
         /// Reads the attribute name.
         /// </summary>
-        private bool ReadAttributeName(DothtmlTokenType tokenType, params char[] stopChars)
+        private bool ReadAttributeName(DothtmlTokenType tokenType, char stopChar)
         {
+            var ch = Peek();
             // read first character
-            if ((!char.IsLetter(Peek()) && !AllowedAttributeFirstChars.Contains(Peek())) || stopChars.Contains(Peek()))
+            if ((!char.IsLetter(ch) && !IsAllowedAttributeFirstChar(ch)) | stopChar == ch)
                 return false;
 
             // read identifier
-            while ((Char.IsLetterOrDigit(Peek()) || AllowedAttributeChars.Contains(Peek())) && !stopChars.Contains(Peek()))
+            while ((Char.IsLetterOrDigit(ch) | IsAllowedAttributeChar(ch)) & stopChar != ch)
             {
                 Read();
+                ch = Peek();
             }
             CreateToken(tokenType);
             return true;
@@ -214,24 +218,26 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
                 Read();
             }
 
-            if (Peek() == '!' || Peek() == '?' || Peek() == '%')
+            var firstChar = Peek();
+
+            if (firstChar == '!' | firstChar == '?' | firstChar == '%')
             {
                 return ReadHtmlSpecial(true);
             }
 
-            if (!char.IsLetterOrDigit(Peek()) && Peek() != '/' && Peek() != ':')
+            if (!char.IsLetterOrDigit(firstChar) & firstChar != '/' & firstChar != ':')
             {
                 CreateToken(DothtmlTokenType.Text, errorProvider: t => CreateTokenError(t, "'<' char is not allowed in normal text"));
                 return ReadElementType.Error;
             }
 
-            CreateToken(DothtmlTokenType.OpenTag);
+            CreateToken(DothtmlTokenType.OpenTag, "<");
 
-            if (Peek() == '/')
+            if (firstChar == '/')
             {
                 // it is a closing tag
                 Read();
-                CreateToken(DothtmlTokenType.Slash);
+                CreateToken(DothtmlTokenType.Slash, "/");
                 isClosingTag = true;
             }
 
@@ -282,7 +288,7 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
             {
                 // self closing tag
                 Read();
-                CreateToken(DothtmlTokenType.Slash);
+                CreateToken(DothtmlTokenType.Slash, "/");
             }
             if (Peek() != '>')
             {
@@ -292,7 +298,7 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
             }
 
             Read();
-            CreateToken(DothtmlTokenType.CloseTag);
+            CreateToken(DothtmlTokenType.CloseTag, ">");
             return ReadElementType.ValidTag;
         }
 
@@ -351,10 +357,10 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
 
         private ReadElementType ReadComment()
         {
-            CreateToken(DothtmlTokenType.OpenComment);
+            CreateToken(DothtmlTokenType.OpenComment, "<!--");
             if (ReadTextUntil(DothtmlTokenType.CommentBody, "-->", false))
             {
-                CreateToken(DothtmlTokenType.CloseComment);
+                CreateToken(DothtmlTokenType.CloseComment, "-->");
                 return ReadElementType.Comment;
             }
             else
@@ -367,10 +373,10 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
 
         private ReadElementType ReadServerComment()
         {
-            CreateToken(DothtmlTokenType.OpenServerComment);
+            CreateToken(DothtmlTokenType.OpenServerComment, "<%--");
             if (ReadTextUntil(DothtmlTokenType.CommentBody, "--%>", false, nestString: "<%--"))
             {
-                CreateToken(DothtmlTokenType.CloseComment);
+                CreateToken(DothtmlTokenType.CloseComment, "--%>");
                 return ReadElementType.ServerComment;
             }
             else
@@ -426,12 +432,12 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
         /// </summary>
         private bool ReadTagOrAttributeName(bool isAttributeName)
         {
-            var readIdentifierFunc = isAttributeName ? (Func<DothtmlTokenType, char[], bool>)ReadAttributeName : (Func<DothtmlTokenType, char[], bool>)ReadIdentifier;
+            var readIdentifierFunc = isAttributeName ? (Func<DothtmlTokenType, char, bool>)ReadAttributeName : (Func<DothtmlTokenType, char, bool>)ReadIdentifier;
 
             if (Peek() != ':')
             {
                 // read the identifier
-                if (!readIdentifierFunc(DothtmlTokenType.Text, new[] { ':' }))
+                if (!readIdentifierFunc(DothtmlTokenType.Text, ':'))
                 {
                     return false;
                 }
@@ -445,9 +451,9 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
             if (Peek() == ':')
             {
                 Read();
-                CreateToken(DothtmlTokenType.Colon);
+                CreateToken(DothtmlTokenType.Colon, ":");
 
-                if (!readIdentifierFunc(DothtmlTokenType.Text, new char[] { }))
+                if (!readIdentifierFunc(DothtmlTokenType.Text, '\0'))
                 {
                     CreateToken(DothtmlTokenType.Text, errorProvider: t => CreateTokenError(t, DothtmlTokenType.OpenTag, DothtmlTokenizerErrors.MissingTagName));
                     return true;
@@ -473,7 +479,7 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
             {
                 // equals sign
                 Read();
-                CreateToken(DothtmlTokenType.Equals);
+                CreateToken(DothtmlTokenType.Equals, "=");
                 SkipWhitespace();
 
                 // attribute value
@@ -533,7 +539,7 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
             var quotes = Peek();
             var quotesToken = quotes == '\'' ? DothtmlTokenType.SingleQuote : DothtmlTokenType.DoubleQuote;
             Read();
-            CreateToken(quotesToken);
+            CreateToken(quotesToken, quotesToken == DothtmlTokenType.SingleQuote ? "'" : "\"");
 
             // read value
             if (Peek() == '{')
@@ -566,7 +572,7 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
             else
             {
                 Read();
-                CreateToken(quotesToken);
+                CreateToken(quotesToken, quotesToken == DothtmlTokenType.SingleQuote ? "'" : "\"");
                 SkipWhitespace();
             }
             return true;
@@ -585,7 +591,7 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
                 doubleCloseBrace = true;
                 Read();
             }
-            CreateToken(DothtmlTokenType.OpenBinding);
+            CreateToken(DothtmlTokenType.OpenBinding, doubleCloseBrace ? "{{" : "{");
             SkipWhitespace();
 
             // read binding name
@@ -656,7 +662,7 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
                 }
                 Read();
             }
-            CreateToken(DothtmlTokenType.CloseBinding);
+            CreateToken(DothtmlTokenType.CloseBinding, doubleCloseBrace ? "}}" : "}");
         }
 
         protected override DothtmlToken NewToken(string text, DothtmlTokenType type, int lineNumber, int columnNumber, int length, int startPosition)

--- a/src/Framework/Framework/Compilation/Parser/TokenizerBase.cs
+++ b/src/Framework/Framework/Compilation/Parser/TokenizerBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
+using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Compilation.Parser
 {
@@ -212,13 +213,26 @@ namespace DotVVM.Framework.Compilation.Parser
 		/// </summary>
 		protected TToken CreateToken(TTokenType type, int charsFromEndToSkip = 0, Func<TToken, TokenError>? errorProvider = null)
 		{
-			var text = CurrentTokenChars.ToString().Substring(0, DistanceSinceLastToken - charsFromEndToSkip);
+			var length = CurrentTokenChars.Length - charsFromEndToSkip;
+			string text;
+
+			
+			if (length < 200)
+			{
+				Span<char> data = stackalloc char[length];
+				CurrentTokenChars.CopyTo(0, data, length);
+				text = ((ReadOnlySpan<char>)data).DotvvmInternString(trySystemIntern: length < 10);
+			}
+			else
+			{
+				text = CurrentTokenChars.ToString().Substring(0, length);
+			}
 
 			var t = NewToken(text,
 							 type,
 							 lineNumber: CurrentLine,
 							 columnNumber: Math.Max(0, PositionOnLine - DistanceSinceLastToken - 1),
-							 length: DistanceSinceLastToken - charsFromEndToSkip,
+							 length: length,
 							 startPosition: LastTokenPosition
 					);
 			Tokens.Add(t);

--- a/src/Framework/Framework/Compilation/Parser/TokenizerBase.cs
+++ b/src/Framework/Framework/Compilation/Parser/TokenizerBase.cs
@@ -318,13 +318,13 @@ namespace DotVVM.Framework.Compilation.Parser
 			var ch = Peek();
 			if (ch != NullChar)
 			{
+				position++;
 				if (ch == '\n' || (ch == '\r' && Peek() != '\n'))
 				{
 					CurrentLine++;
 					PositionOnLine = 0;
 				}
 				PositionOnLine++;
-				position++;
 			}
 
 			return ch;

--- a/src/Framework/Framework/Compilation/ViewCompiler/DefaultViewCompilerCodeEmitter.cs
+++ b/src/Framework/Framework/Compilation/ViewCompiler/DefaultViewCompilerCodeEmitter.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using DotVVM.Framework.Binding;
 using DotVVM.Framework.Controls;
+using DotVVM.Framework.Utils;
 using FastExpressionCompiler;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -27,7 +28,7 @@ namespace DotVVM.Framework.Compilation.ViewCompiler
 
         public ParameterExpression EmitCreateVariable(Expression expression)
         {
-            var name = "c" + CurrentControlIndex;
+            var name = ("c" + CurrentControlIndex).DotvvmInternString();
             CurrentControlIndex++;
 
             var variable = Expression.Variable(expression.Type, name);

--- a/src/Framework/Framework/DotVVM.Framework.csproj
+++ b/src/Framework/Framework/DotVVM.Framework.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk">
+<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>DotVVM</AssemblyTitle>
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
@@ -74,6 +74,9 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="ResourceManagement\ClientGlobalize\JQueryGlobalizeRegisterTemplate.tt">

--- a/src/Framework/Framework/NullableAttributes.cs
+++ b/src/Framework/Framework/NullableAttributes.cs
@@ -123,7 +123,8 @@ namespace System.Diagnostics.CodeAnalysis
         public bool ParameterValue { get; }
     }
 
-        /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
+
+    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
     internal sealed class MemberNotNullAttribute : Attribute
     {
@@ -146,6 +147,7 @@ namespace System.Diagnostics.CodeAnalysis
 #endif
 
 #if !NET5_0_OR_GREATER
+ 
     /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
     internal sealed class MemberNotNullWhenAttribute : Attribute

--- a/src/Framework/Framework/NullableAttributes.cs
+++ b/src/Framework/Framework/NullableAttributes.cs
@@ -123,6 +123,8 @@ namespace System.Diagnostics.CodeAnalysis
         public bool ParameterValue { get; }
     }
 
+#endif
+#if !NET5_0_OR_GREATER
 
     /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
@@ -144,9 +146,7 @@ namespace System.Diagnostics.CodeAnalysis
         public string[] Members { get; }
     }
 
-#endif
 
-#if !NET5_0_OR_GREATER
  
     /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]

--- a/src/Framework/Framework/Routing/DotvvmRouteParser.cs
+++ b/src/Framework/Framework/Routing/DotvvmRouteParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Routing
 {
@@ -44,7 +45,7 @@ namespace DotVVM.Framework.Routing
                 if (url[i] == '/')
                 {
                     // standard URL component
-                    var str = url.Substring(startIndex, i - startIndex);
+                    var str = url.AsSpan(startIndex, i - startIndex).DotvvmInternString();
                     regex.Append(Regex.Escape(str));
                     urlBuilders.Add(_ => str);
                     startIndex = i;
@@ -52,7 +53,7 @@ namespace DotVVM.Framework.Routing
                 else if (url[i] == '{')
                 {
                     // route parameter
-                    var str = url.Substring(startIndex, i - startIndex);
+                    var str = url.AsSpan(startIndex, i - startIndex).DotvvmInternString();
                     i++;
                     AppendParameterParserResult(ParseParameter(url, str, ref i, defaultValues));
                     startIndex = i + 1;
@@ -90,15 +91,16 @@ namespace DotVVM.Framework.Routing
             {
                 throw new ArgumentException($"The route URL '{url}' is not valid! It contains an unclosed parameter.");
             }
-            var name = url.Substring(startIndex, index - startIndex).Trim();
+            var nameSpan = url.AsSpan(startIndex, index - startIndex).Trim();
 
             // determine whether the parameter is optional - it must end with ?, or must be present in the DefaultValues collection
-            var isOptional = name.EndsWith("?", StringComparison.Ordinal);
+            var isOptional = nameSpan.EndsWith("?", StringComparison.Ordinal);
             if (isOptional)
             {
-                name = name.Substring(0, name.Length - 1);
+                nameSpan = nameSpan.Slice(0, nameSpan.Length - 1);
             }
-            else
+            var name = nameSpan.DotvvmInternString(trySystemIntern: true);
+            if (!isOptional)
             {
                 isOptional = defaultValues.ContainsKey(name);
             }

--- a/src/Framework/Framework/Routing/DotvvmRouteParser.cs
+++ b/src/Framework/Framework/Routing/DotvvmRouteParser.cs
@@ -94,7 +94,7 @@ namespace DotVVM.Framework.Routing
             var nameSpan = url.AsSpan(startIndex, index - startIndex).Trim();
 
             // determine whether the parameter is optional - it must end with ?, or must be present in the DefaultValues collection
-            var isOptional = nameSpan.EndsWith("?", StringComparison.Ordinal);
+            var isOptional = nameSpan.EndsWith("?".AsSpan(), StringComparison.Ordinal);
             if (isOptional)
             {
                 nameSpan = nameSpan.Slice(0, nameSpan.Length - 1);

--- a/src/Framework/Framework/Routing/DotvvmRouteParser.cs
+++ b/src/Framework/Framework/Routing/DotvvmRouteParser.cs
@@ -99,7 +99,8 @@ namespace DotVVM.Framework.Routing
             {
                 nameSpan = nameSpan.Slice(0, nameSpan.Length - 1);
             }
-            var name = nameSpan.DotvvmInternString(trySystemIntern: true);
+            var name = nameSpan.DotvvmInternString(null, trySystemIntern: true);
+            //                                            ^ route parameters are super likely to be used somewhere in code  
             if (!isOptional)
             {
                 isOptional = defaultValues.ContainsKey(name);

--- a/src/Framework/Framework/Runtime/Caching/SimpleLruDictionary.cs
+++ b/src/Framework/Framework/Runtime/Caching/SimpleLruDictionary.cs
@@ -18,12 +18,13 @@ namespace DotVVM.Framework.Runtime.Caching
         where TValue : class?
         where TKey : notnull
     {
+        // concurrencyLevel: 1, we don't write in parallel anyway
         // new generation
-        private ConcurrentDictionary<TKey, TValue> hot = new ConcurrentDictionary<TKey, TValue>();
+        private ConcurrentDictionary<TKey, TValue> hot = new ConcurrentDictionary<TKey, TValue>(concurrencyLevel: 1, capacity: 1);
         // old generation
-        private ConcurrentDictionary<TKey, TValue> cold = new ConcurrentDictionary<TKey, TValue>();
+        private ConcurrentDictionary<TKey, TValue> cold = new ConcurrentDictionary<TKey, TValue>(concurrencyLevel: 1, capacity: 1);
         // free to take for GC. however, if the GC does not want to collect, we can still use it
-        private readonly ConcurrentDictionary<TKey, WeakReference<TValue>> dead = new ConcurrentDictionary<TKey, WeakReference<TValue>>();
+        private readonly ConcurrentDictionary<TKey, WeakReference<TValue>> dead = new ConcurrentDictionary<TKey, WeakReference<TValue>>(concurrencyLevel: 1, capacity: 1);
         private TimeSpan lastCleanupTime = TimeSpan.MinValue;
 
         private readonly int generationSize;

--- a/src/Framework/Framework/Runtime/IDotvvmException.cs
+++ b/src/Framework/Framework/Runtime/IDotvvmException.cs
@@ -26,7 +26,7 @@ namespace DotVVM.Framework.Runtime
     }
 
     public abstract record DotvvmExceptionBase(
-        string? msg = null,
+        string? Msg = null,
         DotvvmProperty? RelatedProperty = null,
         DotvvmBindableObject? RelatedControl = null,
         IBinding? RelatedBinding = null,
@@ -35,7 +35,7 @@ namespace DotVVM.Framework.Runtime
         IResource? RelatedResource = null,
         DotvvmLocationInfo? Location = null,
         Exception? InnerException = null
-    ) : RecordExceptions.RecordException(msg, InnerException), IDotvvmException
+    ) : RecordExceptions.RecordException(Msg, InnerException), IDotvvmException
     {
         // small hack so that we can automatically set this property in InvokePageLifeCycleEvent
         public DotvvmBindableObject? RelatedControl { get; set; } = RelatedControl;

--- a/src/Framework/Framework/Utils/ReflectionUtils.cs
+++ b/src/Framework/Framework/Utils/ReflectionUtils.cs
@@ -322,12 +322,6 @@ namespace DotVVM.Framework.Utils
             return !IsPrimitiveType(type);
         }
 
-        public static bool IsDynamicOrObject(this Type type)
-        {
-            return type.GetInterfaces().Contains(typeof(IDynamicMetaObjectProvider)) ||
-                   type == typeof(object);
-        }
-
         public static bool IsDelegate(this Type type)
         {
             return typeof(Delegate).IsAssignableFrom(type);

--- a/src/Framework/Framework/Utils/StringUtils.cs
+++ b/src/Framework/Framework/Utils/StringUtils.cs
@@ -1,4 +1,10 @@
-﻿namespace DotVVM.Framework.Utils
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DotVVM.Framework.Binding;
+using FastExpressionCompiler;
+
+namespace DotVVM.Framework.Utils
 {
     public static class StringUtils
     {
@@ -13,5 +19,2329 @@
                 return source;
             }
         }
+
+        internal static string DotvvmInternString(this char ch, string? str = null) =>
+            ch switch {
+                ' ' => " ",
+                '!' => "!",
+                '"' => "\"",
+                '#' => "#",
+                '$' => "$",
+                '%' => "%",
+                '&' => "&",
+                '\'' => "'",
+                '(' => "(",
+                ')' => ")",
+                '*' => "*",
+                '+' => "+",
+                ',' => ",",
+                '-' => "-",
+                '.' => ".",
+                '/' => "/",
+                '0' => "0",
+                '1' => "1",
+                '2' => "2",
+                '3' => "3",
+                '4' => "4",
+                '5' => "5",
+                '6' => "6",
+                '7' => "7",
+                '8' => "8",
+                '9' => "9",
+                ':' => ":",
+                ';' => ";",
+                '<' => "<",
+                '=' => "=",
+                '>' => ">",
+                '?' => "?",
+                '@' => "@",
+                'A' => "A",
+                'B' => "B",
+                'C' => "C",
+                'D' => "D",
+                'E' => "E",
+                'F' => "F",
+                'G' => "G",
+                'H' => "H",
+                'I' => "I",
+                'J' => "J",
+                'K' => "K",
+                'L' => "L",
+                'M' => "M",
+                'N' => "N",
+                'O' => "O",
+                'P' => "P",
+                'Q' => "Q",
+                'R' => "R",
+                'S' => "S",
+                'T' => "T",
+                'U' => "U",
+                'V' => "V",
+                'W' => "W",
+                'X' => "X",
+                'Y' => "Y",
+                'Z' => "Z",
+                '[' => "[",
+                '\\' => "\\",
+                ']' => "]",
+                '^' => "^",
+                '_' => "_",
+                '`' => "`",
+                'a' => "a",
+                'b' => "b",
+                'c' => "c",
+                'd' => "d",
+                'e' => "e",
+                'f' => "f",
+                'g' => "g",
+                'h' => "h",
+                'i' => "i",
+                'j' => "j",
+                'k' => "k",
+                'l' => "l",
+                'm' => "m",
+                'n' => "n",
+                'o' => "o",
+                'p' => "p",
+                'q' => "q",
+                'r' => "r",
+                's' => "s",
+                't' => "t",
+                'u' => "u",
+                'v' => "v",
+                'w' => "w",
+                'x' => "x",
+                'y' => "y",
+                'z' => "z",
+                '{' => "{",
+                '|' => "|",
+                '}' => "}",
+                '~' => "~",
+                '\n' => "\n",
+                // although .NET intern is quite slow, there is just no reason to have multiple instances of the same character
+                _ => string.Intern(str ?? ch.ToString())
+            };
+
+        internal static string DotvvmInternString(this string str) =>
+            str.AsSpan().DotvvmInternString(str);
+
+        public static void GenerateCode()
+        {
+            // just run dotnet dump and then `dumpheap -stat -strings` to see what is there suspiciously often...
+            var strings = new List<string> {
+                // common tag prefixes
+                "dot", "bp", "bs", "dc", "cc",
+
+                // some JS fragment occuring often
+                "Items()?.length", ".Items()?.length", ".$index()", "$index()", "value", "dotvvm.postBack(", "ko.pureComputed(()=>", "viewModel", "dotvvm.evaluator.wrapObservable(()=>", "$type", "$data", ".$data", "(()=>{let vm=", ",[],", "dotvvm.globalize.bindingNumberToString(", ".Name", ".Id", "(i)=>ko.unwrap(i).Id()", "(i)=>ko.unwrap(i).Text()", "(i)=>ko.unwrap(i).Name()", "(async ()=>{let vm=", ".Visible", ".Enabled", "ko.contextFor(", "import", "service",
+
+                // bindings
+                "value", "resource", "command", "controlCommand", "staticCommand", "staticCommand",
+
+                // html attributes
+                "accept", "accept-charset", "accesskey", "action", "align", "allow", "alt", "async", "autocapitalize", "autocomplete", "autofocus", "autoplay", "background", "bgcolor", "border", "buffered", "capture", "challenge", "charset", "checked", "cite", "class", "code", "codebase", "color", "cols", "colspan", "content", "contenteditable", "contextmenu", "controls", "coords", "crossorigin", "csp", "data", "datetime", "decoding", "default", "defer", "dir", "dirname", "disabled", "download", "draggable", "enctype", "enterkeyhint", "for", "form", "formaction", "formenctype", "formmethod", "formnovalidate", "formtarget", "headers", "height", "hidden", "high", "href", "hreflang", "http-equiv", "icon", "id", "importance", "integrity", "intrinsicsize", "inputmode", "ismap", "itemprop", "keytype", "kind", "label", "lang", "language", "loading", "list", "loop", "low", "manifest", "max", "maxlength", "minlength", "media", "method", "min", "multiple", "muted", "name", "novalidate", "open", "optimum", "pattern", "ping", "placeholder", "poster", "preload", "radiogroup", "readonly", "referrerpolicy", "rel", "required", "reversed", "rows", "rowspan", "sandbox", "scope", "scoped", "selected", "shape", "size", "sizes", "slot", "span", "spellcheck", "src", "srcdoc", "srclang", "srcset", "start", "step", "style", "summary", "tabindex", "target", "title", "translate", "type", "usemap", "value", "width", "wrap",
+
+                "data-ui", "data-bind",
+                "a", "abbr", "acronym", "address", "applet", "area", "article", "aside", "audio", "b", "base", "basefont", "bdi", "bdo", "big", "blockquote", "body", "br", "button", "canvas", "caption", "center", "cite", "code", "col", "colgroup", "data", "datalist", "dd", "del", "details", "dfn", "dialog", "dir", "div", "dl", "dt", "em", "embed", "fieldset", "figcaption", "figure", "font", "footer", "form", "frame", "frameset", "h1", "h2", "h3", "h4", "h5", "h6", "head", "header", "hr", "html", "i", "iframe", "img", "input", "ins", "kbd", "label", "legend", "li", "link", "main", "map", "mark", "meta", "meter", "nav", "noframes", "noscript", "object", "ol", "optgroup", "option", "output", "p", "param", "picture", "pre", "progress", "q", "rp", "rt", "ruby", "s", "samp", "script", "section", "select", "small", "source", "span", "strike", "strong", "style", "sub", "summary", "sup", "svg", "table", "tbody", "td", "template", "textarea", "tfoot", "th", "thead", "time", "title", "tr", "track", "tt", "u", "ul", "var", "video", "wbr",
+
+                // random fragments
+
+                "http://www.w3.org/1999/xhtml",
+
+                "Load", "Init", "PreRender", "ToString", "Equals", "Context", "DotVVM", "en",
+                "_this", "_parent", "_control", "_root",
+                "PostBack.Handlers",
+
+                "true", "false",
+                "  ", "\n\n", "\r\n", "\r\n    ", "\n   ", "\r\n        ", "\n       ", "\r\n            ", "\n           ",
+            };
+
+            strings.AddRange(Enumerable.Range(0, 20).Select(x => "c" + x));
+
+            strings.AddRange(DotvvmProperty.AllProperties.Select(x => x.Name));
+            strings.AddRange(DotvvmProperty.AllProperties.Select(x => x.DeclaringType.Name));
+
+            var lenGroups = strings.Where(l => l.Length > 1).Distinct().GroupBy(x => x.Length).OrderBy(k => k.Key);
+            Console.WriteLine("switch (span.Length)\n{");
+            foreach (var lenGroup in lenGroups)
+            {
+                Console.WriteLine($"    case {lenGroup.Key}:");
+                Console.WriteLine( "        switch (ch)");
+                Console.WriteLine( "        {");
+                var gs = lenGroup.GroupBy(x => x[0]).OrderBy(k => k.Key);
+                foreach (var g in gs)
+                {
+                    var ch = g.Key switch {
+                        '\r' => "\\r",
+                        '\n' => "\\n",
+                        '\t' => "\\t",
+                        '\\' => "\\\\",
+                        '\'' => "\\'",
+                        _ => g.Key.ToString()
+                    };
+                    Console.WriteLine($"            case '{ch}':");
+                    foreach (var str in g)
+                    {
+                        Console.WriteLine($"                if (span.SequenceEqual({str.ToCode()}.AsSpan()))");
+                        Console.WriteLine($"                    return {str.ToCode()};");
+                    }
+                    Console.WriteLine($"                break;");
+                }
+                Console.WriteLine( "        }");
+                Console.WriteLine( "        break;");
+            }
+            Console.WriteLine("}");
+        }
+        internal static string DotvvmInternString(this Span<char> span, string? str = null, bool trySystemIntern = false) =>
+            ((ReadOnlySpan<char>)span).DotvvmInternString(str, trySystemIntern);
+        internal static string DotvvmInternString(this ReadOnlySpan<char> span, string? str = null, bool trySystemIntern = false)
+        {
+            if (span.Length == 0)
+                return "";
+
+            var ch = span[0];
+
+            if (span.Length == 1)
+                return ch.DotvvmInternString();
+switch (span.Length)
+{
+    case 2:
+        switch (ch)
+        {
+            case '\n':
+                if (span.SequenceEqual("\n\n".AsSpan()))
+                    return "\n\n";
+                break;
+            case '\r':
+                if (span.SequenceEqual("\r\n".AsSpan()))
+                    return "\r\n";
+                break;
+            case ' ':
+                if (span.SequenceEqual("  ".AsSpan()))
+                    return "  ";
+                break;
+            case 'I':
+                if (span.SequenceEqual("ID".AsSpan()))
+                    return "ID";
+                break;
+            case 'O':
+                if (span.SequenceEqual("Ok".AsSpan()))
+                    return "Ok";
+                break;
+            case 'b':
+                if (span.SequenceEqual("bp".AsSpan()))
+                    return "bp";
+                if (span.SequenceEqual("bs".AsSpan()))
+                    return "bs";
+                if (span.SequenceEqual("br".AsSpan()))
+                    return "br";
+                break;
+            case 'c':
+                if (span.SequenceEqual("cc".AsSpan()))
+                    return "cc";
+                if (span.SequenceEqual("c0".AsSpan()))
+                    return "c0";
+                if (span.SequenceEqual("c1".AsSpan()))
+                    return "c1";
+                if (span.SequenceEqual("c2".AsSpan()))
+                    return "c2";
+                if (span.SequenceEqual("c3".AsSpan()))
+                    return "c3";
+                if (span.SequenceEqual("c4".AsSpan()))
+                    return "c4";
+                if (span.SequenceEqual("c5".AsSpan()))
+                    return "c5";
+                if (span.SequenceEqual("c6".AsSpan()))
+                    return "c6";
+                if (span.SequenceEqual("c7".AsSpan()))
+                    return "c7";
+                if (span.SequenceEqual("c8".AsSpan()))
+                    return "c8";
+                if (span.SequenceEqual("c9".AsSpan()))
+                    return "c9";
+                break;
+            case 'd':
+                if (span.SequenceEqual("dc".AsSpan()))
+                    return "dc";
+                if (span.SequenceEqual("dd".AsSpan()))
+                    return "dd";
+                if (span.SequenceEqual("dl".AsSpan()))
+                    return "dl";
+                if (span.SequenceEqual("dt".AsSpan()))
+                    return "dt";
+                break;
+            case 'e':
+                if (span.SequenceEqual("em".AsSpan()))
+                    return "em";
+                if (span.SequenceEqual("en".AsSpan()))
+                    return "en";
+                break;
+            case 'h':
+                if (span.SequenceEqual("h1".AsSpan()))
+                    return "h1";
+                if (span.SequenceEqual("h2".AsSpan()))
+                    return "h2";
+                if (span.SequenceEqual("h3".AsSpan()))
+                    return "h3";
+                if (span.SequenceEqual("h4".AsSpan()))
+                    return "h4";
+                if (span.SequenceEqual("h5".AsSpan()))
+                    return "h5";
+                if (span.SequenceEqual("h6".AsSpan()))
+                    return "h6";
+                if (span.SequenceEqual("hr".AsSpan()))
+                    return "hr";
+                break;
+            case 'i':
+                if (span.SequenceEqual("id".AsSpan()))
+                    return "id";
+                break;
+            case 'l':
+                if (span.SequenceEqual("li".AsSpan()))
+                    return "li";
+                break;
+            case 'o':
+                if (span.SequenceEqual("ol".AsSpan()))
+                    return "ol";
+                break;
+            case 'r':
+                if (span.SequenceEqual("rp".AsSpan()))
+                    return "rp";
+                if (span.SequenceEqual("rt".AsSpan()))
+                    return "rt";
+                break;
+            case 't':
+                if (span.SequenceEqual("td".AsSpan()))
+                    return "td";
+                if (span.SequenceEqual("th".AsSpan()))
+                    return "th";
+                if (span.SequenceEqual("tr".AsSpan()))
+                    return "tr";
+                if (span.SequenceEqual("tt".AsSpan()))
+                    return "tt";
+                break;
+            case 'u':
+                if (span.SequenceEqual("ul".AsSpan()))
+                    return "ul";
+                break;
+        }
+        break;
+    case 3:
+        switch (ch)
+        {
+            case '.':
+                if (span.SequenceEqual(".Id".AsSpan()))
+                    return ".Id";
+                break;
+            case 'R':
+                if (span.SequenceEqual("Row".AsSpan()))
+                    return "Row";
+                break;
+            case 'T':
+                if (span.SequenceEqual("Tag".AsSpan()))
+                    return "Tag";
+                break;
+            case 'a':
+                if (span.SequenceEqual("alt".AsSpan()))
+                    return "alt";
+                break;
+            case 'b':
+                if (span.SequenceEqual("bdi".AsSpan()))
+                    return "bdi";
+                if (span.SequenceEqual("bdo".AsSpan()))
+                    return "bdo";
+                if (span.SequenceEqual("big".AsSpan()))
+                    return "big";
+                break;
+            case 'c':
+                if (span.SequenceEqual("csp".AsSpan()))
+                    return "csp";
+                if (span.SequenceEqual("col".AsSpan()))
+                    return "col";
+                if (span.SequenceEqual("c10".AsSpan()))
+                    return "c10";
+                if (span.SequenceEqual("c11".AsSpan()))
+                    return "c11";
+                if (span.SequenceEqual("c12".AsSpan()))
+                    return "c12";
+                if (span.SequenceEqual("c13".AsSpan()))
+                    return "c13";
+                if (span.SequenceEqual("c14".AsSpan()))
+                    return "c14";
+                if (span.SequenceEqual("c15".AsSpan()))
+                    return "c15";
+                if (span.SequenceEqual("c16".AsSpan()))
+                    return "c16";
+                if (span.SequenceEqual("c17".AsSpan()))
+                    return "c17";
+                if (span.SequenceEqual("c18".AsSpan()))
+                    return "c18";
+                if (span.SequenceEqual("c19".AsSpan()))
+                    return "c19";
+                break;
+            case 'd':
+                if (span.SequenceEqual("dot".AsSpan()))
+                    return "dot";
+                if (span.SequenceEqual("dir".AsSpan()))
+                    return "dir";
+                if (span.SequenceEqual("del".AsSpan()))
+                    return "del";
+                if (span.SequenceEqual("dfn".AsSpan()))
+                    return "dfn";
+                if (span.SequenceEqual("div".AsSpan()))
+                    return "div";
+                break;
+            case 'f':
+                if (span.SequenceEqual("for".AsSpan()))
+                    return "for";
+                break;
+            case 'i':
+                if (span.SequenceEqual("img".AsSpan()))
+                    return "img";
+                if (span.SequenceEqual("ins".AsSpan()))
+                    return "ins";
+                break;
+            case 'k':
+                if (span.SequenceEqual("kbd".AsSpan()))
+                    return "kbd";
+                break;
+            case 'l':
+                if (span.SequenceEqual("low".AsSpan()))
+                    return "low";
+                break;
+            case 'm':
+                if (span.SequenceEqual("max".AsSpan()))
+                    return "max";
+                if (span.SequenceEqual("min".AsSpan()))
+                    return "min";
+                if (span.SequenceEqual("map".AsSpan()))
+                    return "map";
+                break;
+            case 'n':
+                if (span.SequenceEqual("nav".AsSpan()))
+                    return "nav";
+                break;
+            case 'p':
+                if (span.SequenceEqual("pre".AsSpan()))
+                    return "pre";
+                break;
+            case 'r':
+                if (span.SequenceEqual("rel".AsSpan()))
+                    return "rel";
+                break;
+            case 's':
+                if (span.SequenceEqual("src".AsSpan()))
+                    return "src";
+                if (span.SequenceEqual("sub".AsSpan()))
+                    return "sub";
+                if (span.SequenceEqual("sup".AsSpan()))
+                    return "sup";
+                if (span.SequenceEqual("svg".AsSpan()))
+                    return "svg";
+                break;
+            case 'v':
+                if (span.SequenceEqual("var".AsSpan()))
+                    return "var";
+                break;
+            case 'w':
+                if (span.SequenceEqual("wbr".AsSpan()))
+                    return "wbr";
+                break;
+        }
+        break;
+    case 4:
+        switch (ch)
+        {
+            case '\n':
+                if (span.SequenceEqual("\n   ".AsSpan()))
+                    return "\n   ";
+                break;
+            case ',':
+                if (span.SequenceEqual(",[],".AsSpan()))
+                    return ",[],";
+                break;
+            case 'D':
+                if (span.SequenceEqual("Date".AsSpan()))
+                    return "Date";
+                if (span.SequenceEqual("Data".AsSpan()))
+                    return "Data";
+                break;
+            case 'E':
+                if (span.SequenceEqual("Edit".AsSpan()))
+                    return "Edit";
+                break;
+            case 'H':
+                if (span.SequenceEqual("Html".AsSpan()))
+                    return "Html";
+                break;
+            case 'I':
+                if (span.SequenceEqual("Init".AsSpan()))
+                    return "Init";
+                if (span.SequenceEqual("Item".AsSpan()))
+                    return "Item";
+                break;
+            case 'L':
+                if (span.SequenceEqual("Load".AsSpan()))
+                    return "Load";
+                break;
+            case 'M':
+                if (span.SequenceEqual("Mode".AsSpan()))
+                    return "Mode";
+                break;
+            case 'N':
+                if (span.SequenceEqual("Name".AsSpan()))
+                    return "Name";
+                break;
+            case 'R':
+                if (span.SequenceEqual("Row2".AsSpan()))
+                    return "Row2";
+                break;
+            case 'S':
+                if (span.SequenceEqual("Size".AsSpan()))
+                    return "Size";
+                break;
+            case 'T':
+                if (span.SequenceEqual("Text".AsSpan()))
+                    return "Text";
+                if (span.SequenceEqual("Trap".AsSpan()))
+                    return "Trap";
+                if (span.SequenceEqual("Type".AsSpan()))
+                    return "Type";
+                break;
+            case 'a':
+                if (span.SequenceEqual("abbr".AsSpan()))
+                    return "abbr";
+                if (span.SequenceEqual("area".AsSpan()))
+                    return "area";
+                break;
+            case 'b':
+                if (span.SequenceEqual("base".AsSpan()))
+                    return "base";
+                if (span.SequenceEqual("body".AsSpan()))
+                    return "body";
+                break;
+            case 'c':
+                if (span.SequenceEqual("cite".AsSpan()))
+                    return "cite";
+                if (span.SequenceEqual("code".AsSpan()))
+                    return "code";
+                if (span.SequenceEqual("cols".AsSpan()))
+                    return "cols";
+                break;
+            case 'd':
+                if (span.SequenceEqual("data".AsSpan()))
+                    return "data";
+                break;
+            case 'f':
+                if (span.SequenceEqual("form".AsSpan()))
+                    return "form";
+                if (span.SequenceEqual("font".AsSpan()))
+                    return "font";
+                break;
+            case 'h':
+                if (span.SequenceEqual("high".AsSpan()))
+                    return "high";
+                if (span.SequenceEqual("href".AsSpan()))
+                    return "href";
+                if (span.SequenceEqual("head".AsSpan()))
+                    return "head";
+                if (span.SequenceEqual("html".AsSpan()))
+                    return "html";
+                break;
+            case 'i':
+                if (span.SequenceEqual("icon".AsSpan()))
+                    return "icon";
+                break;
+            case 'k':
+                if (span.SequenceEqual("kind".AsSpan()))
+                    return "kind";
+                break;
+            case 'l':
+                if (span.SequenceEqual("lang".AsSpan()))
+                    return "lang";
+                if (span.SequenceEqual("list".AsSpan()))
+                    return "list";
+                if (span.SequenceEqual("loop".AsSpan()))
+                    return "loop";
+                if (span.SequenceEqual("link".AsSpan()))
+                    return "link";
+                break;
+            case 'm':
+                if (span.SequenceEqual("main".AsSpan()))
+                    return "main";
+                if (span.SequenceEqual("mark".AsSpan()))
+                    return "mark";
+                if (span.SequenceEqual("meta".AsSpan()))
+                    return "meta";
+                break;
+            case 'n':
+                if (span.SequenceEqual("name".AsSpan()))
+                    return "name";
+                break;
+            case 'o':
+                if (span.SequenceEqual("open".AsSpan()))
+                    return "open";
+                break;
+            case 'p':
+                if (span.SequenceEqual("ping".AsSpan()))
+                    return "ping";
+                break;
+            case 'r':
+                if (span.SequenceEqual("rows".AsSpan()))
+                    return "rows";
+                if (span.SequenceEqual("ruby".AsSpan()))
+                    return "ruby";
+                break;
+            case 's':
+                if (span.SequenceEqual("size".AsSpan()))
+                    return "size";
+                if (span.SequenceEqual("slot".AsSpan()))
+                    return "slot";
+                if (span.SequenceEqual("span".AsSpan()))
+                    return "span";
+                if (span.SequenceEqual("step".AsSpan()))
+                    return "step";
+                if (span.SequenceEqual("samp".AsSpan()))
+                    return "samp";
+                break;
+            case 't':
+                if (span.SequenceEqual("type".AsSpan()))
+                    return "type";
+                if (span.SequenceEqual("time".AsSpan()))
+                    return "time";
+                if (span.SequenceEqual("true".AsSpan()))
+                    return "true";
+                break;
+            case 'w':
+                if (span.SequenceEqual("wrap".AsSpan()))
+                    return "wrap";
+                break;
+        }
+        break;
+    case 5:
+        switch (ch)
+        {
+            case '$':
+                if (span.SequenceEqual("$type".AsSpan()))
+                    return "$type";
+                if (span.SequenceEqual("$data".AsSpan()))
+                    return "$data";
+                break;
+            case '.':
+                if (span.SequenceEqual(".Name".AsSpan()))
+                    return ".Name";
+                break;
+            case 'A':
+                if (span.SequenceEqual("Added".AsSpan()))
+                    return "Added";
+                break;
+            case 'C':
+                if (span.SequenceEqual("Click".AsSpan()))
+                    return "Click";
+                if (span.SequenceEqual("Claim".AsSpan()))
+                    return "Claim";
+                break;
+            case 'D':
+                if (span.SequenceEqual("Delay".AsSpan()))
+                    return "Delay";
+                break;
+            case 'F':
+                if (span.SequenceEqual("Files".AsSpan()))
+                    return "Files";
+                break;
+            case 'L':
+                if (span.SequenceEqual("Label".AsSpan()))
+                    return "Label";
+                break;
+            case 'M':
+                if (span.SequenceEqual("Model".AsSpan()))
+                    return "Model";
+                break;
+            case 'R':
+                if (span.SequenceEqual("Roles".AsSpan()))
+                    return "Roles";
+                break;
+            case 'V':
+                if (span.SequenceEqual("Value".AsSpan()))
+                    return "Value";
+                break;
+            case 'W':
+                if (span.SequenceEqual("Width".AsSpan()))
+                    return "Width";
+                break;
+            case '_':
+                if (span.SequenceEqual("_this".AsSpan()))
+                    return "_this";
+                if (span.SequenceEqual("_root".AsSpan()))
+                    return "_root";
+                break;
+            case 'a':
+                if (span.SequenceEqual("align".AsSpan()))
+                    return "align";
+                if (span.SequenceEqual("allow".AsSpan()))
+                    return "allow";
+                if (span.SequenceEqual("async".AsSpan()))
+                    return "async";
+                if (span.SequenceEqual("aside".AsSpan()))
+                    return "aside";
+                if (span.SequenceEqual("audio".AsSpan()))
+                    return "audio";
+                break;
+            case 'c':
+                if (span.SequenceEqual("class".AsSpan()))
+                    return "class";
+                if (span.SequenceEqual("color".AsSpan()))
+                    return "color";
+                break;
+            case 'd':
+                if (span.SequenceEqual("defer".AsSpan()))
+                    return "defer";
+                break;
+            case 'e':
+                if (span.SequenceEqual("embed".AsSpan()))
+                    return "embed";
+                break;
+            case 'f':
+                if (span.SequenceEqual("frame".AsSpan()))
+                    return "frame";
+                if (span.SequenceEqual("false".AsSpan()))
+                    return "false";
+                break;
+            case 'i':
+                if (span.SequenceEqual("ismap".AsSpan()))
+                    return "ismap";
+                if (span.SequenceEqual("input".AsSpan()))
+                    return "input";
+                break;
+            case 'l':
+                if (span.SequenceEqual("label".AsSpan()))
+                    return "label";
+                break;
+            case 'm':
+                if (span.SequenceEqual("media".AsSpan()))
+                    return "media";
+                if (span.SequenceEqual("muted".AsSpan()))
+                    return "muted";
+                if (span.SequenceEqual("meter".AsSpan()))
+                    return "meter";
+                break;
+            case 'p':
+                if (span.SequenceEqual("param".AsSpan()))
+                    return "param";
+                break;
+            case 's':
+                if (span.SequenceEqual("scope".AsSpan()))
+                    return "scope";
+                if (span.SequenceEqual("shape".AsSpan()))
+                    return "shape";
+                if (span.SequenceEqual("sizes".AsSpan()))
+                    return "sizes";
+                if (span.SequenceEqual("start".AsSpan()))
+                    return "start";
+                if (span.SequenceEqual("style".AsSpan()))
+                    return "style";
+                if (span.SequenceEqual("small".AsSpan()))
+                    return "small";
+                break;
+            case 't':
+                if (span.SequenceEqual("title".AsSpan()))
+                    return "title";
+                if (span.SequenceEqual("table".AsSpan()))
+                    return "table";
+                if (span.SequenceEqual("tbody".AsSpan()))
+                    return "tbody";
+                if (span.SequenceEqual("tfoot".AsSpan()))
+                    return "tfoot";
+                if (span.SequenceEqual("thead".AsSpan()))
+                    return "thead";
+                if (span.SequenceEqual("track".AsSpan()))
+                    return "track";
+                break;
+            case 'v':
+                if (span.SequenceEqual("value".AsSpan()))
+                    return "value";
+                if (span.SequenceEqual("video".AsSpan()))
+                    return "video";
+                break;
+            case 'w':
+                if (span.SequenceEqual("width".AsSpan()))
+                    return "width";
+                break;
+        }
+        break;
+    case 6:
+        switch (ch)
+        {
+            case '\r':
+                if (span.SequenceEqual("\r\n    ".AsSpan()))
+                    return "\r\n    ";
+                break;
+            case '.':
+                if (span.SequenceEqual(".$data".AsSpan()))
+                    return ".$data";
+                break;
+            case 'A':
+                if (span.SequenceEqual("Append".AsSpan()))
+                    return "Append";
+                break;
+            case 'B':
+                if (span.SequenceEqual("Button".AsSpan()))
+                    return "Button";
+                break;
+            case 'C':
+                if (span.SequenceEqual("Column".AsSpan()))
+                    return "Column";
+                if (span.SequenceEqual("Custom".AsSpan()))
+                    return "Custom";
+                if (span.SequenceEqual("Cancel".AsSpan()))
+                    return "Cancel";
+                break;
+            case 'D':
+                if (span.SequenceEqual("DotVVM".AsSpan()))
+                    return "DotVVM";
+                if (span.SequenceEqual("Dialog".AsSpan()))
+                    return "Dialog";
+                if (span.SequenceEqual("Device".AsSpan()))
+                    return "Device";
+                break;
+            case 'E':
+                if (span.SequenceEqual("Equals".AsSpan()))
+                    return "Equals";
+                if (span.SequenceEqual("Events".AsSpan()))
+                    return "Events";
+                break;
+            case 'G':
+                if (span.SequenceEqual("Global".AsSpan()))
+                    return "Global";
+                break;
+            case 'L':
+                if (span.SequenceEqual("Loader".AsSpan()))
+                    return "Loader";
+                break;
+            case 'R':
+                if (span.SequenceEqual("Remove".AsSpan()))
+                    return "Remove";
+                break;
+            case 'S':
+                if (span.SequenceEqual("Script".AsSpan()))
+                    return "Script";
+                if (span.SequenceEqual("Styles".AsSpan()))
+                    return "Styles";
+                break;
+            case 'T':
+                if (span.SequenceEqual("Target".AsSpan()))
+                    return "Target";
+                break;
+            case 'U':
+                if (span.SequenceEqual("Update".AsSpan()))
+                    return "Update";
+                break;
+            case 'V':
+                if (span.SequenceEqual("Values".AsSpan()))
+                    return "Values";
+                break;
+            case 'a':
+                if (span.SequenceEqual("accept".AsSpan()))
+                    return "accept";
+                if (span.SequenceEqual("action".AsSpan()))
+                    return "action";
+                if (span.SequenceEqual("applet".AsSpan()))
+                    return "applet";
+                break;
+            case 'b':
+                if (span.SequenceEqual("border".AsSpan()))
+                    return "border";
+                if (span.SequenceEqual("button".AsSpan()))
+                    return "button";
+                break;
+            case 'c':
+                if (span.SequenceEqual("coords".AsSpan()))
+                    return "coords";
+                if (span.SequenceEqual("canvas".AsSpan()))
+                    return "canvas";
+                if (span.SequenceEqual("center".AsSpan()))
+                    return "center";
+                break;
+            case 'd':
+                if (span.SequenceEqual("dialog".AsSpan()))
+                    return "dialog";
+                break;
+            case 'f':
+                if (span.SequenceEqual("figure".AsSpan()))
+                    return "figure";
+                if (span.SequenceEqual("footer".AsSpan()))
+                    return "footer";
+                break;
+            case 'h':
+                if (span.SequenceEqual("height".AsSpan()))
+                    return "height";
+                if (span.SequenceEqual("hidden".AsSpan()))
+                    return "hidden";
+                if (span.SequenceEqual("header".AsSpan()))
+                    return "header";
+                break;
+            case 'i':
+                if (span.SequenceEqual("import".AsSpan()))
+                    return "import";
+                if (span.SequenceEqual("iframe".AsSpan()))
+                    return "iframe";
+                break;
+            case 'l':
+                if (span.SequenceEqual("legend".AsSpan()))
+                    return "legend";
+                break;
+            case 'm':
+                if (span.SequenceEqual("method".AsSpan()))
+                    return "method";
+                break;
+            case 'o':
+                if (span.SequenceEqual("object".AsSpan()))
+                    return "object";
+                if (span.SequenceEqual("option".AsSpan()))
+                    return "option";
+                if (span.SequenceEqual("output".AsSpan()))
+                    return "output";
+                break;
+            case 'p':
+                if (span.SequenceEqual("poster".AsSpan()))
+                    return "poster";
+                break;
+            case 's':
+                if (span.SequenceEqual("scoped".AsSpan()))
+                    return "scoped";
+                if (span.SequenceEqual("srcdoc".AsSpan()))
+                    return "srcdoc";
+                if (span.SequenceEqual("srcset".AsSpan()))
+                    return "srcset";
+                if (span.SequenceEqual("script".AsSpan()))
+                    return "script";
+                if (span.SequenceEqual("select".AsSpan()))
+                    return "select";
+                if (span.SequenceEqual("source".AsSpan()))
+                    return "source";
+                if (span.SequenceEqual("strike".AsSpan()))
+                    return "strike";
+                if (span.SequenceEqual("strong".AsSpan()))
+                    return "strong";
+                break;
+            case 't':
+                if (span.SequenceEqual("target".AsSpan()))
+                    return "target";
+                break;
+            case 'u':
+                if (span.SequenceEqual("usemap".AsSpan()))
+                    return "usemap";
+                break;
+        }
+        break;
+    case 7:
+        switch (ch)
+        {
+            case 'C':
+                if (span.SequenceEqual("Context".AsSpan()))
+                    return "Context";
+                if (span.SequenceEqual("Checked".AsSpan()))
+                    return "Checked";
+                if (span.SequenceEqual("Column2".AsSpan()))
+                    return "Column2";
+                if (span.SequenceEqual("Command".AsSpan()))
+                    return "Command";
+                if (span.SequenceEqual("Columns".AsSpan()))
+                    return "Columns";
+                if (span.SequenceEqual("Changed".AsSpan()))
+                    return "Changed";
+                if (span.SequenceEqual("Content".AsSpan()))
+                    return "Content";
+                break;
+            case 'D':
+                if (span.SequenceEqual("DataSet".AsSpan()))
+                    return "DataSet";
+                break;
+            case 'E':
+                if (span.SequenceEqual("Enabled".AsSpan()))
+                    return "Enabled";
+                if (span.SequenceEqual("Exclude".AsSpan()))
+                    return "Exclude";
+                break;
+            case 'L':
+                if (span.SequenceEqual("ListBox".AsSpan()))
+                    return "ListBox";
+                if (span.SequenceEqual("Literal".AsSpan()))
+                    return "Literal";
+                break;
+            case 'M':
+                if (span.SequenceEqual("Message".AsSpan()))
+                    return "Message";
+                break;
+            case 'P':
+                if (span.SequenceEqual("Prepend".AsSpan()))
+                    return "Prepend";
+                break;
+            case 'T':
+                if (span.SequenceEqual("TextBox".AsSpan()))
+                    return "TextBox";
+                break;
+            case 'U':
+                if (span.SequenceEqual("UITests".AsSpan()))
+                    return "UITests";
+                break;
+            case 'V':
+                if (span.SequenceEqual("Visible".AsSpan()))
+                    return "Visible";
+                break;
+            case '_':
+                if (span.SequenceEqual("_parent".AsSpan()))
+                    return "_parent";
+                break;
+            case 'a':
+                if (span.SequenceEqual("acronym".AsSpan()))
+                    return "acronym";
+                if (span.SequenceEqual("address".AsSpan()))
+                    return "address";
+                if (span.SequenceEqual("article".AsSpan()))
+                    return "article";
+                break;
+            case 'b':
+                if (span.SequenceEqual("bgcolor".AsSpan()))
+                    return "bgcolor";
+                break;
+            case 'c':
+                if (span.SequenceEqual("command".AsSpan()))
+                    return "command";
+                if (span.SequenceEqual("capture".AsSpan()))
+                    return "capture";
+                if (span.SequenceEqual("charset".AsSpan()))
+                    return "charset";
+                if (span.SequenceEqual("checked".AsSpan()))
+                    return "checked";
+                if (span.SequenceEqual("colspan".AsSpan()))
+                    return "colspan";
+                if (span.SequenceEqual("content".AsSpan()))
+                    return "content";
+                if (span.SequenceEqual("caption".AsSpan()))
+                    return "caption";
+                break;
+            case 'd':
+                if (span.SequenceEqual("default".AsSpan()))
+                    return "default";
+                if (span.SequenceEqual("dirname".AsSpan()))
+                    return "dirname";
+                if (span.SequenceEqual("data-ui".AsSpan()))
+                    return "data-ui";
+                if (span.SequenceEqual("details".AsSpan()))
+                    return "details";
+                break;
+            case 'e':
+                if (span.SequenceEqual("enctype".AsSpan()))
+                    return "enctype";
+                break;
+            case 'h':
+                if (span.SequenceEqual("headers".AsSpan()))
+                    return "headers";
+                break;
+            case 'k':
+                if (span.SequenceEqual("keytype".AsSpan()))
+                    return "keytype";
+                break;
+            case 'l':
+                if (span.SequenceEqual("loading".AsSpan()))
+                    return "loading";
+                break;
+            case 'o':
+                if (span.SequenceEqual("optimum".AsSpan()))
+                    return "optimum";
+                break;
+            case 'p':
+                if (span.SequenceEqual("pattern".AsSpan()))
+                    return "pattern";
+                if (span.SequenceEqual("preload".AsSpan()))
+                    return "preload";
+                if (span.SequenceEqual("picture".AsSpan()))
+                    return "picture";
+                break;
+            case 'r':
+                if (span.SequenceEqual("rowspan".AsSpan()))
+                    return "rowspan";
+                break;
+            case 's':
+                if (span.SequenceEqual("service".AsSpan()))
+                    return "service";
+                if (span.SequenceEqual("sandbox".AsSpan()))
+                    return "sandbox";
+                if (span.SequenceEqual("srclang".AsSpan()))
+                    return "srclang";
+                if (span.SequenceEqual("summary".AsSpan()))
+                    return "summary";
+                if (span.SequenceEqual("section".AsSpan()))
+                    return "section";
+                break;
+        }
+        break;
+    case 8:
+        switch (ch)
+        {
+            case '\n':
+                if (span.SequenceEqual("\n       ".AsSpan()))
+                    return "\n       ";
+                break;
+            case '$':
+                if (span.SequenceEqual("$index()".AsSpan()))
+                    return "$index()";
+                break;
+            case '.':
+                if (span.SequenceEqual(".Visible".AsSpan()))
+                    return ".Visible";
+                if (span.SequenceEqual(".Enabled".AsSpan()))
+                    return ".Enabled";
+                break;
+            case 'C':
+                if (span.SequenceEqual("ClientID".AsSpan()))
+                    return "ClientID";
+                if (span.SequenceEqual("CssClass".AsSpan()))
+                    return "CssClass";
+                if (span.SequenceEqual("CheckBox".AsSpan()))
+                    return "CheckBox";
+                if (span.SequenceEqual("ComboBox".AsSpan()))
+                    return "ComboBox";
+                if (span.SequenceEqual("Control1".AsSpan()))
+                    return "Control1";
+                if (span.SequenceEqual("Control2".AsSpan()))
+                    return "Control2";
+                break;
+            case 'D':
+                if (span.SequenceEqual("DoAction".AsSpan()))
+                    return "DoAction";
+                break;
+            case 'G':
+                if (span.SequenceEqual("GridView".AsSpan()))
+                    return "GridView";
+                break;
+            case 'H':
+                if (span.SequenceEqual("Handlers".AsSpan()))
+                    return "Handlers";
+                break;
+            case 'I':
+                if (span.SequenceEqual("Internal".AsSpan()))
+                    return "Internal";
+                break;
+            case 'M':
+                if (span.SequenceEqual("MyButton".AsSpan()))
+                    return "MyButton";
+                break;
+            case 'N':
+                if (span.SequenceEqual("NewTitle".AsSpan()))
+                    return "NewTitle";
+                break;
+            case 'P':
+                if (span.SequenceEqual("PostBack".AsSpan()))
+                    return "PostBack";
+                break;
+            case 'R':
+                if (span.SequenceEqual("ResultId".AsSpan()))
+                    return "ResultId";
+                if (span.SequenceEqual("RoleView".AsSpan()))
+                    return "RoleView";
+                if (span.SequenceEqual("Repeater".AsSpan()))
+                    return "Repeater";
+                break;
+            case 'S':
+                if (span.SequenceEqual("Suppress".AsSpan()))
+                    return "Suppress";
+                if (span.SequenceEqual("Selector".AsSpan()))
+                    return "Selector";
+                break;
+            case 'T':
+                if (span.SequenceEqual("ToString".AsSpan()))
+                    return "ToString";
+                if (span.SequenceEqual("Template".AsSpan()))
+                    return "Template";
+                break;
+            case 'U':
+                if (span.SequenceEqual("UniqueID".AsSpan()))
+                    return "UniqueID";
+                break;
+            case 'W':
+                if (span.SequenceEqual("Wrappers".AsSpan()))
+                    return "Wrappers";
+                break;
+            case '_':
+                if (span.SequenceEqual("_control".AsSpan()))
+                    return "_control";
+                break;
+            case 'a':
+                if (span.SequenceEqual("autoplay".AsSpan()))
+                    return "autoplay";
+                break;
+            case 'b':
+                if (span.SequenceEqual("buffered".AsSpan()))
+                    return "buffered";
+                if (span.SequenceEqual("basefont".AsSpan()))
+                    return "basefont";
+                break;
+            case 'c':
+                if (span.SequenceEqual("codebase".AsSpan()))
+                    return "codebase";
+                if (span.SequenceEqual("controls".AsSpan()))
+                    return "controls";
+                if (span.SequenceEqual("colgroup".AsSpan()))
+                    return "colgroup";
+                break;
+            case 'd':
+                if (span.SequenceEqual("datetime".AsSpan()))
+                    return "datetime";
+                if (span.SequenceEqual("decoding".AsSpan()))
+                    return "decoding";
+                if (span.SequenceEqual("disabled".AsSpan()))
+                    return "disabled";
+                if (span.SequenceEqual("download".AsSpan()))
+                    return "download";
+                if (span.SequenceEqual("datalist".AsSpan()))
+                    return "datalist";
+                break;
+            case 'f':
+                if (span.SequenceEqual("fieldset".AsSpan()))
+                    return "fieldset";
+                if (span.SequenceEqual("frameset".AsSpan()))
+                    return "frameset";
+                break;
+            case 'h':
+                if (span.SequenceEqual("hreflang".AsSpan()))
+                    return "hreflang";
+                break;
+            case 'i':
+                if (span.SequenceEqual("itemprop".AsSpan()))
+                    return "itemprop";
+                break;
+            case 'l':
+                if (span.SequenceEqual("language".AsSpan()))
+                    return "language";
+                break;
+            case 'm':
+                if (span.SequenceEqual("manifest".AsSpan()))
+                    return "manifest";
+                if (span.SequenceEqual("multiple".AsSpan()))
+                    return "multiple";
+                break;
+            case 'n':
+                if (span.SequenceEqual("noframes".AsSpan()))
+                    return "noframes";
+                if (span.SequenceEqual("noscript".AsSpan()))
+                    return "noscript";
+                break;
+            case 'o':
+                if (span.SequenceEqual("optgroup".AsSpan()))
+                    return "optgroup";
+                break;
+            case 'p':
+                if (span.SequenceEqual("progress".AsSpan()))
+                    return "progress";
+                break;
+            case 'r':
+                if (span.SequenceEqual("resource".AsSpan()))
+                    return "resource";
+                if (span.SequenceEqual("readonly".AsSpan()))
+                    return "readonly";
+                if (span.SequenceEqual("required".AsSpan()))
+                    return "required";
+                if (span.SequenceEqual("reversed".AsSpan()))
+                    return "reversed";
+                break;
+            case 's':
+                if (span.SequenceEqual("selected".AsSpan()))
+                    return "selected";
+                break;
+            case 't':
+                if (span.SequenceEqual("tabindex".AsSpan()))
+                    return "tabindex";
+                if (span.SequenceEqual("template".AsSpan()))
+                    return "template";
+                if (span.SequenceEqual("textarea".AsSpan()))
+                    return "textarea";
+                break;
+        }
+        break;
+    case 9:
+        switch (ch)
+        {
+            case '.':
+                if (span.SequenceEqual(".$index()".AsSpan()))
+                    return ".$index()";
+                break;
+            case 'C':
+                if (span.SequenceEqual("ClaimView".AsSpan()))
+                    return "ClaimView";
+                break;
+            case 'D':
+                if (span.SequenceEqual("DataPager".AsSpan()))
+                    return "DataPager";
+                break;
+            case 'E':
+                if (span.SequenceEqual("EventName".AsSpan()))
+                    return "EventName";
+                if (span.SequenceEqual("EditClick".AsSpan()))
+                    return "EditClick";
+                if (span.SequenceEqual("EmptyData".AsSpan()))
+                    return "EmptyData";
+                break;
+            case 'G':
+                if (span.SequenceEqual("GroupName".AsSpan()))
+                    return "GroupName";
+                break;
+            case 'I':
+                if (span.SequenceEqual("InnerText".AsSpan()))
+                    return "InnerText";
+                if (span.SequenceEqual("IsSpaPage".AsSpan()))
+                    return "IsSpaPage";
+                break;
+            case 'O':
+                if (span.SequenceEqual("OnCommand".AsSpan()))
+                    return "OnCommand";
+                break;
+            case 'P':
+                if (span.SequenceEqual("PreRender".AsSpan()))
+                    return "PreRender";
+                if (span.SequenceEqual("Parameter".AsSpan()))
+                    return "Parameter";
+                break;
+            case 'R':
+                if (span.SequenceEqual("RouteName".AsSpan()))
+                    return "RouteName";
+                if (span.SequenceEqual("RouteLink".AsSpan()))
+                    return "RouteLink";
+                break;
+            case 'T':
+                if (span.SequenceEqual("TextInput".AsSpan()))
+                    return "TextInput";
+                break;
+            case 'U':
+                if (span.SequenceEqual("UrlSuffix".AsSpan()))
+                    return "UrlSuffix";
+                break;
+            case 'V':
+                if (span.SequenceEqual("Validator".AsSpan()))
+                    return "Validator";
+                break;
+            case 'a':
+                if (span.SequenceEqual("accesskey".AsSpan()))
+                    return "accesskey";
+                if (span.SequenceEqual("autofocus".AsSpan()))
+                    return "autofocus";
+                break;
+            case 'c':
+                if (span.SequenceEqual("challenge".AsSpan()))
+                    return "challenge";
+                break;
+            case 'd':
+                if (span.SequenceEqual("draggable".AsSpan()))
+                    return "draggable";
+                if (span.SequenceEqual("data-bind".AsSpan()))
+                    return "data-bind";
+                break;
+            case 'i':
+                if (span.SequenceEqual("integrity".AsSpan()))
+                    return "integrity";
+                if (span.SequenceEqual("inputmode".AsSpan()))
+                    return "inputmode";
+                break;
+            case 'm':
+                if (span.SequenceEqual("maxlength".AsSpan()))
+                    return "maxlength";
+                if (span.SequenceEqual("minlength".AsSpan()))
+                    return "minlength";
+                break;
+            case 't':
+                if (span.SequenceEqual("translate".AsSpan()))
+                    return "translate";
+                break;
+            case 'v':
+                if (span.SequenceEqual("viewModel".AsSpan()))
+                    return "viewModel";
+                break;
+        }
+        break;
+    case 10:
+        switch (ch)
+        {
+            case '\r':
+                if (span.SequenceEqual("\r\n        ".AsSpan()))
+                    return "\r\n        ";
+                break;
+            case 'B':
+                if (span.SequenceEqual("ButtonBase".AsSpan()))
+                    return "ButtonBase";
+                break;
+            case 'D':
+                if (span.SequenceEqual("DataSource".AsSpan()))
+                    return "DataSource";
+                if (span.SequenceEqual("Directives".AsSpan()))
+                    return "Directives";
+                if (span.SequenceEqual("DotvvmView".AsSpan()))
+                    return "DotvvmView";
+                if (span.SequenceEqual("DeviceList".AsSpan()))
+                    return "DeviceList";
+                break;
+            case 'F':
+                if (span.SequenceEqual("FilesCount".AsSpan()))
+                    return "FilesCount";
+                if (span.SequenceEqual("FileUpload".AsSpan()))
+                    return "FileUpload";
+                break;
+            case 'H':
+                if (span.SequenceEqual("HeaderText".AsSpan()))
+                    return "HeaderText";
+                break;
+            case 'I':
+                if (span.SequenceEqual("IsEditable".AsSpan()))
+                    return "IsEditable";
+                break;
+            case 'M':
+                if (span.SequenceEqual("MyProperty".AsSpan()))
+                    return "MyProperty";
+                break;
+            case 'O':
+                if (span.SequenceEqual("OffCommand".AsSpan()))
+                    return "OffCommand";
+                break;
+            case 'P':
+                if (span.SequenceEqual("PrefixText".AsSpan()))
+                    return "PrefixText";
+                break;
+            case 'T':
+                if (span.SequenceEqual("TableUtils".AsSpan()))
+                    return "TableUtils";
+                break;
+            case 'V':
+                if (span.SequenceEqual("Validation".AsSpan()))
+                    return "Validation";
+                break;
+            case 'b':
+                if (span.SequenceEqual("background".AsSpan()))
+                    return "background";
+                if (span.SequenceEqual("blockquote".AsSpan()))
+                    return "blockquote";
+                break;
+            case 'f':
+                if (span.SequenceEqual("formaction".AsSpan()))
+                    return "formaction";
+                if (span.SequenceEqual("formmethod".AsSpan()))
+                    return "formmethod";
+                if (span.SequenceEqual("formtarget".AsSpan()))
+                    return "formtarget";
+                if (span.SequenceEqual("figcaption".AsSpan()))
+                    return "figcaption";
+                break;
+            case 'h':
+                if (span.SequenceEqual("http-equiv".AsSpan()))
+                    return "http-equiv";
+                break;
+            case 'i':
+                if (span.SequenceEqual("importance".AsSpan()))
+                    return "importance";
+                break;
+            case 'n':
+                if (span.SequenceEqual("novalidate".AsSpan()))
+                    return "novalidate";
+                break;
+            case 'r':
+                if (span.SequenceEqual("radiogroup".AsSpan()))
+                    return "radiogroup";
+                break;
+            case 's':
+                if (span.SequenceEqual("spellcheck".AsSpan()))
+                    return "spellcheck";
+                break;
+        }
+        break;
+    case 11:
+        switch (ch)
+        {
+            case 'A':
+                if (span.SequenceEqual("ArticleBase".AsSpan()))
+                    return "ArticleBase";
+                break;
+            case 'C':
+                if (span.SequenceEqual("CheckedItem".AsSpan()))
+                    return "CheckedItem";
+                if (span.SequenceEqual("Concurrency".AsSpan()))
+                    return "Concurrency";
+                break;
+            case 'D':
+                if (span.SequenceEqual("DoubleClick".AsSpan()))
+                    return "DoubleClick";
+                if (span.SequenceEqual("DataContext".AsSpan()))
+                    return "DataContext";
+                break;
+            case 'H':
+                if (span.SequenceEqual("HtmlLiteral".AsSpan()))
+                    return "HtmlLiteral";
+                break;
+            case 'J':
+                if (span.SequenceEqual("JsComponent".AsSpan()))
+                    return "JsComponent";
+                break;
+            case 'M':
+                if (span.SequenceEqual("MaxFileSize".AsSpan()))
+                    return "MaxFileSize";
+                break;
+            case 'R':
+                if (span.SequenceEqual("ReplaceWith".AsSpan()))
+                    return "ReplaceWith";
+                if (span.SequenceEqual("RadioButton".AsSpan()))
+                    return "RadioButton";
+                break;
+            case 'S':
+                if (span.SequenceEqual("SortChanged".AsSpan()))
+                    return "SortChanged";
+                break;
+            case 'c':
+                if (span.SequenceEqual("contextmenu".AsSpan()))
+                    return "contextmenu";
+                if (span.SequenceEqual("crossorigin".AsSpan()))
+                    return "crossorigin";
+                break;
+            case 'f':
+                if (span.SequenceEqual("formenctype".AsSpan()))
+                    return "formenctype";
+                break;
+            case 'p':
+                if (span.SequenceEqual("placeholder".AsSpan()))
+                    return "placeholder";
+                break;
+        }
+        break;
+    case 12:
+        switch (ch)
+        {
+            case '\n':
+                if (span.SequenceEqual("\n           ".AsSpan()))
+                    return "\n           ";
+                break;
+            case 'A':
+                if (span.SequenceEqual("AllowSorting".AsSpan()))
+                    return "AllowSorting";
+                break;
+            case 'C':
+                if (span.SequenceEqual("CheckedValue".AsSpan()))
+                    return "CheckedValue";
+                if (span.SequenceEqual("ClientIDMode".AsSpan()))
+                    return "ClientIDMode";
+                if (span.SequenceEqual("CheckedItems".AsSpan()))
+                    return "CheckedItems";
+                break;
+            case 'D':
+                if (span.SequenceEqual("Dependencies".AsSpan()))
+                    return "Dependencies";
+                break;
+            case 'E':
+                if (span.SequenceEqual("EditTemplate".AsSpan()))
+                    return "EditTemplate";
+                if (span.SequenceEqual("Environments".AsSpan()))
+                    return "Environments";
+                break;
+            case 'F':
+                if (span.SequenceEqual("FormatString".AsSpan()))
+                    return "FormatString";
+                if (span.SequenceEqual("FormControls".AsSpan()))
+                    return "FormControls";
+                break;
+            case 'G':
+                if (span.SequenceEqual("GenerateStub".AsSpan()))
+                    return "GenerateStub";
+                break;
+            case 'I':
+                if (span.SequenceEqual("ItemTemplate".AsSpan()))
+                    return "ItemTemplate";
+                if (span.SequenceEqual("InlineScript".AsSpan()))
+                    return "InlineScript";
+                if (span.SequenceEqual("ItemsControl".AsSpan()))
+                    return "ItemsControl";
+                if (span.SequenceEqual("InnerWrapper".AsSpan()))
+                    return "InnerWrapper";
+                break;
+            case 'N':
+                if (span.SequenceEqual("NamedCommand".AsSpan()))
+                    return "NamedCommand";
+                break;
+            case 'O':
+                if (span.SequenceEqual("OnCreateItem".AsSpan()))
+                    return "OnCreateItem";
+                if (span.SequenceEqual("OuterWrapper".AsSpan()))
+                    return "OuterWrapper";
+                break;
+            case 'P':
+                if (span.SequenceEqual("PathFragment".AsSpan()))
+                    return "PathFragment";
+                if (span.SequenceEqual("PromptButton".AsSpan()))
+                    return "PromptButton";
+                break;
+            case 'R':
+                if (span.SequenceEqual("ResourceName".AsSpan()))
+                    return "ResourceName";
+                break;
+            case 'S':
+                if (span.SequenceEqual("SelectorBase".AsSpan()))
+                    return "SelectorBase";
+                if (span.SequenceEqual("SelectorItem".AsSpan()))
+                    return "SelectorItem";
+                break;
+            case 'T':
+                if (span.SequenceEqual("TitleBinding".AsSpan()))
+                    return "TitleBinding";
+                if (span.SequenceEqual("TemplateHost".AsSpan()))
+                    return "TemplateHost";
+                if (span.SequenceEqual("TextRepeater".AsSpan()))
+                    return "TextRepeater";
+                break;
+            case 'V':
+                if (span.SequenceEqual("ValueBinding".AsSpan()))
+                    return "ValueBinding";
+                break;
+            case 'a':
+                if (span.SequenceEqual("autocomplete".AsSpan()))
+                    return "autocomplete";
+                break;
+            case 'e':
+                if (span.SequenceEqual("enterkeyhint".AsSpan()))
+                    return "enterkeyhint";
+                break;
+        }
+        break;
+    case 13:
+        switch (ch)
+        {
+            case '(':
+                if (span.SequenceEqual("(()=>{let vm=".AsSpan()))
+                    return "(()=>{let vm=";
+                break;
+            case 'A':
+                if (span.SequenceEqual("ArticleEditor".AsSpan()))
+                    return "ArticleEditor";
+                if (span.SequenceEqual("ArticleDetail".AsSpan()))
+                    return "ArticleDetail";
+                break;
+            case 'B':
+                if (span.SequenceEqual("ButtonTagName".AsSpan()))
+                    return "ButtonTagName";
+                if (span.SequenceEqual("ButtonWrapper".AsSpan()))
+                    return "ButtonWrapper";
+                break;
+            case 'C':
+                if (span.SequenceEqual("ColumnVisible".AsSpan()))
+                    return "ColumnVisible";
+                break;
+            case 'D':
+                if (span.SequenceEqual("DotvvmControl".AsSpan()))
+                    return "DotvvmControl";
+                break;
+            case 'E':
+                if (span.SequenceEqual("EmptyItemText".AsSpan()))
+                    return "EmptyItemText";
+                break;
+            case 'H':
+                if (span.SequenceEqual("HideWhenValid".AsSpan()))
+                    return "HideWhenValid";
+                break;
+            case 'I':
+                if (span.SequenceEqual("InlineEditing".AsSpan()))
+                    return "InlineEditing";
+                if (span.SequenceEqual("IncludeInPage".AsSpan()))
+                    return "IncludeInPage";
+                break;
+            case 'M':
+                if (span.SequenceEqual("MultiSelector".AsSpan()))
+                    return "MultiSelector";
+                break;
+            case 'N':
+                if (span.SequenceEqual("NumberBinding".AsSpan()))
+                    return "NumberBinding";
+                break;
+            case 'R':
+                if (span.SequenceEqual("RowDecorators".AsSpan()))
+                    return "RowDecorators";
+                break;
+            case 'S':
+                if (span.SequenceEqual("SelectedValue".AsSpan()))
+                    return "SelectedValue";
+                break;
+            case 'U':
+                if (span.SequenceEqual("UseHistoryApi".AsSpan()))
+                    return "UseHistoryApi";
+                if (span.SequenceEqual("UploadedFiles".AsSpan()))
+                    return "UploadedFiles";
+                break;
+            case 'i':
+                if (span.SequenceEqual("intrinsicsize".AsSpan()))
+                    return "intrinsicsize";
+                break;
+            case 's':
+                if (span.SequenceEqual("staticCommand".AsSpan()))
+                    return "staticCommand";
+                break;
+        }
+        break;
+    case 14:
+        switch (ch)
+        {
+            case '\r':
+                if (span.SequenceEqual("\r\n            ".AsSpan()))
+                    return "\r\n            ";
+                break;
+            case 'C':
+                if (span.SequenceEqual("ChangedBinding".AsSpan()))
+                    return "ChangedBinding";
+                if (span.SequenceEqual("CellDecorators".AsSpan()))
+                    return "CellDecorators";
+                break;
+            case 'E':
+                if (span.SequenceEqual("ExcludedQueues".AsSpan()))
+                    return "ExcludedQueues";
+                break;
+            case 'F':
+                if (span.SequenceEqual("FilterTemplate".AsSpan()))
+                    return "FilterTemplate";
+                break;
+            case 'G':
+                if (span.SequenceEqual("GridViewColumn".AsSpan()))
+                    return "GridViewColumn";
+                break;
+            case 'H':
+                if (span.SequenceEqual("HtmlCapability".AsSpan()))
+                    return "HtmlCapability";
+                if (span.SequenceEqual("HeaderCssClass".AsSpan()))
+                    return "HeaderCssClass";
+                if (span.SequenceEqual("HeaderTemplate".AsSpan()))
+                    return "HeaderTemplate";
+                break;
+            case 'I':
+                if (span.SequenceEqual("InnerViewModel".AsSpan()))
+                    return "InnerViewModel";
+                if (span.SequenceEqual("ItemKeyBinding".AsSpan()))
+                    return "ItemKeyBinding";
+                if (span.SequenceEqual("IncludedQueues".AsSpan()))
+                    return "IncludedQueues";
+                if (span.SequenceEqual("IsSubmitButton".AsSpan()))
+                    return "IsSubmitButton";
+                break;
+            case 'M':
+                if (span.SequenceEqual("MarkupFileName".AsSpan()))
+                    return "MarkupFileName";
+                break;
+            case 'R':
+                if (span.SequenceEqual("RequestContext".AsSpan()))
+                    return "RequestContext";
+                if (span.SequenceEqual("RenderSettings".AsSpan()))
+                    return "RenderSettings";
+                break;
+            case 'S':
+                if (span.SequenceEqual("SetToolTipText".AsSpan()))
+                    return "SetToolTipText";
+                if (span.SequenceEqual("SelectedValues".AsSpan()))
+                    return "SelectedValues";
+                if (span.SequenceEqual("SortExpression".AsSpan()))
+                    return "SortExpression";
+                break;
+            case 'U':
+                if (span.SequenceEqual("UpdateProgress".AsSpan()))
+                    return "UpdateProgress";
+                break;
+            case 'W':
+                if (span.SequenceEqual("WrapperTagName".AsSpan()))
+                    return "WrapperTagName";
+                break;
+            case 'a':
+                if (span.SequenceEqual("accept-charset".AsSpan()))
+                    return "accept-charset";
+                if (span.SequenceEqual("autocapitalize".AsSpan()))
+                    return "autocapitalize";
+                break;
+            case 'c':
+                if (span.SequenceEqual("controlCommand".AsSpan()))
+                    return "controlCommand";
+                break;
+            case 'f':
+                if (span.SequenceEqual("formnovalidate".AsSpan()))
+                    return "formnovalidate";
+                break;
+            case 'k':
+                if (span.SequenceEqual("ko.contextFor(".AsSpan()))
+                    return "ko.contextFor(";
+                break;
+            case 'r':
+                if (span.SequenceEqual("referrerpolicy".AsSpan()))
+                    return "referrerpolicy";
+                break;
+        }
+        break;
+    case 15:
+        switch (ch)
+        {
+            case 'C':
+                if (span.SequenceEqual("ContentTemplate".AsSpan()))
+                    return "ContentTemplate";
+                if (span.SequenceEqual("ControlProperty".AsSpan()))
+                    return "ControlProperty";
+                break;
+            case 'D':
+                if (span.SequenceEqual("DataContextType".AsSpan()))
+                    return "DataContextType";
+                break;
+            case 'E':
+                if (span.SequenceEqual("EnvironmentView".AsSpan()))
+                    return "EnvironmentView";
+                break;
+            case 'F':
+                if (span.SequenceEqual("FilterPlacement".AsSpan()))
+                    return "FilterPlacement";
+                break;
+            case 'I':
+                if (span.SequenceEqual("Items()?.length".AsSpan()))
+                    return "Items()?.length";
+                if (span.SequenceEqual("ItemTextBinding".AsSpan()))
+                    return "ItemTextBinding";
+                if (span.SequenceEqual("InvalidCssClass".AsSpan()))
+                    return "InvalidCssClass";
+                break;
+            case 'O':
+                if (span.SequenceEqual("OriginalMessage".AsSpan()))
+                    return "OriginalMessage";
+                break;
+            case 'P':
+                if (span.SequenceEqual("PrefixRouteName".AsSpan()))
+                    return "PrefixRouteName";
+                if (span.SequenceEqual("PostBackHandler".AsSpan()))
+                    return "PostBackHandler";
+                break;
+            case 'U':
+                if (span.SequenceEqual("UploadCompleted".AsSpan()))
+                    return "UploadCompleted";
+                break;
+            case 'c':
+                if (span.SequenceEqual("contenteditable".AsSpan()))
+                    return "contenteditable";
+                break;
+        }
+        break;
+    case 16:
+        switch (ch)
+        {
+            case '.':
+                if (span.SequenceEqual(".Items()?.length".AsSpan()))
+                    return ".Items()?.length";
+                break;
+            case 'A':
+                if (span.SequenceEqual("AllowedFileTypes".AsSpan()))
+                    return "AllowedFileTypes";
+                break;
+            case 'C':
+                if (span.SequenceEqual("ConcurrencyQueue".AsSpan()))
+                    return "ConcurrencyQueue";
+                if (span.SequenceEqual("ClientIDFragment".AsSpan()))
+                    return "ClientIDFragment";
+                break;
+            case 'D':
+                if (span.SequenceEqual("DefaultRouteName".AsSpan()))
+                    return "DefaultRouteName";
+                break;
+            case 'G':
+                if (span.SequenceEqual("GoToDetailAction".AsSpan()))
+                    return "GoToDetailAction";
+                break;
+            case 'H':
+                if (span.SequenceEqual("HasClaimTemplate".AsSpan()))
+                    return "HasClaimTemplate";
+                if (span.SequenceEqual("HierarchyControl".AsSpan()))
+                    return "HierarchyControl";
+                break;
+            case 'I':
+                if (span.SequenceEqual("ItemValueBinding".AsSpan()))
+                    return "ItemValueBinding";
+                if (span.SequenceEqual("Inner-li:Visible".AsSpan()))
+                    return "Inner-li:Visible";
+                if (span.SequenceEqual("IsMemberTemplate".AsSpan()))
+                    return "IsMemberTemplate";
+                if (span.SequenceEqual("ItemTitleBinding".AsSpan()))
+                    return "ItemTitleBinding";
+                break;
+            case 'L':
+                if (span.SequenceEqual("LastPageTemplate".AsSpan()))
+                    return "LastPageTemplate";
+                break;
+            case 'M':
+                if (span.SequenceEqual("MarkupLineNumber".AsSpan()))
+                    return "MarkupLineNumber";
+                break;
+            case 'N':
+                if (span.SequenceEqual("NextPageTemplate".AsSpan()))
+                    return "NextPageTemplate";
+                break;
+            case 'R':
+                if (span.SequenceEqual("RenderWrapperTag".AsSpan()))
+                    return "RenderWrapperTag";
+                if (span.SequenceEqual("RequiredResource".AsSpan()))
+                    return "RequiredResource";
+                break;
+            case 'S':
+                if (span.SequenceEqual("SelectAllOnFocus".AsSpan()))
+                    return "SelectAllOnFocus";
+                if (span.SequenceEqual("SanitizedMessage".AsSpan()))
+                    return "SanitizedMessage";
+                if (span.SequenceEqual("SelectionChanged".AsSpan()))
+                    return "SelectionChanged";
+                break;
+            case 'U':
+                if (span.SequenceEqual("UploadButtonText".AsSpan()))
+                    return "UploadButtonText";
+                break;
+            case 'd':
+                if (span.SequenceEqual("dotvvm.postBack(".AsSpan()))
+                    return "dotvvm.postBack(";
+                break;
+        }
+        break;
+    case 17:
+        switch (ch)
+        {
+            case 'A':
+                if (span.SequenceEqual("AuthenticatedView".AsSpan()))
+                    return "AuthenticatedView";
+                break;
+            case 'C':
+                if (span.SequenceEqual("ControlWithButton".AsSpan()))
+                    return "ControlWithButton";
+                break;
+            case 'E':
+                if (span.SequenceEqual("EditRowDecorators".AsSpan()))
+                    return "EditRowDecorators";
+                if (span.SequenceEqual("EmptyDataTemplate".AsSpan()))
+                    return "EmptyDataTemplate";
+                break;
+            case 'F':
+                if (span.SequenceEqual("FirstPageTemplate".AsSpan()))
+                    return "FirstPageTemplate";
+                if (span.SequenceEqual("FileUploadWrapper".AsSpan()))
+                    return "FileUploadWrapper";
+                break;
+            case 'I':
+                if (span.SequenceEqual("IsNamingContainer".AsSpan()))
+                    return "IsNamingContainer";
+                break;
+            case 'P':
+                if (span.SequenceEqual("PostBack.Handlers".AsSpan()))
+                    return "PostBack.Handlers";
+                break;
+            case 'R':
+                if (span.SequenceEqual("RequiredResources".AsSpan()))
+                    return "RequiredResources";
+                if (span.SequenceEqual("RenderSpanElement".AsSpan()))
+                    return "RenderSpanElement";
+                if (span.SequenceEqual("RefreshTextButton".AsSpan()))
+                    return "RefreshTextButton";
+                break;
+            case 'S':
+                if (span.SequenceEqual("SeparatorTemplate".AsSpan()))
+                    return "SeparatorTemplate";
+                break;
+            case 'T':
+                if (span.SequenceEqual("TextEditorControl".AsSpan()))
+                    return "TextEditorControl";
+                break;
+            case 'U':
+                if (span.SequenceEqual("UpdateTextOnInput".AsSpan()))
+                    return "UpdateTextOnInput";
+                break;
+            case 'V':
+                if (span.SequenceEqual("ValidationSummary".AsSpan()))
+                    return "ValidationSummary";
+                break;
+        }
+        break;
+    case 18:
+        switch (ch)
+        {
+            case 'A':
+                if (span.SequenceEqual("AllowMultipleFiles".AsSpan()))
+                    return "AllowMultipleFiles";
+                break;
+            case 'C':
+                if (span.SequenceEqual("ControlWithButton2".AsSpan()))
+                    return "ControlWithButton2";
+                break;
+            case 'E':
+                if (span.SequenceEqual("EditCellDecorators".AsSpan()))
+                    return "EditCellDecorators";
+                break;
+            case 'G':
+                if (span.SequenceEqual("GridViewTextColumn".AsSpan()))
+                    return "GridViewTextColumn";
+                break;
+            case 'H':
+                if (span.SequenceEqual("HtmlGenericControl".AsSpan()))
+                    return "HtmlGenericControl";
+                break;
+            case 'P':
+                if (span.SequenceEqual("ParametrizedButton".AsSpan()))
+                    return "ParametrizedButton";
+                break;
+            case 'S':
+                if (span.SequenceEqual("SuccessMessageText".AsSpan()))
+                    return "SuccessMessageText";
+                break;
+            case 'U':
+                if (span.SequenceEqual("UsedPropertiesInfo".AsSpan()))
+                    return "UsedPropertiesInfo";
+                break;
+            case 'V':
+                if (span.SequenceEqual("ValidatorPlacement".AsSpan()))
+                    return "ValidatorPlacement";
+                break;
+        }
+        break;
+    case 19:
+        switch (ch)
+        {
+            case '(':
+                if (span.SequenceEqual("(async ()=>{let vm=".AsSpan()))
+                    return "(async ()=>{let vm=";
+                break;
+            case 'C':
+                if (span.SequenceEqual("CurrentIndexBinding".AsSpan()))
+                    return "CurrentIndexBinding";
+                break;
+            case 'H':
+                if (span.SequenceEqual("HideWhenOnlyOnePage".AsSpan()))
+                    return "HideWhenOnlyOnePage";
+                if (span.SequenceEqual("HeaderRowDecorators".AsSpan()))
+                    return "HeaderRowDecorators";
+                if (span.SequenceEqual("HasNotClaimTemplate".AsSpan()))
+                    return "HasNotClaimTemplate";
+                break;
+            case 'I':
+                if (span.SequenceEqual("IsNotMemberTemplate".AsSpan()))
+                    return "IsNotMemberTemplate";
+                break;
+            case 'S':
+                if (span.SequenceEqual("ServerRenderedLabel".AsSpan()))
+                    return "ServerRenderedLabel";
+                break;
+        }
+        break;
+    case 20:
+        switch (ch)
+        {
+            case 'C':
+                if (span.SequenceEqual("ContentPlaceHolderID".AsSpan()))
+                    return "ContentPlaceHolderID";
+                if (span.SequenceEqual("CheckableControlBase".AsSpan()))
+                    return "CheckableControlBase";
+                break;
+            case 'D':
+                if (span.SequenceEqual("DotvvmBindableObject".AsSpan()))
+                    return "DotvvmBindableObject";
+                break;
+            case 'H':
+                if (span.SequenceEqual("HeaderCellDecorators".AsSpan()))
+                    return "HeaderCellDecorators";
+                break;
+            case 'P':
+                if (span.SequenceEqual("PreviousPageTemplate".AsSpan()))
+                    return "PreviousPageTemplate";
+                break;
+            case 'S':
+                if (span.SequenceEqual("ShowErrorMessageText".AsSpan()))
+                    return "ShowErrorMessageText";
+                if (span.SequenceEqual("ShowHeaderWhenNoData".AsSpan()))
+                    return "ShowHeaderWhenNoData";
+                break;
+            case 'T':
+                if (span.SequenceEqual("TemplatedListControl".AsSpan()))
+                    return "TemplatedListControl";
+                break;
+            case 'k':
+                if (span.SequenceEqual("ko.pureComputed(()=>".AsSpan()))
+                    return "ko.pureComputed(()=>";
+                break;
+        }
+        break;
+    case 21:
+        switch (ch)
+        {
+            case 'A':
+                if (span.SequenceEqual("AuthenticatedTemplate".AsSpan()))
+                    return "AuthenticatedTemplate";
+                break;
+            case 'C':
+                if (span.SequenceEqual("ControlCommandBinding".AsSpan()))
+                    return "ControlCommandBinding";
+                break;
+            case 'H':
+                if (span.SequenceEqual("HideForAnonymousUsers".AsSpan()))
+                    return "HideForAnonymousUsers";
+                break;
+            case 'I':
+                if (span.SequenceEqual("IsEnvironmentTemplate".AsSpan()))
+                    return "IsEnvironmentTemplate";
+                break;
+            case 'R':
+                if (span.SequenceEqual("RenderAsNamedTemplate".AsSpan()))
+                    return "RenderAsNamedTemplate";
+                if (span.SequenceEqual("RecursiveTextRepeater".AsSpan()))
+                    return "RecursiveTextRepeater";
+                break;
+            case 'S':
+                if (span.SequenceEqual("SpaContentPlaceHolder".AsSpan()))
+                    return "SpaContentPlaceHolder";
+                break;
+        }
+        break;
+    case 22:
+        switch (ch)
+        {
+            case '(':
+                if (span.SequenceEqual("(i)=>ko.unwrap(i).Id()".AsSpan()))
+                    return "(i)=>ko.unwrap(i).Id()";
+                break;
+            case 'C':
+                if (span.SequenceEqual("CompositeControlSample".AsSpan()))
+                    return "CompositeControlSample";
+                if (span.SequenceEqual("ConfirmPostBackHandler".AsSpan()))
+                    return "ConfirmPostBackHandler";
+                break;
+            case 'G':
+                if (span.SequenceEqual("GridViewTemplateColumn".AsSpan()))
+                    return "GridViewTemplateColumn";
+                if (span.SequenceEqual("GridViewCheckBoxColumn".AsSpan()))
+                    return "GridViewCheckBoxColumn";
+                break;
+            case 'I':
+                if (span.SequenceEqual("IsControlBindingTarget".AsSpan()))
+                    return "IsControlBindingTarget";
+                break;
+            case 'T':
+                if (span.SequenceEqual("TemplatedMarkupControl".AsSpan()))
+                    return "TemplatedMarkupControl";
+                break;
+            case 'U':
+                if (span.SequenceEqual("UploadErrorMessageText".AsSpan()))
+                    return "UploadErrorMessageText";
+                break;
+        }
+        break;
+    case 23:
+        switch (ch)
+        {
+            case 'C':
+                if (span.SequenceEqual("ConfigurableHtmlControl".AsSpan()))
+                    return "ConfigurableHtmlControl";
+                if (span.SequenceEqual("ConcurrencyQueueSetting".AsSpan()))
+                    return "ConcurrencyQueueSetting";
+                if (span.SequenceEqual("ControlPropertyUpdating".AsSpan()))
+                    return "ControlPropertyUpdating";
+                break;
+            case 'I':
+                if (span.SequenceEqual("IncludeErrorsFromTarget".AsSpan()))
+                    return "IncludeErrorsFromTarget";
+                break;
+            case 'R':
+                if (span.SequenceEqual("ResourceRequiringButton".AsSpan()))
+                    return "ResourceRequiringButton";
+                break;
+            case 'S':
+                if (span.SequenceEqual("ServerSideStylesControl".AsSpan()))
+                    return "ServerSideStylesControl";
+                if (span.SequenceEqual("SuppressPostBackHandler".AsSpan()))
+                    return "SuppressPostBackHandler";
+                break;
+            case 'T':
+                if (span.SequenceEqual("TextOrContentCapability".AsSpan()))
+                    return "TextOrContentCapability";
+                break;
+            case 'i':
+                if (span.SequenceEqual("inner-li:HtmlCapability".AsSpan()))
+                    return "inner-li:HtmlCapability";
+                break;
+        }
+        break;
+    case 24:
+        switch (ch)
+        {
+            case '(':
+                if (span.SequenceEqual("(i)=>ko.unwrap(i).Text()".AsSpan()))
+                    return "(i)=>ko.unwrap(i).Text()";
+                if (span.SequenceEqual("(i)=>ko.unwrap(i).Name()".AsSpan()))
+                    return "(i)=>ko.unwrap(i).Name()";
+                break;
+            case 'C':
+                if (span.SequenceEqual("ConcurrencyQueueSettings".AsSpan()))
+                    return "ConcurrencyQueueSettings";
+                break;
+            case 'I':
+                if (span.SequenceEqual("IsNotEnvironmentTemplate".AsSpan()))
+                    return "IsNotEnvironmentTemplate";
+                break;
+            case 'N':
+                if (span.SequenceEqual("NotAuthenticatedTemplate".AsSpan()))
+                    return "NotAuthenticatedTemplate";
+                break;
+            case 'R':
+                if (span.SequenceEqual("ReferencedViewModuleInfo".AsSpan()))
+                    return "ReferencedViewModuleInfo";
+                if (span.SequenceEqual("RenderLinkForCurrentPage".AsSpan()))
+                    return "RenderLinkForCurrentPage";
+                break;
+            case 'S':
+                if (span.SequenceEqual("StopwatchPostbackHandler".AsSpan()))
+                    return "StopwatchPostbackHandler";
+                break;
+        }
+        break;
+    case 25:
+        switch (ch)
+        {
+            case 'C':
+                if (span.SequenceEqual("ControlPropertyValidation".AsSpan()))
+                    return "ControlPropertyValidation";
+                break;
+            case 'E':
+                if (span.SequenceEqual("ErrorCountPostbackHandler".AsSpan()))
+                    return "ErrorCountPostbackHandler";
+                break;
+            case 'I':
+                if (span.SequenceEqual("IncludeErrorsFromChildren".AsSpan()))
+                    return "IncludeErrorsFromChildren";
+                break;
+        }
+        break;
+    case 26:
+        switch (ch)
+        {
+            case 'N':
+                if (span.SequenceEqual("NumberOfFilesIndicatorText".AsSpan()))
+                    return "NumberOfFilesIndicatorText";
+                break;
+            case 'U':
+                if (span.SequenceEqual("UseHistoryApiSpaNavigation".AsSpan()))
+                    return "UseHistoryApiSpaNavigation";
+                break;
+        }
+        break;
+    case 27:
+        switch (ch)
+        {
+            case 'C':
+                if (span.SequenceEqual("CheckedItemsRepeaterWrapper".AsSpan()))
+                    return "CheckedItemsRepeaterWrapper";
+                break;
+            case 'S':
+                if (span.SequenceEqual("SortAscendingHeaderCssClass".AsSpan()))
+                    return "SortAscendingHeaderCssClass";
+                break;
+        }
+        break;
+    case 28:
+        switch (ch)
+        {
+            case 'C':
+                if (span.SequenceEqual("CompositeControlWithTemplate".AsSpan()))
+                    return "CompositeControlWithTemplate";
+                break;
+            case 'S':
+                if (span.SequenceEqual("SortDescendingHeaderCssClass".AsSpan()))
+                    return "SortDescendingHeaderCssClass";
+                break;
+            case 'h':
+                if (span.SequenceEqual("http://www.w3.org/1999/xhtml".AsSpan()))
+                    return "http://www.w3.org/1999/xhtml";
+                break;
+        }
+        break;
+    case 31:
+        switch (ch)
+        {
+            case 'I':
+                if (span.SequenceEqual("IsMasterPageCompositionFinished".AsSpan()))
+                    return "IsMasterPageCompositionFinished";
+                break;
+        }
+        break;
+    case 32:
+        switch (ch)
+        {
+            case 'C':
+                if (span.SequenceEqual("CompileTimeLifecycleRequirements".AsSpan()))
+                    return "CompileTimeLifecycleRequirements";
+                if (span.SequenceEqual("CompositeListControlWithTemplate".AsSpan()))
+                    return "CompositeListControlWithTemplate";
+                break;
+            case 'M':
+                if (span.SequenceEqual("MarkupControlRegistrationControl".AsSpan()))
+                    return "MarkupControlRegistrationControl";
+                break;
+        }
+        break;
+    case 33:
+        switch (ch)
+        {
+            case 'C':
+                if (span.SequenceEqual("ControlControlCommandInvokeAction".AsSpan()))
+                    return "ControlControlCommandInvokeAction";
+                break;
+        }
+        break;
+    case 34:
+        switch (ch)
+        {
+            case 'A':
+                if (span.SequenceEqual("AttributeToStringConversionControl".AsSpan()))
+                    return "AttributeToStringConversionControl";
+                break;
+        }
+        break;
+    case 36:
+        switch (ch)
+        {
+            case 'S':
+                if (span.SequenceEqual("StaticCommand_ValueAssignmentControl".AsSpan()))
+                    return "StaticCommand_ValueAssignmentControl";
+                break;
+            case 'd':
+                if (span.SequenceEqual("dotvvm.evaluator.wrapObservable(()=>".AsSpan()))
+                    return "dotvvm.evaluator.wrapObservable(()=>";
+                break;
+        }
+        break;
+    case 37:
+        switch (ch)
+        {
+            case 'L':
+                if (span.SequenceEqual("LifecycleRequirementsAssigningVisitor".AsSpan()))
+                    return "LifecycleRequirementsAssigningVisitor";
+                break;
+        }
+        break;
+    case 39:
+        switch (ch)
+        {
+            case 'd':
+                if (span.SequenceEqual("dotvvm.globalize.bindingNumberToString(".AsSpan()))
+                    return "dotvvm.globalize.bindingNumberToString(";
+                break;
+        }
+        break;
+    case 41:
+        switch (ch)
+        {
+            case 'C':
+                if (span.SequenceEqual("ComboBoxDataSourceBoundToStaticCollection".AsSpan()))
+                    return "ComboBoxDataSourceBoundToStaticCollection";
+                break;
+        }
+        break;
+}
+
+            str ??= new string(span);
+            if (trySystemIntern)
+                return string.IsInterned(str) ?? str;
+            return str;
+       }
     }
 }

--- a/src/Framework/Testing/BindingTestHelper.cs
+++ b/src/Framework/Testing/BindingTestHelper.cs
@@ -86,7 +86,7 @@ namespace DotVVM.Framework.Testing
             return new ValueBindingExpression<T>(BindingService, new object[] {
                 CreateDataContext(contexts),
                 new OriginalStringBindingProperty(expression),
-                new BindingParserOptions(typeof(ValueBindingExpression)).AddImports(Configuration.Markup.ImportedNamespaces),
+                BindingParserOptions.Value.AddImports(Configuration.Markup.ImportedNamespaces),
                 new ExpectedTypeBindingProperty(typeof(T))
             });
         }

--- a/src/Framework/Testing/FakeCommandBinding.cs
+++ b/src/Framework/Testing/FakeCommandBinding.cs
@@ -4,6 +4,7 @@ using DotVVM.Framework.Compilation.Javascript;
 using DotVVM.Framework.Runtime.Filters;
 using System.Collections.Immutable;
 using DotVVM.Framework.Binding;
+using DotVVM.Framework.Compilation.ControlTree;
 
 namespace DotVVM.Framework.Testing
 {
@@ -22,6 +23,8 @@ namespace DotVVM.Framework.Testing
         public BindingDelegate BindingDelegate => bindingDelegate ?? throw new NotImplementedException();
 
         public ImmutableArray<IActionFilter> ActionFilters => ImmutableArray<IActionFilter>.Empty;
+
+        public DataContextStack? DataContext => null;
 
         public BindingResolverCollection? GetAdditionalResolvers() => null;
 


### PR DESCRIPTION
* bindings avoid using ConcurrentDictionary, since it's quite expensive in terms of consumed memory
* strings are interned using procedure optimized for most common string I found in a memory dump - html attributes, tags, JS fragments, ... This reduces allocations in the tokenizer by about 20-30%. When I was at it, I also significantly optimized the tokenizer throughput, it now goes about twice as fast.