### PR TITLE
TextOrContentCapability Content can be used multiple times

### DIFF
--- a/src/Framework/Framework/Controls/TextOrContentCapability.cs
+++ b/src/Framework/Framework/Controls/TextOrContentCapability.cs
@@ -59,7 +59,7 @@ namespace DotVVM.Framework.Controls
             if (Text.HasValue)
                 return new DotvvmControl[] { new Literal(Text.Value) };
             else
-                return Content.NotNull();
+                return Content.NotNull().Select(c => (DotvvmControl)c.CloneControl());
         }
     }
 }


### PR DESCRIPTION
I've found issues when the Content property of the capability are used multiple times (e. g. in `Repeater`).
This fix clones the controls so it should work.