### PR TITLE
 Better error message in TextOrContentCapability

### DIFF
--- a/src/Framework/Framework/Controls/TextOrContentCapability.cs
+++ b/src/Framework/Framework/Controls/TextOrContentCapability.cs
@@ -47,6 +47,11 @@ namespace DotVVM.Framework.Controls
 
         public IEnumerable<DotvvmControl> ToControls()
         {
+            if(Text.HasValue && Content == null)
+            {
+                throw new DotvvmControlException(control, "Either Text property or Content must be set.");
+            }
+            
             if (Text.HasValue)
                 return new DotvvmControl[] { new Literal(Text.Value) };
             else


### PR DESCRIPTION
Either Text property or Content must be set - DotvvmControlException added