### PR TITLE
Improve error reporting on lifecycle event exceptions.

### DIFF
--- a/src/Framework/Framework/Controls/DotvvmControlCollection.cs
+++ b/src/Framework/Framework/Controls/DotvvmControlCollection.cs
@@ -302,7 +302,12 @@ namespace DotVVM.Framework.Controls
                     throw;
                 }
                 else
-                    throw new DotvvmControlException(lastProcessedControl, "Unhandled exception occurred while executing page lifecycle event.", ex);
+                {
+                    var eventType = lastLifeCycleEvent + 1;
+                    var baseException = ex.GetBaseException();
+                    var controlType = lastProcessedControl.GetType().Name;
+                    throw new DotvvmControlException(lastProcessedControl, $"Unhandled {baseException.GetType().Name} occurred in {controlType}.{eventType}: {baseException.Message}", ex);
+                }
             }
         }
 
@@ -319,6 +324,7 @@ namespace DotVVM.Framework.Controls
                 // abort when control does not require that
                 if ((parent.LifecycleRequirements & (ControlLifecycleRequirements)reqflag) == 0)
                 {
+                    lastLifeCycleEvent = eventType;
                     continue;
                 }
 


### PR DESCRIPTION
Before the message was only "Unhandled exception occurred while executing page lifecycle event"

Now it includes which event, which control, what exception and the message of the base exception.

![image](https://user-images.githubusercontent.com/7894687/145714005-61ea6b6b-6cb4-464a-a8de-8f53c3015a31.png)
