### PR TITLE
Deprecate StaticCommandJavascriptProperty

### DIFF
--- a/src/Framework/Framework/Binding/BindingProperties.cs
+++ b/src/Framework/Framework/Binding/BindingProperties.cs
@@ -70,6 +70,7 @@ namespace DotVVM.Framework.Binding.Properties
     /// <summary>
     /// Contains JS code, that will invoke the static command. May contain symbolic parameters from `JavascriptTranslator` and `CommandBindingExpression`
     /// </summary>
+    [Obsolete("Deprecated in favor of StaticCommandOptionsLambdaJavascriptProperty. It should contain the same code as this property, but wrapped in a lambda function taking PostbackOption. It will use options.knockoutContext and options.viewModel instead of ko.contextFor(this)")]
     public sealed record StaticCommandJavascriptProperty(
         ParametrizedCode Code
     );

--- a/src/Framework/Framework/Binding/Expressions/StaticCommandBindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/StaticCommandBindingExpression.cs
@@ -11,21 +11,18 @@ using DotVVM.Framework.Runtime.Filters;
 namespace DotVVM.Framework.Binding.Expressions
 {
     [BindingCompilationRequirements(
-        required: new[] { typeof(StaticCommandJavascriptProperty), /*typeof(BindingDelegate)*/ }
+        required: new[] { typeof(StaticCommandOptionsLambdaJavascriptProperty), /*typeof(BindingDelegate)*/ }
     )]
     [Options]
     public class StaticCommandBindingExpression : BindingExpression, IStaticCommandBinding
     {
         public StaticCommandBindingExpression(BindingCompilationService service, IEnumerable<object> properties) : base(service, properties) { }
 
-        private protected MaybePropValue<StaticCommandJavascriptProperty> staticCommandJs;
         private protected MaybePropValue<StaticCommandOptionsLambdaJavascriptProperty> staticCommandLambdaJs;
         private protected MaybePropValue<ActionFiltersBindingProperty> actionFilters;
 
         private protected override void StoreProperty(object p)
         {
-            if (p is StaticCommandJavascriptProperty staticCommandJs)
-                this.staticCommandJs.SetValue(new(staticCommandJs));
             if (p is StaticCommandOptionsLambdaJavascriptProperty staticCommandLambdaJs)
                 this.staticCommandLambdaJs.SetValue(new(staticCommandLambdaJs));
             if (p is ActionFiltersBindingProperty actionFilters)
@@ -36,8 +33,6 @@ namespace DotVVM.Framework.Binding.Expressions
 
         public override object? GetProperty(Type type, ErrorHandlingMode errorMode = ErrorHandlingMode.ThrowException)
         {
-            if (type == typeof(StaticCommandJavascriptProperty))
-                return staticCommandJs.GetValue(this).GetValue(errorMode, this, type);
             if (type == typeof(StaticCommandOptionsLambdaJavascriptProperty))
                 return staticCommandLambdaJs.GetValue(this).GetValue(errorMode, this, type);
             if (type == typeof(ActionFiltersBindingProperty))
@@ -47,7 +42,6 @@ namespace DotVVM.Framework.Binding.Expressions
 
         private protected override IEnumerable<object?> GetOutOfDictionaryProperties() =>
             base.GetOutOfDictionaryProperties().Concat(new object?[] {
-                staticCommandJs.Value.Value,
                 staticCommandLambdaJs.Value.Value,
                 actionFilters.Value.Value,
             });
@@ -57,7 +51,9 @@ namespace DotVVM.Framework.Binding.Expressions
 
         public BindingDelegate BindingDelegate => this.bindingDelegate.GetValueOrThrow(this);
 
-        public ParametrizedCode CommandJavascript => staticCommandJs.GetValueOrThrow(this).Code;
+        [Obsolete("StaticCommandBindingExpression.CommandJavascript is no longer supported. Use KnockoutHelper.GenerateClientPostBackExpression instead.")]
+        public ParametrizedCode CommandJavascript =>
+            this.GetProperty<StaticCommandJavascriptProperty>().Code;
 
         public ParametrizedCode OptionsLambdaJavascript => staticCommandLambdaJs.GetValueOrThrow(this).Code;
 

--- a/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
+++ b/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
@@ -352,6 +352,7 @@ namespace DotVVM.Framework.Compilation.Binding
         public StaticCommandJsAstProperty CompileStaticCommand(DataContextStack dataContext, CastedExpressionBindingProperty expression) =>
             new StaticCommandJsAstProperty(this.staticCommandBindingCompiler.CompileToJavascript(dataContext, expression.Expression));
 
+        [Obsolete("Deprecated in favor of StaticCommandOptionsLambdaJavascriptProperty.")]
         public StaticCommandJavascriptProperty FormatStaticCommand(StaticCommandJsAstProperty code) =>
             new StaticCommandJavascriptProperty(FormatJavascript(code.Expression, allowObservableResult: false, configuration.Debug, AddNullChecks));
 


### PR DESCRIPTION
it's no longer used, we use StaticCommandOptionsLambdaJavascriptProperty
everywhere now and it's existence is only confusing
some users (@quigamdev)