### PR TITLE
Added loaded assemblies tab into the Error Page

### DIFF
--- a/src/Framework/Framework/Hosting/ErrorPages/ErrorFormatter.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/ErrorFormatter.cs
@@ -376,10 +376,16 @@ namespace DotVVM.Framework.Hosting.ErrorPages
             f.Formatters.Add((e, o) => new DictionarySection<string, string>(
                 "Assemblies",
                 "assemblies",
-                AppDomain.CurrentDomain.GetAssemblies().OrderBy(a => a.GetName().Name).Select(a =>
-                    new KeyValuePair<string, string>(a.GetName().Name,
-                        $"Version={a.GetName().Version}, Culture={a.GetName().CultureInfo.DisplayName}, " +
-                        $"PublicKeyToken={a.GetName().GetPublicKeyToken().Select(b => string.Format("{0:x2}", b)).StringJoin(string.Empty)}"))
+                AppDomain.CurrentDomain.GetAssemblies().Where(a => a.GetName().Name != null).OrderBy(a => a.GetName().Name).Select(a => {
+                    var info = a.GetName();
+                    var versionString = (info.Version != null) ? info.Version.ToString() : "unknown version";
+                    var cultureString = (info.CultureInfo != null) ? info.CultureInfo.DisplayName : "unknown culture";
+                    var publicKeyString = (info.GetPublicKeyToken() != null) ? info.GetPublicKeyToken()!
+                        .Select(b => string.Format("{0:x2}", b)).StringJoin(string.Empty) : "unknown public key";
+
+                    return new KeyValuePair<string, string>(info.Name!,
+                        $"Version={versionString}, Culture={cultureString}, PublicKeyToken={publicKeyString}");
+                })
             ));
             f.Formatters.Add((e, o) => new DictionarySection<string, string[]>(
                 "Request Headers",

--- a/src/Framework/Framework/Hosting/ErrorPages/ErrorFormatter.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/ErrorFormatter.cs
@@ -373,6 +373,14 @@ namespace DotVVM.Framework.Hosting.ErrorPages
                     ).ToArray());
             });
             f.Formatters.Add((e, o) => new CookiesSection(o.Request.Cookies));
+            f.Formatters.Add((e, o) => new DictionarySection<string, string>(
+                "Assemblies",
+                "assemblies",
+                AppDomain.CurrentDomain.GetAssemblies().OrderBy(a => a.GetName().Name).Select(a =>
+                    new KeyValuePair<string, string>(a.GetName().Name,
+                        $"Version={a.GetName().Version}, Culture={a.GetName().CultureInfo.DisplayName}, " +
+                        $"PublicKeyToken={a.GetName().GetPublicKeyToken().Select(b => string.Format("{0:x2}", b)).StringJoin(string.Empty)}"))
+            ));
             f.Formatters.Add((e, o) => new DictionarySection<string, string[]>(
                 "Request Headers",
                 "reqHeaders",


### PR DESCRIPTION
This PR adds information about loaded assemblies participating in the execution at the time when an Error Page is generated. I believe that this information can be helpful when diagnosing exceptions from users, such as the following:

* **Missing package**: i.e. trying to use `HotReload` without referencing the proper packages and using framework < 4.0
* **Binary incompatibility**: i.e. `MissingMethodException` when user has incompatible framework and business pack versions
* **Culture issues**: i.e. using a concrete language (culture) that can potentially break some stuff when invoking culture-sensitive operations

![image](https://user-images.githubusercontent.com/12575176/149763392-e1904924-b24f-49e1-a266-464a79f945e2.png)
