### PR TITLE
Fix AddAttribute when used with non-nullable ValueOrBinding

### DIFF
--- a/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
+++ b/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
@@ -192,7 +192,7 @@ namespace DotVVM.Framework.Controls
             where TControl : IControlWithHtmlAttributes
         {
             if (value is not null)
-                control.Attributes.Add(attribute, value);
+                control.Attributes.Add(attribute, ValueOrBindingExtensions.UnwrapToObject(value));
             return control;
         }
         /// <summary> Appends a value into the specified html attribute. If the attribute already exists, the old and new values are merged. Returns <paramref name="control"/> for fluent API usage. </summary>
@@ -200,6 +200,12 @@ namespace DotVVM.Framework.Controls
             where TControl : IControlWithHtmlAttributes
         {
             return AddAttribute(control, attribute, value?.UnwrapToObject());
+        }
+        /// <summary> Appends a value into the specified html attribute. If the attribute already exists, the old and new values are merged. Returns <paramref name="control"/> for fluent API usage. </summary>
+        public static TControl AddAttribute<TControl, TValue>(this TControl control, string attribute, ValueOrBinding<TValue> value)
+            where TControl : IControlWithHtmlAttributes
+        {
+            return AddAttribute(control, attribute, value.UnwrapToObject());
         }
 
         /// <summary> Appends a list of css attributes to the control. If the attributes already exist, the old and new values are merged. Returns <paramref name="control"/> for fluent API usage. </summary>


### PR DESCRIPTION
C# compiler preferred the overload with `object?`
parameter to the `ValueOrBinding<T>` overload...

I also added a ValueOrBinding unwrap to the AddAttribute(object),
to handle the cases when the boxed argument is
ValueOrBinding anyway.