### PR TITLE
Fix type conversion from value to Task<Value>.

### DIFF
--- a/src/Framework/Framework/Compilation/Binding/TypeConversions.cs
+++ b/src/Framework/Framework/Compilation/Binding/TypeConversions.cs
@@ -171,7 +171,8 @@ namespace DotVVM.Framework.Compilation.Binding
                   NullableConversion(src, destType) ??
                   NullLiteralConversion(src, destType) ??
                   BoxingConversion(src, destType) ??
-                  ReferenceConversion(src, destType);
+                  ReferenceConversion(src, destType) ??
+                  TaskConversion(src, destType);
             if (allowToString && destType == typeof(string) && result == null)
             {
                 result = ToStringConversion(src);

--- a/src/Tests/Binding/StaticCommandCompilationTests.cs
+++ b/src/Tests/Binding/StaticCommandCompilationTests.cs
@@ -233,6 +233,17 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        public void StaticCommandCompilation_TaskConversion()
+        {
+            var result = CompileBinding("injectedService.Load()", niceMode: true, new[] { typeof(TestViewModel) }, expectedType: typeof(Task<object>));
+
+            Console.WriteLine(result);
+            var control = @"await dotvvm.staticCommandPostback(""XXXX"", [], options)";
+
+            AreEqual(control, result);
+        }
+
+        [TestMethod]
         public void StaticCommandCompilation_ExpressionBetweenPostbacks_WithParameters()
         {
             var result = CompileBinding("StringProp = injectedService.Load(StringProp, StringProp); \"Test\"; StringProp = injectedService.Load(StringProp)", niceMode: false, new[] { typeof(TestViewModel) });


### PR DESCRIPTION
This is a regression in staticCommands, it was allowed previously
(I don't really understand why), It occurs only when the
command is declared of type Task<T> instead of Func<Task<T>>,
but people used to do this (in BP TreeView), so this adds the
support back.