### PR TITLE
HtmlWriter: Fix self closing tags which actually have children

### DIFF
--- a/src/Framework/Framework/Controls/HtmlWriter.cs
+++ b/src/Framework/Framework/Controls/HtmlWriter.cs
@@ -237,8 +237,10 @@ namespace DotVVM.Framework.Controls
         /// </summary>
         private void RenderBeginTagCore(string name)
         {
-            writer.Write("<");
             AssertIsValidHtmlName(name);
+
+            EnsureTagFullyOpen();
+            writer.Write("<");
             writer.Write(name);
 
 #pragma warning disable CS8605

--- a/src/Tests/Runtime/HtmlWriterTests.cs
+++ b/src/Tests/Runtime/HtmlWriterTests.cs
@@ -30,5 +30,17 @@ namespace DotVVM.Framework.Tests.Runtime
             });
             Assert.AreEqual("<b data-bind=\"a: {}\" />", text);
         }
+
+        [TestMethod]
+        public void ImgTagWithChildren()
+        {
+            var text = WriteHtml(a => {
+                a.RenderBeginTag("img");
+                a.RenderBeginTag("div");
+                a.RenderEndTag();
+                a.RenderEndTag();
+            });
+            Assert.AreEqual("<img><div></div></img>", text);
+        }
     }
 }


### PR DESCRIPTION
We write out self-closing tags only partially to avoid having <img></img>
which is invalid in HTML. However, there was a missing check
that the begin tag is fully written out when we are starting another
tag