### PR TITLE
Move MarkupControlContainer to Infrastructure namespace

### DIFF
--- a/src/Framework/Framework/Controls/Infrastructure/MarkupControlContainer.cs
+++ b/src/Framework/Framework/Controls/Infrastructure/MarkupControlContainer.cs
@@ -6,7 +6,7 @@ using DotVVM.Framework.Hosting;
 using DotVVM.Framework.Utils;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace DotVVM.Framework.Controls
+namespace DotVVM.Framework.Controls.Infrastructure
 {
     /// <summary> Allows using markup controls from code controls or from server-side styles. Use like this <code>new MarkupControlContainer("cc:MyControl", c => c.SetValue(MyControl.NameProperty, "X"))</code> </summary>
     /// <seealso cref="MarkupControlContainer{TMarkupControl}"/>


### PR DESCRIPTION
This control cannot be used from markup, by moving it to the
DotVVM.Framework.Controls.Infrastructure namespace.