### PR TITLE
Fixed and improved serializability analyzers

### DIFF
--- a/src/Analyzers/Analyzers.Tests/Serializability/ViewModelSerializabilityTest.cs
+++ b/src/Analyzers/Analyzers.Tests/Serializability/ViewModelSerializabilityTest.cs
@@ -50,7 +50,7 @@ namespace DotVVM.Analyzers.Tests.Serializability
     }",
 
             VerifyCS.Diagnostic(ViewModelSerializabilityAnalyzer.UseSerializablePropertiesRule)
-                .WithLocation(0).WithArguments("NonSerializableProperty"));
+                .WithLocation(0).WithArguments("this.NonSerializableProperty"));
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace DotVVM.Analyzers.Tests.Serializability
     }",
 
             VerifyCS.Diagnostic(ViewModelSerializabilityAnalyzer.UseSerializablePropertiesRule)
-                .WithLocation(0).WithArguments("NonSerializableList"));
+                .WithLocation(0).WithArguments("this.NonSerializableList"));
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace DotVVM.Analyzers.Tests.Serializability
     }",
 
             VerifyCS.Diagnostic(ViewModelSerializabilityAnalyzer.DoNotUseUninstantiablePropertiesRule)
-                .WithLocation(0).WithArguments("System.Collections.Generic.IList<int>"));
+                .WithLocation(0).WithArguments("this.PotentiallyNonSerializableList"));
         }
 
         [Fact]
@@ -336,7 +336,7 @@ namespace DotVVM.Analyzers.Tests.Serializability
     }",
 
             VerifyCS.Diagnostic(ViewModelSerializabilityAnalyzer.UseSerializablePropertiesRule)
-                .WithLocation(0).WithArguments("LinkedList"));
+                .WithLocation(0).WithArguments("this.LinkedList"));
         }
 
         [Fact]
@@ -505,7 +505,7 @@ namespace DotVVM.Analyzers.Tests.Serializability
     }",
 
             VerifyCS.Diagnostic(ViewModelSerializabilityAnalyzer.UseSerializablePropertiesRule).WithLocation(0)
-                .WithArguments("NonSerializable/Value"));
+                .WithArguments("this.NonSerializable.Value"));
         }
     }
 }

--- a/src/Analyzers/Analyzers.Tests/Serializability/ViewModelSerializabilityTest.cs
+++ b/src/Analyzers/Analyzers.Tests/Serializability/ViewModelSerializabilityTest.cs
@@ -219,6 +219,7 @@ namespace DotVVM.Analyzers.Tests.Serializability
         public class DefaultViewModel : DotvvmViewModelBase
         {
             public DateTime? DateTime { get; set; }
+            public DateTimeOffset? DateTimeOffset { get; set; }
             public TimeSpan? TimeSpan { get; set; }
             public Guid? Guid { get; set; }
         }
@@ -263,6 +264,7 @@ namespace DotVVM.Analyzers.Tests.Serializability
             public object Object { get; set; }
             public string String { get; set; }
             public DateTime DateTime { get; set; }
+            public DateTimeOffset DateTimeOffset { get; set; }
             public TimeSpan TimeSpan { get; set; }
             public Guid Guid { get; set; }
         }

--- a/src/Analyzers/Analyzers.Tests/Serializability/ViewModelSerializabilityTest.cs
+++ b/src/Analyzers/Analyzers.Tests/Serializability/ViewModelSerializabilityTest.cs
@@ -479,5 +479,34 @@ namespace DotVVM.Analyzers.Tests.Serializability
 
             await VerifyCS.VerifyAnalyzerAsync(text);
         }
+
+        [Fact]
+        public async void Test_GenericReferenceType_Properties_ViewModel()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+    using DotVVM.Framework.Controls;
+    using DotVVM.Framework.ViewModel;
+    using System;
+    using System.IO;
+    using System.Collections.Generic;
+
+    namespace ConsoleApplication1
+    {
+        public class DefaultViewModel : DotvvmViewModelBase
+        {
+            public WrappedValue<int> Value { get; set; }
+            {|#0:public WrappedValue<Stream> NonSerializable { get; set; }|}
+        }
+
+        public class WrappedValue<T>
+        {
+            public string Name { get; set; }
+            public T Value { get; set; }
+        }
+    }",
+
+            VerifyCS.Diagnostic(ViewModelSerializabilityAnalyzer.UseSerializablePropertiesRule).WithLocation(0)
+                .WithArguments("ConsoleApplication1.WrappedValue<System.IO.Stream>"));
+        }
     }
 }

--- a/src/Analyzers/Analyzers.Tests/Serializability/ViewModelSerializabilityTest.cs
+++ b/src/Analyzers/Analyzers.Tests/Serializability/ViewModelSerializabilityTest.cs
@@ -50,7 +50,7 @@ namespace DotVVM.Analyzers.Tests.Serializability
     }",
 
             VerifyCS.Diagnostic(ViewModelSerializabilityAnalyzer.UseSerializablePropertiesRule)
-                .WithLocation(0).WithArguments("System.IO.FileInfo"));
+                .WithLocation(0).WithArguments("NonSerializableProperty"));
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace DotVVM.Analyzers.Tests.Serializability
     }",
 
             VerifyCS.Diagnostic(ViewModelSerializabilityAnalyzer.UseSerializablePropertiesRule)
-                .WithLocation(0).WithArguments("System.Collections.Generic.List<System.IO.Stream>"));
+                .WithLocation(0).WithArguments("NonSerializableList"));
         }
 
         [Fact]
@@ -88,13 +88,12 @@ namespace DotVVM.Analyzers.Tests.Serializability
     {
         public class DefaultViewModel : DotvvmViewModelBase
         {
-            public int SerializableProperty { get; set; }
-            {|#0:public IList<Stream> NonSerializableList { get; set; }|}
+            {|#0:public IList<int> PotentiallyNonSerializableList { get; set; }|}
         }
     }",
 
             VerifyCS.Diagnostic(ViewModelSerializabilityAnalyzer.DoNotUseUninstantiablePropertiesRule)
-                .WithLocation(0).WithArguments("System.Collections.Generic.IList<System.IO.Stream>"));
+                .WithLocation(0).WithArguments("System.Collections.Generic.IList<int>"));
         }
 
         [Fact]
@@ -337,7 +336,7 @@ namespace DotVVM.Analyzers.Tests.Serializability
     }",
 
             VerifyCS.Diagnostic(ViewModelSerializabilityAnalyzer.UseSerializablePropertiesRule)
-                .WithLocation(0).WithArguments("System.Collections.Generic.LinkedList<object>"));
+                .WithLocation(0).WithArguments("LinkedList"));
         }
 
         [Fact]
@@ -506,7 +505,7 @@ namespace DotVVM.Analyzers.Tests.Serializability
     }",
 
             VerifyCS.Diagnostic(ViewModelSerializabilityAnalyzer.UseSerializablePropertiesRule).WithLocation(0)
-                .WithArguments("ConsoleApplication1.WrappedValue<System.IO.Stream>"));
+                .WithArguments("NonSerializable/Value"));
         }
     }
 }

--- a/src/Analyzers/Analyzers.Tests/Serializability/ViewModelSerializabilityTest.cs
+++ b/src/Analyzers/Analyzers.Tests/Serializability/ViewModelSerializabilityTest.cs
@@ -311,6 +311,8 @@ namespace DotVVM.Analyzers.Tests.Serializability
         public class UserType
         {
             public string Property { get; set; }
+            public int? NullableProp { get; set; }
+            public bool FlagProp { get; set; }
         }
     }";
 
@@ -450,6 +452,28 @@ namespace DotVVM.Analyzers.Tests.Serializability
         public class DefaultViewModel : DotvvmViewModelBase
         {
             public DefaultViewModel InnerVM { get; set; }
+        }
+    }";
+
+            await VerifyCS.VerifyAnalyzerAsync(text);
+        }
+
+
+        [Fact]
+        public async void Test_WhiteListedDotvvmTypes_Properties_ViewModel()
+        {
+            var text = @"
+    using DotVVM.Framework.Controls;
+    using DotVVM.Framework.ViewModel;
+    using System;
+    using System.Collections.Generic;
+
+    namespace ConsoleApplication1
+    {
+        public class DefaultViewModel : DotvvmViewModelBase
+        {
+            public GridViewDataSet<int> DataSet { get; set; }
+            public UploadedFilesCollection UploadedFiles { get; set; }
         }
     }";
 

--- a/src/Analyzers/Analyzers.Tests/Serializability/ViewModelSerializabilityTest.cs
+++ b/src/Analyzers/Analyzers.Tests/Serializability/ViewModelSerializabilityTest.cs
@@ -88,11 +88,11 @@ namespace DotVVM.Analyzers.Tests.Serializability
     {
         public class DefaultViewModel : DotvvmViewModelBase
         {
-            {|#0:public IList<int> PotentiallyNonSerializableList { get; set; }|}
+            {|#0:public IList<IDisposable> PotentiallyNonSerializableList { get; set; }|}
         }
     }",
 
-            VerifyCS.Diagnostic(ViewModelSerializabilityAnalyzer.DoNotUseUninstantiablePropertiesRule)
+            VerifyCS.Diagnostic(ViewModelSerializabilityAnalyzer.UseSerializablePropertiesRule)
                 .WithLocation(0).WithArguments("this.PotentiallyNonSerializableList"));
         }
 
@@ -295,6 +295,28 @@ namespace DotVVM.Analyzers.Tests.Serializability
         }
 
         [Fact]
+        public async void Test_NoWarningsForEnumerables_ViewModel()
+        {
+            var test = @"
+    using DotVVM.Framework.ViewModel;
+    using System;
+    using System.Collections.Generic;
+
+    namespace ConsoleApplication1
+    {
+        public class DefaultViewModel : DotvvmViewModelBase
+        {
+            public IEnumerable<int> Enumerable { get; set; }
+            public IList<int> List { get; set; }
+            public ICollection<int> Collection { get; set; }
+            public ICollection<IList<IEnumerable<int>>> WowCollection { get; set; }
+        }
+    }";
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
         public async void Test_UserTypesAreSerializableAndSupported_ViewModel()
         {
             var test = @"
@@ -313,7 +335,10 @@ namespace DotVVM.Analyzers.Tests.Serializability
         {
             public string Property { get; set; }
             public int? NullableProp { get; set; }
+            public DateTime? NullableDateTime { get; set; }
+            public DateTimeOffset? NullableDateTimeOffset { get; set; }
             public bool FlagProp { get; set; }
+            public IList<int> List { get; set; }
         }
     }";
 
@@ -333,12 +358,12 @@ namespace DotVVM.Analyzers.Tests.Serializability
         public class DefaultViewModel : DotvvmViewModelBase
         {
             public int SerializableProperty { get; set; }
-            {|#0:public LinkedList<object> LinkedList { get; set; }|}
+            {|#0:public Action Action { get; set; }|}
         }
     }",
 
             VerifyCS.Diagnostic(ViewModelSerializabilityAnalyzer.UseSerializablePropertiesRule)
-                .WithLocation(0).WithArguments("this.LinkedList"));
+                .WithLocation(0).WithArguments("this.Action"));
         }
 
         [Fact]

--- a/src/Analyzers/Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/Analyzers/AnalyzerReleases.Unshipped.md
@@ -6,4 +6,3 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 DotVVM02 | Serializability | Warning | ViewModelSerializabilityAnalyzer
 DotVVM03 | Serializability | Warning | ViewModelSerializabilityAnalyzer
-DotVVM04 | Serializability | Warning | ViewModelSerializabilityAnalyzer

--- a/src/Analyzers/Analyzers/DotvvmDiagnosticIds.cs
+++ b/src/Analyzers/Analyzers/DotvvmDiagnosticIds.cs
@@ -11,6 +11,5 @@ namespace DotVVM.Analyzers
 
         public const string UseSerializablePropertiesInViewModelRuleId = "DotVVM02";
         public const string DoNotUseFieldsInViewModelRuleId = "DotVVM03";
-        public const string DoNotUseUninstantiablePropertiesInViewModelRuleId = "DotVVM04";
     }
 }

--- a/src/Analyzers/Analyzers/Resources.Designer.cs
+++ b/src/Analyzers/Analyzers/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace DotVVM.Analyzers {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -97,7 +97,7 @@ namespace DotVVM.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Property of type &apos;{0}&apos; is not serializable.
+        ///   Looks up a localized string similar to Property on path &apos;{0}&apos; is not serializable.
         /// </summary>
         internal static string Serializability_NonSerializableType_Message {
             get {
@@ -124,7 +124,7 @@ namespace DotVVM.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Property of abstract type &apos;{0}&apos; might not be correctly serialized.
+        ///   Looks up a localized string similar to Abstract property on path &apos;{0}&apos; is not serializable.
         /// </summary>
         internal static string Serializability_UninstantiableType_Message {
             get {

--- a/src/Analyzers/Analyzers/Resources.Designer.cs
+++ b/src/Analyzers/Analyzers/Resources.Designer.cs
@@ -113,32 +113,5 @@ namespace DotVVM.Analyzers {
                 return ResourceManager.GetString("Serializability_NonSerializableType_Title", resourceCulture);
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Use concrete implementation in viewmodels to ensure that all properties are correctly serialized..
-        /// </summary>
-        internal static string Serializability_UninstantiableType_Description {
-            get {
-                return ResourceManager.GetString("Serializability_UninstantiableType_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Abstract property on path &apos;{0}&apos; is not serializable.
-        /// </summary>
-        internal static string Serializability_UninstantiableType_Message {
-            get {
-                return ResourceManager.GetString("Serializability_UninstantiableType_Message", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Interfaces and abstract classes might not be correctly serialized.
-        /// </summary>
-        internal static string Serializability_UninstantiableType_Title {
-            get {
-                return ResourceManager.GetString("Serializability_UninstantiableType_Title", resourceCulture);
-            }
-        }
     }
 }

--- a/src/Analyzers/Analyzers/Resources.resx
+++ b/src/Analyzers/Analyzers/Resources.resx
@@ -135,13 +135,4 @@
   <data name="Serializability_NonSerializableType_Title" xml:space="preserve">
     <value>Properties must be serializable</value>
   </data>
-  <data name="Serializability_UninstantiableType_Description" xml:space="preserve">
-    <value>Use concrete implementation in viewmodels to ensure that all properties are correctly serialized.</value>
-  </data>
-  <data name="Serializability_UninstantiableType_Message" xml:space="preserve">
-    <value>Abstract property on path '{0}' is not serializable</value>
-  </data>
-  <data name="Serializability_UninstantiableType_Title" xml:space="preserve">
-    <value>Interfaces and abstract classes might not be correctly serialized</value>
-  </data>
 </root>

--- a/src/Analyzers/Analyzers/Resources.resx
+++ b/src/Analyzers/Analyzers/Resources.resx
@@ -130,7 +130,7 @@
     <value>Unsupported property type in viewmodel.</value>
   </data>
   <data name="Serializability_NonSerializableType_Message" xml:space="preserve">
-    <value>Property of type '{0}' is not serializable</value>
+    <value>Property on path '{0}' is not serializable</value>
   </data>
   <data name="Serializability_NonSerializableType_Title" xml:space="preserve">
     <value>Properties must be serializable</value>
@@ -139,7 +139,7 @@
     <value>Use concrete implementation in viewmodels to ensure that all properties are correctly serialized.</value>
   </data>
   <data name="Serializability_UninstantiableType_Message" xml:space="preserve">
-    <value>Property of abstract type '{0}' might not be correctly serialized</value>
+    <value>Abstract property on path '{0}' is not serializable</value>
   </data>
   <data name="Serializability_UninstantiableType_Title" xml:space="preserve">
     <value>Interfaces and abstract classes might not be correctly serialized</value>

--- a/src/Analyzers/Analyzers/Serializability/TypeSymbolExtensions.cs
+++ b/src/Analyzers/Analyzers/Serializability/TypeSymbolExtensions.cs
@@ -157,6 +157,7 @@ namespace DotVVM.Analyzers.Serializability
             cacheBuilder.Add(compilation.GetSpecialType(SpecialType.System_DateTime));
             cacheBuilder.Add(compilation.GetTypeByMetadataName("System.Guid")!);
             cacheBuilder.Add(compilation.GetTypeByMetadataName("System.TimeSpan")!);
+            cacheBuilder.Add(compilation.GetTypeByMetadataName("System.DateTimeOffset")!);
 
             return cacheBuilder.ToImmutableHashSet(SymbolEqualityComparer.Default);
         }

--- a/src/Analyzers/Analyzers/Serializability/TypeSymbolExtensions.cs
+++ b/src/Analyzers/Analyzers/Serializability/TypeSymbolExtensions.cs
@@ -70,6 +70,10 @@ namespace DotVVM.Analyzers.Serializability
                         continue;
                     case TypeKind.Class:
                     case TypeKind.Struct:
+                        // Unwrap nullables
+                        if (currentSymbol.NullableAnnotation == NullableAnnotation.Annotated)
+                            currentSymbol = (currentSymbol as INamedTypeSymbol)!.TypeArguments.First();
+
                         var namedTypeSymbol = currentSymbol as INamedTypeSymbol;
                         var arity = namedTypeSymbol?.Arity;
                         var args = namedTypeSymbol?.TypeArguments ?? ImmutableArray.Create<ITypeSymbol>();

--- a/src/Analyzers/Analyzers/Serializability/TypeSymbolExtensions.cs
+++ b/src/Analyzers/Analyzers/Serializability/TypeSymbolExtensions.cs
@@ -124,6 +124,10 @@ namespace DotVVM.Analyzers.Serializability
             referenceTypeBuilder.Add(compilation.GetTypeByMetadataName("System.Collections.Generic.List`1")!);
             referenceTypeBuilder.Add(compilation.GetTypeByMetadataName("System.Collections.Generic.Dictionary`2")!);
 
+            // Whitelisted DotVVM types commonly found in viewmodels
+            referenceTypeBuilder.Add(compilation.GetTypeByMetadataName("DotVVM.Framework.Controls.GridViewDataSet`1")!);
+            referenceTypeBuilder.Add(compilation.GetTypeByMetadataName("DotVVM.Framework.Controls.UploadedFilesCollection")!);
+
             // Common value types: (primitives)
             valueTypeBuilder.Add(compilation.GetSpecialType(SpecialType.System_Boolean));
             valueTypeBuilder.Add(compilation.GetSpecialType(SpecialType.System_Byte));

--- a/src/Analyzers/Analyzers/Serializability/TypeSymbolExtensions.cs
+++ b/src/Analyzers/Analyzers/Serializability/TypeSymbolExtensions.cs
@@ -78,9 +78,9 @@ namespace DotVVM.Analyzers.Serializability
                         var namedTypeSymbol = currentSymbol as INamedTypeSymbol;
                         var arity = namedTypeSymbol?.Arity;
                         var args = namedTypeSymbol?.TypeArguments ?? ImmutableArray.Create<ITypeSymbol>();
-                        var symbol = (arity.HasValue && arity.Value > 0) ? currentSymbol.OriginalDefinition : currentSymbol;
+                        var originalDefinitionSymbol = (arity.HasValue && arity.Value > 0) ? currentSymbol.OriginalDefinition : currentSymbol;
 
-                        if (cache.Contains(symbol))
+                        if (cache.Contains(originalDefinitionSymbol))
                         {
                             // Type is either primitive and/or directly supported by DotVVM
                             foreach (var arg in args)
@@ -95,7 +95,7 @@ namespace DotVVM.Analyzers.Serializability
                         else if (!currentSymbol.ContainingNamespace.ToDisplayString().StartsWith("System"))
                         {
                             // User types are supported if all their properties are supported
-                            foreach (var property in symbol.GetMembers().Where(m => m.Kind == SymbolKind.Property).Cast<IPropertySymbol>())
+                            foreach (var property in currentSymbol.GetMembers().Where(m => m.Kind == SymbolKind.Property).Cast<IPropertySymbol>())
                             {
                                 if (!visited.Contains(property.Type))
                                 {

--- a/src/Analyzers/Analyzers/Serializability/TypeSymbolExtensions.cs
+++ b/src/Analyzers/Analyzers/Serializability/TypeSymbolExtensions.cs
@@ -131,6 +131,9 @@ namespace DotVVM.Analyzers.Serializability
             // Whitelisted DotVVM types commonly found in viewmodels
             cacheBuilder.Add(compilation.GetTypeByMetadataName("DotVVM.Framework.Controls.GridViewDataSet`1")!);
             cacheBuilder.Add(compilation.GetTypeByMetadataName("DotVVM.Framework.Controls.UploadedFilesCollection")!);
+            var bpGridViewDataSet = compilation.GetTypeByMetadataName("DotVVM.BusinessPack.Controls.BusinessPackDataSet`1");
+            if (bpGridViewDataSet != null)
+                cacheBuilder.Add(bpGridViewDataSet);
 
             // Common value types: (primitives)
             cacheBuilder.Add(compilation.GetSpecialType(SpecialType.System_Boolean));

--- a/src/Analyzers/Analyzers/Serializability/ViewModelSerializabilityAnalyzer.cs
+++ b/src/Analyzers/Analyzers/Serializability/ViewModelSerializabilityAnalyzer.cs
@@ -20,9 +20,6 @@ namespace DotVVM.Analyzers.Serializability
         private static readonly LocalizableResourceString doNotUseFieldsTitle = new LocalizableResourceString(nameof(Resources.Serializability_DoNotUseFields_Title), Resources.ResourceManager, typeof(Resources));
         private static readonly LocalizableResourceString doNotUseFieldsMessage = new LocalizableResourceString(nameof(Resources.Serializability_DoNotUseFields_Message), Resources.ResourceManager, typeof(Resources));
         private static readonly LocalizableResourceString doNotUseFieldsDescription = new LocalizableResourceString(nameof(Resources.Serializability_DoNotUseFields_Description), Resources.ResourceManager, typeof(Resources));
-        private static readonly LocalizableResourceString uninstantiableTypeTitle = new LocalizableResourceString(nameof(Resources.Serializability_UninstantiableType_Title), Resources.ResourceManager, typeof(Resources));
-        private static readonly LocalizableResourceString uninstantiableTypeMessage = new LocalizableResourceString(nameof(Resources.Serializability_UninstantiableType_Message), Resources.ResourceManager, typeof(Resources));
-        private static readonly LocalizableResourceString uninstantiableTypeDescription = new LocalizableResourceString(nameof(Resources.Serializability_UninstantiableType_Description), Resources.ResourceManager, typeof(Resources));
         private const string dotvvmViewModelInterfaceMetadataName =  "DotVVM.Framework.ViewModel.IDotvvmViewModel";
         private const string dotvvmBindAttributeMetadataName = "DotVVM.Framework.ViewModel.BindAttribute";
         private const string newtonsoftJsonIgnoreAttributeMetadataName = "Newtonsoft.Json.JsonIgnoreAttribute";
@@ -45,20 +42,10 @@ namespace DotVVM.Analyzers.Serializability
             isEnabledByDefault: true,
             doNotUseFieldsDescription);
 
-        public static DiagnosticDescriptor DoNotUseUninstantiablePropertiesRule = new DiagnosticDescriptor(
-            DotvvmDiagnosticIds.DoNotUseUninstantiablePropertiesInViewModelRuleId,
-            uninstantiableTypeTitle,
-            uninstantiableTypeMessage,
-            DiagnosticCategory.Serializability,
-            DiagnosticSeverity.Warning,
-            isEnabledByDefault: true,
-            uninstantiableTypeDescription);
-
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
             => ImmutableArray.Create(
                 UseSerializablePropertiesRule,
-                DoNotUseFieldsRule,
-                DoNotUseUninstantiablePropertiesRule);
+                DoNotUseFieldsRule);
 
         public override void Initialize(AnalysisContext context)
         {
@@ -124,7 +111,7 @@ namespace DotVVM.Analyzers.Serializability
                 if (propertyTypeSymbol.IsAbstract && !propertyTypeSymbol.IsEnumerable(semanticModel.Compilation))
                 {
                     // Serialization of abstract classes can fail
-                    var diagnostic = Diagnostic.Create(DoNotUseUninstantiablePropertiesRule, property.GetLocation(), $"this.{propertySymbol.Name}");
+                    var diagnostic = Diagnostic.Create(UseSerializablePropertiesRule, property.GetLocation(), $"this.{propertySymbol.Name}");
                     context.ReportDiagnostic(diagnostic);
                     continue;
                 }


### PR DESCRIPTION
This PR introduces a couple of fixes and improvements to serializability analyzers.

- Fixed **bug**: nullables were sometimes incorrectly marked as not serializable.
- Fixed **bug**: certain supported types were incorrectly marked as not serializable (`GridViewDataSet<T>`, `UploadedFilesCollection` and `BusinessPackDataSet<T>`). They do not follow our general rules, however their serialization is well-defined and should not issue warnings.
- Fixed **bug**: that caused that some user-defined generic reference types were incorrectly marked as not serializable
- New **improvement**: symbols obtained from a specific `Compilation` within a specific `SemanticModel` are no longer cached indefinitely. Instead, we now construct cache for each `Compilation`. These caches are held using weak references.
- New **improvement**: sanity check. Serializability analyzers perform a simple sanity check to ensure that everything works before issuing warnings. (This might not be necessary anymore but I decided to leave it there).
- New **improvement**: serializability warnings now issue property paths. This is more straight-forward when looking for the root of the issue - especially when working with multiple levels of nested classes.

Additionally, `DateTimeOffset` was added to supported types. Analyzers no longer generate serializability warnings for properties that implement `IEnumerable` (however element type needs to be still serializable).