### PR TITLE
Fix DotVVM.CommandLine packaging

### DIFF
--- a/src/Tools/CommandLine/DotVVM.CommandLine.csproj
+++ b/src/Tools/CommandLine/DotVVM.CommandLine.csproj
@@ -54,7 +54,7 @@
         <AdditionalProperties>PublishDir=$(OutputPath)tools\netcoreapp3.1\any</AdditionalProperties>
         <Targets>Publish</Targets>
     </ProjectReference>
-    <ProjectReference Include="..\Compiler\DotVVM.Compiler.csproj">
+    <ProjectReference Include="..\Compiler\DotVVM.Compiler.csproj" Condition=" '$(OS)' == 'Windows_NT' ">
         <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
         <SetTargetFramework>TargetFramework=net472</SetTargetFramework>
         <AdditionalProperties>PublishDir=$(OutputPath)tools\net472\any</AdditionalProperties>
@@ -66,7 +66,7 @@
     <ItemGroup>
       <ToolsFile Include="$(OutputPath)\tools\**" />
     </ItemGroup>
-    <Message Text="$(PublishDir)" Importance="High" />
+    <Warning Text="CommandLine should be packaged on Windows because of its dependency on Compiler!" Condition=" '$(OS)' != 'Windows_NT' "/>
     <Copy SourceFiles="@(ToolsFile)" DestinationFolder="$(PublishDir)\tools\%(RecursiveDir)" />
   </Target>
 

--- a/src/Tools/CommandLine/DotVVM.CommandLine.csproj
+++ b/src/Tools/CommandLine/DotVVM.CommandLine.csproj
@@ -8,6 +8,7 @@
     <SignAssembly>true</SignAssembly>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
 
   <!--Related to packaging-->
@@ -46,10 +47,20 @@
     <ProjectReference Include="../../Framework/Framework/DotVVM.Framework.csproj" />
   </ItemGroup>
 
-  <Target Name="BuildCompiler" BeforeTargets="BeforeBuild">
-    <MSBuild Projects="..\Compiler\DotVVM.Compiler.csproj" Targets="Restore;Build;Publish" Properties="TargetFramework=netcoreapp3.1;Configuration=$(Configuration);PublishDir=$(OutputPath)tools\netcoreapp3.1\any" />
-    <MSBuild Projects="..\Compiler\DotVVM.Compiler.csproj" Condition=" '$(OS)' == 'Windows_NT' " Targets="Restore;Build;Publish" Properties="TargetFramework=net472;Configuration=$(Configuration);PublishDir=$(OutputPath)tools\net472\any" />
-  </Target>
+  <ItemGroup>
+    <ProjectReference Include="..\Compiler\DotVVM.Compiler.csproj">
+        <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+        <SetTargetFramework>TargetFramework=netcoreapp3.1</SetTargetFramework>
+        <AdditionalProperties>PublishDir=$(OutputPath)tools\netcoreapp3.1\any</AdditionalProperties>
+        <Targets>Publish</Targets>
+    </ProjectReference>
+    <ProjectReference Include="..\Compiler\DotVVM.Compiler.csproj">
+        <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+        <SetTargetFramework>TargetFramework=net472</SetTargetFramework>
+        <AdditionalProperties>PublishDir=$(OutputPath)tools\net472\any</AdditionalProperties>
+        <Targets>Publish</Targets>
+    </ProjectReference>
+  </ItemGroup>
 
   <Target Name="AddCompilerToPublish" BeforeTargets="Publish;Pack">
     <ItemGroup>
@@ -82,7 +93,6 @@
         $(_IconUrlElement)
         $(_ReleaseNotesElement)
       </_CommonMetadataElements>
-      <_CompilerPath>..\Compiler\bin\$(Configuration)\</_CompilerPath>
     </PropertyGroup>
     <ItemGroup>
       <NuspecProperty Include="PackageType=$(PackageType)" />
@@ -92,7 +102,7 @@
       <NuspecProperty Include="Version=$(PackageVersion)" />
       <NuspecProperty Include="ProjectDirectory=$(MSBuildProjectDirectory)" />
       <NuspecProperty Include="SettingsFile=$(_ToolsSettingsFilePath)" />
-      <NuspecProperty Include="Output=$(PublishDir)" />
+      <NuspecProperty Include="Output=$(PublishDir)**\*" />
     </ItemGroup>
     <PropertyGroup Condition="'$(NuspecFile)' != '' and '$(NuspecProperties)' == ''">
       <NuspecProperties>@(NuspecProperty, ';')</NuspecProperties>

--- a/src/Tools/CommandLine/DotVVM.CommandLine.nuspec
+++ b/src/Tools/CommandLine/DotVVM.CommandLine.nuspec
@@ -9,6 +9,6 @@
 
   <files>
     <file src="$SettingsFile$" target="tools\$TargetFramework$\any" />
-    <file src="$Output$**\*" target="tools\$TargetFramework$\any" />
+    <file src="$Output$" target="tools\$TargetFramework$\any" />
   </files>
 </package>

--- a/src/Tools/Compiler/DotVVM.Compiler.csproj
+++ b/src/Tools/Compiler/DotVVM.Compiler.csproj
@@ -47,6 +47,10 @@ for some reason. What fun. -->
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tools/Compiler/DotVVM.Compiler.csproj
+++ b/src/Tools/Compiler/DotVVM.Compiler.csproj
@@ -47,10 +47,6 @@ for some reason. What fun. -->
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Turns out that the `DotVVM.CommandLine` package did not contain the `DotVVVM.Compiler` dlls, which are required for the `dotvvm lint` command to work. (Honestly, I'm not even able to find a version that ever contained them.) Anyway, this PR addresses this bug.