### PR TITLE
Add _js.InvokeAsync method

### DIFF
--- a/src/Framework/Framework/Binding/HelperNamespace/JsBindingApi.cs
+++ b/src/Framework/Framework/Binding/HelperNamespace/JsBindingApi.cs
@@ -10,25 +10,43 @@ namespace DotVVM.Framework.Binding.HelperNamespace
 {
     public class JsBindingApi
     {
+        /// <summary> Invoke a command in client-side module registered for this page or control. The command cannot return a promise, use <see cref="InvokeAsync" /> for that. </summary>
         public void Invoke(string name, params object[] args) =>
             throw new Exception($"Cannot invoke JS command server-side: {name}({string.Join(", ", args)}).");
+        /// <summary> Invoke a command in client-side module registered for this page or control. <typeparamref name="T"/> is the return type. The command cannot return a promise, use <see cref="InvokeAsync{T}" /> for that. </summary>
         public T Invoke<T>(string name, params object[] args) =>
             throw new Exception($"Cannot invoke JS command server-side: {name}({string.Join(", ", args)}) -> {typeof(T).Name}.");
 
+        /// <summary> Invoke a command in client-side module registered for this page or control. The command can return a Promise. </summary>
+        public void InvokeAsync(string name, params object[] args) =>
+            throw new Exception($"Cannot invoke JS async command server-side: {name}({string.Join(", ", args)}).");
+        /// <summary> Invoke a command in client-side module registered for this page or control. <typeparamref name="T"/> is the return type. The command can return a Promise. </summary>
+        public T InvokeAsync<T>(string name, params object[] args) =>
+            throw new Exception($"Cannot invoke JS async command server-side: {name}({string.Join(", ", args)}) -> {typeof(T).Name}.");
+
         internal static void RegisterJavascriptTranslations(JavascriptTranslatableMethodCollection collection)
         {
-            collection.AddMethodTranslator(typeof(JsBindingApi), nameof(Invoke), new GenericMethodCompiler(
+            var compiler = new GenericMethodCompiler(
                 (a, method) => {
                     var annotation = a[0].Annotation<JsExtensionParameter.ViewModuleAnnotation>().NotNull("invalid call of _js.Invoke");
                     var viewIdOrElementExpr = annotation.IsMarkupControl ? new JsSymbolicParameter(CommandBindingExpression.SenderElementParameter) : (JsExpression)new JsLiteral(annotation.Id);
 
-                    var jsExpression = a[0].Member("call").Invoke(viewIdOrElementExpr, a[1], a[2]);
-                    if (typeof(Task).IsAssignableFrom(method.ReturnType))
+                    var isAsync = typeof(Task).IsAssignableFrom(method.ReturnType) || method.Name == "InvokeAsync";
+
+                    var jsExpression = new JsInvocationExpression(a[0].Member("call"), viewIdOrElementExpr, a[1], a[2]);
+                    if (isAsync)
                     {
-                        jsExpression = jsExpression.WithAnnotation(new ResultIsPromiseAnnotation(e => e));
+                        jsExpression.AddAnnotation(new ResultIsPromiseAnnotation(e => e));
+                    }
+                    else
+                    {
+                        // client-side check that the invocation does not return a Promise
+                        jsExpression.Arguments.Add(new JsLiteral(false));
                     }
                     return jsExpression;
-                }), null, true, true);
+                });
+            collection.AddMethodTranslator(typeof(JsBindingApi), nameof(Invoke), compiler, null, true, true);
+            collection.AddMethodTranslator(typeof(JsBindingApi), nameof(InvokeAsync), compiler, null, true, true);
         }
     }
 }

--- a/src/Tests/ControlTests/SimpleControlTests.cs
+++ b/src/Tests/ControlTests/SimpleControlTests.cs
@@ -285,6 +285,9 @@ namespace DotVVM.Framework.Tests.ControlTests
             var r = await cth.RunPage(typeof(BasicTestViewModel), @"
                 async static command with arg
                 <dot:NamedCommand Name=1
+                                  Command={staticCommand: (int s) => _js.InvokeAsync<int>('myCmd', s)} />
+                async static command with Invoke&lt;Task&gt;
+                <dot:NamedCommand Name=1
                                   Command={staticCommand: (int s) => _js.Invoke<System.Threading.Tasks.Task<int>>('myCmd', s)} />
                 Command with arg
                 <dot:NamedCommand Name=2

--- a/src/Tests/ControlTests/testoutputs/SimpleControlTests.NamedCommand.html
+++ b/src/Tests/ControlTests/testoutputs/SimpleControlTests.NamedCommand.html
@@ -3,6 +3,8 @@
 	<body>
 		async static command with arg                 
 		<!-- ko dotvvm-named-command: { viewIdOrElement: "p0", name: "1", command: (...args)=>(dotvvm.applyPostbackHandlers(async (options) => await dotvvm.viewModules.call("p0", "myCmd", [args[0]]),$element,[],args,$context)) } -->
+		<!-- /ko -->                 async static command with Invoke&lt;Task&gt;                 
+		<!-- ko dotvvm-named-command: { viewIdOrElement: "p0", name: "1", command: (...args)=>(dotvvm.applyPostbackHandlers(async (options) => await dotvvm.viewModules.call("p0", "myCmd", [args[0]]),$element,[],args,$context)) } -->
 		<!-- /ko -->                 Command with arg                 
 		<!-- ko dotvvm-named-command: { viewIdOrElement: "p0", name: "2", command: (...args)=>(dotvvm.postBack($element,[],"yRBKC1vu64PakIw5","",$context,[],args,undefined)) } -->
 		<!-- /ko -->                 sync static command with argument                 

--- a/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModuleInControl.html
+++ b/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModuleInControl.html
@@ -23,13 +23,13 @@
 	<body>
 		<div data-bind="dotvvm-with-view-modules: { modules: [&quot;controlModule&quot;] }">
 			<input onclick="dotvvm.applyPostbackHandlers((options) => {
-	dotvvm.viewModules.call(this, &quot;name&quot;, [1]);
+	dotvvm.viewModules.call(this, &quot;name&quot;, [1], false);
 },this).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
 		</div>
 		<div data-bind="foreach: { data: Collection }">
 			<div data-bind="dotvvm-with-view-modules: { modules: [&quot;controlModule&quot;] }">
 				<input onclick="dotvvm.applyPostbackHandlers((options) => {
-	dotvvm.viewModules.call(this, &quot;name&quot;, [1]);
+	dotvvm.viewModules.call(this, &quot;name&quot;, [1], false);
 },this).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
 			</div>
 			This control should not have any module, it's just a text


### PR DESCRIPTION
Before it was used as Invoke<Task<X>>, which is pretty ugly.
This patch also adds a check that synchronously invoked command
does not return a promise, otherwise it would probably fail with
some undefined access error.
Checking that an async command actually return a promise is unnecessary,
since await in JS is a no-op
for synchronously evaluated values.