### PR TITLE
ValueOrBinding ValueEquals helper

### DIFF
--- a/src/Framework/Framework/Binding/ValueOrBindingExtensions.cs
+++ b/src/Framework/Framework/Binding/ValueOrBindingExtensions.cs
@@ -115,6 +115,30 @@ public static class ValueOrBindingExtensions
             return new(string.IsNullOrWhiteSpace(v.ValueOrDefault));
     }
 
+    /// <summary> Returns if the ValueOrBinding contains a value and the value is equal to <paramref name="value"/>. </summary>
+    public static bool ValueEquals<T>(this ValueOrBinding<T> v, [MaybeNull] T value)
+    {
+        if (v.HasBinding)
+            return false;
+        else
+            return EqualityComparer<T>.Default.Equals(v.ValueOrDefault, value);
+    }
+
+    /// <summary> Returns if the ValueOrBinding contains a value and the value is equal to <paramref name="value"/>. </summary>
+    public static bool ValueEquals<T>(this ValueOrBinding<T> v, [MaybeNull] T value, IEqualityComparer<T> comparer)
+    {
+        if (v.HasBinding)
+            return false;
+        else
+            return comparer.Equals(v.ValueOrDefault, value);
+    }
+
+    /// <summary> Returns true if the ValueOrBinding contains value, but the value is null. </summary>
+    public static bool ValueIsNull<T>(this ValueOrBinding<T> v) => v.HasValue && v.ValueOrDefault is null;
+
+    /// <summary> Returns true if the ValueOrBinding contains value, but the value is null or an empty string. </summary>
+    public static bool ValueIsNullOrEmpty(this ValueOrBinding<string> v) => v.HasValue && string.IsNullOrEmpty(v.ValueOrDefault);
+
     /// <summary> Returns ValueOrBinding with the value of `a &amp;&amp; b`. If both a and b contain a binding, they are combined together. The result is cached, so it's safe to use this method at runtime. </summary>
     public static ValueOrBinding<bool> And(this ValueOrBinding<bool> a, ValueOrBinding<bool> b)
     {


### PR DESCRIPTION
Added ValueEquals extension method for ValueOrBinding to
simplify conditions based on the static value.
Also added ValueIsNull and ValueIsNullOrEmpty.