### PR TITLE
Adjusted validation API and added documentation

### DIFF
--- a/src/Framework/Framework/ViewModel/Validation/DotvvmRequestContextValidationExtensions.cs
+++ b/src/Framework/Framework/ViewModel/Validation/DotvvmRequestContextValidationExtensions.cs
@@ -8,6 +8,10 @@ namespace DotVVM.Framework.ViewModel.Validation
 {
     public static class DotvvmRequestContextValidationExtensions
     {
+        /// <summary>
+        /// Adds a new validation error with the given message and attaches it to the root viewmodel.
+        /// </summary>
+        /// <param name="message">Validation error message</param>
         public static ViewModelValidationError AddModelError(this IDotvvmRequestContext context, string message)
         {
             var error = new ViewModelValidationError(message)
@@ -19,6 +23,13 @@ namespace DotVVM.Framework.ViewModel.Validation
             return error;
         }
 
+        /// <summary>
+        /// Adds a new raw validation error. This method is intended only for advanced use-cases and it partially bypasses the validation framework. 
+        /// Users of this method must provide an absolute validation path from the root viewmodel. Individual path segments need to be delimited using the '/' character. 
+        /// Example 1) /Customer/Id. Example 2) /Items/0/Price.
+        /// </summary>
+        /// <param name="absolutePath">Absolute validation path from the root viewmodel</param>
+        /// <param name="message">Validation error message</param>
         public static ViewModelValidationError AddRawModelError(this IDotvvmRequestContext context, string absolutePath, string message)
         {
             EnsurePathIsRooted(absolutePath);
@@ -31,6 +42,13 @@ namespace DotVVM.Framework.ViewModel.Validation
             return error;
         }
 
+        /// <summary>
+        /// Adds a new validation error with the given message and attaches it to the property determined by the provided expression. 
+        /// The target property must be reachable from the root viewmodel, otherwise the error won't be attached.
+        /// </summary>
+        /// <param name="vm">Viewmodel or one of its descendants (reachable objects)</param>
+        /// <param name="expression">Expression that determines the target property from the provided object</param>
+        /// <param name="message">Validation error message</param>
         public static ViewModelValidationError AddModelError<T, TProp>(this IDotvvmRequestContext context, T vm, Expression<Func<T, TProp>> expression, string message)
         {
             var lambdaExpression = (LambdaExpression)expression;

--- a/src/Framework/Framework/ViewModel/Validation/DotvvmRequestContextValidationExtensions.cs
+++ b/src/Framework/Framework/ViewModel/Validation/DotvvmRequestContextValidationExtensions.cs
@@ -19,13 +19,13 @@ namespace DotVVM.Framework.ViewModel.Validation
             return error;
         }
 
-        public static ViewModelValidationError AddModelError(this IDotvvmRequestContext context, string propertyPath, string message)
+        public static ViewModelValidationError AddRawModelError(this IDotvvmRequestContext context, string absolutePath, string message)
         {
-            EnsurePathIsRooted(propertyPath);
+            EnsurePathIsRooted(absolutePath);
             var error = new ViewModelValidationError(message)
             {
                 IsResolved = true,
-                PropertyPath = propertyPath ?? "/"
+                PropertyPath = absolutePath ?? "/"
             };
             context.ModelState.ErrorsInternal.Add(error);
             return error;

--- a/src/Framework/Framework/ViewModel/Validation/ValidationErrorFactory.cs
+++ b/src/Framework/Framework/ViewModel/Validation/ValidationErrorFactory.cs
@@ -21,10 +21,23 @@ namespace DotVVM.Framework.ViewModel.Validation
 {
     public static class ValidationErrorFactory
     {
+        /// <summary>
+        /// Adds a new validation error with the given message and attaches it to the provided viewmodel. 
+        /// The target viewmodel must be reachable from the root viewmodel, otherwise the error won't be attached.
+        /// </summary>
+        /// <param name="vm">Viewmodel</param>
+        /// <param name="message">Validation error message</param>
         public static ViewModelValidationError AddModelError<T>(this T vm, string message)
             where T : class, IDotvvmViewModel
             => vm.Context.AddModelError(vm, a => a, message);
 
+        /// <summary>
+        /// Adds a new validation error with the given message and attaches it to the property determined by the provided expression. 
+        /// The target property must be reachable from the root viewmodel, otherwise the error won't be attached.
+        /// </summary>
+        /// <param name="vm">Viewmodel or one of its descendant (reachable objects)</param>
+        /// <param name="expr">Expression that determines the target property from the provided object</param>
+        /// <param name="message">Validation error message</param>
         public static ViewModelValidationError AddModelError<T, TProp>(this T vm, Expression<Func<T, TProp>> expr, string message)
             where T : IDotvvmViewModel
         {

--- a/src/Tests/ViewModel/ViewModelValidatorTests.cs
+++ b/src/Tests/ViewModel/ViewModelValidatorTests.cs
@@ -265,7 +265,7 @@ namespace DotVVM.Framework.Tests.ViewModel
             var validationTarget = testViewModel;
             modelState.ValidationTarget = validationTarget;
 
-            testViewModel.Context.AddModelError("Child()", "Validation target path as a knockout expression");
+            testViewModel.Context.AddRawModelError("Child()", "Validation target path as a knockout expression");
             var errors = validator.ValidateViewModel(validationTarget).OrderBy(n => n.PropertyPath);
             modelState.ErrorsInternal.AddRange(errors);
             expander.Expand(modelState, testViewModel);
@@ -404,7 +404,7 @@ namespace DotVVM.Framework.Tests.ViewModel
             var validationTarget = testViewModel;
             modelState.ValidationTarget = validationTarget;
 
-            context.AddModelError(path, "Invalid error path");
+            context.AddRawModelError(path, "Invalid error path");
 
             var errors = validator.ValidateViewModel(validationTarget).OrderBy(n => n.PropertyPath);
             modelState.ErrorsInternal.AddRange(errors);


### PR DESCRIPTION
This PR makes one more change to the validation API and introduces documentation comments for the API.

Right now users can easily end up in a weird situation. Previously, some documentation pages suggested adding validation errors similarly to this: `Context.AddModelError(nameof(MyProperty), "Something wrong with MyProperty")`. This however, uses the old way of providing validation paths. Therefore, right now such usage throws an exception that you are probably attempting to provide a knockout expression which is no longer supported.

In order to make it easier for users (i.e. discover this change during compilation rather than during runtime), I renamed the method to `AddRawModelError(string, string)`. Furthermore, I added documentation comments to better capture in the code what methods should be used under what circumstances.