### PR TITLE
Set up source link

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -33,10 +33,8 @@
 
   <PropertyGroup Label="SourceLink">
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <!-- Symbols are included in the main package. -->
+    <!-- NB: Don't generate symbol packages. Symbols and sources are packed into the dlls. -->
     <IncludeSymbols>false</IncludeSymbols>
-    <!-- <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder> -->
     <DebugType>embedded</DebugType>
     <EmbedAllSources>true</EmbedAllSources>
   </PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -33,10 +33,11 @@
 
   <PropertyGroup Label="SourceLink">
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <DebugType>portable</DebugType>
+    <!-- Symbols are included in the main package. -->
+    <IncludeSymbols>false</IncludeSymbols>
+    <!-- <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder> -->
+    <DebugType>embedded</DebugType>
     <EmbedAllSources>true</EmbedAllSources>
   </PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -39,14 +39,6 @@
     <EmbedAllSources>true</EmbedAllSources>
   </PropertyGroup>
 
-  <Target Name="ResetSourceLinkForPrivateProjects" BeforeTargets="BeforeBuild;DispatchToInnerBuilds;Pack">
-    <PropertyGroup Condition=" '$(PackageId)' == '' ">
-      <PublishRepositoryUrl>false</PublishRepositoryUrl>
-      <IncludeSymbols>false</IncludeSymbols>
-      <EmbedAllSources>false</EmbedAllSources>
-    </PropertyGroup>
-  </Target>
-
   <ItemGroup Label="SourceLink">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -39,6 +39,14 @@
     <EmbedAllSources>true</EmbedAllSources>
   </PropertyGroup>
 
+  <Target Name="ResetSourceLinkForPrivateProjects" BeforeTargets="BeforeBuild;DispatchToInnerBuilds;Pack">
+    <PropertyGroup Condition=" '$(PackageId)' == '' ">
+      <PublishRepositoryUrl>false</PublishRepositoryUrl>
+      <IncludeSymbols>false</IncludeSymbols>
+      <EmbedAllSources>false</EmbedAllSources>
+    </PropertyGroup>
+  </Target>
+
   <ItemGroup Label="SourceLink">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,19 +14,6 @@
     <None Include="$(MSBuildThisFileDirectory)package-icon.png" Pack="true" PackagePath="/" />
   </ItemGroup>
 
-  <!-- Set SourceRevisionId to current git commit hash -->
-  <Target Name="GetGitVersion" BeforeTargets="DispatchToInnerBuilds;BeforeBuild">
-    <Exec Command="git rev-parse HEAD"
-          ConsoleToMsBuild="true"
-          ContinueOnError="true"
-          StandardOutputImportance="low" StandardErrorImportance="low">
-      <Output TaskParameter="ConsoleOutput" PropertyName="SourceRevisionId" />
-    </Exec>
-    <PropertyGroup>
-      <RepositoryCommit>$(SourceRevisionId)</RepositoryCommit>
-    </PropertyGroup>
-  </Target>
-
   <PropertyGroup Label="Licensing">
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -42,9 +29,19 @@
     <DefaultTargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.1;net6.0</DefaultTargetFrameworks>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages>
-    <!-- Pack pdb symbol files -->
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
+
+  <PropertyGroup Label="SourceLink">
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugType>portable</DebugType>
+    <EmbedAllSources>true</EmbedAllSources>
+  </PropertyGroup>
+
+  <ItemGroup Label="SourceLink">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+  </ItemGroup>
 
   <PropertyGroup Condition="$(DOTVVM_ROOT) != ''">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -35,6 +35,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <DebugType>portable</DebugType>
     <EmbedAllSources>true</EmbedAllSources>
   </PropertyGroup>

--- a/src/Tests/DotVVM.Framework.Tests.csproj
+++ b/src/Tests/DotVVM.Framework.Tests.csproj
@@ -1,8 +1,12 @@
 <Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+
     <!-- This async method lacks 'await' -->
     <NoWarn>$(NoWarn);CS1998</NoWarn>
+
+    <!-- Required for CheckTestOutput to function correctly in a CI environment. -->
+    <DeterministicSourcePaths>false</DeterministicSourcePaths>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
     <SignAssembly>True</SignAssembly>


### PR DESCRIPTION
Sets up Source link based on instructions from https://github.com/dotnet/sourcelink.

Also embeds the PDBs in the symbol package (including all C# sources) instead of the main package. (Visual Studio IMO just ignored them anyway because of the missing SourceLink package.) This makes the main package smaller by ~800 KB.

I tested it locally but I'll test it on our internal feed as well.