### PR TITLE
Put entire control hierarchy into the error page

### DIFF
--- a/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
+++ b/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Net;
 using System.Reflection;
 using System.Text;
 using DotVVM.Framework.Binding;
@@ -335,7 +336,7 @@ namespace DotVVM.Framework.Controls
         }
 
         /// <summary> Returns somewhat readable string representing this dotvvm control. </summary>
-        public static string DebugString(this DotvvmBindableObject control, DotvvmConfiguration? config = null, bool multiline = true)
+        public static string DebugString(this DotvvmBindableObject control, DotvvmConfiguration? config = null, bool multiline = true, bool useHtml = false)
         {
             if (control == null) return "null";
 
@@ -377,13 +378,30 @@ namespace DotVVM.Framework.Controls
                 dothtmlString += $"{p.name}={p.croppedValue}";
             }
             dothtmlString += " />";
-
-            var from = (location.file)
+            
+            var fileLocation = (location.file)
                      + (location.line >= 0 ? ":" + location.line : "");
-            if (!String.IsNullOrWhiteSpace(from))
-                from = (multiline ? "\n" : " ") + "from " + from.Trim();
 
-            return dothtmlString + from;
+            if (useHtml)
+            {
+                dothtmlString = $"<code class='element'>{WebUtility.HtmlEncode(dothtmlString)}</code>";
+
+                if (!string.IsNullOrWhiteSpace(fileLocation))
+                {
+                    fileLocation = $"<code class='location'>{WebUtility.HtmlEncode(fileLocation)}</code>";
+                }
+            }
+
+            var endOfLine = useHtml ? "<br />" : Environment.NewLine;
+
+            if (!string.IsNullOrWhiteSpace(fileLocation))
+            {
+                return dothtmlString + (multiline ? endOfLine : " ") + "from " + fileLocation;
+            }
+            else
+            {
+                return dothtmlString;
+            }
         }
     }
 }

--- a/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
+++ b/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
@@ -348,7 +348,8 @@ namespace DotVVM.Framework.Controls
                               where p.DeclaringType != typeof(Internal)
                               let isAttached = !p.DeclaringType.IsAssignableFrom(type)
                               orderby !isAttached, p.Name
-                              let name = isAttached ? p.DeclaringType.Name + "." + p.Name : p.Name
+                              let coreName = p is GroupedDotvvmProperty gp ? gp.PropertyGroup.Prefixes.First() + gp.GroupMemberName : p.Name
+                              let name = isAttached ? p.DeclaringType.Name + "." + coreName : coreName
                               let value = rawValue == null ? "<null>" :
                                           rawValue is ITemplate ? "<a template>" :
                                           rawValue is DotvvmBindableObject ? $"<control {rawValue.GetType()}>" :
@@ -375,7 +376,7 @@ namespace DotVVM.Framework.Controls
                     dothtmlString += "\n" + new string(' ', prefixLength);
                 dothtmlString += $"{p.name}={p.croppedValue}";
             }
-            dothtmlString += "/>";
+            dothtmlString += " />";
 
             var from = (location.file)
                      + (location.line >= 0 ? ":" + location.line : "");

--- a/src/Framework/Framework/Hosting/ErrorPages/ErrorFormatter.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/ErrorFormatter.cs
@@ -408,8 +408,8 @@ namespace DotVVM.Framework.Hosting.ErrorPages
                     return null;
                 return new ExceptionAdditionalInfo(
                     "Control Hierarchy",
-                    control.GetAllAncestors(includingThis: true).Select(c => c.DebugString()).ToArray(),
-                    ExceptionAdditionalInfo.DisplayMode.ToHtmlList
+                    control.GetAllAncestors(includingThis: true).Select(c => c.DebugString(useHtml: true, multiline: false)).ToArray(),
+                    ExceptionAdditionalInfo.DisplayMode.ToHtmlListUnencoded
                 );
             });
 

--- a/src/Framework/Framework/Hosting/ErrorPages/ErrorFormatter.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/ErrorFormatter.cs
@@ -407,9 +407,9 @@ namespace DotVVM.Framework.Hosting.ErrorPages
                 if (control is null)
                     return null;
                 return new ExceptionAdditionalInfo(
-                    "DotVVM Control",
-                    new [] { control.DebugString() },
-                    ExceptionAdditionalInfo.DisplayMode.ToString
+                    "Control Hierarchy",
+                    control.GetAllAncestors(includingThis: true).Select(c => c.DebugString()).ToArray(),
+                    ExceptionAdditionalInfo.DisplayMode.ToHtmlList
                 );
             });
 

--- a/src/Framework/Framework/Hosting/ErrorPages/ExceptionAdditionalInfo.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/ExceptionAdditionalInfo.cs
@@ -15,6 +15,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
         public enum DisplayMode
         {
             ToHtmlList,
+            ToHtmlListUnencoded,
             ToString,
             ObjectBrowser,
             KVTable

--- a/src/Framework/Framework/Hosting/ErrorPages/ExceptionSectionFormatter.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/ExceptionSectionFormatter.cs
@@ -48,7 +48,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
                     w.WriteUnencoded("</h3>");
                     if (info.Objects != null)
                     {
-                        if (info.Display == ExceptionAdditionalInfo.DisplayMode.ToHtmlList)
+                        if (info.Display == ExceptionAdditionalInfo.DisplayMode.ToHtmlList || info.Display == ExceptionAdditionalInfo.DisplayMode.ToHtmlListUnencoded)
                         {
                             w.WriteUnencoded("<ul>");
                         }
@@ -66,8 +66,12 @@ namespace DotVVM.Framework.Hosting.ErrorPages
                             {
                                 w.WriteUnencoded("<li>" + WebUtility.HtmlEncode(obj.ToString()) + "</li>");
                             }
+                            else if (info.Display == ExceptionAdditionalInfo.DisplayMode.ToHtmlListUnencoded)
+                            {
+                                w.WriteUnencoded("<li>" + obj + "</li>");
+                            }
                         }
-                        if (info.Display == ExceptionAdditionalInfo.DisplayMode.ToHtmlList)
+                        if (info.Display == ExceptionAdditionalInfo.DisplayMode.ToHtmlList || info.Display == ExceptionAdditionalInfo.DisplayMode.ToHtmlListUnencoded)
                         {
                             w.WriteUnencoded("</ul>");
                         }

--- a/src/Framework/Framework/Resources/Styles/DotVVM.Internal.css
+++ b/src/Framework/Framework/Resources/Styles/DotVVM.Internal.css
@@ -309,3 +309,17 @@ hr {
     .compile-progress span:nth-child(3) {
         animation-delay: 500ms
     }
+
+ul {
+    margin: 1em;
+}
+    ul li {
+        margin: .25em 1em;
+    }
+
+code.element {
+    color: var(--error-dark-color);
+}
+code.location {
+    font-weight: bold;
+}

--- a/src/Samples/Common/Controls/ExceptionThrower.cs
+++ b/src/Samples/Common/Controls/ExceptionThrower.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Hosting;
+
+namespace DotVVM.Samples.Common.Controls
+{
+    public class ExceptionThrower : DotvvmControl 
+    {
+
+        public ExceptionThrowerStage Stage
+        {
+            get { return (ExceptionThrowerStage)GetValue(StageProperty); }
+            set { SetValue(StageProperty, value); }
+        }
+        public static readonly DotvvmProperty StageProperty
+            = DotvvmProperty.Register<ExceptionThrowerStage, ExceptionThrower>(c => c.Stage, ExceptionThrowerStage.Render);
+
+
+        protected override void OnInit(IDotvvmRequestContext context)
+        {
+            if (Stage == ExceptionThrowerStage.Init)
+            {
+                throw new Exception("ExceptionThrower");
+            }
+            base.OnInit(context);
+        }
+
+        protected override void OnLoad(IDotvvmRequestContext context)
+        {
+            if (Stage == ExceptionThrowerStage.Load)
+            {
+                throw new Exception("ExceptionThrower");
+            }
+            base.OnLoad(context);
+        }
+
+        protected override void OnPreRender(IDotvvmRequestContext context)
+        {
+            if (Stage == ExceptionThrowerStage.PreRender)
+            {
+                throw new Exception("ExceptionThrower");
+            }
+            base.OnPreRender(context);
+        }
+
+        public override void Render(IHtmlWriter writer, IDotvvmRequestContext context)
+        {
+            if (Stage == ExceptionThrowerStage.Render)
+            {
+                throw new Exception("ExceptionThrower");
+            }
+            base.Render(writer, context);
+        }
+    }
+
+    public enum ExceptionThrowerStage
+    {
+        Render,
+        Init,
+        Load,
+        PreRender
+    }
+}

--- a/src/Samples/Common/DotVVM.Samples.Common.csproj
+++ b/src/Samples/Common/DotVVM.Samples.Common.csproj
@@ -69,6 +69,8 @@
     <None Remove="Views\ControlSamples\ValidationSummary\MessagesRendering.dothtml" />
     <None Remove="Views\ControlSamples\ValidationSummary\Performance.dothtml" />
     <None Remove="Views\Errors\CorruptedContentBetweenContentControls.dothtml" />
+    <None Remove="Views\Errors\ExceptionInLifecycle.dothtml" />
+    <None Remove="Views\Errors\ExceptionInRender.dothtml" />
     <None Remove="Views\Errors\InvalidServiceDirective.dothtml" />
     <None Remove="Views\Errors\InvalidLocationFallback.dothtml" />
     <None Remove="Views\Errors\ResourceCircularDependency.dothtml" />

--- a/src/Samples/Common/ViewModels/Errors/ExceptionInLifecycleViewModel.cs
+++ b/src/Samples/Common/ViewModels/Errors/ExceptionInLifecycleViewModel.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.Errors
+{
+    public class ExceptionInLifecycleViewModel : DotvvmViewModelBase
+    {
+        
+    }
+}
+

--- a/src/Samples/Common/ViewModels/Errors/ExceptionInRenderViewModel.cs
+++ b/src/Samples/Common/ViewModels/Errors/ExceptionInRenderViewModel.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.Errors
+{
+    public class ExceptionInRenderViewModel : DotvvmViewModelBase
+    {
+        
+    }
+}
+

--- a/src/Samples/Common/Views/Errors/ExceptionInLifecycle.dothtml
+++ b/src/Samples/Common/Views/Errors/ExceptionInLifecycle.dothtml
@@ -1,0 +1,23 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.Errors.ExceptionInLifecycleViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+
+    <h1>Exception in Load phase</h1>
+
+    <div>
+        <strong>
+            <cc:ExceptionThrower Stage="Load" />
+        </strong>
+    </div>
+
+</body>
+</html>
+
+

--- a/src/Samples/Common/Views/Errors/ExceptionInRender.dothtml
+++ b/src/Samples/Common/Views/Errors/ExceptionInRender.dothtml
@@ -1,0 +1,23 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.Errors.ExceptionInRenderViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+
+    <h1>Exception in Render phase</h1>
+
+    <div>
+        <strong>
+            <cc:ExceptionThrower Stage="Render" />
+        </strong>
+    </div>
+
+</body>
+</html>
+
+

--- a/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
@@ -166,6 +166,8 @@ namespace DotVVM.Testing.Abstractions
         public const string Errors_CorruptedContentBetweenContentControls = "Errors/CorruptedContentBetweenContentControls";
         public const string Errors_EmptyBinding = "Errors/EmptyBinding";
         public const string Errors_EncryptedPropertyInValueBinding = "Errors/EncryptedPropertyInValueBinding";
+        public const string Errors_ExceptionInLifecycle = "Errors/ExceptionInLifecycle";
+        public const string Errors_ExceptionInRender = "Errors/ExceptionInRender";
         public const string Errors_FieldInValueBinding = "Errors/FieldInValueBinding";
         public const string Errors_InvalidLocationFallback = "Errors/InvalidLocationFallback";
         public const string Errors_InvalidRouteName = "Errors/InvalidRouteName";

--- a/src/Samples/Tests/Tests/ErrorsTests.cs
+++ b/src/Samples/Tests/Tests/ErrorsTests.cs
@@ -453,6 +453,34 @@ namespace DotVVM.Samples.Tests
             });
         }
 
+        [Fact]
+        public void Error_ExceptionInRender()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.Errors_ExceptionInRender);
+
+                AssertUI.InnerText(browser.First(".exceptionMessage"), s => s.Contains("ExceptionThrower"));
+                browser.First("label[for=menu_radio_stack_trace]").Click();
+
+                AssertUI.InnerText(browser.First(".exceptionAdditionalInfo"), s => s.Contains("<strong />"));
+                AssertUI.InnerText(browser.First(".exceptionAdditionalInfo"), s => s.Contains("ExceptionInRender.dothtml"));
+            });
+        }
+
+        [Fact]
+        public void Error_ExceptionInLifecycle()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.Errors_ExceptionInLifecycle);
+
+                AssertUI.InnerText(browser.First(".exceptionMessage"), s => s.Contains("ExceptionThrower"));
+                browser.First("label[for=menu_radio_stack_trace]").Click();
+
+                AssertUI.InnerText(browser.First(".exceptionAdditionalInfo"), s => s.Contains("<strong />"));
+                AssertUI.InnerText(browser.First(".exceptionAdditionalInfo"), s => s.Contains("ExceptionInLifecycle.dothtml"));
+            });
+        }
+
         public ErrorsTests(ITestOutputHelper output) : base(output)
         {
         }


### PR DESCRIPTION
This comes in quite useful when debugging complex control
hierarchies created in code. This implementation
looks a bit crude, but it works...

![image](https://user-images.githubusercontent.com/7894687/146437177-3c91f145-c7eb-43f1-8d65-8b35d45e18e6.png)
