### PR TITLE
Remove breaking change in HtmlLiteral

### DIFF
--- a/src/Framework/Framework/Controls/HtmlLiteral.cs
+++ b/src/Framework/Framework/Controls/HtmlLiteral.cs
@@ -39,7 +39,7 @@ namespace DotVVM.Framework.Controls
 
             if (!RenderWrapperTag && !RenderOnServer && HasValueBinding(HtmlProperty))
             {
-                throw new DotvvmControlException(this, "The HtmlLiteral control doesn't support client-side rendering without wrapper tag. Enable server rendering or the wrapper tag.");
+                throw new DotvvmControlException(this, "The HtmlLiteral control doesn't support client-side rendering without wrapper tag. Use resource binding to render the value on server or allow the wrapper tag.");
             }
             
             if (RenderWrapperTag && HasValueBinding(HtmlProperty))

--- a/src/Tests/ControlTests/DotvvmErrorTests.cs
+++ b/src/Tests/ControlTests/DotvvmErrorTests.cs
@@ -13,6 +13,7 @@ using DotVVM.Framework.ViewModel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using DotVVM.Framework.Testing;
+using DotVVM.Framework.Tests.Runtime;
 
 namespace DotVVM.Framework.Tests.ControlTests
 {
@@ -41,6 +42,28 @@ namespace DotVVM.Framework.Tests.ControlTests
 
             Assert.AreEqual("Cannot find resource named 'ResourceDoesNotExist' referenced by the @js directive!", r.Message);
             Assert.AreEqual("ResourceDoesNotExist", r.AffectedSpans.Single().Trim());
+        }
+
+        [TestMethod]
+        public async Task HtmlLiteral_InvalidWrapperTagUsage()
+        {
+            await check.CheckExceptionAsync(() =>
+                cth.RunPage(typeof(object), @" <dot:HtmlLiteral Html='' RenderWrapperTag=false WrapperTagName=span />"));
+        }
+
+        [TestMethod]
+        public async Task HtmlLiteral_InvalidWrapperTagUsage2()
+        {
+            var e = await Assert.ThrowsExceptionAsync<DotvvmControlException>(() =>
+                cth.RunPage(typeof(object), @" <dot:HtmlLiteral Html='' RenderWrapperTag=false class=my-class />"));
+            Assert.AreEqual("Cannot set HTML attributes, Visible, ID, Postback.Update, ... bindings on a control which does not render its own element!", e.Message);
+        }
+
+        [TestMethod]
+        public async Task AuthView_InvalidWrapperTagUsage()
+        {
+            await check.CheckExceptionAsync(() =>
+                cth.RunPage(typeof(object), @" <dot:AuthenticatedView WrapperTagName=span> </dot:AuthenticatedView>"));
         }
     }
 }

--- a/src/Tests/ControlTests/SimpleControlTests.cs
+++ b/src/Tests/ControlTests/SimpleControlTests.cs
@@ -349,6 +349,22 @@ namespace DotVVM.Framework.Tests.ControlTests
             check.CheckString(r.FormattedHtml, fileExtension: "html");
         }
 
+        [TestMethod]
+        public async Task HtmlLiteral()
+        {
+            var r = await cth.RunPage(typeof(BasicTestViewModel), @"
+                <!-- Static text -->
+                <dot:HtmlLiteral class=c1 Html='some text' />
+                <!-- Resource binding -->
+                <dot:HtmlLiteral class=c1 Html={resource: Label} />
+                <!-- Value binding in <span> -->
+                <dot:HtmlLiteral class=c1 Html={value: Label} WrapperTagName=span />
+                <!-- Static text, no wrapper -->
+                <dot:HtmlLiteral Html='some text' RenderWrapperTag=false />
+            ");
+            check.CheckString(r.FormattedHtml, fileExtension: "html");
+        }
+
         public class BasicTestViewModel: DotvvmViewModelBase
         {
             [Bind(Name = "int")]

--- a/src/Tests/ControlTests/testoutputs/DotvvmErrorTests.AuthView_InvalidWrapperTagUsage.txt
+++ b/src/Tests/ControlTests/testoutputs/DotvvmErrorTests.AuthView_InvalidWrapperTagUsage.txt
@@ -1,0 +1,2 @@
+DotvvmCompilationException occurred: Validation error in AuthenticatedView at line 6: The WrapperTagName property cannot be set when RenderWrapperTag is false!
+    at void DotVVM.Framework.Compilation.Validation.ControlUsageValidationVisitor.VisitAndAssert(ResolvedTreeRoot view)

--- a/src/Tests/ControlTests/testoutputs/DotvvmErrorTests.HtmlLiteral_InvalidWrapperTagUsage.txt
+++ b/src/Tests/ControlTests/testoutputs/DotvvmErrorTests.HtmlLiteral_InvalidWrapperTagUsage.txt
@@ -1,0 +1,2 @@
+DotvvmCompilationException occurred: Validation error in HtmlLiteral at line 6: The WrapperTagName property cannot be set when RenderWrapperTag is false!
+    at void DotVVM.Framework.Compilation.Validation.ControlUsageValidationVisitor.VisitAndAssert(ResolvedTreeRoot view)

--- a/src/Tests/ControlTests/testoutputs/DotvvmErrorTests.HtmlLiteral_InvalidWrapperTagUsage2.txt
+++ b/src/Tests/ControlTests/testoutputs/DotvvmErrorTests.HtmlLiteral_InvalidWrapperTagUsage2.txt
@@ -1,0 +1,2 @@
+DotvvmControlException occurred: Cannot set HTML attributes, Visible, ID, Postback.Update, ... bindings on a control which does not render its own element!
+    at void DotVVM.Framework.Controls.HtmlGenericControl.EnsureNoAttributesSet(in RenderState r)

--- a/src/Tests/ControlTests/testoutputs/SimpleControlTests.HtmlLiteral.html
+++ b/src/Tests/ControlTests/testoutputs/SimpleControlTests.HtmlLiteral.html
@@ -1,0 +1,16 @@
+<html>
+	<head></head>
+	<body>
+		
+		<!-- Static text -->
+		<div class="c1">some text</div>
+		
+		<!-- Resource binding -->
+		<div class="c1">My Label</div>
+		
+		<!-- Value binding in <span> -->
+		<span class="c1" data-bind="html: Label"></span>
+		
+		<!-- Static text, no wrapper -->                 some text
+	</body>
+</html>

--- a/src/Tests/Runtime/RuntimeErrorTests.cs
+++ b/src/Tests/Runtime/RuntimeErrorTests.cs
@@ -22,6 +22,7 @@ using DotVVM.Framework.Utils;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.Compilation;
 using DotVVM.Framework.Testing;
+using System.Threading.Tasks;
 
 namespace DotVVM.Framework.Tests.Runtime
 {
@@ -46,6 +47,21 @@ namespace DotVVM.Framework.Tests.Runtime
                 else
                     return $"{msg}\n\n{inner}";
             }
+        }
+
+        public static async Task CheckExceptionAsync(this OutputChecker check, Func<Task> action, string checkName = null, string fileExtension = "txt", [CallerMemberName] string memberName = null, [CallerFilePath] string sourceFilePath = null)
+        {
+            try
+            {
+                await action();
+            }
+            catch (Exception exception)
+            {
+                var error = FormatException(exception);
+                check.CheckString(error, checkName, fileExtension, memberName, sourceFilePath);
+                return;
+            }
+            throw new Exception("Expected test to fail.");
         }
 
         public static void CheckException(this OutputChecker check, Action action, string checkName = null, string fileExtension = "txt", [CallerMemberName] string memberName = null, [CallerFilePath] string sourceFilePath = null)


### PR DESCRIPTION
We added too strict control validator to ConfigurableHtmlControl,
this commit only allows parts of it if it's certain
that the markup will produce a runtime error.