### PR TITLE
Serializability analysis fix for generics and suppress on compilation errors

### DIFF
--- a/src/Analyzers/Analyzers.Tests/Serializability/ViewModelSerializabilityTest.cs
+++ b/src/Analyzers/Analyzers.Tests/Serializability/ViewModelSerializabilityTest.cs
@@ -720,5 +720,26 @@ namespace DotVVM.Analyzers.Tests.Serializability
             VerifyCS.Diagnostic(ViewModelSerializabilityAnalyzer.UseSerializablePropertiesRule).WithLocation(0)
                 .WithArguments("this.NonSerializable.Value"));
         }
+
+        [Fact]
+        public async void Test_GenericViewModelType_Properties_ViewModel()
+        {
+            var text = @"
+    using DotVVM.Framework.Controls;
+    using DotVVM.Framework.ViewModel;
+    using System;
+    using System.IO;
+    using System.Collections.Generic;
+
+    namespace ConsoleApplication1
+    {
+        public class DefaultViewModel<T> : DotvvmViewModelBase
+        {
+            public T Property { get; set; }
+        }
+    }";
+
+            await VerifyCS.VerifyAnalyzerAsync(text);
+        }
     }
 }

--- a/src/Analyzers/Analyzers/Serializability/ViewModelSerializabilityAnalyzer.cs
+++ b/src/Analyzers/Analyzers/Serializability/ViewModelSerializabilityAnalyzer.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
-using DotVVM.Analyzers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -105,6 +101,7 @@ namespace DotVVM.Analyzers.Serializability
             var semanticModel = context.SemanticModel;
             foreach (var property in viewModel.ChildNodes().OfType<PropertyDeclarationSyntax>())
             {
+                // Resolve property symbol
                 if (semanticModel.GetDeclaredSymbol(property) is not IPropertySymbol propertySymbol)
                     continue;
 
@@ -220,6 +217,13 @@ namespace DotVVM.Analyzers.Serializability
                         context.ReportDiagnostic(Diagnostic.Create(UseSerializablePropertiesRule, location, path));
                         context.MarkAsNotSerializable(propertyType, UseSerializablePropertiesRule);
                     }
+                    break;
+
+                case TypeKind.TypeParameter:
+                    // Assume this is correct. This gets otherwise complicated. Possible solution:
+                    // 1.) Check for available generic type constraints (these might hint whether the type is serializable or not)
+                    // 2.) Check the context this viewmodel is used in (i.e. analyze only concrete instantiations of the generic type definition)
+                    // TODO: Maybe add (partial) support for this in future
                     break;
 
                 default:


### PR DESCRIPTION
This PR introduces some further changes / improvements to DotVVM analyzers.

1. Generic type parameters of viewmodels have been excluded from serializability analysis. It gets a bit more complicated when users define generic viewmodels. It can be implemented in future, but I doubt it is commonly used. Therefore, for now we assume that these are serializable

2. Serializability analysis is not longer run on incomplete type members (nodes with attached compilation errors). Otherwise this could get a bit annoying, for example in the following situation:
   - User tries to add a new property to viewmodel and types the following: `public int MyProperty`
   - We immediately issue a warning that user should not use fields for storing viewmodel state (notice that field definition is not completed - there is a missing semicolon, nor it is a property definition as it is missing accessors)
   - User finishes the definition by adding ` { get; set; }`
   - The warning is removed as it is now considered a serializable property

