### PR TITLE
Fix Analyzers.Package build

### DIFF
--- a/src/Analyzers/Analyzers.Package/DotVVM.Analyzers.Package.csproj
+++ b/src/Analyzers/Analyzers.Package/DotVVM.Analyzers.Package.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>DotVVM.Analyzers.Package</AssemblyName>
     <PackageId>DotVVM.Analyzers</PackageId>
     <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Framework/Framework/DotVVM.Framework.csproj
+++ b/src/Framework/Framework/DotVVM.Framework.csproj
@@ -91,7 +91,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Pack analyzers together with the main DotVVM package -->
+    <ProjectReference Include="../../Analyzers/Analyzers.Package/DotVVM.Analyzers.Package.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(DOTVVM_ROOT)' != ''">
+    <None Include="$(DOTVVM_ROOT)/artifacts/bin/DotVVM.Analyzers.Package/$(Configuration)/netstandard2.0/DotVVM.Analyzers.dll" PackagePath="analyzers/dotnet/cs" Pack="true" Visible="false" />
+    <None Include="$(DOTVVM_ROOT)/artifacts/bin/DotVVM.Analyzers.Package/$(Configuration)/netstandard2.0/DotVVM.Analyzers.CodeFixes.dll" PackagePath="analyzers/dotnet/cs" Pack="true" Visible="false" />
+    <None Include="../../Analyzers/Analyzers.Package/tools/*.ps1" PackagePath="tools" Pack="true" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(DOTVVM_ROOT)' == ''">
     <None Include="../../Analyzers/Analyzers.Package/bin/$(Configuration)/netstandard2.0/DotVVM.Analyzers.dll" PackagePath="analyzers/dotnet/cs" Pack="true" Visible="false" />
     <None Include="../../Analyzers/Analyzers.Package/bin/$(Configuration)/netstandard2.0/DotVVM.Analyzers.CodeFixes.dll" PackagePath="analyzers/dotnet/cs" Pack="true" Visible="false" />
     <!-- Add install / uninstall scripts for .NET Framework -->


### PR DESCRIPTION
Adds a Analyzers.Package project reference to Framework with `ReferenceOutputAssembly=false`. This causes Analyzers.Package to be transitively built instead of it being assumed that it is has already been built.