### PR TITLE
Added property paths to JS validation errors

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/utils/evaluator.ts
+++ b/src/Framework/Framework/Resources/Scripts/utils/evaluator.ts
@@ -40,20 +40,19 @@ export function findPathToChildObject(vm: any, child: any, path: string): string
         return path;
     }
 
-    vm = ko.unwrap(vm);
     if (typeof vm !== "object" || vm == null) {
         return null;
     }
 
     if (Array.isArray(vm)) {
         // Iterate over its elements
-        vm.forEach(function (value, index) {
-            let result = findPathToChildObject(value, child, path + "/" + `[${index}]`)
+        let index = 0;
+        for (const value of vm) {
+            let result = findPathToChildObject(value, child, path + `/[${index}]`)
             if (result != null)
                 return result;
-
             index++;
-        })
+        }
     }
     else {
         // Iterate over its properties

--- a/src/Framework/Framework/Resources/Scripts/utils/evaluator.ts
+++ b/src/Framework/Framework/Resources/Scripts/utils/evaluator.ts
@@ -1,5 +1,6 @@
 import { isObservableArray } from "./knockout";
 import { logError } from "./logging";
+import { keys } from "./objects";
 
 /**
  * Traverses provided context according to given path.
@@ -31,6 +32,44 @@ export function traverseContext(context: any, path: string): any {
     }
 
     return currentLevel
+}
+
+export function findPathToChildObject(vm: any, child: any, path: string): string | null {
+    if (vm == child) {
+        // We found the child
+        return path;
+    }
+
+    vm = ko.unwrap(vm);
+    if (typeof vm !== "object" || vm == null) {
+        return null;
+    }
+
+    if (Array.isArray(vm)) {
+        // Iterate over its elements
+        vm.forEach(function (value, index) {
+            let result = findPathToChildObject(value, child, path + "/" + `[${index}]`)
+            if (result != null)
+                return result;
+
+            index++;
+        })
+    }
+    else {
+        // Iterate over its properties
+        for (const propertyName of keys(vm)) {
+            if (propertyName.startsWith('$')) {
+                continue;
+            }
+
+            var propertyValue = vm[propertyName];
+            let result = findPathToChildObject(propertyValue, child, path + "/" + propertyName);
+            if (result != null)
+                return result;
+        }
+    }
+
+    return null;
 }
 
 export function evaluateOnViewModel(context: any, expression: string): any {

--- a/src/Framework/Framework/Resources/Scripts/validation/error.ts
+++ b/src/Framework/Framework/Resources/Scripts/validation/error.ts
@@ -20,10 +20,10 @@ export function getErrors<T>(o: KnockoutObservable<T> | null): ValidationError[]
 
 export class ValidationError {
 
-    private constructor(public errorMessage: string, public validatedObservable: KnockoutObservable<any>) {
+    private constructor(public errorMessage: string, public propertyPath: string, public validatedObservable: KnockoutObservable<any>) {
     }
 
-    public static attach(errorMessage: string, observable: KnockoutObservable<any>): ValidationError {
+    public static attach(errorMessage: string, propertyPath: string, observable: KnockoutObservable<any>): ValidationError {
         if (!errorMessage) {
             throw new Error(`String "${errorMessage}" is not a valid ValidationError message.`);
         }
@@ -35,7 +35,7 @@ export class ValidationError {
         if (!unwrapped.hasOwnProperty(errorsSymbol)) {
             unwrapped[errorsSymbol] = [];
         }
-        const error = new ValidationError(errorMessage, unwrapped);
+        const error = new ValidationError(errorMessage, propertyPath, unwrapped);
         unwrapped[errorsSymbol].push(error);
         allErrors.push(error);
         return error;

--- a/src/Framework/Framework/Resources/Scripts/validation/validation.ts
+++ b/src/Framework/Framework/Resources/Scripts/validation/validation.ts
@@ -169,7 +169,7 @@ function validateRecursive(observable: KnockoutObservable<any>, propertyValue: a
         if (!propertyValue) return;
         let i = 0;
         for (const item of propertyValue) {
-            validateRecursive(item, ko.unwrap(item), type[0], propertyPath + "/" + "[" + i + "]");
+            validateRecursive(item, ko.unwrap(item), type[0], `${propertyPath}/[${i}]`);
             i++;
         }
         

--- a/src/Framework/Framework/Resources/Scripts/validation/validation.ts
+++ b/src/Framework/Framework/Resources/Scripts/validation/validation.ts
@@ -11,7 +11,7 @@ import { DotvvmPostbackError } from "../shared-classes"
 import { getObjectTypeInfo } from "../metadata/typeMap"
 import { tryCoerce } from "../metadata/coercer"
 import { primitiveTypes } from "../metadata/primitiveTypes"
-import { lastSetErrorSymbol } from "../state-manager"
+import { currentStateSymbol, lastSetErrorSymbol } from "../state-manager"
 import { logError } from "../utils/logging"
 
 type ValidationSummaryBinding = {
@@ -62,8 +62,9 @@ const runClientSideValidation = (validationTarget: any, options: PostbackOptions
     watchAndTriggerValidationErrorChanged(options,
         () => {
             detachAllErrors();
-            const root = dotvvm.viewModelObservables['root'];
-            const path = evaluator.findPathToChildObject(root, validationTarget, "")!;
+            const root = dotvvm.state;
+            const target = ko.unwrap(validationTarget)[currentStateSymbol];
+            const path = evaluator.findPathToChildObject(root, target, "")!;
             validateViewModel(validationTarget, path);
         });
 }

--- a/src/Framework/Framework/Resources/Scripts/validation/validation.ts
+++ b/src/Framework/Framework/Resources/Scripts/validation/validation.ts
@@ -185,7 +185,7 @@ function validateRecursive(observable: KnockoutObservable<any>, propertyValue: a
             if (Array.isArray(propertyValue)) {
                 let i = 0;
                 for (const item of propertyValue) {
-                    validateRecursive(item, ko.unwrap(item), { type: "dynamic" }, propertyPath + "/" + "[" + i + "]");
+                    validateRecursive(item, ko.unwrap(item), { type: "dynamic" }, `${propertyPath}/[${i}]`);
                     i++;
                 }
             } else if (propertyValue && typeof propertyValue === "object") {


### PR DESCRIPTION
This PR adds property paths into `ValidationError` type. It can be easily inspected in console to quickly determine which part of viewModel is being violated. Property path format is consistent with validation changes introduced in 4.0 (absolute paths from root vm and uses slashes instead of knockout expression syntax). See an example:

![image](https://user-images.githubusercontent.com/12575176/150362706-374a4b96-93ae-40b0-9899-841f182f3ba7.png)