### PR TITLE
Add AddCssClass and AddCssStyle extension methods for ValueOrBinding

### DIFF
--- a/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
+++ b/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
@@ -130,6 +130,16 @@ namespace DotVVM.Framework.Binding
                 yield return x;
         }
 
+        /// <summary> Return a <see cref="DotvvmProperty" /> defined by this capability with the specified name. `null` is returned if there is no property with the name or if this capability does not have property mapping.
+        /// <code> HtmlGenericControl.HtmlCapabilityProperty.FindProperty("Visible") </code> </summary>
+        public DotvvmProperty? FindProperty(string name) =>
+            PropertyMapping?.FirstOrDefault(p => p.prop.Name == name).dotvvmProperty;
+
+        /// <summary> Return a <see cref="DotvvmPropertyGroup" /> defined by this capability with the specified name. `null` is returned if there is no property with the name or if this capability does not have property mapping.
+        /// <code> HtmlGenericControl.HtmlCapabilityProperty.FindPropertyGroup("Attributes") </code> </summary>
+        public DotvvmPropertyGroup? FindPropertyGroup(string name) =>
+            PropertyGroupMapping?.FirstOrDefault(p => p.prop.Name == name).dotvvmPropertyGroup;
+
         private static void AssertPropertyNotDefined(DotvvmCapabilityProperty p, bool postContent = false)
         {
             if (Find(p.DeclaringType.NotNull(), p.PropertyType, p.Prefix) is {} existingCapability)

--- a/src/Framework/Framework/Binding/ValueOrBinding.cs
+++ b/src/Framework/Framework/Binding/ValueOrBinding.cs
@@ -95,6 +95,12 @@ namespace DotVVM.Framework.Binding
         public static ValueOrBinding<T> DownCast<T2>(ValueOrBinding<T2> createFrom)
             where T2 : T => new ValueOrBinding<T>(createFrom.binding, createFrom.value!);
 
+        /// <summary> Returns a ValueOrBinding with new type T which is a base type of the old T2 </summary>
+        public static ValueOrBinding<T> UpCast(ValueOrBinding createFrom) =>
+            createFrom.BindingOrDefault != null ?
+            new ValueOrBinding<T>(createFrom.BindingOrDefault) :
+            new ValueOrBinding<T>((T)createFrom.BoxedValue!);
+
         /// <summary> Returns a ValueOrBinding with new type T2 which is a derived type of the old T. Will throw an exception if the conversion is not possible. </summary>
         public ValueOrBinding<T2> UpCast<T2>()
             where T2 : T =>

--- a/src/Framework/Framework/Binding/VirtualPropertyGroupDictionary.cs
+++ b/src/Framework/Framework/Binding/VirtualPropertyGroupDictionary.cs
@@ -138,9 +138,9 @@ namespace DotVVM.Framework.Binding
             control.properties.Set(group.GetDotvvmProperty(key), value.UnwrapToObject());
         }
         public void Set(string key, TValue value) =>
-            this.Set(key, new ValueOrBinding<TValue>(value));
+            control.properties.Set(group.GetDotvvmProperty(key), value);
         public void SetBinding(string key, IBinding binding) =>
-            this.Set(key, new ValueOrBinding<TValue>(binding));
+            control.properties.Set(group.GetDotvvmProperty(key), binding);
 
         public bool ContainsKey(string key)
         {

--- a/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.CapabilityCache.cs
+++ b/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.CapabilityCache.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Net;
+using System.Reflection;
+using System.Text;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Compilation.ControlTree;
+using DotVVM.Framework.Configuration;
+using DotVVM.Framework.Hosting;
+using DotVVM.Framework.Utils;
+
+namespace DotVVM.Framework.Controls
+{
+    public static partial class DotvvmBindableObjectHelper
+    {
+        internal class CapabilityPropertyCache<T>
+        {
+            internal readonly static DotvvmCapabilityProperty? HtmlCapabilityProperty =
+                DotvvmCapabilityProperty.Find(typeof(T), typeof(HtmlCapability));
+            internal readonly static DotvvmPropertyGroup? HtmlAttributes =
+                HtmlCapabilityProperty?.FindPropertyGroup(nameof(HtmlCapability.Attributes));
+            internal readonly static DotvvmPropertyGroup? CssClasses =
+                HtmlCapabilityProperty?.FindPropertyGroup(nameof(HtmlCapability.CssClasses));
+            internal readonly static DotvvmPropertyGroup? CssStyles =
+                HtmlCapabilityProperty?.FindPropertyGroup(nameof(HtmlCapability.CssStyles));
+            internal readonly static DotvvmProperty? Visible =
+                HtmlCapabilityProperty?.FindProperty(nameof(HtmlCapability.Visible));
+        }
+
+        /// <summary> Returns a mutable dictionary of html attributes defined in <see cref="HtmlCapability.Attributes" /> </summary>
+        public static VirtualPropertyGroupDictionary<object?> GetHtmlAttributesDictionary<T>(this T control)
+            where T: IObjectWithCapability<HtmlCapability>
+        {
+            var c = CapabilityPropertyCache<T>.HtmlAttributes;
+            if (c is null)
+                throw new ArgumentException($"Type {typeof(T).FullName} does not have HtmlCapability.Attributes with proper mapping.");
+            return new VirtualPropertyGroupDictionary<object?>(control.Self, c);
+        }
+
+        /// <summary> Returns a mutable dictionary of css classes defined in the <see cref="HtmlCapability.CssClasses" /> </summary>
+        public static VirtualPropertyGroupDictionary<bool> GetCssClassesDictionary<T>(this T control)
+            where T: IObjectWithCapability<HtmlCapability>
+        {
+            var c = CapabilityPropertyCache<T>.CssClasses;
+            if (c is null)
+                throw new ArgumentException($"Type {typeof(T).FullName} does not have HtmlCapability.CssClasses with proper mapping.");
+            return new VirtualPropertyGroupDictionary<bool>(control.Self, c);
+        }
+
+        /// <summary> Returns a mutable dictionary of css styles defined in the <see cref="HtmlCapability.CssStyles" /> </summary>
+        public static VirtualPropertyGroupDictionary<object?> GetCssStylesDictionary<T>(this T control)
+            where T: IObjectWithCapability<HtmlCapability>
+        {
+            var c = CapabilityPropertyCache<T>.CssStyles;
+            if (c is null)
+                throw new ArgumentException($"Type {typeof(T).FullName} does not have HtmlCapability.CssStyles with proper mapping.");
+            return new VirtualPropertyGroupDictionary<object?>(control.Self, c);
+        }
+
+        /// <summary> Little hack to convert <see cref="IObjectWithCapability{HtmlCapability}" /> to IControlWithHtmlAttributes, so we can share code paths </summary>
+        internal static ControlAsObjectWithAttributes AsObjectWithHtmlAttributes<T>(this T control)
+            where T: IObjectWithCapability<HtmlCapability>
+        {
+            return new ControlAsObjectWithAttributes(control.GetHtmlAttributesDictionary(), control.Self);
+        }
+        internal struct ControlAsObjectWithAttributes : IControlWithHtmlAttributes, IObjectWithCapability<HtmlCapability>
+        {
+            public ControlAsObjectWithAttributes(VirtualPropertyGroupDictionary<object?> attributes, DotvvmBindableObject self)
+            {
+                Attributes = attributes;
+                Self = self;
+            }
+
+            public VirtualPropertyGroupDictionary<object?> Attributes { get; }
+
+            public DotvvmBindableObject Self { get; }
+        }
+    }
+}

--- a/src/Framework/Framework/Controls/HtmlGenericControl.cs
+++ b/src/Framework/Framework/Controls/HtmlGenericControl.cs
@@ -19,7 +19,7 @@ namespace DotVVM.Framework.Controls
     /// <summary>
     /// A control that represents plain HTML tag.
     /// </summary>
-    public class HtmlGenericControl : DotvvmControl, IControlWithHtmlAttributes
+    public class HtmlGenericControl : DotvvmControl, IControlWithHtmlAttributes, IObjectWithCapability<HtmlCapability>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HtmlGenericControl"/> class.
@@ -87,30 +87,33 @@ namespace DotVVM.Framework.Controls
                 HtmlCapabilityProperty.SetValue(this, html);
         }
 
-        /// <summary>
-        /// Gets the attributes.
-        /// </summary>
+        /// <summary> A dictionary of html attributes that are rendered on this control's html tag. </summary>
         [PropertyGroup(new[] { "", "html:" })]
         public VirtualPropertyGroupDictionary<object?> Attributes => new(this, AttributesGroupDescriptor);
 
+        /// <summary> A dictionary of html attributes that are rendered on this control's html tag. </summary>
         [MarkupOptions(MappingMode = MappingMode.Attribute, AllowBinding = true, AllowHardCodedValue = true, AllowValueMerging = true, AttributeValueMerger = typeof(HtmlAttributeValueMerger), AllowAttributeWithoutValue = true)]
         public static DotvvmPropertyGroup AttributesGroupDescriptor =
             DotvvmPropertyGroup.Register<object, HtmlGenericControl>(new [] { "", "html:" }, nameof(Attributes));
 
+        /// <summary> A dictionary of css classes. All classes whose value is `true` will be placed in the `class` attribute. </summary>
         [PropertyGroup("Class-", ValueType = typeof(bool))]
         public VirtualPropertyGroupDictionary<bool> CssClasses => new(this, CssClassesGroupDescriptor);
 
+        /// <summary> A dictionary of css classes. All classes whose value is `true` will be placed in the `class` attribute. </summary>
         public static DotvvmPropertyGroup CssClassesGroupDescriptor =
             DotvvmPropertyGroup.Register<bool, HtmlGenericControl>("Class-", nameof(CssClasses));
 
+        /// <summary> A dictionary of css styles which will be placed in the `style` attribute. </summary>
         [PropertyGroup("Style-")]
         public VirtualPropertyGroupDictionary<object> CssStyles => new(this, CssStylesGroupDescriptor);
 
+        /// <summary> A dictionary of css styles which will be placed in the `style` attribute. </summary>
         public static DotvvmPropertyGroup CssStylesGroupDescriptor =
             DotvvmPropertyGroup.Register<object, HtmlGenericControl>("Style-", nameof(CssStyles));
 
         /// <summary>
-        /// Gets or sets the inner text of the HTML element.
+        /// Gets or sets the inner text of the HTML element. Note that this property can only be used on HtmlGenericControl directly and when the control does not have any children.
         /// </summary>
         public string? InnerText
         {
@@ -128,7 +131,7 @@ namespace DotVVM.Framework.Controls
         public string? TagName { get; protected set; }
 
         /// <summary>
-        /// Gets or sets whether the control is visible.
+        /// Gets or sets whether the control is visible. When set to false, `style="display: none"` will be added to this control.
         /// </summary>
         [MarkupOptions(AllowHardCodedValue = false)]
         public bool Visible
@@ -575,21 +578,26 @@ namespace DotVVM.Framework.Controls
     [DotvvmControlCapability]
     public sealed record HtmlCapability
     {
+        /// <summary> A dictionary of html attributes that are rendered on this control's html tag. </summary>
         [PropertyGroup("", "html:")]
         [MarkupOptions(MappingMode = MappingMode.Attribute, AllowBinding = true, AllowHardCodedValue = true, AllowValueMerging = true, AttributeValueMerger = typeof(HtmlAttributeValueMerger), AllowAttributeWithoutValue = true)]
         public IDictionary<string, ValueOrBinding<object?>> Attributes { get; init; } = new Dictionary<string, ValueOrBinding<object?>>();
+
+        /// <summary> A dictionary of css classes. All classes which value is `true` will be placed in the `class` attribute. </summary>
         [PropertyGroup("Class-")]
         public IDictionary<string, ValueOrBinding<bool>> CssClasses { get; init; } = new Dictionary<string, ValueOrBinding<bool>>();
-        [PropertyGroup("Style-")]
-        public IDictionary<string, ValueOrBinding<object>> CssStyles { get; init; } = new Dictionary<string, ValueOrBinding<object>>();
-        public ValueOrBinding<bool> Visible { get; init; } = new(true);
 
         public ValueOrBinding<string?> ID { get; init; }
 
 
-
-
         public bool IsEmpty() => Attributes.Count == 0 && CssClasses.Count == 0 && CssStyles.Count == 0 && Visible.ValueOrDefault == true && ID.ValueOrDefault == null;
+
+        /// <summary> A dictionary of css styles which will be placed in the `style` attribute. </summary>
+        [PropertyGroup("Style-")]
+        public IDictionary<string, ValueOrBinding<object?>> CssStyles { get; init; } = new Dictionary<string, ValueOrBinding<object?>>();
+
+        /// <summary> When set to false, `style="display: none"` will be added to this control. </summary>
+        public ValueOrBinding<bool> Visible { get; init; } = new(true);
     }
 
     [DotvvmControlCapability]

--- a/src/Framework/Framework/Controls/HtmlGenericControl.cs
+++ b/src/Framework/Framework/Controls/HtmlGenericControl.cs
@@ -589,8 +589,13 @@ namespace DotVVM.Framework.Controls
 
         public ValueOrBinding<string?> ID { get; init; }
 
-
-        public bool IsEmpty() => Attributes.Count == 0 && CssClasses.Count == 0 && CssStyles.Count == 0 && Visible.ValueOrDefault == true && ID.ValueOrDefault == null;
+        /// <summary> Returns true if all properties are set to default value </summary>
+        public bool IsEmpty() =>
+            Attributes.Count == 0 &&
+            CssClasses.Count == 0 &&
+            CssStyles.Count == 0 &&
+            Visible.HasValue && Visible.ValueOrDefault == true &&
+            ID.HasValue && ID.ValueOrDefault == null;
 
         /// <summary> A dictionary of css styles which will be placed in the `style` attribute. </summary>
         [PropertyGroup("Style-")]

--- a/src/Framework/Framework/Controls/IControlWithHtmlAttributes.cs
+++ b/src/Framework/Framework/Controls/IControlWithHtmlAttributes.cs
@@ -10,6 +10,7 @@ namespace DotVVM.Framework.Controls
     /// </summary>
     public interface IControlWithHtmlAttributes
     {
+        /// <summary> A dictionary of html attributes that are rendered on this control's html tag. </summary>
         VirtualPropertyGroupDictionary<object?> Attributes { get; } 
     }
 }

--- a/src/Tests/ControlTests/CompositeControlTests.cs
+++ b/src/Tests/ControlTests/CompositeControlTests.cs
@@ -233,6 +233,22 @@ namespace DotVVM.Framework.Tests.ControlTests
             Assert.AreEqual("Control type DotVVM.Framework.Controls.HtmlGenericControl can't be used in collection of type DotVVM.Framework.Controls.Repeater.", e.Message);
         }
 
+        [TestMethod]
+        public async Task ClassBindingControl()
+        {
+            var r = await cth.RunPage(typeof(BasicTestViewModel), @"
+                <!-- Active=false -->
+                <cc:ClassBindingControl Active=false />
+                <!-- Active=true -->
+                <cc:ClassBindingControl Active Width=100 />
+                <!-- bindings -->
+                <cc:ClassBindingControl Active={value: Integer > 100} Width={value: Integer} />
+                "
+            );
+
+            check.CheckString(r.FormattedHtml, fileExtension: "html");
+        }
+
         public class BasicTestViewModel: DotvvmViewModelBase
         {
             [Bind(Name = "int")]
@@ -509,6 +525,18 @@ namespace DotVVM.Framework.Tests.ControlTests
         )
         {
             return new Literal(repeaters.Count().ToString());
+        }
+    }
+    public class ClassBindingControl: CompositeControl
+    {
+        public static DotvvmControl GetContents(
+            ValueOrBinding<bool> active,
+            ValueOrBinding<int>? width
+        )
+        {
+            return new HtmlGenericControl("div")
+                .AddCssClass("is-active", active)
+                .AddCssStyle("width", width);
         }
     }
 }

--- a/src/Tests/ControlTests/testoutputs/CompositeControlTests.ClassBindingControl.html
+++ b/src/Tests/ControlTests/testoutputs/CompositeControlTests.ClassBindingControl.html
@@ -1,0 +1,14 @@
+<html>
+	<head></head>
+	<body>
+		
+		<!-- Active=false -->
+		<div></div>
+		
+		<!-- Active=true -->
+		<div class="is-active" style="width:100"></div>
+		
+		<!-- bindings -->
+		<div class="is-active" data-bind="css: { &quot;is-active&quot;: int() > 100 }, style: { width: int }" style="width:10000000"></div>
+	</body>
+</html>


### PR DESCRIPTION
Some not very nice code has to be used in Fluent UI and BS5 for this,
so it would be nice to have this helper.

In order for AddCssClass to work with any html control, not only
HtmlGenericControl, generic mechanism for handling property
groups from capabilies was introduced
 - see DotvvmCapabilityProperty.FindProperty
 - and see DotvvmBindableObjectHelper.CapabilityCache.cs

the FindProperty can lookup any property from a specified capability.
The CapabilityCache makes it reasonably fast specifically for
HtmlCapability