### PR TITLE
remove implicit conversion to ValueOrBinding<T>

### DIFF
--- a/src/Framework/Framework/Binding/ValueOrBinding.cs
+++ b/src/Framework/Framework/Binding/ValueOrBinding.cs
@@ -154,7 +154,7 @@ namespace DotVVM.Framework.Binding
                 return processValue(this.Evaluate(control)!);
         }
 
-        public static implicit operator ValueOrBinding<T>(T val) => new ValueOrBinding<T>(val);
+        public static explicit operator ValueOrBinding<T>(T val) => new ValueOrBinding<T>(val);
 
         public const string EqualsDisabledReason = "Equals is disabled on ValueOrBinding<T> as it may lead to unexpected behavior. Please use object.ReferenceEquals for reference comparison or evaluate the ValueOrBinding<T> and compare the value. Or use IsNull/NotNull for nullchecks on bindings.";
         [Obsolete(EqualsDisabledReason, error: true)]

--- a/src/Framework/Framework/Binding/ValueOrBindingExtensions.cs
+++ b/src/Framework/Framework/Binding/ValueOrBindingExtensions.cs
@@ -32,7 +32,7 @@ public static class ValueOrBindingExtensions
                 binding.GetProperty<NegatedBindingExpression>().Binding
             );
         else
-            return !v.ValueOrDefault;
+            return new(!v.ValueOrDefault);
     }
     /// <summary> Returns ValueOrBinding with the value of `!a`. The resulting binding is cached, so it's safe to use this method at runtime. </summary>
     public static ValueOrBinding<bool?> Negate(this ValueOrBinding<bool?> v)
@@ -42,7 +42,7 @@ public static class ValueOrBindingExtensions
                 binding.GetProperty<NegatedBindingExpression>().Binding
             );
         else
-            return !v.ValueOrDefault;
+            return new(!v.ValueOrDefault);
     }
     /// <summary> Returns a binding with the value of `!bindingValue`. The resulting binding is cached, so it's safe to use this method at runtime. </summary>
     public static T Negate<T>(this T binding)
@@ -58,7 +58,7 @@ public static class ValueOrBindingExtensions
                 binding.GetProperty<IsMoreThanZeroBindingProperty>().Binding
             );
         else
-            return v.ValueOrDefault > 0;
+            return new(v.ValueOrDefault > 0);
     }
     /// <summary> Returns ValueOrBinding with the value of `a.Items` where a is grid view dataset. The resulting binding is cached, so it's safe to use this method at runtime. </summary>
     public static ValueOrBinding<IList<T>> GetItems<T>(this ValueOrBinding<IBaseGridViewDataSet<T>> v)
@@ -119,9 +119,9 @@ public static class ValueOrBindingExtensions
     public static ValueOrBinding<bool> And(this ValueOrBinding<bool> a, ValueOrBinding<bool> b)
     {
         if (a.HasValue)
-            return a.ValueOrDefault ? b : false;
+            return a.ValueOrDefault ? b : new(false);
         if (b.HasValue)
-            return b.ValueOrDefault ? a : false;
+            return b.ValueOrDefault ? a : new(false);
         return new(BindingCombinator.GetCombination(
             BindingCombinator.AndAlsoCombination,
             a.BindingOrDefault,
@@ -132,9 +132,9 @@ public static class ValueOrBindingExtensions
     public static ValueOrBinding<bool> Or(this ValueOrBinding<bool> a, ValueOrBinding<bool> b)
     {
         if (a.HasValue)
-            return a.ValueOrDefault ? true : b;
+            return a.ValueOrDefault ? new(true) : b;
         if (b.HasValue)
-            return b.ValueOrDefault ? true : a;
+            return b.ValueOrDefault ? new(true) : a;
         return new(BindingCombinator.GetCombination(
             BindingCombinator.OrElseCombination,
             a.BindingOrDefault,

--- a/src/Framework/Framework/Binding/VirtualPropertyGroupDictionary.cs
+++ b/src/Framework/Framework/Binding/VirtualPropertyGroupDictionary.cs
@@ -137,6 +137,10 @@ namespace DotVVM.Framework.Binding
         {
             control.properties.Set(group.GetDotvvmProperty(key), value.UnwrapToObject());
         }
+        public void Set(string key, TValue value) =>
+            this.Set(key, new ValueOrBinding<TValue>(value));
+        public void SetBinding(string key, IBinding binding) =>
+            this.Set(key, new ValueOrBinding<TValue>(binding));
 
         public bool ContainsKey(string key)
         {
@@ -159,8 +163,8 @@ namespace DotVVM.Framework.Binding
             if (!control.properties.TryAdd(prop, val))
                 AddOnConflict(prop, val);
         }
-        void IDictionary<string, TValue>.Add(string key, TValue value) =>
-            this.Add(key, value);
+        public void Add(string key, TValue value) =>
+            this.Add(key, new ValueOrBinding<TValue>(value));
 
         public void AddBinding(string key, IBinding? binding)
         {

--- a/src/Framework/Framework/Compilation/Styles/StyleBuilderMethods.Helpers.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleBuilderMethods.Helpers.cs
@@ -34,7 +34,7 @@ public static partial class StyleBuilderExtensionMethods
     public static T ReplaceWith<T, TControl>(
         this T sb,
         TControl newControl,
-        Action<StyleBuilder<TControl>>? styleBuilder = null,
+        Action<IStyleBuilder<TControl>>? styleBuilder = null,
         StyleOverrideOptions options = StyleOverrideOptions.Overwrite)
         where T: IStyleBuilder
         where TControl: DotvvmBindableObject =>
@@ -57,7 +57,7 @@ public static partial class StyleBuilderExtensionMethods
     public static T WrapWith<T, TControl>(
         this T sb,
         TControl wrapperControl,
-        Action<StyleBuilder<TControl>>? styleBuilder = null,
+        Action<IStyleBuilder<TControl>>? styleBuilder = null,
         StyleOverrideOptions options = StyleOverrideOptions.Append)
         where T: IStyleBuilder
         where TControl: DotvvmBindableObject =>
@@ -80,7 +80,7 @@ public static partial class StyleBuilderExtensionMethods
     public static T Append<T, TControl>(
         this T sb,
         TControl control,
-        Action<StyleBuilder<TControl>>? styleBuilder = null,
+        Action<IStyleBuilder<TControl>>? styleBuilder = null,
         StyleOverrideOptions options = StyleOverrideOptions.Append)
         where T: IStyleBuilder
         where TControl: DotvvmBindableObject =>
@@ -103,7 +103,7 @@ public static partial class StyleBuilderExtensionMethods
     public static T Prepend<T, TControl>(
         this T sb,
         TControl control,
-        Action<StyleBuilder<TControl>>? styleBuilder = null,
+        Action<IStyleBuilder<TControl>>? styleBuilder = null,
         StyleOverrideOptions options = StyleOverrideOptions.Append)
         where T: IStyleBuilder
         where TControl: DotvvmBindableObject =>

--- a/src/Framework/Framework/Compilation/Styles/StyleBuilderMethods.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleBuilderMethods.cs
@@ -21,17 +21,40 @@ public static partial class StyleBuilderExtensionMethods
     public static IStyleBuilder<TControl> SetProperty<TControl, TProperty>(
         this IStyleBuilder<TControl> sb,
         Expression<Func<TControl, TProperty>> property,
+        ValueOrBinding<TProperty>? value,
+        StyleOverrideOptions options = StyleOverrideOptions.Overwrite)
+    {
+        var dotprop = DotvvmPropertyUtils.GetDotvvmPropertyFromExpression(property);
+        return sb.SetDotvvmProperty(dotprop, value, options);
+    }
+
+    /// <summary> Sets a specified property on the matching controls. The referenced property must be a wrapper around a DotvvmProperty. </summary>
+    public static IStyleBuilder<TControl> SetProperty<TControl, TProperty>(
+        this IStyleBuilder<TControl> sb,
+        Expression<Func<TControl, TProperty>> property,
+        TProperty value,
+        StyleOverrideOptions options = StyleOverrideOptions.Overwrite)
+    {
+        var dotprop = DotvvmPropertyUtils.GetDotvvmPropertyFromExpression(property);
+        return sb.SetDotvvmProperty(dotprop, value, options);
+    }
+
+    /// <summary> Sets a specified property on the matching controls. The referenced property must be a wrapper around a DotvvmProperty. </summary>
+    public static IStyleBuilder<TControl> SetProperty<TControl, TProperty>(
+        this IStyleBuilder<TControl> sb,
+        Expression<Func<TControl, ValueOrBinding<TProperty>>> property,
         ValueOrBinding<TProperty> value,
         StyleOverrideOptions options = StyleOverrideOptions.Overwrite)
     {
         var dotprop = DotvvmPropertyUtils.GetDotvvmPropertyFromExpression(property);
         return sb.SetDotvvmProperty(dotprop, value, options);
     }
+
     /// <summary> Sets a specified property on the matching controls. The referenced property must be a wrapper around a DotvvmProperty. </summary>
     public static IStyleBuilder<TControl> SetProperty<TControl, TProperty>(
         this IStyleBuilder<TControl> sb,
         Expression<Func<TControl, ValueOrBinding<TProperty>>> property,
-        ValueOrBinding<TProperty> value,
+        TProperty value,
         StyleOverrideOptions options = StyleOverrideOptions.Overwrite)
     {
         var dotprop = DotvvmPropertyUtils.GetDotvvmPropertyFromExpression(property);
@@ -44,7 +67,7 @@ public static partial class StyleBuilderExtensionMethods
         this T sb,
         DotvvmProperty property,
         TControl prototypeControl,
-        Action<StyleBuilder<TControl>>? styleBuilder = null,
+        Action<IStyleBuilder<TControl>>? styleBuilder = null,
         StyleOverrideOptions options = StyleOverrideOptions.Overwrite)
         where T: IStyleBuilder
         where TControl: DotvvmBindableObject
@@ -63,7 +86,7 @@ public static partial class StyleBuilderExtensionMethods
         this IStyleBuilder<TControl> sb,
         Expression<Func<TControl, object>> property,
         TInnerControl prototypeControl,
-        Action<StyleBuilder<TInnerControl>>? styleBuilder = null,
+        Action<IStyleBuilder<TInnerControl>>? styleBuilder = null,
         StyleOverrideOptions options = StyleOverrideOptions.Overwrite)
         where TInnerControl: DotvvmBindableObject
     {
@@ -78,7 +101,7 @@ public static partial class StyleBuilderExtensionMethods
         this IStyleBuilder<TControl> sb,
         Expression<Func<TControl, object>> property,
         TInnerControl prototypeControl,
-        Action<StyleBuilder<TInnerControl>>? styleBuilder = null)
+        Action<IStyleBuilder<TInnerControl>>? styleBuilder = null)
         where TInnerControl: DotvvmBindableObject =>
         sb.SetControlProperty(property, prototypeControl, styleBuilder, StyleOverrideOptions.Append);
 
@@ -88,7 +111,7 @@ public static partial class StyleBuilderExtensionMethods
         this T sb,
         DotvvmProperty property,
         TControl controlPrototype,
-        Action<StyleBuilder<TControl>>? styleBuilder = null)
+        Action<IStyleBuilder<TControl>>? styleBuilder = null)
         where T: IStyleBuilder
         where TControl: DotvvmBindableObject =>
         sb.SetControlProperty(property, controlPrototype, styleBuilder, StyleOverrideOptions.Append);
@@ -98,7 +121,7 @@ public static partial class StyleBuilderExtensionMethods
         this T sb,
         DotvvmProperty property,
         string tag,
-        Action<StyleBuilder<HtmlGenericControl>>? styleBuilder = null,
+        Action<IStyleBuilder<HtmlGenericControl>>? styleBuilder = null,
         StyleOverrideOptions options = StyleOverrideOptions.Overwrite)
         where T: IStyleBuilder
     {
@@ -154,10 +177,10 @@ public static partial class StyleBuilderExtensionMethods
         sb.AddApplicator(new GenericPropertyStyleApplicator<T>(property, value, options));
 
     /// <summary> Sets a specified property on the matching controls. The value can be computed from any property on the control using the IStyleMatchContext. </summary>
-    public static IStyleBuilder<TControl> SetProperty<TControl, TProperty>(
+    public static IStyleBuilder<TControl> SetProperty<TControl>(
         this IStyleBuilder<TControl> sb,
-        Expression<Func<TControl, TProperty>> property,
-        Func<IStyleMatchContext<TControl>, TProperty> value,
+        Expression<Func<TControl, object?>> property,
+        Func<IStyleMatchContext<TControl>, object?> value,
         StyleOverrideOptions options = StyleOverrideOptions.Overwrite)
     {
         var dotprop = DotvvmPropertyUtils.GetDotvvmPropertyFromExpression(property);
@@ -304,8 +327,17 @@ public static partial class StyleBuilderExtensionMethods
         sb.SetPropertyGroupMember("html:", attribute, value, StyleOverrideOptions.Append);
 
     /// <summary> Appends value to the specified attribute. </summary>
-    public static IStyleBuilder<T> AppendAttribute<T>(this IStyleBuilder<T> sb, string attribute, Func<IStyleMatchContext<T>, ValueOrBinding<string>> value) =>
+    public static T AppendAttribute<T>(this T sb, string attribute, string value)
+        where T: IStyleBuilder =>
 
+        sb.SetPropertyGroupMember("html:", attribute, value, StyleOverrideOptions.Append);
+
+    /// <summary> Appends value to the specified attribute. </summary>
+    public static IStyleBuilder<T> AppendAttribute<T>(this IStyleBuilder<T> sb, string attribute, Func<IStyleMatchContext<T>, ValueOrBinding<string>> value) =>
+        sb.SetPropertyGroupMember("html:", attribute, c => value(c), StyleOverrideOptions.Append);
+
+    /// <summary> Appends value to the specified attribute. </summary>
+    public static IStyleBuilder<T> AppendAttribute<T>(this IStyleBuilder<T> sb, string attribute, Func<IStyleMatchContext<T>, string> value) =>
         sb.SetPropertyGroupMember("html:", attribute, c => value(c), StyleOverrideOptions.Append);
 
     /// <summary> Sets HTML attribute of the control. </summary>

--- a/src/Framework/Framework/Compilation/Styles/StyleRepository.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleRepository.cs
@@ -38,7 +38,7 @@ namespace DotVVM.Framework.Compilation.Styles
         /// <param name="matcher">If this function returns true, the style will be applied, otherwise not.</param>
         /// <param name="allowDerived">Also allow classes that are derived from <typeparamref name="T"/>.</param>
         /// <returns>A <see cref="StyleBuilder{T}"/> that can be used to style the control.</returns>
-        public StyleBuilder<T> Register<T>(Func<StyleMatchContext<T>, bool>? matcher = null, bool allowDerived = true)
+        public IStyleBuilder<T> Register<T>(Func<StyleMatchContext<T>, bool>? matcher = null, bool allowDerived = true)
             where T : DotvvmBindableObject
         {
             ThrowIfFrozen();
@@ -54,7 +54,7 @@ namespace DotVVM.Framework.Compilation.Styles
         /// <param name="matcher">If this function returns true, the style will be applied, otherwise not.</param>
         /// <param name="allowDerived">Also allow classes that are derived from <paramref name="type"/>.</param>
         /// <returns>A <see cref="StyleBuilder{T}"/> that can be used to style the control.</returns>
-        public StyleBuilder<DotvvmBindableObject> Register(Type type, Func<IStyleMatchContext, bool>? matcher = null, bool allowDerived = true)
+        public IStyleBuilder<DotvvmBindableObject> Register(Type type, Func<IStyleMatchContext, bool>? matcher = null, bool allowDerived = true)
         {
             ThrowIfFrozen();
             var styleBuilder = new StyleBuilder<DotvvmBindableObject>(matcher, allowDerived, type);
@@ -68,7 +68,7 @@ namespace DotVVM.Framework.Compilation.Styles
         /// <param name="tagName">The HTML tag the style is applied to.</param>
         /// <param name="matcher">If this function returns true, the style will be applied, otherwise not.</param>
         /// <returns>A <see cref="StyleBuilder{T}"/> that can be used to style the control.</returns>
-        public StyleBuilder<HtmlGenericControl> Register(string tagName, Func<StyleMatchContext<HtmlGenericControl>, bool>? matcher = null)
+        public IStyleBuilder<HtmlGenericControl> Register(string tagName, Func<StyleMatchContext<HtmlGenericControl>, bool>? matcher = null)
         {
             ThrowIfFrozen();
             if (matcher != null)
@@ -85,32 +85,29 @@ namespace DotVVM.Framework.Compilation.Styles
         /// Registers a server-side style for a root component.
         /// </summary>
         /// <returns>A <see cref="StyleBuilder{T}"/> that can be used to style the control.</returns>
-        public StyleBuilder<DotvvmControl> RegisterRoot() =>
+        public IStyleBuilder<DotvvmControl> RegisterRoot() =>
             Register<DotvvmControl>(c => c.Parent is null);
 
         /// <summary>
         /// Registers a server-side style for any component of type DotvvmControl (which is almost everything with exception of special objects like GridViewColumn)
         /// </summary>
         /// <returns>A <see cref="StyleBuilder{T}"/> that can be used to style the control.</returns>
-        public StyleBuilder<DotvvmControl> RegisterAnyControl(Func<StyleMatchContext<DotvvmControl>, bool>? matcher = null) =>
+        public IStyleBuilder<DotvvmControl> RegisterAnyControl(Func<StyleMatchContext<DotvvmControl>, bool>? matcher = null) =>
             Register<DotvvmControl>(matcher);
 
         /// <summary>
         /// Registers a server-side style for any component (including special objects like GridViewColumn)
         /// </summary>
         /// <returns>A <see cref="StyleBuilder{T}"/> that can be used to style the control.</returns>
-        public StyleBuilder<DotvvmBindableObject> RegisterAnyObject(Func<StyleMatchContext<DotvvmBindableObject>, bool>? matcher = null) =>
+        public IStyleBuilder<DotvvmBindableObject> RegisterAnyObject(Func<StyleMatchContext<DotvvmBindableObject>, bool>? matcher = null) =>
             Register<DotvvmBindableObject>(matcher);
 
         /// <summary>
         /// Registers a server-side style for any component that have specified Styles.Tag (including special objects like GridViewColumn)
         /// </summary>
         /// <returns>A <see cref="StyleBuilder{T}"/> that can be used to style the control.</returns>
-        public StyleBuilder<DotvvmBindableObject> RegisterForTag(string tag, Func<StyleMatchContext<DotvvmBindableObject>, bool>? matcher = null) =>
+        public IStyleBuilder<DotvvmBindableObject> RegisterForTag(string tag, Func<StyleMatchContext<DotvvmBindableObject>, bool>? matcher = null) =>
             Register<DotvvmBindableObject>(m => m.HasTag(tag) && matcher?.Invoke(m) != false);
-
-        
-        
 
         private bool isFrozen = false;
         private void ThrowIfFrozen()

--- a/src/Framework/Framework/Controls/Button.cs
+++ b/src/Framework/Framework/Controls/Button.cs
@@ -61,6 +61,14 @@ namespace DotVVM.Framework.Controls
         }
 
         public Button(
+            string text,
+            ICommandBinding click,
+            ButtonTagName tagName = ButtonTagName.input
+        ) : this(new TextOrContentCapability(text), click, tagName)
+        {
+        }
+
+        public Button(
             TextOrContentCapability content,
             ICommandBinding click,
             ButtonTagName tagName = ButtonTagName.button

--- a/src/Framework/Framework/Controls/ConfirmPostBackHandler.cs
+++ b/src/Framework/Framework/Controls/ConfirmPostBackHandler.cs
@@ -33,5 +33,9 @@ namespace DotVVM.Framework.Controls
         {
             this.SetValue(MessageProperty, message);
         }
+        public ConfirmPostBackHandler(string message)
+        {
+            this.SetValue(MessageProperty, message);
+        }
     }
 }

--- a/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
+++ b/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
@@ -55,6 +55,13 @@ namespace DotVVM.Framework.Controls
         public static TControl SetProperty<TControl, TProperty>(this TControl control, Expression<Func<TControl, TProperty>> prop, ValueOrBinding<TProperty> value)
             where TControl : DotvvmBindableObject
         {
+            control.SetValue(control.GetDotvvmProperty(prop), value.UnwrapToObject());
+            return control;
+        }
+        /// <summary> Sets value or binding into the DotvvmProperty referenced in the lambda expression. Returns <paramref name="control"/> for fluent API usage. </summary>
+        public static TControl SetProperty<TControl, TProperty>(this TControl control, Expression<Func<TControl, TProperty>> prop, TProperty value)
+            where TControl : DotvvmBindableObject
+        {
             control.SetValue(control.GetDotvvmProperty(prop), value);
             return control;
         }
@@ -85,6 +92,22 @@ namespace DotVVM.Framework.Controls
                 control.SetProperty(property, valueOrBinding.GetValueOrDefault());
             else
                 control.Properties.Remove(property);
+            return control;
+        }
+
+        /// <summary> Sets value or binding into the DotvvmProperty with specified name. Returns <paramref name="control"/> for fluent API usage. </summary>
+        public static TControl SetProperty<TControl>(this TControl control, string propName, object? value)
+            where TControl : DotvvmBindableObject
+        {
+            control.SetProperty(control.GetDotvvmProperty(propName), value);
+            return control;
+        }
+
+        /// <summary> Sets value or binding into the DotvvmProperty. Returns <paramref name="control"/> for fluent API usage. </summary>
+        public static TControl SetProperty<TControl>(this TControl control, DotvvmProperty property, object? value)
+            where TControl: DotvvmBindableObject
+        {
+            control.SetValue(property, value);
             return control;
         }
 
@@ -193,6 +216,13 @@ namespace DotVVM.Framework.Controls
             where TControl : IControlWithHtmlAttributes
         {
             return AddAttribute(control, "class", className.UnwrapToObject());
+        }
+
+        /// <summary> Appends a css class to this control. Note that it is currently not supported if multiple bindings would have to be joined together. Returns <paramref name="control"/> for fluent API usage. </summary>
+        public static TControl AddCssClass<TControl>(this TControl control, string className)
+            where TControl : IControlWithHtmlAttributes
+        {
+            return AddAttribute(control, "class", className);
         }
 
         /// <summary> Appends a list of css classes to this control. Returns <paramref name="control"/> for fluent API usage. </summary>

--- a/src/Framework/Framework/Controls/HtmlGenericControl.cs
+++ b/src/Framework/Framework/Controls/HtmlGenericControl.cs
@@ -494,7 +494,7 @@ namespace DotVVM.Framework.Controls
         public IDictionary<string, ValueOrBinding<bool>> CssClasses { get; init; } = new Dictionary<string, ValueOrBinding<bool>>();
         [PropertyGroup("Style-")]
         public IDictionary<string, ValueOrBinding<object>> CssStyles { get; init; } = new Dictionary<string, ValueOrBinding<object>>();
-        public ValueOrBinding<bool> Visible { get; init; } = true;
+        public ValueOrBinding<bool> Visible { get; init; } = new(true);
 
         public ValueOrBinding<string?> ID { get; init; }
     }

--- a/src/Framework/Framework/Controls/TextOrContentCapability.cs
+++ b/src/Framework/Framework/Controls/TextOrContentCapability.cs
@@ -17,6 +17,10 @@ namespace DotVVM.Framework.Controls
         {
             this.Text = text;
         }
+        public TextOrContentCapability(string text)
+        {
+            this.Text = new(text);
+        }
         public TextOrContentCapability(IEnumerable<DotvvmControl> content)
         {
             this.Content = content.ToList();

--- a/src/Tests/ControlTests/CompositeControlTests.cs
+++ b/src/Tests/ControlTests/CompositeControlTests.cs
@@ -301,7 +301,8 @@ namespace DotVVM.Framework.Tests.ControlTests
                 "c" => new MarkupControlContainer<CustomControlWithSomeProperty>("cc:CustomControlWithSomeProperty", c => c.SomeProperty = "ahoj"),
                 "d" => new MarkupControlContainer("cc:CustomControlWithSomeProperty", c => {
                         c.SetValue(CustomControlWithSomeProperty.SomePropertyProperty, "test");
-                    })
+                    }),
+                _ => throw null
             };
         }
     }

--- a/src/Tests/ControlTests/ServerSideStyleTests.cs
+++ b/src/Tests/ControlTests/ServerSideStyleTests.cs
@@ -135,7 +135,7 @@ namespace DotVVM.Framework.Tests.ControlTests
                     );
                 c.Styles.RegisterAnyControl(c => c.HasTag("b"))
                     .AddPostbackHandler(
-                        c => new ConfirmPostBackHandler(c.GetHtmlAttribute("data-msg") ?? "default message")
+                        c => new ConfirmPostBackHandler(c.GetHtmlAttribute("data-msg") ?? new("default message"))
                     )
                     .AddPostbackHandler(
                         c => new ConfirmPostBackHandler("Handler for some other property") { EventName = "Bazmek" }

--- a/src/Tests/Runtime/CapabilityPropertyTests.cs
+++ b/src/Tests/Runtime/CapabilityPropertyTests.cs
@@ -78,7 +78,7 @@ namespace DotVVM.Framework.Tests.Runtime
             Assert.AreEqual("Z", control.GetValue<string>("SomethingElse"));
             Assert.AreEqual("Z", control.GetValue(c => c.GetCapability<TestCapability>().SomethingElse));
 
-            control.SetCapability(new HtmlCapability { Attributes = { ["attr"] = "a" } });
+            control.SetCapability(new HtmlCapability { Attributes = { ["attr"] = new("a") } });
             Assert.AreEqual("a", control.Attributes["attr"]);
             control.AddAttribute("class", "x");
             control.AddAttribute("class", "y");


### PR DESCRIPTION
We have decided that it causes more problems than good (ambiguous overloads, ...)
and since C# 9 it's just a matter of putting there `new(X)`