### PR TITLE
styles: Fix some gitches

### DIFF
--- a/src/Framework/Framework/Compilation/Styles/ResolvedControlHelper.cs
+++ b/src/Framework/Framework/Compilation/Styles/ResolvedControlHelper.cs
@@ -164,7 +164,19 @@ namespace DotVVM.Framework.Compilation.Styles
 
         public static void SetContent(ResolvedControl control, ResolvedControl[] innerControls, StyleOverrideOptions options)
         {
-            if (control.Metadata.DefaultContentProperty is DotvvmProperty defaultProp)
+            if (innerControls.Length == 0)
+            {
+                if (options == StyleOverrideOptions.Overwrite)
+                {
+                    // remove the existing value
+                    control.Content.Clear();
+                    if (control.Metadata.DefaultContentProperty is {} dp)
+                    {
+                        control.RemoveProperty(dp);
+                    }
+                }
+            }
+            else if (control.Metadata.DefaultContentProperty is {} defaultProp)
             {
                 var setter = ResolvedControlHelper.TranslateProperty(defaultProp, innerControls, control.DataContextTypeStack, null);
 

--- a/src/Framework/Framework/Compilation/Styles/StyleBuilderMethods.Helpers.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleBuilderMethods.Helpers.cs
@@ -45,12 +45,10 @@ public static partial class StyleBuilderExtensionMethods
             options
         );
     /// <summary> Replaces the matching controls with a new control while copying all properties to the new one.</summary>
-    public static T ReplaceWith<T, TControl>(
-        this T sb,
-        Func<IStyleMatchContext<T>, TControl> handler,
-        StyleOverrideOptions options = StyleOverrideOptions.Overwrite)
-        where T: IStyleBuilder
-        where TControl: DotvvmBindableObject =>
+    public static IStyleBuilder<T> ReplaceWith<T>(
+        this IStyleBuilder<T> sb,
+        Func<IStyleMatchContext<T>, DotvvmBindableObject> handler,
+        StyleOverrideOptions options = StyleOverrideOptions.Overwrite) =>
         sb.SetDotvvmProperty(Styles.ReplaceWithProperty, handler, options);
 
     /// <summary> Wraps the matching controls with a new control - places the new control instead of the original control which is moved inside the wrapper control </summary>
@@ -68,12 +66,10 @@ public static partial class StyleBuilderExtensionMethods
             options
         );
     /// <summary> Wraps the matching controls with a new control - places the new control instead of the original control which is moved inside the wrapper control </summary>
-    public static T WrapWith<T, TControl>(
-        this T sb,
-        Func<IStyleMatchContext<T>, TControl> handler,
-        StyleOverrideOptions options = StyleOverrideOptions.Append)
-        where T: IStyleBuilder
-        where TControl: DotvvmBindableObject =>
+    public static IStyleBuilder<T> WrapWith<T>(
+        this IStyleBuilder<T> sb,
+        Func<IStyleMatchContext<T>, DotvvmBindableObject> handler,
+        StyleOverrideOptions options = StyleOverrideOptions.Append) =>
         sb.SetDotvvmProperty(Styles.WrappersProperty, handler, options);
 
     /// <summary> Adds a new control bellow the matched control. </summary>
@@ -91,12 +87,10 @@ public static partial class StyleBuilderExtensionMethods
             options
         );
     /// <summary> Adds a new control bellow the matched control. </summary>
-    public static T Append<T, TControl>(
-        this T sb,
-        Func<IStyleMatchContext<T>, TControl> handler,
-        StyleOverrideOptions options = StyleOverrideOptions.Append)
-        where T: IStyleBuilder
-        where TControl: DotvvmBindableObject =>
+    public static IStyleBuilder<T> Append<T>(
+        this IStyleBuilder<T> sb,
+        Func<IStyleMatchContext<T>, DotvvmBindableObject> handler,
+        StyleOverrideOptions options = StyleOverrideOptions.Append) =>
         sb.SetDotvvmProperty(Styles.AppendProperty, handler, options);
 
     /// <summary> Adds a new control above the matched control. </summary>
@@ -114,11 +108,9 @@ public static partial class StyleBuilderExtensionMethods
             options
         );
     /// <summary> Adds a new control above the matched control. </summary>
-    public static T Prepend<T, TControl>(
-        this T sb,
-        Func<IStyleMatchContext<T>, TControl> handler,
-        StyleOverrideOptions options = StyleOverrideOptions.Append)
-        where T: IStyleBuilder
-        where TControl: DotvvmBindableObject =>
+    public static IStyleBuilder<T> Prepend<T, TControl>(
+        this IStyleBuilder<T> sb,
+        Func<IStyleMatchContext<T>, DotvvmBindableObject> handler,
+        StyleOverrideOptions options = StyleOverrideOptions.Append) =>
         sb.SetDotvvmProperty(Styles.PrependProperty, handler, options);
 }

--- a/src/Framework/Framework/Compilation/Styles/StyleMatchContextMethods.cs
+++ b/src/Framework/Framework/Compilation/Styles/StyleMatchContextMethods.cs
@@ -307,6 +307,20 @@ public static class StyleMatchContextExtensionMethods
         return c.Property<TProp>(property);
     }
 
+    /// <summary> Gets the property value or null if it's not defined. </summary>
+    public static IValueBinding<TProp>? Property<TControl, TProp>(this IStyleMatchContext<TControl> c, Expression<Func<TControl, IValueBinding<TProp>?>> pp)
+    {
+        var property = DotvvmPropertyUtils.GetDotvvmPropertyFromExpression(pp);
+        return (IValueBinding<TProp>?) c.Property<TProp>(property).BindingOrDefault;
+    }
+
+    /// <summary> Gets the property value or null if it's not defined. </summary>
+    public static IValueBinding? Property<TControl>(this IStyleMatchContext<TControl> c, Expression<Func<TControl, IValueBinding?>> pp)
+    {
+        var property = DotvvmPropertyUtils.GetDotvvmPropertyFromExpression(pp);
+        return (IValueBinding?) c.Property<object>(property).BindingOrDefault;
+    }
+
     private static IStyleMatchContext ChildContext(this IStyleMatchContext c, ResolvedControl control) =>
         new StyleMatchContext<DotvvmBindableObject>(c, control, c.Configuration);
 


### PR DESCRIPTION
* type signatures of styles.Append, Replace, Prepend with the lambda function was broken and essentially could not be used
* Replace didn't work on controls which don't allow children. We call SetContent with an empty array there, so I added a check that if the array is empty we do nothing
* Added overload of `StyleMatchContext.Property(x => x.Prop)` for cases when Prop is `IValueBinding`. Then it does not make sense to wrap it in the ValueOrBinding and returning the IValueBinding directly is better