### PR TITLE
ActiveDotvvmProperty support for null command binding added

### DIFF
--- a/src/Framework/Framework/Binding/ActiveDotvvmProperty.cs
+++ b/src/Framework/Framework/Binding/ActiveDotvvmProperty.cs
@@ -10,20 +10,27 @@ using DotVVM.Framework.Hosting;
 
 namespace DotVVM.Framework.Binding
 {
-    public abstract class ActiveDotvvmProperty: DotvvmProperty
+    public abstract class ActiveDotvvmProperty : DotvvmProperty
     {
         public abstract void AddAttributesToRender(IHtmlWriter writer, IDotvvmRequestContext context, DotvvmControl control);
 
 
         public static ActiveDotvvmProperty RegisterCommandToAttribute<TDeclaringType>(string name, string attributeName)
         {
-            return DelegateActionProperty<ICommandBinding>.Register<TDeclaringType>(name, (writer, context, property, control) =>
-            {
-                var binding = control.GetCommandBinding(property) ?? throw new DotvvmControlException(control, $"Command binding expression was expected in {property}.") {
-                    RelatedProperty = property
-                };
-                var script = KnockoutHelper.GenerateClientPostBackScript(name, binding, control);
-                writer.AddAttribute(attributeName, script);
+            return DelegateActionProperty<ICommandBinding>.Register<TDeclaringType>(name, (writer, context, property, control) => {
+                var value = control.GetValueRaw(property);
+                if (value is null)
+                {
+                }
+                else if (value is ICommandBinding binding)
+                {
+                    var script = KnockoutHelper.GenerateClientPostBackScript(name, binding, control);
+                    writer.AddAttribute(attributeName, script);
+                }
+                else
+                {
+                    throw new DotvvmControlException(control, $"Command binding expression was expected in {property}, got {value} instead.");
+                }
             });
         }
     }


### PR DESCRIPTION
In case click was null, `control.SetProperty(Events.ClickProperty, click);` resulted in Exception, but rather property should not be set.