### PR TITLE
Fixed issue with incorrect token `StartPosition` for interpolated expressions

### DIFF
--- a/src/Framework/Framework/Compilation/Parser/Binding/Parser/BindingParser.cs
+++ b/src/Framework/Framework/Compilation/Parser/Binding/Parser/BindingParser.cs
@@ -1191,10 +1191,7 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
             var rawExpression = text.Substring(positionInToken, end - positionInToken);
             var innerExpressionTokenizer = new BindingTokenizer(tokenPositionInBinding + positionInToken);
             innerExpressionTokenizer.Tokenize(rawExpression);
-            var innerExpressionParser = new BindingParser()
-            {
-                Tokens = innerExpressionTokenizer.Tokens
-            };
+            var innerExpressionParser = new BindingParser() { Tokens = innerExpressionTokenizer.Tokens };
             expression = innerExpressionParser.ReadFormattedExpression();
 
             if (expression.HasNodeErrors)

--- a/src/Framework/Framework/Compilation/Parser/Binding/Parser/BindingParser.cs
+++ b/src/Framework/Framework/Compilation/Parser/Binding/Parser/BindingParser.cs
@@ -1190,6 +1190,8 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
             tokenizer.Tokenize(rawExpression);
             var parser = new BindingParser() { Tokens = tokenizer.Tokens };
             expression = parser.ReadFormattedExpression();
+            expression.StartPosition = start;
+
             if (expression.HasNodeErrors)
             {
                 error = string.Join(" ", new[] { $"Error while parsing expression \"{rawExpression}\"." }.Concat(expression.NodeErrors));

--- a/src/Framework/Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenizer.cs
+++ b/src/Framework/Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenizer.cs
@@ -8,9 +8,11 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Tokenizer
     public class BindingTokenizer : TokenizerBase<BindingToken, BindingTokenType>
     {
         private readonly ISet<char> operatorCharacters = new HashSet<char> { '+', '-', '*', '/', '^', '\\', '%', '<', '>', '=', '&', '|', '~', '!', ';' };
+        internal readonly int bindingPositionOffset;
 
-        public BindingTokenizer() : base(BindingTokenType.Identifier, BindingTokenType.WhiteSpace)
+        public BindingTokenizer(int bindingPositionOffset = 0) : base(BindingTokenType.Identifier, BindingTokenType.WhiteSpace)
         {
+            this.bindingPositionOffset = bindingPositionOffset;
         }
 
         public bool IsOperator(char c) => operatorCharacters.Contains(c);
@@ -272,7 +274,7 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Tokenizer
 
         protected override BindingToken NewToken(string text, BindingTokenType type, int lineNumber, int columnNumber, int length, int startPosition)
         {
-            return new BindingToken(text, type, lineNumber, columnNumber, length, startPosition);
+            return new BindingToken(text, type, lineNumber, columnNumber, length, startPosition + bindingPositionOffset);
         }
 
         private void FinishIncompleteIdentifier()

--- a/src/Framework/Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenizer.cs
+++ b/src/Framework/Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenizer.cs
@@ -7,7 +7,7 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Tokenizer
 {
     public class BindingTokenizer : TokenizerBase<BindingToken, BindingTokenType>
     {
-        private readonly ISet<char> operatorCharacters = new HashSet<char> { '+', '-', '*', '/', '^', '\\', '%', '<', '>', '=', '&', '|', '~', '!', ';' };
+        private static readonly HashSet<char> operatorCharacters = new HashSet<char> { '+', '-', '*', '/', '^', '\\', '%', '<', '>', '=', '&', '|', '~', '!', ';' };
         internal readonly int bindingPositionOffset;
 
         public BindingTokenizer(int bindingPositionOffset = 0) : base(BindingTokenType.Identifier, BindingTokenType.WhiteSpace)

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/ParserBase.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/ParserBase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using DotVVM.Framework.Compilation.Parser.Binding.Tokenizer;
 using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
@@ -29,7 +30,6 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
 
         public List<TToken> Tokens { get; set; } = new List<TToken>();
         protected int CurrentIndex { get; set; }
-
         
         /// <summary>
         /// Skips the whitespace.

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/ParserBase.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/ParserBase.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using DotVVM.Framework.Compilation.Parser.Binding.Tokenizer;
 using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
@@ -30,7 +29,8 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
 
         public List<TToken> Tokens { get; set; } = new List<TToken>();
         protected int CurrentIndex { get; set; }
-        
+
+
         /// <summary>
         /// Skips the whitespace.
         /// </summary>

--- a/src/Tests/Parser/Binding/BindingParserTests.cs
+++ b/src/Tests/Parser/Binding/BindingParserTests.cs
@@ -185,19 +185,25 @@ namespace DotVVM.Framework.Tests.Parser.Binding
             Assert.IsFalse(result.HasNodeErrors);
             Assert.AreEqual(2, result.Arguments.Count);
             Assert.AreEqual("Argument1", ((SimpleNameBindingParserNode)result.Arguments[0]).Name);
+            Assert.AreEqual(9, ((SimpleNameBindingParserNode)result.Arguments[0]).StartPosition);
+            Assert.AreEqual("Argument1".Length, ((SimpleNameBindingParserNode)result.Arguments[0]).Length);
+            Assert.AreEqual(26, ((SimpleNameBindingParserNode)result.Arguments[1]).StartPosition);
+            Assert.AreEqual("Argument2".Length, ((SimpleNameBindingParserNode)result.Arguments[1]).Length);
             Assert.AreEqual("Argument2", ((SimpleNameBindingParserNode)result.Arguments[1]).Name);
         }
 
         [TestMethod]
-        [DataRow("$'{DateProperty:dd/MM/yyyy}'", "{0:dd/MM/yyyy}")]
-        [DataRow("$'{IntProperty:####}'", "{0:####}")]
-        public void BindingParser_InterpolatedString_WithFormattingComponent_Valid(string expression, string formatOptions)
+        [DataRow("$'{DateProperty:dd/MM/yyyy}'", "DateProperty:dd/MM/yyyy", "{0:dd/MM/yyyy}")]
+        [DataRow("$'{IntProperty:####}'", "IntProperty:####", "{0:####}")]
+        public void BindingParser_InterpolatedString_WithFormattingComponent_Valid(string interpolatedString, string interpolation, string formatOptions)
         {
-            var result = bindingParserNodeFactory.Parse(expression) as InterpolatedStringBindingParserNode;
+            var result = bindingParserNodeFactory.Parse(interpolatedString) as InterpolatedStringBindingParserNode;
             Assert.IsFalse(result.HasNodeErrors);
             Assert.AreEqual(1, result.Arguments.Count);
             Assert.AreEqual(typeof(FormattedBindingParserNode), result.Arguments.First().GetType());
             Assert.AreEqual(formatOptions, ((FormattedBindingParserNode)result.Arguments.First()).Format);
+            Assert.AreEqual(3, ((FormattedBindingParserNode)result.Arguments.First()).StartPosition);
+            Assert.AreEqual(interpolation.Length, ((FormattedBindingParserNode)result.Arguments.First()).Length);
         }
 
         [TestMethod]

--- a/src/Tests/Parser/Binding/BindingParserTests.cs
+++ b/src/Tests/Parser/Binding/BindingParserTests.cs
@@ -178,7 +178,18 @@ namespace DotVVM.Framework.Tests.Parser.Binding
         }
 
         [TestMethod]
-        public void BindingParser_InterpolatedString_Valid()
+        public void BindingParser_InterpolatedString_BinaryOperationInterpolation()
+        {
+            var result = bindingParserNodeFactory.Parse("$'{'x' + 'y' + 'z'}'") as InterpolatedStringBindingParserNode;
+            Assert.AreEqual("{0}", result.Format);
+            Assert.IsFalse(result.HasNodeErrors);
+            Assert.AreEqual(1, result.Arguments.Count);
+            Assert.AreEqual(typeof(BinaryOperatorBindingParserNode), result.Arguments[0].GetType());
+            Assert.AreEqual("x + y + z", result.Arguments[0].ToDisplayString());
+        }
+
+        [TestMethod]
+        public void BindingParser_InterpolatedString_MultipleInterpolations()
         {
             var result = bindingParserNodeFactory.Parse("$\"Hello {Argument1} with {Argument2}!\"") as InterpolatedStringBindingParserNode;
             Assert.AreEqual("Hello {0} with {1}!", result.Format);
@@ -190,6 +201,15 @@ namespace DotVVM.Framework.Tests.Parser.Binding
             Assert.AreEqual(26, ((SimpleNameBindingParserNode)result.Arguments[1]).StartPosition);
             Assert.AreEqual("Argument2".Length, ((SimpleNameBindingParserNode)result.Arguments[1]).Length);
             Assert.AreEqual("Argument2", ((SimpleNameBindingParserNode)result.Arguments[1]).Name);
+        }
+
+        [TestMethod]
+        public void BindingParser_InterpolatedString_NestedExpressions_StartPositions()
+        {
+            var result = bindingParserNodeFactory.Parse("$'ABC{$'DEF{'GHI!'}'}'") as InterpolatedStringBindingParserNode;
+            Assert.AreEqual(0, result.StartPosition);
+            Assert.AreEqual(6, result.Arguments.First().StartPosition /* $'DEF{'GHI!'}' */);
+            Assert.AreEqual(12, (result.Arguments.First() as InterpolatedStringBindingParserNode).Arguments.First().StartPosition /* 'GHI!'' */);
         }
 
         [TestMethod]

--- a/src/Tests/Parser/Binding/BindingParserTests.cs
+++ b/src/Tests/Parser/Binding/BindingParserTests.cs
@@ -213,6 +213,20 @@ namespace DotVVM.Framework.Tests.Parser.Binding
         }
 
         [TestMethod]
+        public void BindingParser_InterpolatedString_ComplexNestedExpressions_StartPositions()
+        {
+            var result = bindingParserNodeFactory.Parse("Method($'ABC{Method($'DEF{'GHI!'}')}')") as FunctionCallBindingParserNode;
+            Assert.AreEqual(0, result.StartPosition);
+
+            var interpolationOuter = result.ArgumentExpressions.First() as InterpolatedStringBindingParserNode;
+            Assert.AreEqual(7, interpolationOuter.StartPosition);
+            var innerMethodCall = interpolationOuter.Arguments.First() as FunctionCallBindingParserNode;
+            Assert.AreEqual(13, innerMethodCall.StartPosition);
+            var interpolationInner = innerMethodCall.ArgumentExpressions.First() as InterpolatedStringBindingParserNode;
+            Assert.AreEqual(20, interpolationInner.StartPosition);
+        }
+
+        [TestMethod]
         [DataRow("$'{DateProperty:dd/MM/yyyy}'", "DateProperty:dd/MM/yyyy", "{0:dd/MM/yyyy}")]
         [DataRow("$'{IntProperty:####}'", "IntProperty:####", "{0:####}")]
         public void BindingParser_InterpolatedString_WithFormattingComponent_Valid(string interpolatedString, string interpolation, string formatOptions)


### PR DESCRIPTION
This PR fixes an issue that breaks the WIP string interpolation feature in VS Extension. 

Whenever an interpolated expression is parsed, we create a new instance of `BindingTokenizer` and `BindingParser`. However, we should also set an appropriate start indices for these expressions.

This is the behaviour I want to achieve:
![image](https://user-images.githubusercontent.com/12575176/147937695-4c3422aa-b648-4980-9fb5-3b11f94bcc16.png)

However, right now it can desynchronize into something like this:
![image](https://user-images.githubusercontent.com/12575176/147937816-f77be9c9-6db6-4f88-a5ef-518970f0c020.png)
(Note that all interpolations are starting on the first index - which is the data currently generated by framework)
