### PR TITLE
Improve error message in html attribute merging

### DIFF
--- a/src/Framework/Framework/Compilation/HtmlAttributeValueMerger.cs
+++ b/src/Framework/Framework/Compilation/HtmlAttributeValueMerger.cs
@@ -46,7 +46,7 @@ namespace DotVVM.Framework.Compilation
             if (a is string aString && b is string bString)
                 return HtmlWriter.JoinAttributeValues(gProp.GroupMemberName, aString, bString);
 
-            throw new NotSupportedException($"Cannot merge html attribute values {a} and {b}, the values must be of type string.");
+            throw new NotSupportedException($"Cannot merge '{gProp.GroupMemberName}' attribute values {a} and {b}, the values must be of type string.");
         }
     }
 }


### PR DESCRIPTION
When you have a long chain of .AddAttribute(...),
the stacktrace won't tell you much, so we'll just include the name of the
attribute in the error message.