### PR TITLE
js translation: Fix X + Y when X or Y is null

### DIFF
--- a/src/Framework/Framework/Compilation/Javascript/Ast/JsAstHelpers.cs
+++ b/src/Framework/Framework/Compilation/Javascript/Ast/JsAstHelpers.cs
@@ -25,6 +25,8 @@ namespace DotVVM.Framework.Compilation.Javascript.Ast
 
         public static JsExpression Unary(this JsExpression target, UnaryOperatorType type, bool isPrefix = true) =>
             new JsUnaryExpression(type, target, isPrefix);
+        public static JsExpression Binary(this JsExpression left, BinaryOperatorType type, JsExpression right) =>
+            new JsBinaryExpression(left, type, right);
         public static JsExpression Await(this JsExpression target) =>
             target.Unary(UnaryOperatorType.Await);
 

--- a/src/Framework/Framework/Compilation/Javascript/JsParensFixingVisitor.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JsParensFixingVisitor.cs
@@ -20,6 +20,11 @@ namespace DotVVM.Framework.Compilation.Javascript
 
         public bool NeedsParens(byte parentPrecedence)
         {
+            // there is an exception to the rule: ?? can not be chained with && and ||, even though it has lower precedence
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator#no_chaining_with_and_or_or_operators
+            if (parentPrecedence == 4 && Precedence is 5 or 6)
+                return true;
+
             return Precedence < parentPrecedence ||
                 (Precedence == parentPrecedence & !IsPreferredSide);
         }

--- a/src/Framework/Framework/Compilation/Javascript/PrimitiveToStringTranslator.cs
+++ b/src/Framework/Framework/Compilation/Javascript/PrimitiveToStringTranslator.cs
@@ -1,42 +1,66 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using DotVVM.Framework.Binding;
 using DotVVM.Framework.Compilation.Javascript.Ast;
 using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Compilation.Javascript
 {
 
-    public partial class JavascriptTranslatableMethodCollection
+    class PrimitiveToStringTranslator : IJavascriptMethodTranslator
     {
-        class PrimitiveToStringTranslator : IJavascriptMethodTranslator
+        internal static bool CanBeNull(Expression expr)
         {
-            static (bool canConvert, bool isNullable, bool isStringAlready) ToStringCheck(Expression expr)
+            if (expr.GetParameterAnnotation() is { } annotation)
             {
-                while (expr.NodeType == ExpressionType.Convert) expr = ((UnaryExpression)expr).Operand;
-                var type = expr.Type.UnwrapNullableType();
-                var isStringRepresentedType =
-                    type == typeof(string) || type == typeof(TimeSpan) || type == typeof(Guid) || type.IsEnum;
-                return (
-                    type.IsPrimitive || type.IsEnum || type == typeof(Enum) || isStringRepresentedType,
-                    expr.Type.IsNullable(),
-                    isStringRepresentedType
-                );
+                // view model and extension parameters can't be null 
+                return false;
             }
-            public JsExpression? TryTranslateCall(LazyTranslatedExpression? context, LazyTranslatedExpression[] arguments, MethodInfo method)
+
+            if (expr.NodeType == ExpressionType.Convert)
             {
-                var arg = context ?? arguments[0];
-                var (canConvert, isNullable, isStringAlready) = ToStringCheck(arg.OriginalExpression);
-                if (!canConvert)
-                    return null;
-                var js = arg.JsExpression();
-                // convert null to empty string, not "null"
-                if (isNullable)
-                    js = new JsBinaryExpression(js, BinaryOperatorType.NullishCoalescing, new JsLiteral(""));
-                if (!isStringAlready)
-                    js = new JsIdentifierExpression("String").Invoke(js);
-                return js;
+                var cast = (UnaryExpression)expr;
+                return CanBeNull(cast.Operand);
             }
+
+            if (expr is MemberExpression member)
+            {
+                if (!expr.Type.IsValueType || expr.Type.IsNullable())
+                    return true;
+                return member.Expression is {} && CanBeNull(member.Expression);
+            }
+
+
+
+            return true; // assume it can be
+            
+        }
+        static (bool canConvert, bool isNullable, bool isStringAlready) ToStringCheck(Expression expr)
+        {
+            while (expr.NodeType == ExpressionType.Convert) expr = ((UnaryExpression)expr).Operand;
+            var type = expr.Type.UnwrapNullableType();
+            var isStringRepresentedType =
+                type == typeof(string) || type == typeof(TimeSpan) || type == typeof(Guid) || type.IsEnum;
+            return (
+                type.IsPrimitive || type.IsEnum || type == typeof(Enum) || isStringRepresentedType,
+                CanBeNull(expr),
+                isStringRepresentedType
+            );
+        }
+        public JsExpression? TryTranslateCall(LazyTranslatedExpression? context, LazyTranslatedExpression[] arguments, MethodInfo method)
+        {
+            var arg = context ?? arguments[0];
+            var (canConvert, isNullable, isStringAlready) = ToStringCheck(arg.OriginalExpression);
+            if (!canConvert)
+                return null;
+            var js = arg.JsExpression();
+            // convert null to empty string, not "null"
+            if (isNullable)
+                js = new JsBinaryExpression(js, BinaryOperatorType.NullishCoalescing, new JsLiteral(""));
+            if (!isStringAlready)
+                js = new JsIdentifierExpression("String").Invoke(js);
+            return js;
         }
     }
 }

--- a/src/Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/Tests/Binding/JavascriptCompilationTests.cs
@@ -107,7 +107,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JavascriptCompilation_UnwrappedObservables()
         {
             var js = CompileBinding("TestViewModel2.Collection[0].StringValue.Length + TestViewModel2.Collection[8].StringValue", new[] { typeof(TestViewModel) });
-            Assert.AreEqual("TestViewModel2().Collection()[0]().StringValue().length+TestViewModel2().Collection()[8]().StringValue()", js);
+            Assert.AreEqual("(TestViewModel2().Collection()[0]().StringValue().length??\"\")+(TestViewModel2().Collection()[8]().StringValue()??\"\")", js);
         }
 
         [TestMethod]
@@ -304,7 +304,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_LambdaWithDelegateInvocation()
         {
             var result = this.CompileBinding("arg(12) + _this", new [] { typeof(string) }, typeof(Func<Func<int, string>, string>));
-            Assert.AreEqual("(arg)=>ko.unwrap(arg)(12)+$data", result);
+            Assert.AreEqual("(arg)=>(ko.unwrap(arg)(12)??\"\")+$data", result);
         }
 
         [TestMethod]
@@ -1007,7 +1007,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JavascriptCompilation_AssignAndUse()
         {
             var result = CompileBinding("StringProp2 = (_this.StringProp = _this.StringProp2 = 'lol') + 'hmm'", typeof(TestViewModel));
-            Assert.AreEqual("StringProp2(StringProp(StringProp2(\"lol\").StringProp2()).StringProp()+\"hmm\").StringProp2", result);
+            Assert.AreEqual("StringProp2((StringProp(StringProp2(\"lol\").StringProp2()).StringProp()??\"\")+\"hmm\").StringProp2", result);
         }
 
         [TestMethod]
@@ -1028,14 +1028,14 @@ namespace DotVVM.Framework.Tests.Binding
         public void JavascriptCompilation_AssignmentExpectsObservable()
         {
             var result = CompileBinding("_api.RefreshOnChange(StringProp = StringProp2, StringProp + StringProp2)", typeof(TestViewModel));
-            Assert.AreEqual("dotvvm.api.refreshOn(StringProp(StringProp2()).StringProp,ko.pureComputed(()=>StringProp()+StringProp2()))", result);
+            Assert.AreEqual("dotvvm.api.refreshOn(StringProp(StringProp2()).StringProp,ko.pureComputed(()=>(StringProp()??\"\")+(StringProp2()??\"\")))", result);
         }
 
         [TestMethod]
         public void JavascriptCompilation_ApiRefreshOn()
         {
             var result = CompileBinding("_api.RefreshOnChange('here would be the API invocation', StringProp + StringProp2)", typeof(TestViewModel));
-            Assert.AreEqual("dotvvm.api.refreshOn(\"here would be the API invocation\",ko.pureComputed(()=>StringProp()+StringProp2()))", result);
+            Assert.AreEqual("dotvvm.api.refreshOn(\"here would be the API invocation\",ko.pureComputed(()=>(StringProp()??\"\")+(StringProp2()??\"\")))", result);
         }
 
         [DataTestMethod]

--- a/src/Tests/Binding/StaticCommandCompilationTests.cs
+++ b/src/Tests/Binding/StaticCommandCompilationTests.cs
@@ -341,7 +341,7 @@ namespace DotVVM.Framework.Tests.Binding
             Console.WriteLine(result);
             var control = @"{
 	let vm = options.viewModel;
-	vm.StringProp(await MethodExtensions.test(vm.StringProp, ""a"") + await dotvvm.staticCommandPostback(""XXXX"", [vm.StringProp.state], options));
+	vm.StringProp((await MethodExtensions.test(vm.StringProp, ""a"") ?? """") + (await dotvvm.staticCommandPostback(""XXXX"", [vm.StringProp.state], options) ?? """"));
 }";
 
             AreEqual(control, result);
@@ -385,7 +385,7 @@ namespace DotVVM.Framework.Tests.Binding
             Console.WriteLine(result);
             var expectedResult = @"{
 	let vm = options.viewModel;
-	vm.StringProp(await options.knockoutContext.$control.Change.state(vm.StringProp.state) + await dotvvm.staticCommandPostback(""XXXX"", [vm.StringProp.state], options));
+	vm.StringProp((await options.knockoutContext.$control.Change.state(vm.StringProp.state) ?? """") + (await dotvvm.staticCommandPostback(""XXXX"", [vm.StringProp.state], options) ?? """"));
 }";
 
             AreEqual(expectedResult, result);

--- a/src/Tests/ControlTests/SimpleControlTests.cs
+++ b/src/Tests/ControlTests/SimpleControlTests.cs
@@ -72,12 +72,14 @@ namespace DotVVM.Framework.Tests.ControlTests
                     {{value: Integer}}
                     {{value: Float}}
                     {{value: DateTime}}
+                    {{value: NullableString}}
                 </span>
                 <!-- literal syntax, server rendering -->
                 <span RenderSettings.Mode=Server>
                     {{value: Integer}}
                     {{value: Float}}
                     {{value: DateTime}}
+                    {{value: NullableString}}
                 </span>
                 <!-- control syntax, client rendering -->
                 <span RenderSettings.Mode=Client>
@@ -374,6 +376,8 @@ namespace DotVVM.Framework.Tests.ControlTests
             [Bind(Name = "date")]
             public DateTime DateTime { get; set; } = DateTime.Parse("2020-08-11T16:01:44.5141480");
             public string Label { get; } = "My Label";
+
+            public string NullableString { get; } = null;
 
             public GridViewDataSet<CustomerData> Customers { get; set; } = new GridViewDataSet<CustomerData>() {
                 RowEditOptions = {

--- a/src/Tests/ControlTests/testoutputs/CompositeControlTests.WrappedRepeaterControl.html
+++ b/src/Tests/ControlTests/testoutputs/CompositeControlTests.WrappedRepeaterControl.html
@@ -4,7 +4,7 @@
 		
 		<!-- simple list -->
 		<p class="css-class-from-markup my-repeated-button" data-bind="foreach: { data: List }" id="test-id">
-			<button class="the-only-class-for-button-element" data-bind="text: $parent.Label() + $data" id="test-id_c9a0_c9a0a0_inner-button" onclick="dotvvm.postBack(this,[&quot;List/[$index]&quot;],&quot;WHRHt9Mi4BuLdRIz&quot;,&quot;&quot;,null,[],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button"></button>
+			<button class="the-only-class-for-button-element" data-bind="text: ($parent.Label() ?? &quot;&quot;) + $data" id="test-id_c9a0_c9a0a0_inner-button" onclick="dotvvm.postBack(this,[&quot;List/[$index]&quot;],&quot;WHRHt9Mi4BuLdRIz&quot;,&quot;&quot;,null,[],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button"></button>
 		</p>
 	</body>
 </html>

--- a/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.StyleBindingMapping.html
+++ b/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.StyleBindingMapping.html
@@ -6,7 +6,7 @@
 		resource binding
 		<div class="a class123-some-class" data-custom-class-attr="some-class"></div>
 		value binding
-		<div data-bind="class: &quot;a class123-&quot; + SomeClass(), attr: { &quot;data-custom-class-attr&quot;: SomeClass }"></div>
+		<div data-bind="class: &quot;a class123-&quot; + (SomeClass() ?? &quot;&quot;), attr: { &quot;data-custom-class-attr&quot;: SomeClass }"></div>
 		checkbox with checkbox-checked class
 		<input data-bind="class: int() > 10 == true ? &quot;checkbox-checked&quot; : &quot;&quot;, dotvvm-CheckState: int() > 10" type="checkbox">
 		<input data-bind="class: Boolean() == true ? &quot;checkbox-checked&quot; : &quot;&quot;, dotvvm-CheckState: Boolean" type="checkbox">

--- a/src/Tests/ControlTests/testoutputs/SimpleControlTests.Literal_ClientServerRendering.html
+++ b/src/Tests/ControlTests/testoutputs/SimpleControlTests.Literal_ClientServerRendering.html
@@ -3,10 +3,11 @@
 	<body>
 		
 		<!-- literal syntax, client rendering -->
-		<span data-bind="text: dotvvm.globalize.bindingNumberToString(int)() + &quot;\n                    &quot; + dotvvm.globalize.bindingNumberToString(float)() + &quot;\n                    &quot; + dotvvm.globalize.bindingDateToString(date)()"></span>
+		<span data-bind="text: dotvvm.globalize.bindingNumberToString(int)() + &quot;\n                    &quot; + dotvvm.globalize.bindingNumberToString(float)() + &quot;\n                    &quot; + (dotvvm.globalize.bindingDateToString(date)() ?? &quot;&quot;) + &quot;\n                    &quot; + (NullableString() ?? &quot;&quot;)"></span>
 		
 		<!-- literal syntax, server rendering -->
-		<span data-bind="text: dotvvm.globalize.bindingNumberToString(int)() + &quot;\n                    &quot; + dotvvm.globalize.bindingNumberToString(float)() + &quot;\n                    &quot; + dotvvm.globalize.bindingDateToString(date)()">10000000                     0.11111                     8/11/2020 4:01:44 PM</span>
+		<span data-bind="text: dotvvm.globalize.bindingNumberToString(int)() + &quot;\n                    &quot; + dotvvm.globalize.bindingNumberToString(float)() + &quot;\n                    &quot; + (dotvvm.globalize.bindingDateToString(date)() ?? &quot;&quot;) + &quot;\n                    &quot; + (NullableString() ?? &quot;&quot;)">10000000                     0.11111                     8/11/2020 4:01:44 PM
+		</span>
 		
 		<!-- control syntax, client rendering -->
 		<span>

--- a/src/Tests/Runtime/ControlTree/ServerSideStyleTests.cs
+++ b/src/Tests/Runtime/ControlTree/ServerSideStyleTests.cs
@@ -392,7 +392,7 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
                 .Single(c => c.Metadata.Type == typeof(HtmlGenericControl));
 
             var r = div.Properties.Values.OfType<ResolvedPropertyBinding>().Single().Binding;
-            Assert.AreEqual("\"a class1-\"+$data[0]()+\" class2-\"+$data[1]()", r.Binding.CastTo<IValueBinding>().KnockoutExpression.ToDefaultString());
+            Assert.AreEqual("\"a class1-\"+($data[0]()??\"\")+\" class2-\"+($data[1]()??\"\")", r.Binding.CastTo<IValueBinding>().KnockoutExpression.ToDefaultString());
         }
 
         [TestMethod]

--- a/src/Tests/Runtime/JavascriptCompilation/JsNullChecksTests.cs
+++ b/src/Tests/Runtime/JavascriptCompilation/JsNullChecksTests.cs
@@ -79,7 +79,7 @@ namespace DotVVM.Framework.Tests.Runtime.JavascriptCompilation
                 .Indexer(new JsLiteral(7));
             expr = JavascriptNullCheckAdder.AddNullChecks(expr);
             var node = JsTemporaryVariableResolver.ResolveVariables(expr);
-            Assert.AreEqual("(a&&a[5]??[])[7]", node.FormatScript(), node.FormatScript(niceMode: true));
+            Assert.AreEqual("((a&&a[5])??[])[7]", node.FormatScript(), node.FormatScript(niceMode: true));
         }
 
         [TestMethod]

--- a/src/Tests/Runtime/JavascriptCompilation/JsParensInsersionTests.cs
+++ b/src/Tests/Runtime/JavascriptCompilation/JsParensInsersionTests.cs
@@ -11,6 +11,7 @@ namespace DotVVM.Framework.Tests.Runtime.JavascriptCompilation
     [TestClass]
     public class JsParensInsertionTests
     {
+        static JsExpression id(string identifier) => new JsIdentifierExpression(identifier);
         public static void AssertFormatting(string expectedString, JsNode node, bool niceMode = false)
         {
             Assert.AreEqual(expectedString, node.Clone().FormatScript(niceMode));
@@ -38,6 +39,16 @@ namespace DotVVM.Framework.Tests.Runtime.JavascriptCompilation
             AssertFormatting("a.b(4+b,5)", new JsIdentifierExpression("a").Member("b").Invoke(
                 new JsBinaryExpression(new JsLiteral(4), BinaryOperatorType.Plus, new JsIdentifierExpression("b")),
                 new JsLiteral(5)));
+        }
+
+        [TestMethod]
+        public void JsParens_NullCoallesing()
+        {
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator#no_chaining_with_and_or_or_operators
+            AssertFormatting("(a&&b)??c", id("a").Binary(BinaryOperatorType.ConditionalAnd, id("b")).Binary(BinaryOperatorType.NullishCoalescing, id("c")));
+            AssertFormatting("c??(a&&b)", id("c").Binary(BinaryOperatorType.NullishCoalescing, id("a").Binary(BinaryOperatorType.ConditionalAnd, id("b"))));
+            AssertFormatting("a&&(b??c)", id("a").Binary(BinaryOperatorType.ConditionalAnd, id("b").Binary(BinaryOperatorType.NullishCoalescing, id("c"))));
+            AssertFormatting("(a??b)&&c", id("a").Binary(BinaryOperatorType.NullishCoalescing, id("b")).Binary(BinaryOperatorType.ConditionalAnd, id("c")));
         }
 
         [TestMethod]


### PR DESCRIPTION
This results in the null value being replaced by null in .NET
and users expect that to be the case in bindings
translated to JS.