### PR TITLE
Add support for IEnumerable<T> in control properties

### DIFF
--- a/src/Framework/Framework/Binding/ControlPropertyBindingDataContextChangeAttribute.cs
+++ b/src/Framework/Framework/Binding/ControlPropertyBindingDataContextChangeAttribute.cs
@@ -41,7 +41,7 @@ namespace DotVVM.Framework.Binding
                 return dataContext;
             }
 
-            throw new Exception($"Property '{PropertyName}' is required on '{control.Metadata.Type.Name}'.");
+            throw new Exception($"Property '{PropertyName}' is required on '{control.Metadata.Type.CSharpName}'.");
         }
 
         public override Type? GetChildDataContextType(Type dataContext, DataContextStack controlContextStack, DotvvmBindableObject control, DotvvmProperty? property = null)

--- a/src/Framework/Framework/Compilation/ControlTree/ControlTreeHelper.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ControlTreeHelper.cs
@@ -32,7 +32,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
         public static IPropertyDescriptor GetPropertyGroupMember(this IControlResolverMetadata metadata, string prefix, string name)
         {
             var group = metadata.PropertyGroups.FirstOrDefault(f => f.Prefix == prefix).PropertyGroup;
-            if (group == null) throw new NotSupportedException($"Control { metadata.Type.Name } does not support property group with prefix '{prefix}'.");
+            if (group == null) throw new NotSupportedException($"Control { metadata.Type.CSharpName } does not support property group with prefix '{prefix}'.");
             return group.GetDotvvmProperty(name);
         }
     }

--- a/src/Framework/Framework/Compilation/ControlTree/ControlTreeResolverBase.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ControlTreeResolverBase.cs
@@ -236,7 +236,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
             if (controlMetadata.DataContextConstraint != null && dataContext != null && !controlMetadata.DataContextConstraint.IsAssignableFrom(dataContext.DataContextType))
             {
                 ((DothtmlNode?)dataContextAttribute ?? element)
-                   .AddError($"The control '{controlMetadata.Type.Name}' requires a DataContext of type '{controlMetadata.DataContextConstraint.FullName}'!");
+                   .AddError($"The control '{controlMetadata.Type.CSharpName}' requires a DataContext of type '{controlMetadata.DataContextConstraint.CSharpFullName}'!");
             }
 
             ProcessAttributeProperties(control, element.Attributes.Where(a => a.AttributeName != "DataContext").ToArray(), dataContext!);
@@ -247,7 +247,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
             var unknownContent = control.Content.Where(c => !c.Metadata.Type.IsAssignableTo(new ResolvedTypeDescriptor(typeof(DotvvmControl))));
             foreach (var unknownControl in unknownContent)
             {
-                unknownControl.DothtmlNode!.AddError($"The control '{ unknownControl.Metadata.Type.FullName }' does not inherit from DotvvmControl and thus cannot be used in content.");
+                unknownControl.DothtmlNode!.AddError($"The control '{ unknownControl.Metadata.Type.CSharpName }' does not inherit from DotvvmControl and thus cannot be used in content.");
             }
 
             return control;
@@ -327,7 +327,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
                 {
                     if (!treeBuilder.AddProperty(control, treeBuilder.BuildPropertyValue(property, (property as DotVVM.Framework.Binding.DotvvmProperty)?.DefaultValue, attribute), out var error)) attribute.AddError(error);
                 }
-                else attribute.AddError($"The attribute '{property.Name}' on the control '{control.Metadata.Type.FullName}' must have a value!");
+                else attribute.AddError($"The attribute '{property.Name}' on the control '{control.Metadata.Type.CSharpName}' must have a value!");
             }
             else if (attribute.ValueNode is DothtmlValueBindingNode valueBindingNode)
             {
@@ -422,7 +422,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
                                 control.Metadata.Type.IsAssignableTo(new ResolvedTypeDescriptor
                             (typeof(CompositeControl))) ?
                                 " CompositeControls don't allow content by default and Content or ContentTemplate property is missing on this control." : "";
-                            item.AddError($"Content not allowed inside {control.Metadata.Type.Name}.{compositeControlHelp}");
+                            item.AddError($"Content not allowed inside {control.Metadata.Type.CSharpName}.{compositeControlHelp}");
                         }
                     }
                 }
@@ -460,7 +460,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
                         c => {
                             // empty nodes are only filtered, non-empty nodes cause errors
                             if (c.DothtmlNode.IsNotEmpty())
-                                c.DothtmlNode.AddError($"Control type {c.Metadata.Type.FullName} can't be used in collection of type {type.FullName}.");
+                                c.DothtmlNode.AddError($"Control type {c.Metadata.Type.CSharpFullName} can't be used in collection of type {type.CSharpFullName}.");
                         });
 
             // resolve data context
@@ -472,18 +472,6 @@ namespace DotVVM.Framework.Compilation.ControlTree
             {
                 // template
                 return treeBuilder.BuildPropertyTemplate(property, ProcessTemplate(control, elementContent, dataContext), propertyWrapperElement);
-            }
-            else if (IsCollectionProperty(property))
-            {
-                var collectionType = GetCollectionType(property);
-                // collection of elements
-                var collection = elementContent.Select(childObject => ProcessNode(control, childObject, control.Metadata, dataContext)!);
-                if (collectionType != null)
-                {
-                    collection = filterByType(collectionType, collection);
-                }
-
-                return treeBuilder.BuildPropertyControlCollection(property, collection.ToArray(), propertyWrapperElement);
             }
             else if (property.PropertyType.IsEqualTo(new ResolvedTypeDescriptor(typeof(string))))
             {
@@ -514,9 +502,29 @@ namespace DotVVM.Framework.Compilation.ControlTree
                     return treeBuilder.BuildPropertyControl(property, null, propertyWrapperElement);
                 }
             }
+            else if (IsCollectionProperty(property))
+            {
+                var collectionType = GetCollectionType(property);
+                    
+                // collection of elements
+                var collection = elementContent.Select(childObject => ProcessNode(control, childObject, control.Metadata, dataContext)!);
+                if (collectionType is null)
+                {
+                    control.DothtmlNode!.AddError($"The property '{property.FullName}' is a collection, but the collection type could not be determined.");
+                }
+                else
+                {
+                    if (!collectionType.IsAssignableTo(ResolvedTypeDescriptor.Create(typeof(IDotvvmObjectLike))))
+                        control.DothtmlNode!.AddError($"The property '{property.FullName}' of type '{property.PropertyType.CSharpName}' cannot be used as an inner element. It is not a collection of DotvvmControl or IDotvvmObjectLike.");
+
+                    collection = filterByType(collectionType, collection);
+                }
+
+                return treeBuilder.BuildPropertyControlCollection(property, collection.ToArray(), propertyWrapperElement);
+            }
             else
             {
-                control.DothtmlNode!.AddError($"The property '{property.FullName}' is not supported!");
+                control.DothtmlNode!.AddError($"The property '{property.FullName}' cannot be used as an inner element. The type '{property.PropertyType.CSharpName}' is not supported.");
                 return treeBuilder.BuildPropertyValue(property, null, propertyWrapperElement);
             }
         }
@@ -559,7 +567,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
 
         protected virtual bool IsCollectionProperty(IPropertyDescriptor property)
         {
-            return property.PropertyType.IsAssignableTo(new ResolvedTypeDescriptor(typeof(ICollection)));
+            return property.PropertyType.IsAssignableTo(new ResolvedTypeDescriptor(typeof(IEnumerable)));
         }
 
         protected virtual ITypeDescriptor? GetCollectionType(IPropertyDescriptor property)

--- a/src/Framework/Framework/Compilation/ControlTree/ITypeDescriptor.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ITypeDescriptor.cs
@@ -11,6 +11,10 @@ namespace DotVVM.Framework.Compilation.ControlTree
         string? Assembly { get; }
 
         string FullName { get; }
+        /// <summary> Returns type name with generic arguments in the C# style. Does not include namespaces. </summary>
+        string CSharpName { get; }
+        /// <summary> Returns type name including namespace with generic arguments in the C# style. </summary>
+        string CSharpFullName { get; }
 
         bool IsAssignableTo(ITypeDescriptor typeDescriptor);
 

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedTypeDescriptor.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedTypeDescriptor.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.Utils;
+using FastExpressionCompiler;
 
 namespace DotVVM.Framework.Compilation.ControlTree.Resolved
 {
@@ -28,6 +29,9 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
         public string? Assembly => Type.Assembly?.FullName;
 
         public string FullName => Type.FullName ?? (string.IsNullOrEmpty(Namespace) ? Name : (Namespace + "." + Name));
+
+        public string CSharpName => Type.ToCode(stripNamespace: true);
+        public string CSharpFullName => Type.ToCode();
 
         public bool IsAssignableTo(ITypeDescriptor typeDescriptor)
         {

--- a/src/Framework/Framework/Compilation/Validation/DefaultControlUsageValidator.cs
+++ b/src/Framework/Framework/Compilation/Validation/DefaultControlUsageValidator.cs
@@ -29,7 +29,7 @@ namespace DotVVM.Framework.Compilation.Validation
             if (missingProperties.Any())
             {
                 yield return new ControlUsageError(
-                    $"The control '{ control.Metadata.Type.FullName }' is missing required properties: { string.Join(", ", missingProperties.Select(p => "'" + p.Name + "'")) }.",
+                    $"The control '{ control.Metadata.Type.CSharpName }' is missing required properties: { string.Join(", ", missingProperties.Select(p => "'" + p.Name + "'")) }.",
                     control.DothtmlNode
                 );
             }
@@ -38,7 +38,7 @@ namespace DotVVM.Framework.Compilation.Validation
             foreach (var unknownControl in unknownContent)
             {
                 yield return new ControlUsageError(
-                    $"The control '{ unknownControl.Metadata.Type.FullName }' does not inherit from DotvvmControl and thus cannot be used in content.",
+                    $"The control '{ unknownControl.Metadata.Type.CSharpName }' does not inherit from DotvvmControl and thus cannot be used in content.",
                     control.DothtmlNode
                 );
             }

--- a/src/Framework/Framework/Controls/CloneTemplate.cs
+++ b/src/Framework/Framework/Controls/CloneTemplate.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using DotVVM.Framework.Hosting;
 
 namespace DotVVM.Framework.Controls
@@ -8,6 +10,10 @@ namespace DotVVM.Framework.Controls
         public CloneTemplate(params DotvvmBindableObject[] controls)
         {
             this.Controls = controls;
+        }
+        public CloneTemplate(IEnumerable<DotvvmBindableObject> controls)
+        {
+            this.Controls = controls.ToArray();
         }
 
         public DotvvmBindableObject[] Controls { get; }

--- a/src/Framework/Framework/Controls/TextOrContentCapability.cs
+++ b/src/Framework/Framework/Controls/TextOrContentCapability.cs
@@ -1,5 +1,6 @@
 using DotVVM.Framework.Binding;
 using DotVVM.Framework.Controls.Infrastructure;
+using DotVVM.Framework.Hosting;
 using DotVVM.Framework.Utils;
 using System.Collections.Generic;
 using System.Linq;
@@ -64,7 +65,7 @@ namespace DotVVM.Framework.Controls
 
         public ITemplate ToTemplate()
         {
-            return new CloneTemplate();
+            return new CloneTemplate(ToControls());
         }
     }
 }

--- a/src/Framework/Framework/Controls/TextOrContentCapability.cs
+++ b/src/Framework/Framework/Controls/TextOrContentCapability.cs
@@ -61,5 +61,10 @@ namespace DotVVM.Framework.Controls
             else
                 return Content.NotNull();
         }
+
+        public ITemplate ToTemplate()
+        {
+            return new CloneTemplate();
+        }
     }
 }

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.Markup.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.Markup.json
@@ -48,7 +48,9 @@
             "Name": "ConfigurationSerializationTests",
             "Namespace": "DotVVM.Framework.Tests.Runtime",
             "Assembly": "DotVVM.Framework.Tests, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da",
-            "FullName": "DotVVM.Framework.Tests.Runtime.ConfigurationSerializationTests"
+            "FullName": "DotVVM.Framework.Tests.Runtime.ConfigurationSerializationTests",
+            "CSharpName": "ConfigurationSerializationTests",
+            "CSharpFullName": "DotVVM.Framework.Tests.Runtime.ConfigurationSerializationTests"
           },
           "Inherit": true
         },
@@ -61,7 +63,9 @@
             "Name": "Func`1",
             "Namespace": "System",
             "Assembly": "CoreLibrary",
-            "FullName": "System.Func`1[[System.Collections.Generic.IEnumerable`1[[System.Lazy`1[[System.IServiceProvider, ComponentLibrary]], CoreLibrary]], CoreLibrary]]"
+            "FullName": "System.Func`1[[System.Collections.Generic.IEnumerable`1[[System.Lazy`1[[System.IServiceProvider, ComponentLibrary]], CoreLibrary]], CoreLibrary]]",
+            "CSharpName": "Func<IEnumerable<Lazy<IServiceProvider>>>",
+            "CSharpFullName": "System.Func<System.Collections.Generic.IEnumerable<System.Lazy<System.IServiceProvider>>>"
           },
           "Inherit": true
         }

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.RestAPI.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.RestAPI.json
@@ -20,7 +20,9 @@
             "Name": "TestApiClient",
             "Namespace": "DotVVM.Framework.Tests.Binding",
             "Assembly": "DotVVM.Framework.Tests, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da",
-            "FullName": "DotVVM.Framework.Tests.Binding.TestApiClient"
+            "FullName": "DotVVM.Framework.Tests.Binding.TestApiClient",
+            "CSharpName": "TestApiClient",
+            "CSharpFullName": "DotVVM.Framework.Tests.Binding.TestApiClient"
           },
           "Inherit": true
         }


### PR DESCRIPTION
Also improves the error messages when property type is not suported + a test that it works automatically (without MarkupOption) in CompositeControl.