### PR TITLE
Fix style registration with variable control type

### DIFF
--- a/src/Framework/Framework/Compilation/Styles/StyleBuilder.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleBuilder.cs
@@ -33,9 +33,10 @@ namespace DotVVM.Framework.Compilation.Styles
 
         public Type ControlType => style.ControlType;
 
-        public StyleBuilder(Func<StyleMatchContext<T>, bool>? matcher, bool allowDerived)
+        public StyleBuilder(Func<StyleMatchContext<T>, bool>? matcher, bool allowDerived, Type? controlType = null)
         {
-            style = new Style(!allowDerived, matcher);
+            controlType ??= typeof(T);
+            style = new Style(!allowDerived, matcher, controlType);
         }
 
         public IStyle GetStyle() => style;
@@ -58,8 +59,8 @@ namespace DotVVM.Framework.Compilation.Styles
 
         class Style : CompileTimeStyleBase
         {
-            public Style(bool exactTypeMatch, Func<StyleMatchContext<T>, bool>? matcher)
-                : base(typeof(T), exactTypeMatch)
+            public Style(bool exactTypeMatch, Func<StyleMatchContext<T>, bool>? matcher, Type controlType)
+                : base(controlType, exactTypeMatch)
             {
                 Matcher = matcher;
             }

--- a/src/Framework/Framework/Compilation/Styles/StyleRepository.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleRepository.cs
@@ -57,7 +57,7 @@ namespace DotVVM.Framework.Compilation.Styles
         public StyleBuilder<DotvvmBindableObject> Register(Type type, Func<IStyleMatchContext, bool>? matcher = null, bool allowDerived = true)
         {
             ThrowIfFrozen();
-            var styleBuilder = new StyleBuilder<DotvvmBindableObject>(matcher, allowDerived);
+            var styleBuilder = new StyleBuilder<DotvvmBindableObject>(matcher, allowDerived, type);
             Styles.Add(styleBuilder.GetStyle());
             return styleBuilder;
         }


### PR DESCRIPTION
A problem occured when Register(typeof(HtmlGenericControl)).SetAttribute("x", "y"),
because the generic type argument is DotvvmBindableObject and not
HtmlGenericControl