### PR TITLE
Null-value attributes and styles should not be rendered 

### DIFF
--- a/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
+++ b/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
@@ -244,9 +244,11 @@ namespace DotVVM.Framework.Controls
         }
 
         /// <summary> Adds a css inline style - the `style` attribute. Returns <paramref name="control"/> for fluent API usage. </summary>
-        public static TControl AddCssStyle<TControl>(this TControl control, string name, string styleValue)
+        public static TControl AddCssStyle<TControl>(this TControl control, string name, string? styleValue)
             where TControl : IControlWithHtmlAttributes
         {
+            if (styleValue == null)
+                return control;
             return AddAttribute(control, "style", name + ":" + styleValue);
         }
 

--- a/src/Framework/Framework/Controls/HtmlGenericControl.cs
+++ b/src/Framework/Framework/Controls/HtmlGenericControl.cs
@@ -344,7 +344,11 @@ namespace DotVVM.Framework.Controls
 
         private void AddHtmlAttribute(IHtmlWriter writer, string name, object? value)
         {
-            if (value is string || value == null)
+            if (value == null)
+            {
+                return;
+            }
+            else if (value is string)
             {
                 writer.AddAttribute(name, (string?)value, true);
             }


### PR DESCRIPTION
I am not sure if this is a good idea, but the typical scenario is when we need to conditionally include some attribute:

```
control.SetAttribute("disabled", enabled.Select(v => v ? null : "disabled"));
``` 

I want either to include the attribute (`disabled=disabled` value), or do not render it at all.

However, when the `enabled` is `true` on the server (the transformed expression evaluates to `null`), it renders the `disabled`:
```
data-bind="attr: { 'disabled': Enabled() ? null : 'disabled'}" disabled="" ...
```

When the page loads, the attribute is removed by Knockout because it supports this logic. But our server-side rendering doesn't respect this.

I am not sure how many things we can break by this, but I have a feeling that on some places we have this logic and on other places we do not.
