### PR TITLE
Fix a bug in MarkupControl when property is used multiple times

### DIFF
--- a/src/Framework/Framework/Compilation/ControlTree/UsedPropertiesFindingVisitor.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/UsedPropertiesFindingVisitor.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using DotVVM.Framework.Binding;
@@ -14,7 +15,7 @@ namespace DotVVM.Framework.Compilation
 
         class ExpressionInspectingVisitor: ExpressionVisitor
         {
-            public List<DotvvmProperty> UsedProperties { get; } = new();
+            public HashSet<DotvvmProperty> UsedProperties { get; } = new();
             public bool UsesViewModel { get; set; }
             protected override Expression VisitConstant(ConstantExpression node)
             {
@@ -57,7 +58,8 @@ namespace DotVVM.Framework.Compilation
 
             base.VisitView(view);
 
-            var info = new ControlUsedPropertiesInfo(exprVisitor.UsedProperties.ToArray(), exprVisitor.UsesViewModel);
+            var props = exprVisitor.UsedProperties.OrderBy(p => p.Name).ToArray();
+            var info = new ControlUsedPropertiesInfo(props, exprVisitor.UsesViewModel);
 
             view.SetProperty(new ResolvedPropertyValue(Internal.UsedPropertiesInfoProperty, info));
         }

--- a/src/Tests/ControlTests/testoutputs/MarkupControlTests.MarkupControl_PropertyUsedManyTimes.html
+++ b/src/Tests/ControlTests/testoutputs/MarkupControlTests.MarkupControl_PropertyUsedManyTimes.html
@@ -1,0 +1,21 @@
+<html>
+	<head></head>
+	<body>
+		<div data-bind="dotvvm-with-control-properties: { Another: int }">
+			
+			<!-- ko text: $control.Another -->
+			<!-- /ko -->  10000000 
+			<!-- ko text: $control.Another -->
+			<!-- /ko -->
+			<span class="x" data-bind="css: { x: $control.Another() > 10 }"></span>
+		</div>
+		<div data-bind="dotvvm-with-control-properties: { Another: 10 }">
+			
+			<!-- ko text: $control.Another -->
+			<!-- /ko -->  10 
+			<!-- ko text: $control.Another -->
+			<!-- /ko -->
+			<span data-bind="css: { x: $control.Another() > 10 }"></span>
+		</div>
+	</body>
+</html>


### PR DESCRIPTION
Since we introduced the UsedPropertiesFindingVisitor,
it would include a property multiple times if it was used
more than once.