### PR TITLE
Added pdb files to nuget packages

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -39,6 +39,8 @@
     <DefaultTargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.1;net6.0</DefaultTargetFrameworks>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
+    <!-- Pack pdb symbol files -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(DOTVVM_ROOT) != ''">


### PR DESCRIPTION
This PR changes the way we bundle nuget packages by including pdb files. This should enhance debugging experience and also show some more information on error pages.