### PR TITLE
Serialize records correctly

### DIFF
--- a/src/Framework/Framework/Hosting/Middlewares/DotvvmFileUploadMiddleware.cs
+++ b/src/Framework/Framework/Hosting/Middlewares/DotvvmFileUploadMiddleware.cs
@@ -111,8 +111,8 @@ namespace DotVVM.Framework.Hosting.Middlewares
                 }
                 else
                 {
-                    await outputRenderer.RenderPlainTextResponse(context, errorMessage);
                     context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+                    await outputRenderer.RenderPlainTextResponse(context, errorMessage);
                 }
             }
             

--- a/src/Framework/Framework/Utils/ExpressionUtils.cs
+++ b/src/Framework/Framework/Utils/ExpressionUtils.cs
@@ -36,6 +36,21 @@ namespace DotVVM.Framework.Utils
         public static BinaryExpression UpdateType(this BinaryExpression expr, ExpressionType type) =>
             Expression.MakeBinary(type, expr.Left, expr.Right);
 
+        public static Expression WrapException(Expression expr, Action<Exception> wrapException)
+        {
+            var p = Expression.Parameter(typeof(Exception), "ex");
+            return Expression.TryCatch(
+                expr,
+                Expression.Catch(
+                    p,
+                    Expression.Block(
+                        Expression.Invoke(Expression.Constant(wrapException), p),
+                        Expression.Rethrow(expr.Type)
+                    )
+                )
+            );
+        }
+
         /// <summary> Substitutes arguments in the LambdaExpression with the specified expressions. </summary>
         public static Expression Replace(this LambdaExpression ex, params Expression[] parameters)
         {

--- a/src/Framework/Framework/Utils/FunctionalExtensions.cs
+++ b/src/Framework/Framework/Utils/FunctionalExtensions.cs
@@ -85,6 +85,17 @@ namespace DotVVM.Framework.Utils
         public static IEnumerable<(int, T)> Indexed<T>(this IEnumerable<T> enumerable) =>
             enumerable.Select((a, b) => (b, a));
 
+        public static int FindIndex<T>(this IEnumerable<T> enumerable, Func<T, bool> predicate)
+        {
+            int i = 0;
+            foreach (var x in enumerable)
+            {
+                if (predicate(x)) return i;
+                i++;
+            }
+            return -1;
+        }
+
         public static T NotNull<T>([NotNull] this T? target, string message = "Unexpected null value.")
             where T : class =>
             target ?? throw new Exception(message);

--- a/src/Framework/Framework/ViewModel/Serialization/ViewModelJsonConverter.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/ViewModelJsonConverter.cs
@@ -9,6 +9,7 @@ using DotVVM.Framework.Configuration;
 using System.Reflection;
 using DotVVM.Framework.Utils;
 using System.Security;
+using System.Diagnostics;
 
 namespace DotVVM.Framework.ViewModel.Serialization
 {
@@ -68,6 +69,16 @@ namespace DotVVM.Framework.ViewModel.Serialization
         /// </summary>
         public override object? ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
+            if (existingValue is {})
+            {
+                Debug.Assert(objectType.IsInstanceOfType(existingValue));
+
+                // the existingValue might be more specific type than objectType.
+                // this important for deserialization of IPagingOptions which are pre-populated with PagingOptions
+                // otherwise, we'd not be able to deserialize the interface, because it has no constructor
+
+                objectType = existingValue.GetType();
+            }
             // handle null keyword
             if (reader.TokenType == JsonToken.Null)
             {

--- a/src/Framework/Framework/ViewModel/Serialization/ViewModelJsonConverter.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/ViewModelJsonConverter.cs
@@ -83,9 +83,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
             {
                 // deserialize
                 var serializationMap = GetSerializationMapForType(objectType);
-                var instance = serializationMap.ConstructorFactory(Services);
-                serializationMap.ReaderFactory(reader, serializer, instance, evReader.Value);
-                return instance;
+                return serializationMap.ReaderFactory(reader, serializer, existingValue, evReader.Value, Services);
             }
             finally
             {
@@ -126,14 +124,14 @@ namespace DotVVM.Framework.ViewModel.Serialization
         /// <summary>
         /// Populates the specified JObject.
         /// </summary>
-        public virtual void Populate(JsonReader reader, JsonSerializer serializer, object value)
+        public virtual object Populate(JsonReader reader, JsonSerializer serializer, object value)
         {
             var evSuppressed = evReader.Value.Suppressed;
             try
             {
                 if (reader.TokenType == JsonToken.None) reader.Read();
                 var serializationMap = GetSerializationMapForType(value.GetType());
-                serializationMap.ReaderFactory(reader, serializer, value, evReader.Value);
+                return serializationMap.ReaderFactory(reader, serializer, value, evReader.Value, Services);
             }
             finally
             {

--- a/src/Framework/Framework/ViewModel/Serialization/ViewModelPropertyMap.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/ViewModelPropertyMap.cs
@@ -51,6 +51,8 @@ namespace DotVVM.Framework.ViewModel.Serialization
 
         public JsonConverter? JsonConverter { get; set; }
 
+        public ParameterInfo? ConstructorParameter { get; set; }
+
         /// <summary>
         /// Gets whether the property is transferred both ways.
         /// </summary>

--- a/src/Framework/Testing/DotvvmTestHelper.cs
+++ b/src/Framework/Testing/DotvvmTestHelper.cs
@@ -109,6 +109,7 @@ namespace DotVVM.Framework.Testing
 
         public static DotvvmConfiguration CreateConfiguration(Action<IServiceCollection>? customServices = null) =>
             DotvvmConfiguration.CreateDefault(s => {
+                s.AddSingleton<ITestSingletonService, TestSingletonService>();
                 customServices?.Invoke(s);
                 RegisterMoqServices(s);
             });
@@ -200,5 +201,9 @@ namespace DotVVM.Framework.Testing
                 Thread.CurrentThread.CurrentUICulture = originalUICulture;
             }
         }
+
+
+        public interface ITestSingletonService { }
+        public class TestSingletonService: ITestSingletonService { }
     }
 }


### PR DESCRIPTION
the serializer now supports injecting parameters into the constructor.

Instead of writing data directly into the properties, we
now first deserialize all properties into local variables
and then either call setters or use them as constructor parameters.