### PR TITLE
Throw an error when an orphaned property group is present

### DIFF
--- a/src/Framework/Framework/Binding/DotvvmProperty.cs
+++ b/src/Framework/Framework/Binding/DotvvmProperty.cs
@@ -421,7 +421,7 @@ namespace DotVVM.Framework.Binding
             var properties =
                (from p in controlType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
                 where !registeredProperties.ContainsKey((p.DeclaringType!, p.Name))
-                where p.GetCustomAttribute<PropertyGroupAttribute>() == null
+                where !p.IsDefined(typeof(PropertyGroupAttribute))
                 let markupOptions = p.GetCustomAttribute<MarkupOptionsAttribute>()
                 where markupOptions != null && markupOptions.MappingMode != MappingMode.Exclude
                 select p).ToArray();

--- a/src/Framework/Framework/Compilation/ControlTree/ControlResolverMetadata.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ControlResolverMetadata.cs
@@ -43,6 +43,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
         protected override void LoadProperties(Dictionary<string, IPropertyDescriptor> result)
         {
             DotvvmProperty.CheckAllPropertiesAreRegistered(controlType.Type);
+            DotvvmPropertyGroup.CheckAllPropertiesAreRegistered(controlType.Type);
             foreach (var property in DotvvmProperty.ResolveProperties(controlType.Type))
             {
                 result.Add(property.Name, property);

--- a/src/Framework/Framework/Compilation/ControlTree/DotvvmPropertyGroup.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/DotvvmPropertyGroup.cs
@@ -169,6 +169,22 @@ namespace DotVVM.Framework.Compilation.ControlTree
             }
         }
 
+        public static void CheckAllPropertiesAreRegistered(Type controlType)
+        {
+            var properties =
+               (from p in controlType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                where !descriptorDictionary.ContainsKey((p.DeclaringType!, p.Name))
+                where p.IsDefined(typeof(PropertyGroupAttribute))
+                select p).ToArray();
+
+            if (properties.Any())
+            {
+                var deprecationHelp = " DotVVM version <= 3.x did support this, but this feature was removed as it lead to many issues. Please register the property group using DotvvmPropertyGroup.Register and then use VirtualPropertyGroupDictionary<T> to access the values.";
+                throw new NotSupportedException($"Control '{controlType.Name}' has property groups that are not registered: {string.Join(", ", properties.Select(p => p.Name))}." + deprecationHelp);
+            }
+        }
+
+
         public struct PrefixArray
         {
             public readonly string[] Values;

--- a/src/Framework/Framework/Compilation/Styles/ResolvedControlHelper.cs
+++ b/src/Framework/Framework/Compilation/Styles/ResolvedControlHelper.cs
@@ -78,6 +78,7 @@ namespace DotVVM.Framework.Compilation.Styles
             }
 
             DotvvmProperty.CheckAllPropertiesAreRegistered(type);
+            DotvvmPropertyGroup.CheckAllPropertiesAreRegistered(type);
 
             return rc;
         }

--- a/src/Framework/Framework/ViewModel/IDotvvmViewModel.cs
+++ b/src/Framework/Framework/ViewModel/IDotvvmViewModel.cs
@@ -8,13 +8,15 @@ namespace DotVVM.Framework.ViewModel
 {
     public interface IDotvvmViewModel
     {
-
         IDotvvmRequestContext Context { get; set; }
 
+        /// <summary> Initializes the view model. Called by DotVVM before incoming JSON viewmodel is deserialized. </summary>
         Task Init();
 
+        /// <summary> Loads additional data into the view model. Called by DotVVM after viewmodel is deserialized and before command is invoked. </summary>
         Task Load();
 
+        /// <summary> Called by DotVVM after the command is invoked and before output is rendered. Useful for re-loading data after the command is invoked (for example, after new page index is changed). </summary>
         Task PreRender();
 
     }

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolverTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolverTests.cs
@@ -625,6 +625,16 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
             Assert.IsInstanceOfType(exception.InnerException, typeof(NotSupportedException));
             StringAssert.Contains(exception.InnerException.Message, "Control 'ClassWithDefaultDotvvmControlContent_NoDotvvmProperty' has properties that are not registered as a DotvvmProperty but have a MarkupOptionsAttribute: Property.");
         }
+        
+        [TestMethod]
+        public void ResolvedTree_VirtualPropertyGroupsNotSupported()
+        {
+            var exception = Assert.ThrowsException<NotSupportedException>(() => ParseSource(@"
+@viewModel object
+<cc:ClassWithUnsupportedPropertyGroup />"));
+            // Assert.IsInstanceOfType(exception, typeof(NotSupportedException));
+            StringAssert.Contains(exception.Message, "Control 'ClassWithUnsupportedPropertyGroup' has property groups that are not registered: MyGroup");
+        }
 
         [TestMethod]
         public void ResolvedTree_GridViewWithColumns()
@@ -807,6 +817,11 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
     {
         [MarkupOptions(MappingMode = MappingMode.InnerElement)]
         public List<DotvvmControl> Property { get; set; }
+    }
+    public class ClassWithUnsupportedPropertyGroup: HtmlGenericControl
+    {
+        [PropertyGroup("MyGroup:")]
+        public Dictionary<string, bool> MyGroup { get; set; }
     }
 
     [DataContextChanger]


### PR DESCRIPTION
It's an indication that the deprecated method
of declaring property groups has been used,
so it's better to throw an error informing the user what to do
than just silently ignore the property.