### PR TITLE
Fix cookies on https: remove the Domain field

### DIFF
--- a/src/Framework/Hosting.AspNetCore/Security/DefaultCsrfProtector.cs
+++ b/src/Framework/Hosting.AspNetCore/Security/DefaultCsrfProtector.cs
@@ -132,8 +132,7 @@ namespace DotVVM.Framework.Security
                     {
                         HttpOnly = true,                                // Don't allow client script access
                         Secure = context.HttpContext.Request.IsHttps,   // If request goes trough HTTPS, mark as secure only
-                        SameSite = canUseSameSite ? SameSiteMode.Lax : SameSiteMode.None,
-                        Domain = context.HttpContext.Request.Url.Host
+                        SameSite = canUseSameSite ? SameSiteMode.Lax : SameSiteMode.None
                     });
 
                 // Return newly generated SID


### PR DESCRIPTION
The Domain flag is not allowed for __Host- cookies, because it
specifies that the cookie should be sent to subdomains.