### PR TITLE
Fix null warnings on net6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,21 +30,21 @@ jobs:
     - name: Build (without warnings)
       run: dotnet build src/Framework/Framework --configuration Release --no-restore --no-incremental /property:WarningLevel=0
     - name: Build
-      run: dotnet build src/Framework/Framework --configuration Release --no-restore --no-incremental --framework netstandard2.1 /WarnAsError
+      run: dotnet build src/Framework/Framework --configuration Release --no-restore --no-incremental --framework net6.0 /WarnAsError
     - name: Build (Debug)
-      run: dotnet build src/Framework/Framework --configuration Debug --no-restore --no-incremental --framework netstandard2.1 /WarnAsError
+      run: dotnet build src/Framework/Framework --configuration Debug --no-restore --no-incremental --framework net6.0 /WarnAsError
     - name: Build Testing
-      run: dotnet build src/Framework/Testing --no-incremental --framework netstandard2.1 /WarnAsError
+      run: dotnet build src/Framework/Testing --no-incremental --framework net6.0 /WarnAsError
     - name: Build Hosting.AspNetCore
-      run: dotnet build src/Framework/Hosting.AspNetCore --no-incremental /WarnAsError --framework net5.0
+      run: dotnet build src/Framework/Hosting.AspNetCore --no-incremental /WarnAsError --framework net6.0
     - name: Build Tracing.MiniProfiler
-      run: dotnet build src/Tracing/MiniProfiler.AspNetCore --no-incremental /WarnAsError
+      run: dotnet build src/Tracing/MiniProfiler.AspNetCore --no-incremental /WarnAsError --framework net6.0
     - name: Build Tracing.ApplicationInsights
-      run: dotnet build src/Tracing/ApplicationInsights.AspNetCore --no-incremental /WarnAsError
+      run: dotnet build src/Tracing/ApplicationInsights.AspNetCore --no-incremental /WarnAsError --framework net6.0
     - name: Build Dynamic Data
-      run: dotnet build src/DynamicData/DynamicData --no-incremental --framework netstandard2.1 /WarnAsError
+      run: dotnet build src/DynamicData/DynamicData --no-incremental --framework net6.0 /WarnAsError
     - name: Build Compiler
-      run: dotnet build src/Tools/Compiler --no-incremental /WarnAsError
+      run: dotnet build src/Tools/Compiler --no-incremental /WarnAsError --framework net6.0
 
   unit-tests:
     name: dotnet unit tests

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
     <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
     <!-- Disable warning for missing XML doc comments. -->
     <NoWarn>$(NoWarn);CS1591;CS1573</NoWarn>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <DefaultTargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.1;net6.0;net472</DefaultTargetFrameworks>
     <DefaultTargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.1;net6.0</DefaultTargetFrameworks>
     <Version>4.0.0-preview01-122136</Version>

--- a/src/Framework/Core/Common/KnownTypeMatchers.cs
+++ b/src/Framework/Core/Common/KnownTypeMatchers.cs
@@ -22,7 +22,7 @@ namespace DotVVM.Core.Common
 
         public bool IsKnownType(Type type)
         {
-            return type.Namespace.StartsWith(@namespace, StringComparison.Ordinal);
+            return type.Namespace is not null && type.Namespace.StartsWith(@namespace, StringComparison.Ordinal);
         }
     }
 

--- a/src/Framework/Core/ComponentModel/DataAnnotations/ClientFormatAttribute.cs
+++ b/src/Framework/Core/ComponentModel/DataAnnotations/ClientFormatAttribute.cs
@@ -27,12 +27,12 @@ namespace System.ComponentModel.DataAnnotations
 
         public bool AllowEmptyString { get; set; } = true;
 
-        public override bool IsValid(object value)
+        public override bool IsValid(object? value)
         {
             return true;
         }
 
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
         {
             return ValidationResult.Success;
         }

--- a/src/Framework/Framework/Binding/BindingFactory.cs
+++ b/src/Framework/Framework/Binding/BindingFactory.cs
@@ -44,7 +44,7 @@ namespace DotVVM.Framework.Binding
                 if (ctor == null) throw new NotSupportedException($"Could not find .ctor(BindingCompilationService service, object[] properties) on binding '{type.FullName}'.");
                 var bindingServiceParam = Expression.Parameter(typeof(BindingCompilationService));
                 var propertiesParam = Expression.Parameter(typeof(object?[]));
-                var expression = Expression.New(ctor, bindingServiceParam, TypeConversion.ImplicitConversion(propertiesParam, ctor.GetParameters()[1].ParameterType));
+                var expression = Expression.New(ctor, bindingServiceParam, TypeConversion.ImplicitConversion(propertiesParam, ctor.GetParameters()[1].ParameterType, throwException: true)!);
                 return Expression.Lambda<Func<BindingCompilationService, object?[], IBinding>>(expression, bindingServiceParam, propertiesParam).CompileFast(flags: CompilerFlags.ThrowOnNotSupportedExpression);
             })(service, properties);
         }

--- a/src/Framework/Framework/Binding/BindingHelper.cs
+++ b/src/Framework/Framework/Binding/BindingHelper.cs
@@ -434,6 +434,9 @@ namespace DotVVM.Framework.Binding
             protected override Expression VisitParameter(ParameterExpression node)
             {
                 if (node.GetParameterAnnotation() != null) return node;
+
+                if (node.Name is null) return base.VisitParameter(node);
+
                 if (node.Name == "_this") return node.AddParameterAnnotation(new BindingParameterAnnotation(DataContext));
                 else if (node.Name == "_parent") return node.AddParameterAnnotation(new BindingParameterAnnotation(DataContext.Parent));
                 else if (node.Name == "_root") return node.AddParameterAnnotation(new BindingParameterAnnotation(DataContext.EnumerableItems().Last()));

--- a/src/Framework/Framework/Binding/DotvvmBindingCacheHelper.cs
+++ b/src/Framework/Framework/Binding/DotvvmBindingCacheHelper.cs
@@ -18,7 +18,7 @@ namespace DotVVM.Framework.Binding
             this.compilationService = compilationService;
         }
 
-        public T CreateCachedBinding<T>(string identifier, object[] keys, Func<T> factory) where T: IBinding
+        public T CreateCachedBinding<T>(string identifier, object?[] keys, Func<T> factory) where T: IBinding
         {
             return this.cache.GetOrAdd(new CacheKey(typeof(T), identifier, keys), _ => {
                 foreach (var k in keys)
@@ -32,7 +32,7 @@ namespace DotVVM.Framework.Binding
             return CreateCachedBinding<T>(identifier, keys, () => (T)BindingFactory.CreateBinding(this.compilationService, typeof(T), properties));
         }
 
-        internal static void CheckEqualsImplementation(object k)
+        internal static void CheckEqualsImplementation(object? k)
         {
             // whitelist for some common singletons
             if (k is null || k is DotvvmProperty) return;
@@ -47,11 +47,11 @@ namespace DotVVM.Framework.Binding
 
         class CacheKey: IEquatable<CacheKey>
         {
-            private readonly object[] keys;
+            private readonly object?[] keys;
             private readonly Type type;
             private readonly string id;
 
-            public CacheKey(Type type, string id, object[] keys)
+            public CacheKey(Type type, string id, object?[] keys)
             {
                 this.type = type ?? throw new ArgumentNullException(nameof(type));
                 this.id = id ?? throw new ArgumentNullException("Cache identifier can't be null", nameof(id));

--- a/src/Framework/Framework/Binding/DotvvmCapabilityProperty.CodeGeneration.cs
+++ b/src/Framework/Framework/Binding/DotvvmCapabilityProperty.CodeGeneration.cs
@@ -76,19 +76,19 @@ namespace DotVVM.Framework.Binding
                 var valueParameter = Expression.Parameter(type, "value");
                 var ctor = typeof(VirtualPropertyGroupDictionary<>)
                     .MakeGenericType(propType)
-                    .GetConstructor(new [] { typeof(DotvvmBindableObject), typeof(DotvvmPropertyGroup) });
+                    .GetConstructor(new [] { typeof(DotvvmBindableObject), typeof(DotvvmPropertyGroup) })!;
                 var createMethod = typeof(VirtualPropertyGroupDictionary<>)
                     .MakeGenericType(propType)
                     .GetMethod(
                         typeof(ValueOrBinding).IsAssignableFrom(elementType) ? nameof(VirtualPropertyGroupDictionary<int>.CreatePropertyDictionary) :
                         nameof(VirtualPropertyGroupDictionary<int>.CreateValueDictionary),
                         BindingFlags.Public | BindingFlags.Static
-                    );
+                    )!;
                 var enumerableType = typeof(IEnumerable<>).MakeGenericType(typeof(KeyValuePair<,>).MakeGenericType(typeof(string), elementType));
                 var copyFromMethod =
                     typeof(VirtualPropertyGroupDictionary<>)
                     .MakeGenericType(propType)
-                    .GetMethod("CopyFrom", new [] { enumerableType, typeof(bool) });
+                    .GetMethod("CopyFrom", new [] { enumerableType, typeof(bool) })!;
                 return (
                     Lambda(
                         Convert(Call(createMethod, currentControlParameter, Constant(pgroup)), type),
@@ -142,11 +142,11 @@ namespace DotVVM.Framework.Binding
                     var getValueOrBindingMethod =
                         typeof(Helpers).GetMethod(
                             isNullable ? "GetOptionalValueOrBinding" : "GetValueOrBinding"
-                        ).MakeGenericMethod(innerType);
+                        )!.MakeGenericMethod(innerType);
                     var setValueOrBindingMethod =
                         typeof(Helpers).GetMethod(
                             isNullable ? "SetOptionalValueOrBinding" : "SetValueOrBinding"
-                        ).MakeGenericMethod(innerType);
+                        )!.MakeGenericMethod(innerType);
                     return (
                         Expression.Lambda(
                             Expression.Call(
@@ -166,7 +166,7 @@ namespace DotVVM.Framework.Binding
                     var getValueMethod = (from m in typeof(DotvvmBindableObject).GetMethods()
                                         where m.Name == "GetValue" && !m.IsGenericMethod
                                         select m).Single();
-                    var setValueMethod = typeof(DotvvmBindableObject).GetMethod("SetValue", new[] { typeof(DotvvmProperty), typeof(object) });
+                    var setValueMethod = typeof(DotvvmBindableObject).GetMethod("SetValue", new[] { typeof(DotvvmProperty), typeof(object) })!;
                     return (
                         Expression.Lambda(
                             Expression.Convert(

--- a/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
+++ b/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
@@ -66,7 +66,7 @@ namespace DotVVM.Framework.Binding
             attributeProvider ??=
                 declaringType.GetProperty(dotnetFieldName) ??
                 declaringType.GetField(dotnetFieldName) ??
-                (ICustomAttributeProvider)declaringType.GetField(dotnetFieldName + "Property") ??
+                (ICustomAttributeProvider?)declaringType.GetField(dotnetFieldName + "Property") ??
                 throw new Exception($"Capability backing field could not be found and capabilityAttributeProvider argument was not provided. Property: {declaringType.Name}.{name}. Please declare a field or property named {dotnetFieldName}.");
 
             DotvvmProperty.InitializeProperty(this, attributeProvider);
@@ -82,7 +82,7 @@ namespace DotVVM.Framework.Binding
         
         /// <summary> Looks up a capability on the specified control (<paramref name="declaringType"/>).
         /// If multiple capabilities of this type are registered, <see cref="Find(Type, Type, string)" /> method must be used to retrieve the one with specified prefix. </summary>
-        public static DotvvmCapabilityProperty? Find(Type declaringType, Type capabilityType)
+        public static DotvvmCapabilityProperty? Find(Type? declaringType, Type capabilityType)
         {
             var c = GetCapabilities(declaringType, capabilityType);
             if (c.Length == 1) return c[0];
@@ -90,7 +90,7 @@ namespace DotVVM.Framework.Binding
         }
 
         /// <summary> Looks up a capability on the specified control (<paramref name="declaringType"/>). </summary>
-        public static DotvvmCapabilityProperty? Find(Type declaringType, Type capabilityType, string? globalPrefix)
+        public static DotvvmCapabilityProperty? Find(Type? declaringType, Type capabilityType, string? globalPrefix)
         {
             if (globalPrefix is null)
                 return Find(declaringType, capabilityType);
@@ -108,7 +108,7 @@ namespace DotVVM.Framework.Binding
             capabilityRegistry.Values.Where(c => c.DeclaringType.IsAssignableFrom(declaringType));
 
         /// <summary> Lists capabilities of the selected type on the specified control (<paramref name="declaringType"/>). </summary>
-        public static ImmutableArray<DotvvmCapabilityProperty> GetCapabilities(Type declaringType, Type capabilityType)
+        public static ImmutableArray<DotvvmCapabilityProperty> GetCapabilities(Type? declaringType, Type capabilityType)
         {
             var r = ImmutableArray<DotvvmCapabilityProperty>.Empty;
             while (declaringType != typeof(DotvvmBindableObject) && declaringType is not null)

--- a/src/Framework/Framework/Binding/Expressions/BindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/BindingExpression.cs
@@ -346,8 +346,7 @@ namespace DotVVM.Framework.Binding.Expressions
                 fromDataContext.IsEmpty && attributes is null or { Length: 0 } ?
                     new BindingResolverCollection(Enumerable.Empty<Delegate>()) :
                     new BindingResolverCollection(
-                        attributes
-                        .SelectMany(o => o.GetResolvers())
+                        (attributes?.SelectMany(o => o.GetResolvers()) ?? Enumerable.Empty<Delegate>())
                         .Concat(fromDataContext)
                         .ToArray());
 

--- a/src/Framework/Framework/Binding/Expressions/ValueBindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/ValueBindingExpression.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using DotVVM.Framework.Compilation.ControlTree;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 
 namespace DotVVM.Framework.Binding.Expressions
 {
@@ -167,14 +168,16 @@ namespace DotVVM.Framework.Binding.Expressions
                 }
             }
 
-            public override Expression Visit(Expression node)
+            [return: NotNullIfNotNull("node")]
+            public override Expression? Visit(Expression? node)
             {
+                if (node is null) return null;
                 if (node.NodeType == ExpressionType.Convert && node is UnaryExpression unary &&
                     unary.Operand.NodeType == ExpressionType.ArrayIndex && unary.Operand is BinaryExpression indexer &&
                     indexer.Right is ConstantExpression indexConstant &&
                     indexer.Left == vmParameter)
                 {
-                    int index = (int)indexConstant.Value;
+                    int index = (int)indexConstant.Value!;
                     while (VmTypes.Count <= index) VmTypes.Add(null);
                     if (VmTypes[index]?.IsAssignableFrom(unary.Type) != true)
                     {

--- a/src/Framework/Framework/Binding/ValueOrBinding.cs
+++ b/src/Framework/Framework/Binding/ValueOrBinding.cs
@@ -172,7 +172,7 @@ namespace DotVVM.Framework.Binding
         public override int GetHashCode() => throw new NotSupportedException(EqualsDisabledReason);
 #pragma warning restore CS0809
 
-        public override string ToString() =>
+        public override string? ToString() =>
             HasBinding ? binding.ToString() :
             value is null ? "null" : value.ToString();
 

--- a/src/Framework/Framework/Binding/ValueOrBindingExtensions.cs
+++ b/src/Framework/Framework/Binding/ValueOrBindingExtensions.cs
@@ -142,13 +142,13 @@ public static class ValueOrBindingExtensions
     }
 
     internal static IBinding CreateConstantBinding(
-        object constant,
+        object? constant,
         Type type,
         BindingCompilationService service,
         BindingParserOptions bpo) =>
         service.Cache.CreateCachedBinding(
             "dotvvm-ConstantBinding",
-            new object [] { type, constant, bpo },
+            new object? [] { type, constant, bpo },
             () => {
                 var expr = Expression.Constant(constant, type);
                 return service.CreateBinding(bpo.BindingType, new object[] {

--- a/src/Framework/Framework/Compilation/Binding/BindingExpressionBuilder.cs
+++ b/src/Framework/Framework/Compilation/Binding/BindingExpressionBuilder.cs
@@ -71,7 +71,7 @@ namespace DotVVM.Framework.Compilation.Binding
 
         public TypeRegistry InitSymbols(DataContextStack dataContext)
         {
-            return AddTypeSymbols(TypeRegistry.Default(compiledAssemblyCache).AddSymbols(GetParameters(dataContext).Select(d => new KeyValuePair<string, Expression>(d.Name, d))), dataContext);
+            return AddTypeSymbols(TypeRegistry.Default(compiledAssemblyCache).AddSymbols(GetParameters(dataContext).Select(d => new KeyValuePair<string, Expression>(d.Name!, d))), dataContext);
         }
 
         public TypeRegistry AddTypeSymbols(TypeRegistry reg, DataContextStack dataContext)
@@ -132,14 +132,13 @@ namespace DotVVM.Framework.Compilation.Binding
     {
         public static Expression ParseWithLambdaConversion(this IBindingExpressionBuilder builder, string expression, DataContextStack dataContexts, BindingParserOptions options, Type expectedType, params KeyValuePair<string, Expression>[] additionalSymbols)
         {
-            if (expectedType.IsDelegate())
+            if (expectedType.IsDelegate(out var invokeMethod))
             {
-                var resultType = expectedType.GetMethod("Invoke").ReturnType;
-                var delegateSymbols = expectedType
-                                      .GetMethod("Invoke")
+                var resultType = invokeMethod.ReturnType;
+                var delegateSymbols = invokeMethod
                                       .GetParameters()
                                       .Select((p, index) => new KeyValuePair<string, Expression>(
-                                          p.Name,
+                                          p.Name.NotNull(),
                                           Expression.Parameter(p.ParameterType, p.Name)
                                               .AddParameterAnnotation(new BindingParameterAnnotation(
                                                   extensionParameter: new TypeConversion.MagicLambdaConversionExtensionParameter(index, p.Name, p.ParameterType)))

--- a/src/Framework/Framework/Compilation/Binding/ExpressionBuildingVisitor.cs
+++ b/src/Framework/Framework/Compilation/Binding/ExpressionBuildingVisitor.cs
@@ -266,7 +266,7 @@ namespace DotVVM.Framework.Compilation.Binding
             inferer.EndFunctionCall();
             ThrowOnErrors();
 
-            return memberExpressionFactory.Call(target, args);
+            return memberExpressionFactory.Call(target!, args);
         }
 
         protected override Expression VisitSimpleName(SimpleNameBindingParserNode node)
@@ -299,7 +299,7 @@ namespace DotVVM.Framework.Compilation.Binding
                 falseExpr = TypeConversion.ImplicitConversion(falseExpr, trueExpr.Type, allowToString: true) ?? falseExpr;
             }
 
-            return Expression.Condition(condition, trueExpr, falseExpr);
+            return Expression.Condition(condition!, trueExpr, falseExpr);
         }
 
         protected override Expression VisitMemberAccess(MemberAccessBindingParserNode node)
@@ -308,8 +308,8 @@ namespace DotVVM.Framework.Compilation.Binding
             var typeParameters = nameNode is GenericNameBindingParserNode
                 ? ResolveGenericArguments(nameNode.CastTo<GenericNameBindingParserNode>().TypeArguments)
                 : null;
-            var identifierName = (typeParameters?.Count() ?? 0) > 0
-                ? $"{nameNode.Name}`{typeParameters.Count()}"
+            var identifierName = (typeParameters?.Length ?? 0) > 0
+                ? $"{nameNode.Name}`{typeParameters!.Length}"
                 : nameNode.Name;
 
             var target = Visit(node.TargetExpression);
@@ -420,7 +420,7 @@ namespace DotVVM.Framework.Compilation.Binding
                 throw new BindingCompilationException("Parameter identifiers must be unique.", node);
 
             // Make sure that parameter identifiers do not collide with existing symbols within registry
-            var collision = lambdaParameters.FirstOrDefault(param => Registry.Resolve(param.Name, false) != null);
+            var collision = lambdaParameters.FirstOrDefault(param => Registry.Resolve(param.Name!, false) != null);
             if (collision != null)
             {
                 throw new BindingCompilationException($"Identifier \"{collision.Name}\" is already in use. Choose a different " +
@@ -505,7 +505,7 @@ namespace DotVVM.Framework.Compilation.Binding
                 return ExpressionHelper.RewriteTaskSequence(left, right);
             }
 
-            var variables = new [] { variable }.Where(x => x != null);
+            var variables = variable is null ? Array.Empty<ParameterExpression>() : new [] { variable };
             if (right is BlockExpression rightBlock)
             {
                 // flat the `(a; b; c; d; e; ...)` expression down

--- a/src/Framework/Framework/Compilation/Binding/ExpressionHelper.cs
+++ b/src/Framework/Framework/Compilation/Binding/ExpressionHelper.cs
@@ -79,9 +79,11 @@ namespace DotVVM.Framework.Compilation.Binding
 
         public static Expression? ApplyBinder(DynamicMetaObjectBinder binder, bool throwException, params Expression[] expressions)
         {
-            var result = binder.Bind(DynamicMetaObject.Create(null, expressions[0]),
+            // This null just works and C# compiler seems to produce too, I think they have bug in the type annotations
+            //                                                vvvv
+            var result = binder.Bind(DynamicMetaObject.Create(null!, expressions[0]),
                 expressions.Skip(1).Select(e =>
-                    DynamicMetaObject.Create(null, e)).ToArray()
+                    DynamicMetaObject.Create(null!, e)).ToArray()
             );
 
             if (result.Expression.NodeType == ExpressionType.Convert)

--- a/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
+++ b/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
@@ -303,11 +303,11 @@ namespace DotVVM.Framework.Compilation.Binding
         {
             if (expression.Expression.Type.Implements(typeof(ICollection), out var ifc) || expression.Expression.Type.Implements(typeof(ICollection<>), out ifc))
                 return new DataSourceLengthBinding(binding.DeriveBinding(
-                    Expression.Property(expression.Expression, ifc.GetProperty(nameof(ICollection.Count)))
+                    Expression.Property(expression.Expression, ifc.GetProperty(nameof(ICollection.Count))!)
                 ));
             else if (expression.Expression.Type.Implements(typeof(IBaseGridViewDataSet), out var igridviewdataset))
                 return new DataSourceLengthBinding(binding.DeriveBinding(
-                    Expression.Property(Expression.Property(expression.Expression, igridviewdataset.GetProperty(nameof(IBaseGridViewDataSet.Items))), typeof(ICollection).GetProperty(nameof(ICollection.Count)))
+                    Expression.Property(Expression.Property(expression.Expression, igridviewdataset.GetProperty(nameof(IBaseGridViewDataSet.Items))!), typeof(ICollection).GetProperty(nameof(ICollection.Count))!)
                 ));
             else if (expression.Expression.Type == typeof(string))
                 return new DataSourceLengthBinding(binding.DeriveBinding(
@@ -315,7 +315,7 @@ namespace DotVVM.Framework.Compilation.Binding
                 ));
             else if (expression.Expression.Type.Implements(typeof(IEnumerable<>)))
                 return new DataSourceLengthBinding(binding.DeriveBinding(
-                    Expression.Call(typeof(Enumerable), "Count", new[] { ReflectionUtils.GetEnumerableType(expression.Expression.Type) }, expression.Expression)
+                    Expression.Call(typeof(Enumerable), "Count", new[] { ReflectionUtils.GetEnumerableType(expression.Expression.Type)! }, expression.Expression)
                 ));
             else throw new NotSupportedException($"Cannot find collection length from binding '{expression.Expression}'.");
         }

--- a/src/Framework/Framework/Compilation/Binding/MethodGroupExpression.cs
+++ b/src/Framework/Framework/Compilation/Binding/MethodGroupExpression.cs
@@ -22,7 +22,7 @@ namespace DotVVM.Framework.Compilation.Binding
         public bool HasExtensionCandidates { get; }
         public bool IsStatic => Target is StaticClassIdentifierExpression;
 
-        private static MethodInfo CreateDelegateMethodInfo = typeof(Delegate).GetMethod("CreateDelegate", new[] { typeof(Type), typeof(object), typeof(MethodInfo) });
+        private static MethodInfo CreateDelegateMethodInfo = typeof(Delegate).GetMethod("CreateDelegate", new[] { typeof(Type), typeof(object), typeof(MethodInfo) })!;
 
         public MethodGroupExpression(Expression target, string methodName, Type[]? typeArgs = null, List<MethodInfo>? candidates = null, bool hasExtensionCandidates = false)
         {
@@ -37,7 +37,7 @@ namespace DotVVM.Framework.Compilation.Binding
         {
             if (delegateType == null || delegateType == typeof(object)) return CreateDelegateExpression();
             if (!typeof(Delegate).IsAssignableFrom(delegateType)) if (throwException) throw new Exception("Could not convert method group expression to a non delegate type."); else return null;
-            var invokeMethod = delegateType.GetMethod("Invoke");
+            var invokeMethod = delegateType.GetMethod("Invoke")!;
             var args = invokeMethod.GetParameters().Select(p => p.ParameterType).ToArray();
             var method = Target.Type.GetMethods(BindingFlags.Public | (IsStatic ? BindingFlags.Static : BindingFlags.Instance))
                 .FirstOrDefault(m => m.Name == MethodName && m.GetParameters().Select(p => p.ParameterType).SequenceEqual(args) && m.ReturnType == invokeMethod.ReturnType);
@@ -55,11 +55,11 @@ namespace DotVVM.Framework.Compilation.Binding
         {
             if (returnType == null || returnType == typeof(void))
             {
-                return Type.GetType("System.Action`" + args.Length).MakeGenericType(args);
+                return Type.GetType("System.Action`" + args.Length)!.MakeGenericType(args);
             }
             else
             {
-                return Type.GetType("System.Func`" + (args.Length + 1)).MakeGenericType(args.Concat(new[] { returnType }).ToArray());
+                return Type.GetType("System.Func`" + (args.Length + 1))!.MakeGenericType(args.Concat(new[] { returnType }).ToArray());
             }
         }
 
@@ -68,7 +68,7 @@ namespace DotVVM.Framework.Compilation.Binding
             return GetDelegateType(methodInfo.ReturnType, methodInfo.GetParameters().Select(a => a.ParameterType).ToArray());
         }
 
-        protected MethodInfo GetMethod()
+        protected MethodInfo? GetMethod()
             => Target.Type.GetMethod(MethodName, BindingFlags.Public | (IsStatic ? BindingFlags.Static : BindingFlags.Instance));
 
         public Expression CreateDelegateExpression()

--- a/src/Framework/Framework/Compilation/Binding/StaticClassIdentifier.cs
+++ b/src/Framework/Framework/Compilation/Binding/StaticClassIdentifier.cs
@@ -15,6 +15,6 @@ namespace DotVVM.Framework.Compilation.Binding
             this.Type = type;
         }
 
-        public override string ToString() => Type.FullName;
+        public override string ToString() => Type.FullName ?? "";
     }
 }

--- a/src/Framework/Framework/Compilation/Binding/StaticCommandBindingCompiler.cs
+++ b/src/Framework/Framework/Compilation/Binding/StaticCommandBindingCompiler.cs
@@ -62,7 +62,7 @@ namespace DotVVM.Framework.Compilation.Binding
                     variables.Select(v => {
                         var tmpVar = new JsTemporaryVariableParameter();
                         return Expression.Parameter(v.Type, v.Name).AddParameterAnnotation(new BindingParameterAnnotation(extensionParameter:
-                            new JavascriptTranslationVisitor.FakeExtensionParameter(_ => new JsSymbolicParameter(tmpVar), v.Name, new ResolvedTypeDescriptor(v.Type))
+                            new JavascriptTranslationVisitor.FakeExtensionParameter(_ => new JsSymbolicParameter(tmpVar), v.Name!, new ResolvedTypeDescriptor(v.Type))
                         ));
                     }).ToArray()
                 );

--- a/src/Framework/Framework/Compilation/Binding/TypeConversions.cs
+++ b/src/Framework/Framework/Compilation/Binding/TypeConversions.cs
@@ -226,7 +226,7 @@ namespace DotVVM.Framework.Compilation.Binding
             //	A constant-expression (§7.19) of type int can be converted to type sbyte, byte, short, ushort, uint, or ulong, provided the value of the constant-expression is within the range of the destination type.
             if (src.Type == typeof(int))
             {
-                var value = (int)srcValue;
+                var value = (int)srcValue!;
                 if (destType == typeof(sbyte))
                 {
                     if (value >= SByte.MinValue && value <= SByte.MinValue)
@@ -273,7 +273,7 @@ namespace DotVVM.Framework.Compilation.Binding
             //	A constant-expression of type long can be converted to type ulong, provided the value of the constant-expression is not negative.
             if (src.Type == typeof(long))
             {
-                var value = (long)srcValue;
+                var value = (long)srcValue!;
                 if (destType == typeof(ulong))
                 {
                     if (value >= 0)
@@ -286,7 +286,7 @@ namespace DotVVM.Framework.Compilation.Binding
             // nonstandard implicit string conversions
             if (src.Type == typeof(string))
             {
-                var value = (string)srcValue;
+                var value = (string)srcValue!;
                 // to enum
                 if (destType.IsEnum)
                 {
@@ -313,8 +313,7 @@ namespace DotVVM.Framework.Compilation.Binding
         /// </summary>
         public static Expression? ImplicitNumericConversion(Expression src, Type target)
         {
-            List<Type> allowed;
-            if (ImplicitNumericConversions.TryGetValue(src.Type, out allowed))
+            if (ImplicitNumericConversions.TryGetValue(src.Type, out var allowed))
             {
                 if (allowed.Contains(target))
                 {
@@ -329,13 +328,12 @@ namespace DotVVM.Framework.Compilation.Binding
         /// It also replaces special ExtensionParameters attached to the expression for lambda parameters
         public static Expression? MagicLambdaConversion(Expression expr, Type expectedType)
         {
-            if (expectedType.IsDelegate())
+            if (expectedType.IsDelegate(out var invokeMethod))
             {
                 if (expr.Type.IsDelegate())
                     return expr;
-                var resultType = expectedType.GetMethod("Invoke").ReturnType;
-                var delegateArgs = expectedType
-                                      .GetMethod("Invoke")
+                var resultType = invokeMethod.ReturnType;
+                var delegateArgs = invokeMethod
                                       .GetParameters()
                                       .Select(p => Expression.Parameter(p.ParameterType, p.Name))
                                       .ToArray();

--- a/src/Framework/Framework/Compilation/Binding/TypeRegistry.cs
+++ b/src/Framework/Framework/Compilation/Binding/TypeRegistry.cs
@@ -41,7 +41,7 @@ namespace DotVVM.Framework.Compilation.Binding
         }
 
         public TypeRegistry AddSymbols(IEnumerable<ParameterExpression> symbols) =>
-            AddSymbols(symbols.Select(s => new KeyValuePair<string, Expression>(s.Name, s)));
+            AddSymbols(symbols.Select(s => new KeyValuePair<string, Expression>(s.Name!, s)));
 
         public TypeRegistry AddSymbols(IEnumerable<KeyValuePair<string, Expression>> symbols)
         {

--- a/src/Framework/Framework/Compilation/BindingCompiler.cs
+++ b/src/Framework/Framework/Compilation/BindingCompiler.cs
@@ -20,6 +20,7 @@ using DotVVM.Framework.Controls;
 using System.Diagnostics;
 using DotVVM.Framework.Compilation.ViewCompiler;
 using DotVVM.Framework.Utils;
+using System.Diagnostics.CodeAnalysis;
 
 namespace DotVVM.Framework.Compilation
 {
@@ -52,7 +53,8 @@ namespace DotVVM.Framework.Compilation
                 this.AssertAllReplaced = assertAllReplaced;
             }
 
-            public override Expression Visit(Expression node)
+            [return: NotNullIfNotNull("node")]
+            public override Expression? Visit(Expression? node)
             {
                 if (node?.GetParameterAnnotation() is BindingParameterAnnotation ann)
                 {
@@ -138,7 +140,7 @@ namespace DotVVM.Framework.Compilation
             return (IBinding)Activator.CreateInstance(binding.GetType(), new object[] {
                 bindingService,
                 properties
-            });
+            })!;
 
             T? cloneNestedBinding<T>(T b)
                 where T: class, IBinding =>

--- a/src/Framework/Framework/Compilation/CompiledAssemblyCache.cs
+++ b/src/Framework/Framework/Compilation/CompiledAssemblyCache.cs
@@ -58,7 +58,7 @@ namespace DotVVM.Framework.Compilation
                     .Concat(configuration.Markup.Assemblies)
                     .Distinct()
                     .Where(s => !string.IsNullOrWhiteSpace(s))
-                    .Select(n => Assembly.Load(new AssemblyName(n)));
+                    .Select(n => Assembly.Load(new AssemblyName(n!)));
 
             var references = diAssembly.GetReferencedAssemblies().Select(Assembly.Load)
                 .Concat(markupAssemblies)

--- a/src/Framework/Framework/Compilation/ControlTree/BindingExtensionParameter.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/BindingExtensionParameter.cs
@@ -29,7 +29,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
 
         public BindingExtensionParameter(string identifier, ITypeDescriptor? type, bool inherit)
         {
-            this.Identifier = identifier;
+            this.Identifier = identifier ?? throw new ArgumentNullException(nameof(identifier));
             this.ParameterType = type ?? ResolvedTypeDescriptor.Create(typeof(object));
             this.Inherit = inherit;
         }
@@ -39,7 +39,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
         /// Returns a JS expression that is put into the emitted JS code on the place of the parameter
         public abstract JsExpression GetJsTranslation(JsExpression dataContext);
 
-        public override bool Equals(object obj) =>
+        public override bool Equals(object? obj) =>
             obj is BindingExtensionParameter other && Equals(other);
 
         public virtual bool Equals(BindingExtensionParameter other) =>

--- a/src/Framework/Framework/Compilation/ControlTree/ControlResolverMetadataBase.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ControlResolverMetadataBase.cs
@@ -48,7 +48,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
         {
             get
             {
-                IPropertyDescriptor result;
+                IPropertyDescriptor? result;
                 if (Type.IsAssignableTo(new ResolvedTypeDescriptor(typeof(CompositeControl))))
                 {
                     // properties Content and ContentTemplate are used as content by default, if they exist

--- a/src/Framework/Framework/Compilation/ControlTree/ControlTreeResolverBase.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ControlTreeResolverBase.cs
@@ -822,7 +822,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
 
             var baseControlDirective = !directives.ContainsKey(ParserConstants.BaseTypeDirective)
                 ? null
-                : (IAbstractBaseTypeDirective)directives[ParserConstants.BaseTypeDirective].SingleOrDefault();
+                : (IAbstractBaseTypeDirective?)directives[ParserConstants.BaseTypeDirective].SingleOrDefault();
 
             if (baseControlDirective != null)
             {

--- a/src/Framework/Framework/Compilation/ControlTree/DefaultControlResolver.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/DefaultControlResolver.cs
@@ -70,7 +70,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
         /// </summary>
         private void InvokeStaticConstructorsOnAllControls()
         {
-            var dotvvmAssembly = typeof(DotvvmControl).Assembly.GetName().Name;
+            var dotvvmAssembly = typeof(DotvvmControl).Assembly.GetName().Name!;
             var dotvvmInitTask = InvokeStaticConstructorsOnDotvvmControls();
 
             if (configuration.ExperimentalFeatures.ExplicitAssemblyLoading.Enabled)

--- a/src/Framework/Framework/Compilation/ControlTree/DotvvmPropertyGroup.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/DotvvmPropertyGroup.cs
@@ -14,7 +14,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
 {
     public class DotvvmPropertyGroup : IPropertyGroupDescriptor
     {
-        public FieldInfo DescriptorField { get; }
+        public FieldInfo? DescriptorField { get; }
 
         public ICustomAttributeProvider AttributeProvider { get; }
 
@@ -45,7 +45,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
         /// <summary> The capabilities which use this property. </summary>
         public ImmutableArray<DotvvmCapabilityProperty> UsedInCapabilities { get; internal set; } = ImmutableArray<DotvvmCapabilityProperty>.Empty;
 
-        internal DotvvmPropertyGroup(PrefixArray prefixes, Type valueType, Type declaringType, FieldInfo descriptorField, ICustomAttributeProvider attributeProvider, string name, object? defaultValue)
+        internal DotvvmPropertyGroup(PrefixArray prefixes, Type valueType, Type declaringType, FieldInfo? descriptorField, ICustomAttributeProvider attributeProvider, string name, object? defaultValue)
         {
             this.DescriptorField = descriptorField;
             this.DeclaringType = declaringType;
@@ -56,7 +56,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
             (this.MarkupOptions, this.DataContextChangeAttributes, this.DataContextManipulationAttribute, this.ObsoleteAttribute) = InitFromAttributes(attributeProvider, name);
             if (MarkupOptions.AllowValueMerging)
             {
-                ValueMerger = (IAttributeValueMerger)Activator.CreateInstance(MarkupOptions.AttributeValueMerger);
+                ValueMerger = (IAttributeValueMerger?)Activator.CreateInstance(MarkupOptions.AttributeValueMerger);
             }
         }
 
@@ -154,7 +154,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
         {
             RuntimeHelpers.RunClassConstructor(type.TypeHandle);
             if (type.BaseType != typeof(object))
-                RunClassConstructor(type.BaseType);
+                RunClassConstructor(type.BaseType!);
         }
 
         public static IEnumerable<DotvvmPropertyGroup> GetPropertyGroups(Type controlType)

--- a/src/Framework/Framework/Compilation/ControlTree/ObsoletionVisitor.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ObsoletionVisitor.cs
@@ -15,14 +15,18 @@ namespace DotVVM.Framework.Compilation
                 return;
             }
 
+            var message = $"Property {setter.Property.Name} is obsolete";
+            if (setter.Property.ObsoleteAttribute.Message is {} workaroundMessage)
+                message += ": " + workaroundMessage;
+
             // NB: the obsolete attribute should NEVER cause a compilation error in dothtml if the property is an alias
             if (setter.Property.ObsoleteAttribute.IsError && setter.Property is not DotvvmPropertyAlias)
             {
-                setter.DothtmlNode.AddError(setter.Property.ObsoleteAttribute.Message);
+                setter.DothtmlNode.AddError(message);
             }
             else
             {
-                setter.DothtmlNode.AddWarning(setter.Property.ObsoleteAttribute.Message);
+                setter.DothtmlNode.AddWarning(message);
             }
         }
     }

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/PropertyGroupMember.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/PropertyGroupMember.cs
@@ -20,7 +20,7 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
 			this.Name = name;
 		}
 
-		public override bool Equals(object obj) => obj is PropertyGroupMember && Equals((PropertyGroupMember)obj);
+		public override bool Equals(object? obj) => obj is PropertyGroupMember && Equals((PropertyGroupMember)obj);
 		public bool Equals(PropertyGroupMember other) => other.Group == Group && Name == other.Name;
 
 		public override int GetHashCode() =>

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedBinding.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedBinding.cs
@@ -84,6 +84,6 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
         {
         }
 
-        public override string ToString() => Binding.ToString();
+        public override string? ToString() => Binding.ToString();
     }
 }

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedPropertyCapability.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedPropertyCapability.cs
@@ -65,9 +65,9 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
                 {
                     value = value as IBinding ?? convertValue(value, elementType);
                     if (value is IBinding)
-                        return t.GetConstructor(new [] { typeof(IBinding) }).Invoke(new [] { value });
+                        return t.GetConstructor(new [] { typeof(IBinding) })!.Invoke(new [] { value });
                     else
-                        return t.GetConstructor(new [] { elementType }).Invoke(new [] { value });
+                        return t.GetConstructor(new [] { elementType })!.Invoke(new [] { value });
                 }
                 // TODO: controls and templates
                 if (throwExceptions)
@@ -98,7 +98,7 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
                 var dictionaryElementType = DotvvmCapabilityProperty.Helpers.GetDictionaryElement(prop.PropertyType);
                 var dictionary = (System.Collections.IDictionary)(
                     propertyOriginalValue ??
-                    Activator.CreateInstance(typeof(Dictionary<,>).MakeGenericType(typeof(string), dictionaryElementType))
+                    Activator.CreateInstance(typeof(Dictionary<,>).MakeGenericType(typeof(string), dictionaryElementType))!
                 );
 
                 if (properties.Length > 0)
@@ -117,7 +117,7 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
         private static string DebugFormatValue(object? v) =>
             v is null ? "null" :
             v is IEnumerable<object> vs ? $"[{string.Join(", ", vs.Select(DebugFormatValue))}]" :
-            v.ToString();
+            $"{v}";
 
         public override string ToString() =>
             $"{{{string.Join(", ", Values.Select(x => x.Key.Name + "." + DebugFormatValue(x.Value)))}}}";

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedPropertyValue.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedPropertyValue.cs
@@ -26,7 +26,7 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
         private static string DebugFormatValue(object? v) =>
             v is null ? "null" :
             v is IEnumerable<object> vs ? $"[{string.Join(", ", vs.Select(DebugFormatValue))}]" :
-            v.ToString();
+            $"{v}";
 
         public override string ToString() => $"{Property}=\"{DebugFormatValue(Value)}\"";
     }

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedTypeDescriptor.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedTypeDescriptor.cs
@@ -58,7 +58,7 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
             }
 
             // handle iEnumerables
-            Type iEnumerable;
+            Type? iEnumerable;
             if (Type.IsGenericType && Type.GetGenericTypeDefinition() == typeof(IEnumerable<>))
             {
                 iEnumerable = Type;

--- a/src/Framework/Framework/Compilation/ControlTree/UsedPropertiesFindingVisitor.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/UsedPropertiesFindingVisitor.cs
@@ -6,6 +6,7 @@ using DotVVM.Framework.Binding;
 using DotVVM.Framework.Binding.Expressions;
 using DotVVM.Framework.Compilation.ControlTree.Resolved;
 using DotVVM.Framework.Controls;
+using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Compilation
 {
@@ -26,7 +27,7 @@ namespace DotVVM.Framework.Compilation
             protected override Expression VisitMember(MemberExpression node)
             {
                 if (typeof(DotvvmProperty).IsAssignableFrom(node.Type) && node.Member is FieldInfo { IsStatic: true } field)
-                    UsedProperties.Add((DotvvmProperty)field.GetValue(null));
+                    UsedProperties.Add((DotvvmProperty)field.GetValue(null).NotNull());
                 return base.VisitMember(node);
             }
 

--- a/src/Framework/Framework/Compilation/ControlType.cs
+++ b/src/Framework/Framework/Compilation/ControlType.cs
@@ -4,7 +4,7 @@ using DotVVM.Framework.Compilation.ControlTree.Resolved;
 
 namespace DotVVM.Framework.Compilation
 {
-    public class ControlType : IControlType
+    public sealed class ControlType : IControlType
     {
         public Type Type { get; private set; }
 
@@ -16,7 +16,7 @@ namespace DotVVM.Framework.Compilation
 
         ITypeDescriptor? IControlType.DataContextRequirement => ResolvedTypeDescriptor.Create(DataContextRequirement);
 
-        protected static void ValidateControlClass(Type control)
+        static void ValidateControlClass(Type control)
         {
             if (!control.IsPublic)
                 throw new Exception($"Control {control.FullName} is not publicly accessible. Make sure that control is not internal.");
@@ -34,9 +34,9 @@ namespace DotVVM.Framework.Compilation
         }
 
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            if (ReferenceEquals(null, obj))
+            if (obj is null)
             {
                 return false;
             }
@@ -44,24 +44,15 @@ namespace DotVVM.Framework.Compilation
             {
                 return true;
             }
-            if (obj.GetType() != this.GetType())
-            {
-                return false;
-            }
-            return Equals((ControlType)obj);
+            return obj is ControlType ct && Equals(ct);
         }
 
-        protected bool Equals(ControlType other)
+        public bool Equals(ControlType other)
         {
             return Equals(Type, other.Type) && VirtualPath == other.VirtualPath;
         }
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return ((Type != null ? Type.GetHashCode() : 53515466) * 397) ^ (VirtualPath != null ? VirtualPath.GetHashCode() : 145132);
-            }
-        }
+        public override int GetHashCode() =>
+            (Type, VirtualPath).GetHashCode();
     }
 }

--- a/src/Framework/Framework/Compilation/DefaultAttributeValueMerger.cs
+++ b/src/Framework/Framework/Compilation/DefaultAttributeValueMerger.cs
@@ -83,7 +83,7 @@ namespace DotVVM.Framework.Compilation
             }
         }
 
-        protected virtual ResolvedPropertySetter EmitConstant(object value, DotvvmProperty property, ref string? error)
+        protected virtual ResolvedPropertySetter EmitConstant(object? value, DotvvmProperty property, ref string? error)
         {
             return new ResolvedPropertyValue(property, value);
         }
@@ -131,7 +131,7 @@ namespace DotVVM.Framework.Compilation
                 CSharpBinderFlags.None, name, null, context,
                 new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.UseCompileTimeType | CSharpArgumentInfoFlags.IsStaticType, null) }
                 .Concat(ExpressionHelper.GetBinderArguments(parameters.Length)));
-            var result = binder.Bind(DynamicMetaObject.Create(context, Expression.Constant(context)), parameters.Select(e => DynamicMetaObject.Create(null, e)).ToArray());
+            var result = binder.Bind(DynamicMetaObject.Create(context, Expression.Constant(context)), parameters.Select(e => DynamicMetaObject.Create(null!, e)).ToArray());
             if (result.Expression.NodeType == ExpressionType.Throw) return null;
             Expression expr = result.Expression;
             if (expr.NodeType == ExpressionType.Convert)

--- a/src/Framework/Framework/Compilation/ExtensionMethodsCache.cs
+++ b/src/Framework/Framework/Compilation/ExtensionMethodsCache.cs
@@ -88,7 +88,7 @@ namespace DotVVM.Framework.Compilation
         internal void ClearCaches(Type[] types)
         {
             foreach (var t in types)
-                methodsCache.TryRemove(t.Namespace, out _);
+                methodsCache.TryRemove(t.Namespace ?? "", out _);
         }
 
     }

--- a/src/Framework/Framework/Compilation/Inference/Inferers/LambdaInferer.cs
+++ b/src/Framework/Framework/Compilation/Inference/Inferers/LambdaInferer.cs
@@ -87,10 +87,10 @@ namespace DotVVM.Framework.Compilation.Inference
         {
             parameters = null;
 
-            if (!ReflectionUtils.IsDelegate(delegateType))
+            if (!delegateType.IsDelegate(out var invokeMethod))
                 return false;
 
-            var delegateParameters = delegateType.GetMethod("Invoke", BindingFlags.Public | BindingFlags.Instance).GetParameters();
+            var delegateParameters = invokeMethod.GetParameters();
             if (delegateParameters.Length != argsCount)
                 return false;
 

--- a/src/Framework/Framework/Compilation/Inference/TypeInferer.cs
+++ b/src/Framework/Framework/Compilation/Inference/TypeInferer.cs
@@ -79,7 +79,7 @@ namespace DotVVM.Framework.Compilation.Inference
             // Check if we can remove some candidates
             // Also try to infer generics based on provided argument
             var tempInstantiations = new Dictionary<string, Type>();
-            foreach (var candidate in context.Target.Candidates.Where(c => c.GetParameters().Length > index))
+            foreach (var candidate in context.Target.Candidates!.Where(c => c.GetParameters().Length > index))
             {
                 var parameters = candidate.GetParameters();
                 var parameterType = parameters[index].ParameterType;

--- a/src/Framework/Framework/Compilation/Javascript/Ast/IAnnotatable.cs
+++ b/src/Framework/Framework/Compilation/Javascript/Ast/IAnnotatable.cs
@@ -125,7 +125,7 @@ namespace DotVVM.Framework.Compilation.Javascript.Ast
             if (annotation == null)
                 throw new ArgumentNullException("annotation");
             retry: // Retry until successful
-            object oldAnnotation = Interlocked.CompareExchange(ref this.annotations, annotation, null);
+            object? oldAnnotation = Interlocked.CompareExchange(ref this.annotations, annotation, null);
             if (oldAnnotation == null)
             {
                 return annotation; // we successfully added a single annotation

--- a/src/Framework/Framework/Compilation/Javascript/EnumGetNamesMethodTranslator.cs
+++ b/src/Framework/Framework/Compilation/Javascript/EnumGetNamesMethodTranslator.cs
@@ -9,7 +9,7 @@ namespace DotVVM.Framework.Compilation.Javascript
     {
         public JsExpression TryTranslateCall(LazyTranslatedExpression? context, LazyTranslatedExpression[] arguments, MethodInfo method)
         {
-            var enumNames = (string[])method.Invoke(null, new object[0]);
+            var enumNames = (string[])method.Invoke(null, new object[0])!;
 
             return new JsArrayExpression(enumNames.Select(n => new JsLiteral(n)))
                 .WithAnnotation(new ViewModelInfoAnnotation(typeof(string[]), containsObservables: false));

--- a/src/Framework/Framework/Compilation/Javascript/InvocationRewriterExpressionVisitor.cs
+++ b/src/Framework/Framework/Compilation/Javascript/InvocationRewriterExpressionVisitor.cs
@@ -7,7 +7,7 @@ namespace DotVVM.Framework.Compilation.Javascript
     {
         protected override Expression VisitInvocation(InvocationExpression node)
         {
-            var invokeMethod = node.Expression.Type.GetMethod("Invoke");
+            var invokeMethod = node.Expression.Type.GetMethod("Invoke")!;
 
             return Expression.Call(node.Expression, invokeMethod, node.Arguments); ;
         }

--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslator.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslator.cs
@@ -163,13 +163,15 @@ namespace DotVVM.Framework.Compilation.Javascript
         public ViewModelSerializationMap? SerializationMap { get; set; }
         public bool? ContainsObservables { get; set; }
 
-        public bool Equals(ViewModelInfoAnnotation other) =>
+        public bool Equals(ViewModelInfoAnnotation? other) =>
+            object.ReferenceEquals(this, other) ||
+            other is not null &&
             Type == other.Type &&
             IsControl == other.IsControl &&
             ExtensionParameter == other.ExtensionParameter &&
             ContainsObservables == other.ContainsObservables;
 
-        public override bool Equals(object obj) => obj is ViewModelInfoAnnotation obj2 && this.Equals(obj2);
+        public override bool Equals(object? obj) => obj is ViewModelInfoAnnotation obj2 && this.Equals(obj2);
 
         public override int GetHashCode() => (Type, ExtensionParameter, IsControl, ContainsObservables).GetHashCode();
 

--- a/src/Framework/Framework/Compilation/NamespaceImport.cs
+++ b/src/Framework/Framework/Compilation/NamespaceImport.cs
@@ -27,7 +27,7 @@ namespace DotVVM.Framework.Compilation
 			this.Alias = alias;
 		}
 
-        public override bool Equals(object obj) =>
+        public override bool Equals(object? obj) =>
             obj is NamespaceImport other && Equals(other);
 
         public bool Equals(NamespaceImport other) =>

--- a/src/Framework/Framework/Compilation/Parser/Binding/Parser/BindingParserNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Binding/Parser/BindingParserNode.cs
@@ -38,7 +38,7 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
             yield return this;
         }
 
-        public BindingParserNode FindNodeByPosition(int position)
+        public BindingParserNode? FindNodeByPosition(int position)
         {
             return EnumerateNodes().LastOrDefault(n => n.StartPosition <= position && position < n.EndPosition);
         }

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlNode.cs
@@ -48,7 +48,7 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
 
         public abstract IEnumerable<DothtmlNode> EnumerateChildNodes();
 
-        public DothtmlNode FindNodeByPosition(int position)
+        public DothtmlNode? FindNodeByPosition(int position)
         {
             return EnumerateNodes().LastOrDefault(n => n.StartPosition <= position && position < n.EndPosition);
         }

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlRootNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlRootNode.cs
@@ -32,7 +32,7 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
         }
 
 
-        public string GetDirectiveValue(string directiveName)
+        public string? GetDirectiveValue(string directiveName)
         {
             return Directives.Where(d => string.Equals(d.Name, directiveName, StringComparison.OrdinalIgnoreCase))
                 .Select(d => d.Value)

--- a/src/Framework/Framework/Compilation/Styles/ResolvedControlHelper.cs
+++ b/src/Framework/Framework/Compilation/Styles/ResolvedControlHelper.cs
@@ -44,7 +44,7 @@ namespace DotVVM.Framework.Compilation.Styles
                 var control = new ResolvedControl(new ControlResolverMetadata(new ControlType(descriptor.ControlType, path, descriptor.DataContextType)), null, new(), dataContext);
                 if (markupControl.SetProperties is object)
                 {
-                    var templateControl = (DotvvmMarkupControl)Activator.CreateInstance(descriptor.ControlType);
+                    var templateControl = (DotvvmMarkupControl)Activator.CreateInstance(descriptor.ControlType)!;
                     markupControl.SetProperties(templateControl);
                     foreach (var p in templateControl.properties)
                     {
@@ -95,7 +95,7 @@ namespace DotVVM.Framework.Compilation.Styles
             value is null ||
             ReflectionUtils.IsPrimitiveType(value.GetType()) ||
             IsImmutableObject(value.GetType()) ||
-            value is Array && ReflectionUtils.IsPrimitiveType(value.GetType().GetElementType());
+            value is Array && ReflectionUtils.IsPrimitiveType(value.GetType().GetElementType()!);
 
         public static ResolvedPropertySetter TranslateProperty(DotvvmProperty property, object? value, DataContextStack dataContext, DotvvmConfiguration? config)
         {

--- a/src/Framework/Framework/Compilation/Styles/StyleMatchContextMethods.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleMatchContextMethods.cs
@@ -287,7 +287,7 @@ public static class StyleMatchContextExtensionMethods
 
     private static T GetDefault<T>(DotvvmProperty p)
     {
-        var def = p is DotvvmCapabilityProperty ? (T)Activator.CreateInstance(p.PropertyType) : p.DefaultValue;
+        var def = p is DotvvmCapabilityProperty ? (T)Activator.CreateInstance(p.PropertyType)! : p.DefaultValue;
         if (def is T d) return d;
         if (def is null && !typeof(T).IsValueType) return default!;
         throw new Exception($"Property {p} is probably not of type {typeof(T).Name}, its default value {def ?? "null"} is not assignable to the requested type.");

--- a/src/Framework/Framework/Compilation/Styles/StyleMatcher.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleMatcher.cs
@@ -62,7 +62,7 @@ namespace DotVVM.Framework.Compilation.Styles
             foreach (var s in Styles[type]) yield return s;
             do
             {
-                type = type.BaseType;
+                type = type.BaseType!;
 
                 foreach (var s in Styles[type])
                     if (!s.ExactTypeMatch)
@@ -78,7 +78,7 @@ namespace DotVVM.Framework.Compilation.Styles
                 if (t.IsAssignableFrom(typeof(DotvvmBindableObject))) return ImmutableArray<IStyle>.Empty;
                 var configurationParameter = Expression.Parameter(typeof(DotvvmConfiguration));
                 var controlParameter = Expression.Parameter(typeof(ResolvedControl));
-                return GetImplicitStyles(t.BaseType).Concat(
+                return GetImplicitStyles(t.BaseType!).Concat(
                     from m in t.GetMethods(BindingFlags.Public | BindingFlags.Static)
                     where m.IsDefined(typeof(ApplyControlStyleAttribute))
                     let parameters = m.GetParameters()

--- a/src/Framework/Framework/Compilation/Validation/DefaultControlUsageValidator.cs
+++ b/src/Framework/Framework/Compilation/Validation/DefaultControlUsageValidator.cs
@@ -79,13 +79,13 @@ namespace DotVVM.Framework.Compilation.Validation
                     }
                 }
                 var r = method.Invoke(null, args);
-                if (r is IEnumerable<ControlUsageError>)
+                if (r is IEnumerable<ControlUsageError> errors)
                 {
-                    result.AddRange((IEnumerable<ControlUsageError>)r);
+                    result.AddRange(errors);
                 }
-                else if (r is IEnumerable<string>)
+                else if (r is IEnumerable<string> stringErrors)
                 {
-                    result.AddRange((r as IEnumerable<string>).Select(e => new ControlUsageError(e)));
+                    result.AddRange(stringErrors.Select(e => new ControlUsageError(e)));
                 }
                 continue;
                 Error:;
@@ -112,7 +112,7 @@ namespace DotVVM.Framework.Compilation.Validation
                 throw new Exception($"ControlUsageValidator attributes on '{type.FullName}' are in an inconsistent state. Make sure all attributes have an Override property set to the same value.");
 
             if (overrideValidation.Any() && overrideValidation[0]) return methods;
-            var ancestorMethods = FindMethods(type.BaseType);
+            var ancestorMethods = FindMethods(type.BaseType!);
             return ancestorMethods.Concat(methods).ToArray();
         }
 

--- a/src/Framework/Framework/Compilation/ViewCompiler/DefaultViewCompilerCodeEmitter.cs
+++ b/src/Framework/Framework/Compilation/ViewCompiler/DefaultViewCompilerCodeEmitter.cs
@@ -44,7 +44,7 @@ namespace DotVVM.Framework.Compilation.ViewCompiler
         /// <summary>
         /// Emits the create object expression.
         /// </summary>
-        public ParameterExpression EmitCreateObject(Type type, object[]? constructorArguments = null)
+        public ParameterExpression EmitCreateObject(Type type, object?[]? constructorArguments = null)
         {
             constructorArguments ??= new object[0];
             return EmitCreateObject(type, constructorArguments.Select(EmitValue));
@@ -83,7 +83,7 @@ namespace DotVVM.Framework.Compilation.ViewCompiler
         private Expression EmitCreateObjectExpression(Type type, IEnumerable<Expression> arguments)
         {
             var argumentTypes = arguments.Select(a => a.Type).ToArray();
-            var constructor = type.GetConstructor(argumentTypes);
+            var constructor = type.GetConstructor(argumentTypes).NotNull($"Could not find constructor of {type}");
 
             return Expression.New(constructor, arguments.ToArray());
         }
@@ -191,9 +191,9 @@ namespace DotVVM.Framework.Compilation.ViewCompiler
             blockStack.Peek().Expressions.Add(magicSetValueCall);
         }
 
-        private bool TryCreateArrayOfConstants(Expression?[] values, out object[] invertedValues)
+        private bool TryCreateArrayOfConstants(Expression?[] values, out object?[] invertedValues)
         {
-            invertedValues = new object[values.Length];
+            invertedValues = new object?[values.Length];
             for (int i = 0; i < values.Length; i++)
             {
                 if (values[i] == null) { continue; }
@@ -351,7 +351,7 @@ namespace DotVVM.Framework.Compilation.ViewCompiler
 
             public BlockInfo(ParameterExpression[] parameters)
             {
-                Parameters = parameters.ToDictionary(k => k.Name, v => v);
+                Parameters = parameters.ToDictionary(k => k.Name.NotNull(), v => v);
             }
 
             public ParameterExpression GetParameterOrVariable(string identifierName)

--- a/src/Framework/Framework/Compilation/ViewCompiler/ViewCompilingVisitor.cs
+++ b/src/Framework/Framework/Compilation/ViewCompiler/ViewCompilingVisitor.cs
@@ -49,7 +49,8 @@ namespace DotVVM.Framework.Compilation.ViewCompiler
 
             var pageName =
                 isPageView ? emitter.EmitCreateObject(emitter.ResultControlType).Name :
-                                           EmitCreateControl(view.Metadata.Type, new object[0]).Name;
+                             EmitCreateControl(view.Metadata.Type, new object[0]).Name;
+            pageName.NotNull();
             emitter.RegisterDotvvmProperties(pageName);
 
             emitter.EmitSetDotvvmProperty(pageName, Internal.UniqueIDProperty, pageName);
@@ -176,7 +177,7 @@ namespace DotVVM.Framework.Compilation.ViewCompiler
                 return;
 
             var parentName = controlName.NotNull();
-            var collectionName = emitter.EmitEnsureCollectionInitialized(parentName, propertyControlCollection.Property).Name;
+            var collectionName = emitter.EmitEnsureCollectionInitialized(parentName, propertyControlCollection.Property).Name.NotNull();
 
             foreach (var control in propertyControlCollection.Controls)
             {
@@ -230,12 +231,12 @@ namespace DotVVM.Framework.Compilation.ViewCompiler
             if (control.Metadata.VirtualPath == null)
             {
                 // compiled control
-                name = EmitCreateControl(control.Metadata.Type, control.ConstructorParameters).Name;
+                name = EmitCreateControl(control.Metadata.Type, control.ConstructorParameters).Name.NotNull();
             }
             else
             {
                 // markup control
-                name = emitter.EmitInvokeControlBuilder(control.Metadata.Type, control.Metadata.VirtualPath).Name;
+                name = emitter.EmitInvokeControlBuilder(control.Metadata.Type, control.Metadata.VirtualPath).Name.NotNull();
             }
 
             emitter.RegisterDotvvmProperties(name);

--- a/src/Framework/Framework/Configuration/HtmlTagAttributePair.cs
+++ b/src/Framework/Framework/Configuration/HtmlTagAttributePair.cs
@@ -51,13 +51,13 @@ namespace DotVVM.Framework.Configuration
             var value = reader.ReadAsString();
             if (value == null)
             {
-                ThrowInvalidFormatException();
+                throw InvalidFormatException();
             }
 
             var match = Regex.Match(value, @"^([a-zA-Z0-9]+)\[([a-zA-Z0-9]+)\]$");
             if (!match.Success)
             {
-                ThrowInvalidFormatException();
+                throw InvalidFormatException();
             }
 
             if (existingValue == null)
@@ -70,10 +70,8 @@ namespace DotVVM.Framework.Configuration
             return pair;
         }
 
-        private static void ThrowInvalidFormatException()
-        {
-            throw new JsonSerializationException("HTML attribute definition expected! Correct syntax is 'a[href]': { }");
-        }
+        private static Exception InvalidFormatException() =>
+            new JsonSerializationException("HTML attribute definition expected! Correct syntax is 'a[href]': { }");
 
         public override bool CanConvert(Type objectType)
         {

--- a/src/Framework/Framework/Controls/ClaimView.cs
+++ b/src/Framework/Framework/Controls/ClaimView.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Security.Claims;
 using DotVVM.Framework.Binding;
 using DotVVM.Framework.Hosting;
+using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Controls
 {
@@ -107,14 +108,14 @@ namespace DotVVM.Framework.Controls
         {
             if (user != null)
             {
-                return Values?.Any(v => user.HasClaim(Claim, v.Trim()))
-                    ?? user.HasClaim(ClaimIsOfRequiredType);
+                var claimType = Claim.NotNull("ClaimView.Claim must not be null");
+                if (Values is {} allowedValues)
+                    return allowedValues.Any(v => user.HasClaim(claimType, v.Trim()));
+                else
+                    return user.HasClaim(c => string.Equals(c.Type, claimType, StringComparison.OrdinalIgnoreCase));
             }
 
             return false;
         }
-
-        private bool ClaimIsOfRequiredType(Claim claim)
-            => string.Equals(claim.Type, Claim, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Framework/Framework/Controls/CompositeControl.cs
+++ b/src/Framework/Framework/Controls/CompositeControl.cs
@@ -50,7 +50,7 @@ namespace DotVVM.Framework.Controls
                     parameter.HasDefaultValue ?
                         (ValueOrBinding<object>?)ValueOrBinding<object>.FromBoxedValue(parameter.DefaultValue) :
                         (ValueOrBinding<object>?)null;
-                var newProperty = DotvvmCapabilityProperty.InitializeArgument(parameter, parameter.Name, parameter.ParameterType, controlType, null, defaultValue);
+                var newProperty = DotvvmCapabilityProperty.InitializeArgument(parameter, parameter.Name!, parameter.ParameterType, controlType, null, defaultValue);
 
                 var (getter, setter) =
                     newProperty is DotvvmProperty p ? DotvvmCapabilityProperty.CodeGeneration.CreatePropertyAccessors(parameter.ParameterType, p) :

--- a/src/Framework/Framework/Controls/DotvvmControl.cs
+++ b/src/Framework/Framework/Controls/DotvvmControl.cs
@@ -416,7 +416,7 @@ namespace DotVVM.Framework.Controls
         public DotvvmControl? FindControlByUniqueId(string controlUniqueId)
         {
             var parts = controlUniqueId.Split('_');
-            DotvvmControl result = this;
+            DotvvmControl? result = this;
             for (var i = 0; i < parts.Length; i++)
             {
                 result = result.GetAllDescendants(c => !IsNamingContainer(c))

--- a/src/Framework/Framework/Controls/GridView.cs
+++ b/src/Framework/Framework/Controls/GridView.cs
@@ -544,7 +544,11 @@ namespace DotVVM.Framework.Controls
 
         public override IEnumerable<DotvvmBindableObject> GetLogicalChildren()
         {
-            return base.GetLogicalChildren().Concat(Columns).Concat(RowDecorators);
+            return base.GetLogicalChildren().Concat(
+                Columns ?? Enumerable.Empty<GridViewColumn>()
+            ).Concat(
+                RowDecorators ?? Enumerable.Empty<Decorator>()
+            );
         }
     }
 }

--- a/src/Framework/Framework/Controls/HtmlWriter.cs
+++ b/src/Framework/Framework/Controls/HtmlWriter.cs
@@ -161,7 +161,7 @@ namespace DotVVM.Framework.Controls
 
             if (dataBindAttributes.Contains(name))
             {
-                var currentGroup = (KnockoutBindingGroup)dataBindAttributes[name];
+                var currentGroup = (KnockoutBindingGroup)dataBindAttributes[name]!;
                 currentGroup.AddFrom(bindingGroup);
             }
             else

--- a/src/Framework/Framework/Controls/PropertyImmutableHashtable.cs
+++ b/src/Framework/Framework/Controls/PropertyImmutableHashtable.cs
@@ -55,10 +55,12 @@ namespace DotVVM.Framework.Controls
 
         class EqCmp : IEqualityComparer<DotvvmProperty[]>
         {
-            public bool Equals(DotvvmProperty[] x, DotvvmProperty[] y)
+            public bool Equals(DotvvmProperty[]? x, DotvvmProperty[]? y)
             {
+                if (object.ReferenceEquals(x, y)) return true;
+                if (x == null || y == null) return false;
                 if (x.Length != y.Length) return false;
-                if (x == y) return true;
+
                 for (int i = 0; i < x.Length; i++)
                     if (x[i] != y[i]) return false;
                 return true;
@@ -161,8 +163,8 @@ namespace DotVVM.Framework.Controls
 
         public class DotvvmPropertyComparer : IComparer<DotvvmProperty>
         {
-            public int Compare(DotvvmProperty a, DotvvmProperty b) =>
-                string.Compare(a.FullName, b.FullName, StringComparison.Ordinal);
+            public int Compare(DotvvmProperty? a, DotvvmProperty? b) =>
+                string.Compare(a?.FullName, b?.FullName, StringComparison.Ordinal);
 
             public static readonly DotvvmPropertyComparer Instance = new();
         }

--- a/src/Framework/Framework/Controls/SpaContentPlaceHolder.cs
+++ b/src/Framework/Framework/Controls/SpaContentPlaceHolder.cs
@@ -71,7 +71,7 @@ namespace DotVVM.Framework.Controls
 
         public string GetSpaContentPlaceHolderUniqueId()
         {
-            var dotvvmViewId = GetAllAncestors().FirstOrDefault(a => a is DotvvmView).GetType().ToString();
+            var dotvvmViewId = GetAllAncestors().First(a => a is DotvvmView).GetType().ToString();
             var markupRelativeFilePath = (string?)GetValue(Internal.MarkupFileNameProperty);
 
             return HashUtils.HashAndBase64Encode(

--- a/src/Framework/Framework/Diagnostics/DiagnosticsServerConfiguration.cs
+++ b/src/Framework/Framework/Diagnostics/DiagnosticsServerConfiguration.cs
@@ -36,6 +36,8 @@ namespace DotVVM.Framework.Diagnostics
             try
             {
                 var path = DiagnosticsFilePath;
+                if (path is null)
+                    return;
                 var info = new FileInfo(path);
                 if (info.Exists && configurationLastWriteTimeUtc != info.LastWriteTimeUtc)
                 {

--- a/src/Framework/Framework/Hosting/DotvvmPropertySerializableList.cs
+++ b/src/Framework/Framework/Hosting/DotvvmPropertySerializableList.cs
@@ -34,7 +34,7 @@ namespace DotVVM.Framework.Hosting
                 }
             )
             .GroupBy(p => p.declaringType)
-            .ToDictionary(p => p.Key.FullName, p => p.ToDictionary(p => p.name, p => p.p).ToSorted(StringComparer.OrdinalIgnoreCase)).ToSorted(StringComparer.OrdinalIgnoreCase);
+            .ToDictionary(p => p.Key.FullName!, p => p.ToDictionary(p => p.name, p => p.p).ToSorted(StringComparer.OrdinalIgnoreCase)).ToSorted(StringComparer.OrdinalIgnoreCase);
 
         public static SortedDictionary<string, SortedDictionary<string, DotvvmPropertyInfo>> Capabilities =>
             DotvvmProperty.AllProperties
@@ -53,7 +53,7 @@ namespace DotVVM.Framework.Hosting
                 }
             )
             .GroupBy(p => p.declaringType)
-            .ToDictionary(p => p.Key.FullName, p => p.ToDictionary(p => p.name, p => p.p).ToSorted(StringComparer.OrdinalIgnoreCase)).ToSorted(StringComparer.OrdinalIgnoreCase);
+            .ToDictionary(p => p.Key.FullName!, p => p.ToDictionary(p => p.name, p => p.p).ToSorted(StringComparer.OrdinalIgnoreCase)).ToSorted(StringComparer.OrdinalIgnoreCase);
 
         public static SortedDictionary<string, SortedDictionary<string, DotvvmPropertyGroupInfo>> PropertyGroups =>
             DotvvmPropertyGroup.AllGroups
@@ -73,7 +73,7 @@ namespace DotVVM.Framework.Hosting
                 }
             )
             .GroupBy(p => p.declaringType)
-            .ToDictionary(p => p.Key.FullName, p => p.ToDictionary(p => p.name, p => p.p).ToSorted(StringComparer.OrdinalIgnoreCase)).ToSorted(StringComparer.OrdinalIgnoreCase);
+            .ToDictionary(p => p.Key.FullName!, p => p.ToDictionary(p => p.name, p => p.p).ToSorted(StringComparer.OrdinalIgnoreCase)).ToSorted(StringComparer.OrdinalIgnoreCase);
 
 
 

--- a/src/Framework/Framework/Hosting/ErrorPages/ErrorFormatter.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/ErrorFormatter.cs
@@ -47,15 +47,14 @@ namespace DotVVM.Framework.Hosting.ErrorPages
             var additionalInfos = InfoLoaders.Select(info => info(exception))
                 .Where(info => info != null && info.Objects != null).ToArray()
                 .Union(InfoCollectionLoader.Select(infoCollection => infoCollection(exception))
-                    .Where(infoCollection => infoCollection != null)
-                    .SelectMany(infoCollection => infoCollection)
+                    .SelectMany(infoCollection => infoCollection ?? Enumerable.Empty<ExceptionAdditionalInfo>())
                     .Where(info => info != null && info.Objects != null).ToArray())
                 .ToArray();
 
             stack.Reverse();
 
             var m = new ExceptionModel(
-                exception.GetType().FullName,
+                exception.GetType().FullName ?? "Unknown exception",
                 exception.Message,
                 stack.ToArray(),
                 exception,
@@ -121,7 +120,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
                 else
                 {
                     // guess by method name
-                    var urlFileName = frame.Method.DeclaringType.FullName.Replace("DotVVM.Framework", "")
+                    var urlFileName = frame.Method.DeclaringType.FullName!.Replace("DotVVM.Framework", "")
                         .Replace('.', '/');
                     if (urlFileName.Contains("+"))
                         urlFileName = urlFileName.Remove(urlFileName.IndexOf('+')); // remove nested class
@@ -187,7 +186,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
             const string DotNetIcon = "http://referencesource.microsoft.com/favicon.ico";
             const string SourceUrl = "http://referencesource.microsoft.com/";
             if (frame.Method?.DeclaringType?.Assembly != null &&
-                ReferenceSourceAssemblies.Contains(frame.Method.DeclaringType.Assembly.GetName().Name))
+                ReferenceSourceAssemblies.Contains(frame.Method.DeclaringType.Assembly.GetName().Name ?? ""))
             {
                 if (!String.IsNullOrEmpty(frame.At?.FileName))
                 {
@@ -205,7 +204,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
                     else
                     {
                         var url = SourceUrl + "#q=" +
-                                  WebUtility.HtmlEncode(frame.Method.DeclaringType.FullName.Replace('+', '.') + "." +
+                                  WebUtility.HtmlEncode(frame.Method.DeclaringType.FullName!.Replace('+', '.') + "." +
                                                         frame.Method.Name);
                         return FrameMoreInfo.CreateThumbLink(url, DotNetIcon);
                     }
@@ -216,9 +215,9 @@ namespace DotVVM.Framework.Hosting.ErrorPages
 
         protected static string GetGenericFullName(Type type)
         {
-            if (!type.IsGenericType) return type.FullName;
+            var name = type.FullName ?? type.Name;
+            if (!type.IsGenericType) return name;
 
-            var name = type.FullName;
             name = name.Remove(name.IndexOf("`", StringComparison.Ordinal));
             var typeInfo = type.GetTypeInfo();
 
@@ -317,7 +316,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
             return template.TransformText();
         }
 
-        static (string name, object value) StripBindingProperty(string name, object value)
+        static (string name, object? value) StripBindingProperty(string name, object value)
         {
             var t = value.GetType();
             var props = t.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
@@ -365,12 +364,12 @@ namespace DotVVM.Framework.Hosting.ErrorPages
             f.Formatters.Add((e, o) => {
                 var b = e.AllInnerExceptions().OfType<IDotvvmException>().Select(a => a.RelatedBinding).OfType<ICloneableBinding>().FirstOrDefault();
                 if (b == null) return null;
-                return new DictionarySection<object, object>("Binding", "binding",
-                    new []{ new KeyValuePair<object, object>("Type", b.GetType().FullName) }
+                return new DictionarySection<object, object?>("Binding", "binding",
+                    new []{ new KeyValuePair<object, object?>("Type", b.GetType().FullName!) }
                     .Concat(
                         b.GetAllComputedProperties()
                         .Select(a => StripBindingProperty(a.GetType().Name, a))
-                        .Select(a => new KeyValuePair<object, object>(a.name, a.value))
+                        .Select(a => new KeyValuePair<object, object?>(a.name, a.value))
                     ).ToArray());
             });
             f.Formatters.Add((e, o) => new CookiesSection(o.Request.Cookies));
@@ -384,7 +383,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
             ));
             f.AddInfoLoader<ReflectionTypeLoadException>(e => new ExceptionAdditionalInfo(
                 "Loader Exceptions",
-                e.LoaderExceptions.Select(lde => lde.GetType().Name + ": " + lde.Message).ToArray(),
+                e.LoaderExceptions.Select(lde => lde!.GetType().Name + ": " + lde.Message).ToArray(),
                 ExceptionAdditionalInfo.DisplayMode.ToString
             ));
             f.AddInfoLoader<DotvvmCompilationException>(e => {

--- a/src/Framework/Framework/Hosting/ErrorPages/ErrorPageTemplate.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/ErrorPageTemplate.cs
@@ -71,7 +71,7 @@ $@"<!DOCTYPE html>
         <meta charset=UTF-8 />
         <style type=text/css>
 ");
-            using (var cssStream = typeof(DotvvmConfiguration).Assembly.GetManifestResourceStream(InternalCssResourceName))
+            using (var cssStream = typeof(DotvvmConfiguration).Assembly.GetManifestResourceStream(InternalCssResourceName)!)
             using (var cssReader = new StreamReader(cssStream))
             {
                 WriteLine(cssReader.ReadToEnd());
@@ -138,7 +138,7 @@ $@"
         <p>&nbsp;</p>
         <script>
 ");
-        using (var jsStream = typeof(DotvvmConfiguration).Assembly.GetManifestResourceStream(ErrorPageJsResourceName))
+        using (var jsStream = typeof(DotvvmConfiguration).Assembly.GetManifestResourceStream(ErrorPageJsResourceName)!)
         using (var jsReader = new StreamReader(jsStream))
         {
             WriteLine(jsReader.ReadToEnd());

--- a/src/Framework/Framework/Hosting/ErrorPages/ExceptionSectionFormatter.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/ExceptionSectionFormatter.cs
@@ -102,8 +102,11 @@ namespace DotVVM.Framework.Hosting.ErrorPages
             w.WriteUnencoded("</div>");
         }
 
-        protected virtual string FormatMethod(MethodBase method)
+        protected virtual string FormatMethod(MethodBase? method)
         {
+            if (method == null)
+                return "Unknown method";
+
             var sb = new StringBuilder();
             if (method.DeclaringType != null)
             {

--- a/src/Framework/Framework/Hosting/ErrorPages/IErrorWriter.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/IErrorWriter.cs
@@ -9,8 +9,8 @@ namespace DotVVM.Framework.Hosting.ErrorPages
 {
     public interface IErrorWriter
     {
-        void WriteUnencoded(string str);
-        void WriteText(string str);
+        void WriteUnencoded(string? str);
+        void WriteText(string? str);
         void ObjectBrowser(object? obj);
         void WriteKVTable<K, V>(IEnumerable<KeyValuePair<K, V>> table, string className = "");
         void WriteSourceCode(SourceModel source, bool collapse = true);

--- a/src/Framework/Framework/Hosting/ErrorPages/StackFrameModel.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/StackFrameModel.cs
@@ -9,7 +9,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
 {
     public class StackFrameModel
     {
-        public StackFrameModel(MethodBase method, string? formattedMethod, SourceModel at, IFrameMoreInfo[]? moreInfo)
+        public StackFrameModel(MethodBase? method, string? formattedMethod, SourceModel at, IFrameMoreInfo[]? moreInfo)
         {
             Method = method;
             FormattedMethod = formattedMethod;
@@ -17,7 +17,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
             MoreInfo = moreInfo ?? new IFrameMoreInfo[0];
         }
 
-        public MethodBase Method { get; set; }
+        public MethodBase? Method { get; set; }
         public string? FormattedMethod { get; set; }
         public SourceModel At { get; set; }
         public IFrameMoreInfo[] MoreInfo { get; set; }

--- a/src/Framework/Framework/Hosting/LocalizablePresenter.cs
+++ b/src/Framework/Framework/Hosting/LocalizablePresenter.cs
@@ -49,7 +49,7 @@ namespace DotVVM.Framework.Hosting
         {
             void redirect(IDotvvmRequestContext context)
             {
-                var routeParameters = context.Parameters.ToDictionary(e => e.Key, e => e.Value);
+                var routeParameters = context.Parameters!.ToDictionary(e => e.Key, e => e.Value);
                 if (context.Configuration.DefaultCulture.Equals(routeParameters[name]))
                     throw new Exception($"The specified default culture is probably invalid");
                 routeParameters[name] = context.Configuration.DefaultCulture;
@@ -78,7 +78,7 @@ namespace DotVVM.Framework.Hosting
                     context.HttpContext.Request.Query
                     .Where(q => q.Key != name)
                     .Concat(new[]{ new KeyValuePair<string, string>(name, context.Configuration.DefaultCulture) })
-                    .Select(q => Uri.EscapeUriString(q.Key) + "=" + Uri.EscapeUriString(q.Value)).Apply(s => string.Join("&", s));
+                    .Select(q => Uri.EscapeDataString(q.Key) + "=" + Uri.EscapeDataString(q.Value)).Apply(s => string.Join("&", s));
                 if (url.ToString() == context.HttpContext.Request.Url.ToString())
                     throw new Exception($"The specified default culture is probably invalid");
                 context.RedirectToUrl(url.ToString());

--- a/src/Framework/Framework/Hosting/Middlewares/DotvvmFileUploadMiddleware.cs
+++ b/src/Framework/Framework/Hosting/Middlewares/DotvvmFileUploadMiddleware.cs
@@ -61,22 +61,23 @@ namespace DotVVM.Framework.Hosting.Middlewares
         {
             var context = request.HttpContext;
 
-            // verify the request
-            var isPost = context.Request.Method == "POST";
-            if (isPost && !context.Request.ContentType!.StartsWith("multipart/form-data", StringComparison.Ordinal))
-            {
-                context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
-                return;
-            }
-
             var uploadedFiles = new List<UploadedFile>();
             var errorMessage = "";
+            var isPost = context.Request.Method == "POST";
             if (isPost)
             {
+                var contentType = context.Request.ContentType;
+                if (contentType is null || !contentType.StartsWith("multipart/form-data", StringComparison.Ordinal))
+                {
+                    context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+                    return;
+                }
+                // verify the request
+
                 try
                 {
                     // get the boundary
-                    var boundary = Regex.Match(context.Request.ContentType, @"boundary=""?(?<boundary>[^\n\;\"" ]*)").Groups["boundary"];
+                    var boundary = Regex.Match(contentType, @"boundary=""?(?<boundary>[^\n\;\"" ]*)").Groups["boundary"];
                     if (!boundary.Success || string.IsNullOrWhiteSpace(boundary.Value))
                     {
                         context.Response.StatusCode = (int)HttpStatusCode.BadRequest;

--- a/src/Framework/Framework/ResourceManagement/ReflectionAssemblyJsonConverter.cs
+++ b/src/Framework/Framework/ResourceManagement/ReflectionAssemblyJsonConverter.cs
@@ -34,7 +34,7 @@ namespace DotVVM.Framework.ResourceManagement
         {
             if (reader.Value is string name)
             {
-                return Type.GetType(name);
+                return Type.GetType(name) ?? throw new Exception($"Cannot find type {name}.");
             }
             else throw new NotSupportedException();
         }

--- a/src/Framework/Framework/Security/ProtectionHelpers.cs
+++ b/src/Framework/Framework/Security/ProtectionHelpers.cs
@@ -16,7 +16,7 @@ namespace DotVVM.Framework.Security
         {
             var user = context.HttpContext.User;
             
-            if (user != null && user.Identity.IsAuthenticated)
+            if (user is { Identity.IsAuthenticated: true })
             {
                 return "user" + user.Identity.Name ?? "";
             }

--- a/src/Framework/Framework/Testing/TestPathString.cs
+++ b/src/Framework/Framework/Testing/TestPathString.cs
@@ -14,7 +14,7 @@ namespace DotVVM.Framework.Testing
 
         public string? Value { get; }
 
-        public bool Equals(IPathString other) =>
+        public bool Equals(IPathString? other) =>
             other == this ||
             other != null && other.HasValue() == this.HasValue() && other.Value == this.Value;
 

--- a/src/Framework/Framework/Testing/TestQueryCollection.cs
+++ b/src/Framework/Framework/Testing/TestQueryCollection.cs
@@ -35,7 +35,8 @@ namespace DotVVM.Framework.Testing
         {
         }
 
-        public bool Equals(TestQueryCollection other) =>
-            other.OrderBy(k => k.Key).SequenceEqual(this.OrderBy(k => k.Key));
+        public bool Equals(TestQueryCollection? other) =>
+            Object.ReferenceEquals(this, other) ||
+            other != null && other.OrderBy(k => k.Key).SequenceEqual(this.OrderBy(k => k.Key));
     }
 }

--- a/src/Framework/Framework/Utils/ExpressionComparer.cs
+++ b/src/Framework/Framework/Utils/ExpressionComparer.cs
@@ -17,7 +17,7 @@ namespace DotVVM.Framework.Utils
             if (cacheHashValues) CacheHashValues();
         }
 
-        public static bool Equals(MemberInfo a, MemberInfo b)
+        public static bool Equals(MemberInfo? a, MemberInfo? b)
         {
             if (a == b) return true;
             if (a == null || b == null) return false;
@@ -31,14 +31,14 @@ namespace DotVVM.Framework.Utils
             return mi.MetadataToken * 17 + (mi.DeclaringType?.GetTypeInfo()?.MetadataToken ?? 0);
         }
 
-        bool IEqualityComparer<MemberInfo>.Equals(MemberInfo a, MemberInfo b) => Equals(a, b);
+        bool IEqualityComparer<MemberInfo>.Equals(MemberInfo? a, MemberInfo? b) => Equals(a, b);
         int IEqualityComparer<MemberInfo>.GetHashCode(MemberInfo a) => GetHashCode(a);
 
 
         [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
-        public bool Equals(Expression x, Expression y)
+        public bool Equals(Expression? x, Expression? y)
         {
-            if ((object)x == (object)y) return true;
+            if (object.ReferenceEquals(x, y)) return true;
             if (x == null || y == null) return false;
             var type = x.NodeType;
             if (y.NodeType != type) return false;
@@ -119,7 +119,7 @@ namespace DotVVM.Framework.Utils
                 case ExpressionType.Constant:
                     var constX = (ConstantExpression)x;
                     var constY = (ConstantExpression)y;
-                    return constX.Value == constY.Value || constX.Value.Equals(constY.Value);
+                    return Object.Equals(constX.Value, constY.Value);
                 case ExpressionType.Invoke:
                     var invX = (InvocationExpression)x;
                     var invY = (InvocationExpression)y;
@@ -197,7 +197,7 @@ namespace DotVVM.Framework.Utils
             return hash;
         }
         [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
-        public int GetHashCode(Expression obj)
+        public int GetHashCode(Expression? obj)
         {
             unchecked
             {
@@ -356,8 +356,11 @@ namespace DotVVM.Framework.Utils
                     //return Equals(minitX, minitY) && minitX.Bindings.Zip(minitY.Bindings, (a, b) => a.BindingType == b.BindingType && a.Member == b.Member).All(f => f);
                     case ExpressionType.New:
                         var newe = (NewExpression)obj;
-                        hash *= 31;
-                        hash += GetHashCode(newe.Constructor);
+                        if (newe.Constructor != null)
+                        {
+                            hash *= 31;
+                            hash += GetHashCode(newe.Constructor);
+                        }
                         foreach (var arg in newe.Arguments)
                         {
                             hash *= 29;

--- a/src/Framework/Framework/Utils/ExpressionUtils.cs
+++ b/src/Framework/Framework/Utils/ExpressionUtils.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Diagnostics;
 using DotVVM.Framework.Compilation.ControlTree;
+using System.Diagnostics.CodeAnalysis;
 
 namespace DotVVM.Framework.Utils
 {
@@ -148,21 +149,21 @@ namespace DotVVM.Framework.Utils
             public Action<PropertyInfo>? PropertyInfoAction { get; set; }
             public Action<MethodInfo>? MethodInfoAction { get; set; }
 
-            private void Invoke(MethodInfo method)
+            private void Invoke(MethodInfo? method)
             {
                 if (method == null) return;
                 if (MethodInfoAction != null) MethodInfoAction(method);
                 if (MemberInfoAction != null) MemberInfoAction(method);
             }
 
-            private void Invoke(PropertyInfo property)
+            private void Invoke(PropertyInfo? property)
             {
                 if (property == null) return;
                 if (PropertyInfoAction != null) PropertyInfoAction(property);
                 if (MemberInfoAction != null) MemberInfoAction(property);
             }
 
-            private void Invoke(MemberInfo memberInfo)
+            private void Invoke(MemberInfo? memberInfo)
             {
                 if (memberInfo == null) return;
                 if (memberInfo is PropertyInfo propInfo) Invoke(propInfo);
@@ -224,7 +225,7 @@ namespace DotVVM.Framework.Utils
                 if (node.Member.MemberType == MemberTypes.Property)
                 {
                     var i = Visit(node.Expression);
-                    if (i.NodeType == ExpressionType.Constant)
+                    if (i is { NodeType: ExpressionType.Constant })
                     {
                         var ce = (ConstantExpression)i;
                         var prop = ce.Type.GetProperty(node.Member.Name)!;
@@ -236,7 +237,7 @@ namespace DotVVM.Framework.Utils
                 else if (node.Member.MemberType == MemberTypes.Field)
                 {
                     var i = Visit(node.Expression);
-                    if (i.NodeType == ExpressionType.Constant)
+                    if (i is { NodeType: ExpressionType.Constant })
                     {
                         var ce = (ConstantExpression)i;
                         var f = (FieldInfo)node.Member;
@@ -256,7 +257,7 @@ namespace DotVVM.Framework.Utils
                 if (lc != null && rc != null)
                 {
                     if (node.Method != null)
-                        return Expression.Constant(node.Method.Invoke(null, new object[] { lc.Value, rc.Value }), node.Type);
+                        return Expression.Constant(node.Method.Invoke(null, new [] { lc.Value, rc.Value }), node.Type);
                     else return node;
                 }
                 else return base.VisitBinary(node);
@@ -268,7 +269,7 @@ namespace DotVVM.Framework.Utils
                 if (op is ConstantExpression constantExpression && node.Method != null)
                 {
                     return Expression.Constant(
-                        node.Method.Invoke(null, new object[] { constantExpression.Value }), node.Type);
+                        node.Method.Invoke(null, new [] { constantExpression.Value }), node.Type);
                 }
                 else return base.VisitUnary(node);
             }
@@ -287,9 +288,10 @@ namespace DotVVM.Framework.Utils
             }
 
             public Func<Expression, Expression> Replacer { get; }
-            public override Expression Visit(Expression expr)
+            [return: NotNullIfNotNull("expr")]
+            public override Expression? Visit(Expression? expr)
             {
-                return Replacer(base.Visit(expr));
+                return base.Visit(expr)?.Apply(Replacer);
             }
         }
     }

--- a/src/Framework/Framework/Utils/FunctionalExtensions.cs
+++ b/src/Framework/Framework/Utils/FunctionalExtensions.cs
@@ -85,15 +85,17 @@ namespace DotVVM.Framework.Utils
         public static IEnumerable<(int, T)> Indexed<T>(this IEnumerable<T> enumerable) =>
             enumerable.Select((a, b) => (b, a));
 
-        public static T NotNull<T>(this T? target, string message = "Unexpected null value.")
+        public static T NotNull<T>([NotNull] this T? target, string message = "Unexpected null value.")
             where T : class =>
             target ?? throw new Exception(message);
 
-        public static SortedDictionary<K, V> ToSorted<K, V>(this IDictionary<K, V> d, IComparer<K>? c = null) =>
+        public static SortedDictionary<K, V> ToSorted<K, V>(this IDictionary<K, V> d, IComparer<K>? c = null)
+            where K: notnull =>
             new(d, c ?? Comparer<K>.Default);
     }
 
     sealed class ObjectWithComparer<T> : IEquatable<ObjectWithComparer<T>>, IEquatable<T>
+        where T: notnull
     {
         public ObjectWithComparer(T @object, IEqualityComparer<T> comparer)
         {
@@ -104,11 +106,11 @@ namespace DotVVM.Framework.Utils
         public IEqualityComparer<T> Comparer { get; }
         public T Object { get; }
 
-        public bool Equals(ObjectWithComparer<T> other) => Comparer.Equals(Object, other.Object);
+        public bool Equals(ObjectWithComparer<T>? other) => other != null && Comparer.Equals(Object, other.Object);
 
-        public bool Equals(T other) => Comparer.Equals(Object, other);
+        public bool Equals(T? other) => other != null && Comparer.Equals(Object, other);
 
-        public override bool Equals(object obj) =>
+        public override bool Equals(object? obj) =>
             obj is ObjectWithComparer<T> objC ? Equals(objC) :
             obj is T objT ? Equals(objT) :
             false;

--- a/src/Framework/Framework/Utils/HttpAbstractions/KeyValueAccumulator.cs
+++ b/src/Framework/Framework/Utils/HttpAbstractions/KeyValueAccumulator.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 namespace Microsoft.AspNet.WebUtilities
 {
     public class KeyValueAccumulator<TKey, TValue>
+        where TKey : notnull
     {
         private Dictionary<TKey, List<TValue>> _accumulator;
         IEqualityComparer<TKey> _comparer;
@@ -20,8 +21,7 @@ namespace Microsoft.AspNet.WebUtilities
 
         public void Append(TKey key, TValue value)
         {
-            List<TValue> values;
-            if (_accumulator.TryGetValue(key, out values))
+            if (_accumulator.TryGetValue(key, out var values))
             {
                 values.Add(value);
             }

--- a/src/Framework/Framework/Utils/HttpAbstractions/MultipartReaderStream.cs
+++ b/src/Framework/Framework/Utils/HttpAbstractions/MultipartReaderStream.cs
@@ -303,7 +303,7 @@ namespace Microsoft.AspNet.WebUtilities
                 int countLimit = segment1.Offset - matchOffset + segment1.Count;
                 for (matchCount = 0; matchCount < matchBytes.Length && matchCount < countLimit; matchCount++)
                 {
-                    if (matchBytes[matchCount] != segment1.Array[matchOffset + matchCount])
+                    if (matchBytes[matchCount] != segment1.Array![matchOffset + matchCount])
                     {
                         matchCount = 0;
                         break;

--- a/src/Framework/Framework/Utils/ReadOnlyDictionaryWrapper.cs
+++ b/src/Framework/Framework/Utils/ReadOnlyDictionaryWrapper.cs
@@ -1,10 +1,12 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 
 namespace DotVVM.Framework.Utils
 {
     internal class ReadOnlyDictionaryWrapper<TKey, TValue> : IReadOnlyDictionary<TKey, TValue>
+        where TKey: notnull
     {
         private ConcurrentDictionary<TKey, TValue> dictionary;
 
@@ -25,7 +27,8 @@ namespace DotVVM.Framework.Utils
 
         public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => dictionary.GetEnumerator();
 
-        public bool TryGetValue(TKey key, out TValue value) => dictionary.TryGetValue(key, out value);
+        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value) =>
+            dictionary.TryGetValue(key, out value);
 
         IEnumerator IEnumerable.GetEnumerator() => dictionary.GetEnumerator();
 

--- a/src/Framework/Framework/Utils/TupleComparer.cs
+++ b/src/Framework/Framework/Utils/TupleComparer.cs
@@ -20,7 +20,7 @@ namespace DotVVM.Framework.Utils
             (comparer2?.Equals(x.Item2, y.Item2) ?? x.Item2?.Equals(y.Item2) ?? y.Item2 == null);
 
         public int GetHashCode((T1, T2) x) =>
-            (comparer1?.GetHashCode(x.Item1) ?? x.Item1?.GetHashCode() ?? 1906945227) * 101265739 ^
-            (comparer2?.GetHashCode(x.Item2) ?? x.Item2?.GetHashCode() ?? 652178751) * 540893449;
+            (x.Item1 == null ? 1906945227 : comparer1?.GetHashCode(x.Item1) ?? x.Item1.GetHashCode()) * 101265739 ^
+            (x.Item2 == null ? 0652178751 : comparer2?.GetHashCode(x.Item2) ?? x.Item2.GetHashCode()) * 540893449;
     }
 }

--- a/src/Framework/Framework/ViewModel/ChildViewModelsCache.cs
+++ b/src/Framework/Framework/ViewModel/ChildViewModelsCache.cs
@@ -50,7 +50,7 @@ namespace DotVVM.Framework.ViewModel
         public static void SetViewModelClientPath(IDotvvmViewModel viewModel, ParametrizedCode path) =>
             viewModelPaths.Add(viewModel, path);
 
-        public static ParametrizedCode GetViewModelClientPath(IDotvvmViewModel viewModel) =>
+        public static ParametrizedCode? GetViewModelClientPath(IDotvvmViewModel viewModel) =>
             viewModelPaths.TryGetValue(viewModel, out var p) ? p : p;
 
         /// <summary> Clear cache when hot reload happens </summary>

--- a/src/Framework/Framework/ViewModel/DotvvmViewModelBase.cs
+++ b/src/Framework/Framework/ViewModel/DotvvmViewModelBase.cs
@@ -55,22 +55,22 @@ namespace DotVVM.Framework.ViewModel
         }
 
         public virtual Task Init()
-            => Task.FromResult(0);
+            => Task.CompletedTask;
 
         public virtual Task Load()
-            => Task.FromResult(0);
+            => Task.CompletedTask;
 
         public virtual Task PreRender()
-            => Task.FromResult(0);
+            => Task.CompletedTask;
 
         protected virtual IEnumerable<IDotvvmViewModel> GetChildViewModels()
         {
             // PERF: precompile ViewModels getter
             var thisType = GetType();
-            var properties = ChildViewModelsCache.GetChildViewModelsProperties(thisType).Select(p => (IDotvvmViewModel)p.GetValue(this, null));
-            var collection = ChildViewModelsCache.GetChildViewModelsCollection(thisType).SelectMany(p => (IEnumerable<IDotvvmViewModel>)p.GetValue(this, null) ?? new IDotvvmViewModel[0]);
+            var properties = ChildViewModelsCache.GetChildViewModelsProperties(thisType).Select(p => (IDotvvmViewModel?)p.GetValue(this, null));
+            var collection = ChildViewModelsCache.GetChildViewModelsCollection(thisType).SelectMany(p => (IEnumerable<IDotvvmViewModel?>?)p.GetValue(this, null) ?? new IDotvvmViewModel[0]);
 
-            return properties.Concat(collection).Where(c => c != null).ToArray();
+            return properties.Concat(collection).Where(c => c != null).ToArray()!;
         }
 
 

--- a/src/Framework/Framework/ViewModel/Serialization/DotvvmDictionaryConverter.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/DotvvmDictionaryConverter.cs
@@ -31,11 +31,11 @@ namespace DotVVM.Framework.ViewModel.Serialization
 
                 var itemEnumerator = dict.GetEnumerator();
 
-                var keyProp = dictionaryEntryType.GetProperty(nameof(DictionaryEntry.Key));
-                var valueProp = dictionaryEntryType.GetProperty(nameof(DictionaryEntry.Value));
+                var keyProp = dictionaryEntryType.GetProperty(nameof(DictionaryEntry.Key))!;
+                var valueProp = dictionaryEntryType.GetProperty(nameof(DictionaryEntry.Value))!;
 
                 var list = Activator.CreateInstance(listType);
-                var invokeMethod = listType.GetMethod(nameof(List<object>.Add));
+                var invokeMethod = listType.GetMethod(nameof(List<object>.Add))!;
                 while (itemEnumerator.MoveNext())
                 {
                     var item = Activator.CreateInstance(keyValuePair, keyProp.GetValue(itemEnumerator.Current), valueProp.GetValue(itemEnumerator.Current));
@@ -60,16 +60,16 @@ namespace DotVVM.Framework.ViewModel.Serialization
                 var listType = listGenericType.MakeGenericType(keyValuePair);
 
                 var dict = existingValue as IDictionary;
-                dict ??= (IDictionary)Activator.CreateInstance(objectType);
+                dict ??= (IDictionary)Activator.CreateInstance(objectType)!;
 
-                var keyProp = keyValuePair.GetProperty(nameof(KeyValuePair<object, object>.Key));
-                var valueProp = keyValuePair.GetProperty(nameof(KeyValuePair<object, object>.Value));
+                var keyProp = keyValuePair.GetProperty(nameof(KeyValuePair<object, object>.Key))!;
+                var valueProp = keyValuePair.GetProperty(nameof(KeyValuePair<object, object>.Value))!;
 
                 var value = serializer.Deserialize(reader, listType) as IEnumerable;
                 if (value is null) throw new Exception($"Could not deserialize object with path '{reader.Path}' as IEnumerable.");
                 foreach (var item in value)
                 {
-                    dict.Add(keyProp.GetValue(item), valueProp.GetValue(item));
+                    dict.Add(keyProp.GetValue(item)!, valueProp.GetValue(item));
                 }
                 return dict;
             }

--- a/src/Framework/Framework/ViewModel/Serialization/ViewModelSerializationMapper.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/ViewModelSerializationMapper.cs
@@ -104,7 +104,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
         private static bool IsSetterSupported(PropertyInfo property)
         {
             // support all properties of KeyValuePair<,>
-            if (property.DeclaringType.IsGenericType && property.DeclaringType.GetGenericTypeDefinition() == typeof(KeyValuePair<,>)) return true;
+            if (property.DeclaringType!.IsGenericType && property.DeclaringType.GetGenericTypeDefinition() == typeof(KeyValuePair<,>)) return true;
 
             return property.SetMethod != null && property.SetMethod.IsPublic;
         }

--- a/src/Framework/Framework/ViewModel/Serialization/ViewModelTypeMetadataSerializer.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/ViewModelTypeMetadataSerializer.cs
@@ -260,7 +260,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
                 CultureName = cultureName;
             }
 
-            public override bool Equals(object obj) => obj is ViewModelSerializationMapWithCulture culture && Equals(culture);
+            public override bool Equals(object? obj) => obj is ViewModelSerializationMapWithCulture culture && Equals(culture);
             public bool Equals(ViewModelSerializationMapWithCulture other) => EqualityComparer<ViewModelSerializationMap>.Default.Equals(Map, other.Map) && CultureName == other.CultureName;
 
             public override int GetHashCode()

--- a/src/Framework/Framework/ViewModel/Validation/ValidationErrorFactory.cs
+++ b/src/Framework/Framework/ViewModel/Validation/ValidationErrorFactory.cs
@@ -106,13 +106,13 @@ namespace DotVVM.Framework.ViewModel.Validation
                 return base.VisitMember(node);
             }
 
-            private object? Expand(Expression current)
+            private object? Expand(Expression? current)
             {
                 if (current is ConstantExpression constant)
                 {
                     return constant.Value;
                 }
-                if (!(current is MemberExpression member))
+                if (current is not MemberExpression member)
                 {
                     return null;
                 }

--- a/src/Framework/Framework/ViewModel/Validation/ViewModelValidationRuleTranslator.cs
+++ b/src/Framework/Framework/ViewModel/Validation/ViewModelValidationRuleTranslator.cs
@@ -21,7 +21,7 @@ namespace DotVVM.Framework.ViewModel.Validation
 
                 var displayAttribute = property.GetCustomAttribute<DisplayAttribute>();
                 if (displayAttribute != null)
-                    validationRule.PropertyNameResolver = () => displayAttribute.GetName();
+                    validationRule.PropertyNameResolver = () => displayAttribute.GetName()!;
 
                 switch (attribute)
                 {

--- a/src/Framework/Framework/ViewModel/Validation/ViewModelValidator.cs
+++ b/src/Framework/Framework/ViewModel/Validation/ViewModelValidator.cs
@@ -12,12 +12,12 @@ namespace DotVVM.Framework.ViewModel.Validation
     public class ViewModelValidator : IViewModelValidator
     {
         private readonly IViewModelSerializationMapper viewModelSerializationMapper;
-        private readonly Dictionary<object, object> validationItems;
+        private readonly Dictionary<object, object?> validationItems;
 
         public ViewModelValidator(IViewModelSerializationMapper viewModelMapper, DotvvmConfiguration dotvvmConfiguration)
         {
             this.viewModelSerializationMapper = viewModelMapper;
-            this.validationItems = new Dictionary<object, object> { { typeof(DotvvmConfiguration), dotvvmConfiguration} };
+            this.validationItems = new Dictionary<object, object?> { { typeof(DotvvmConfiguration), dotvvmConfiguration} };
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace DotVVM.Framework.ViewModel.Validation
 
                     foreach (var memberPath in paths)
                     {
-                        yield return new ViewModelValidationError(error.ErrorMessage, memberPath, viewModel);
+                        yield return new ViewModelValidationError(error.ErrorMessage ?? "An unknown error.", memberPath, viewModel);
                     }
                 }
             }

--- a/src/Framework/Hosting.AspNetCore/DotVVM.Framework.Hosting.AspNetCore.csproj
+++ b/src/Framework/Hosting.AspNetCore/DotVVM.Framework.Hosting.AspNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>dotvvmwizard.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/src/Framework/Testing/DotVVM.Framework.Testing.csproj
+++ b/src/Framework/Testing/DotVVM.Framework.Testing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>

--- a/src/Tools/Compiler/DotVVM.Compiler.csproj
+++ b/src/Tools/Compiler/DotVVM.Compiler.csproj
@@ -10,8 +10,8 @@ for some reason. What fun. -->
 
   <!-- Related to compilation -->
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' " >netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' " >netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' " >netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' " >netcoreapp3.1;net6.0;net472</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>

--- a/src/Tracing/ApplicationInsights.AspNetCore/DotVVM.Tracing.ApplicationInsights.AspNetCore.csproj
+++ b/src/Tracing/ApplicationInsights.AspNetCore/DotVVM.Tracing.ApplicationInsights.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>DotVVM.Tracing.ApplicationInsights.AspNetCore</AssemblyTitle>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>dotvvmwizard.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/src/Tracing/MiniProfiler.AspNetCore/DotVVM.Tracing.MiniProfiler.AspNetCore.csproj
+++ b/src/Tracing/MiniProfiler.AspNetCore/DotVVM.Tracing.MiniProfiler.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>DotVVM.Tracing.MiniProfiler.AspNetCore</AssemblyTitle>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>dotvvmwizard.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
They added much of new annotations which caused a lot of
warnings in DotVVM when built against net6.0.
I moved the CI /WarnAsError to net6.0