### PR TITLE
Do not throw away leading whitespaces when parsing interpolations

### DIFF
--- a/src/Framework/Framework/Compilation/Parser/Binding/Parser/BindingParser.cs
+++ b/src/Framework/Framework/Compilation/Parser/Binding/Parser/BindingParser.cs
@@ -1194,6 +1194,15 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
             var innerExpressionParser = new BindingParser() { Tokens = innerExpressionTokenizer.Tokens };
             expression = innerExpressionParser.ReadFormattedExpression();
 
+            // For Visual Studio extension we need to know also leading whitespaces
+            // Note that these are by default omitted by binding parser
+            if (innerExpressionTokenizer.Tokens.FirstOrDefault()?.Type == BindingTokenType.WhiteSpace)
+            {
+                var token = innerExpressionTokenizer.Tokens.First();
+                expression.StartPosition -= token.Length;
+                expression.Tokens.Insert(0, token);
+            }
+
             if (expression.HasNodeErrors)
             {
                 error = string.Join(" ", new[] { $"Error while parsing expression \"{rawExpression}\"." }.Concat(expression.NodeErrors));

--- a/src/Tests/Parser/Binding/BindingParserTests.cs
+++ b/src/Tests/Parser/Binding/BindingParserTests.cs
@@ -204,6 +204,18 @@ namespace DotVVM.Framework.Tests.Parser.Binding
         }
 
         [TestMethod]
+        public void BindingParser_InterpolatedString_Expression_WithWhitespaces_StartPositions()
+        {
+            var result = bindingParserNodeFactory.Parse("$'ABC{ x }'") as InterpolatedStringBindingParserNode;
+            Assert.AreEqual(0, result.StartPosition);
+            Assert.AreEqual(6, result.Arguments.First().StartPosition /* $' x ' */);
+            Assert.AreEqual(3, result.Arguments.First().Tokens.Count);
+            Assert.AreEqual(BindingTokenType.WhiteSpace, result.Arguments.First().Tokens.First().Type /* 1 whitespace */);
+            Assert.AreEqual(BindingTokenType.Identifier, result.Arguments.First().Tokens.Skip(1).First().Type /* identifier x */);
+            Assert.AreEqual(BindingTokenType.WhiteSpace, result.Arguments.First().Tokens.Skip(2).First().Type /* 1 whitespace */);
+        }
+
+        [TestMethod]
         public void BindingParser_InterpolatedString_NestedExpressions_StartPositions()
         {
             var result = bindingParserNodeFactory.Parse("$'ABC{$'DEF{'GHI!'}'}'") as InterpolatedStringBindingParserNode;


### PR DESCRIPTION
This PR adds information about leading whitespace token for interpolated expressions. This information is usually thrown away using `SkipWhiteSpace()` method call. However, for VS Extension this information is important - otherwise having interpolations with leading whitespaces can break syntax highlighting.