### PR TITLE
Feature/add dotvvm version serialized configuration

### DIFF
--- a/src/Framework/Framework/Hosting/VisualStudioHelper.cs
+++ b/src/Framework/Framework/Hosting/VisualStudioHelper.cs
@@ -20,6 +20,7 @@ namespace DotVVM.Framework.Hosting
             }
 
             var obj = new {
+                dotvvmVersion = typeof(DotvvmConfiguration).Assembly.GetName().Version,
                 config,
                 properties = includeProperties ? DotvvmPropertySerializableList.Properties : null,
                 capabilities = includeProperties ? DotvvmPropertySerializableList.Capabilities : null,

--- a/src/Tests/Runtime/ConfigurationSerializationTests.cs
+++ b/src/Tests/Runtime/ConfigurationSerializationTests.cs
@@ -29,6 +29,7 @@ namespace DotVVM.Framework.Tests.Runtime
         {
             var serialized = DotVVM.Framework.Hosting.VisualStudioHelper.SerializeConfig(config, includeProperties);
             serialized = Regex.Replace(serialized, "Version=[0-9.]+", "Version=***");
+            serialized = Regex.Replace(serialized, "\"dotvvmVersion\": \"[0-9]\\.[0-9]\\.[0-9]\\.[0-9]\"", "\"dotvvmVersion\": \"*.*.*.*\"");
             var jobject = JObject.Parse(serialized);
             if (jobject["properties"] is object)
                 foreach (var testControl in ((JObject)jobject["properties"]).Properties().Where(p => p.Name.Contains(".Tests.")).ToArray())

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.AuxOptions.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.AuxOptions.json
@@ -1,4 +1,5 @@
 {
+  "dotvvmVersion": "*.*.*.*",
   "config": {
     "applicationPhysicalPath": "/opt/myApp",
     "markup": {

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.ExperimentalFeatures.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.ExperimentalFeatures.json
@@ -1,4 +1,5 @@
 {
+  "dotvvmVersion": "*.*.*.*",
   "config": {
     "markup": {
       "importedNamespaces": [

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.Markup.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.Markup.json
@@ -1,4 +1,5 @@
 {
+  "dotvvmVersion": "*.*.*.*",
   "config": {
     "markup": {
       "controls": [

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.RestAPI.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.RestAPI.json
@@ -1,4 +1,5 @@
 {
+  "dotvvmVersion": "*.*.*.*",
   "config": {
     "markup": {
       "importedNamespaces": [

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -1,4 +1,5 @@
 {
+  "dotvvmVersion": "*.*.*.*",
   "config": {
     "markup": {
       "controls": [

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeEmptyConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeEmptyConfig.json
@@ -1,4 +1,5 @@
 {
+  "dotvvmVersion": "*.*.*.*",
   "config": {
     "markup": {
       "importedNamespaces": [

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeResources.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeResources.json
@@ -1,4 +1,5 @@
 {
+  "dotvvmVersion": "*.*.*.*",
   "config": {
     "markup": {
       "importedNamespaces": [

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeRoutes.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeRoutes.json
@@ -1,4 +1,5 @@
 {
+  "dotvvmVersion": "*.*.*.*",
   "config": {
     "markup": {
       "importedNamespaces": [


### PR DESCRIPTION
This PR adds DotVVM Framework version to the JSON that contains serialized DotVVM configuration. Obtaining this information within extension code-base is harder. Moreover, this information does not change frequently.