### PR TITLE
Allow multiple AddClass() even when some contain binding

### DIFF
--- a/src/Framework/Framework/Compilation/HtmlAttributeValueMerger.cs
+++ b/src/Framework/Framework/Compilation/HtmlAttributeValueMerger.cs
@@ -46,7 +46,13 @@ namespace DotVVM.Framework.Compilation
             if (a is string aString && b is string bString)
                 return HtmlWriter.JoinAttributeValues(gProp.GroupMemberName, aString, bString);
 
-            throw new NotSupportedException($"Cannot merge '{gProp.GroupMemberName}' attribute values {a} and {b}, the values must be of type string.");
+            // append to list. Order does not matter in html attributes
+            if (a is HtmlGenericControl.AttributeList alist)
+                return new HtmlGenericControl.AttributeList(b, alist);
+            else if (b is HtmlGenericControl.AttributeList blist)
+                return new HtmlGenericControl.AttributeList(a, blist);
+
+            return new HtmlGenericControl.AttributeList(a, new HtmlGenericControl.AttributeList(b, null));
         }
     }
 }

--- a/src/Framework/Framework/Compilation/Javascript/JsParensFixingVisitor.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JsParensFixingVisitor.cs
@@ -22,7 +22,7 @@ namespace DotVVM.Framework.Compilation.Javascript
         {
             // there is an exception to the rule: ?? can not be chained with && and ||, even though it has lower precedence
             // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator#no_chaining_with_and_or_or_operators
-            if (parentPrecedence == 4 && Precedence is 5 or 6)
+            if (parentPrecedence == NullishCoalescing && Precedence is ConditionalAnd or ConditionalOr)
                 return true;
 
             return Precedence < parentPrecedence ||
@@ -32,34 +32,87 @@ namespace DotVVM.Framework.Compilation.Javascript
         public override string ToString()
         {
             var name = Precedence switch {
-                20 => "max",
-                17 => "postfix unary",
-                16 => "prefix unary",
-                14 => "*",
-                13 => "+",
-                12 => ">>",
-                11 => "<=",
-                10 => "==",
-                9 => "&&",
-                8 => "^",
-                7 => "|",
-                6 => "&&",
-                5 => "||",
-                4 => "??",
-                3 => "? :",
-                2 => "=",
-                1 => "method argument",
-                0 => ",",
+                Atomic => "max",
+                UnaryPostfix => "postfix unary",
+                UnaryPrefix => "prefix unary",
+                Multiplication => "*",
+                Addition => "+",
+                BinaryShifts => ">>",
+                Comparison => "<=",
+                Equal => "==",
+                BitwiseAnd => "&",
+                BitwiseXor => "^",
+                BitwiseOr => "|",
+                ConditionalAnd => "&&",
+                ConditionalOr => "||",
+                NullishCoalescing => "??",
+                Conditional => "? :",
+                Assignment => "=",
+                ArrowFunction => "() => {}",
+                Sequence => ",",
+                0 => "0",
                 _ => "?"
             };
             return Precedence + (IsPreferredSide ? "+" : "-") + " (" + name + ")";
         }
 
         public static readonly OperatorPrecedence Max = new OperatorPrecedence(20, true);
+
+        /// <summary> atomic expression, like `x`, `(x + y)`, `0`, `{"f": 123}`, `x[1]`, ... </summary>
+        public const byte Atomic = 20;
+        /// <summary> postfix unary expressions `x++`, `x--` </summary>
+        public const byte UnaryPostfix = 17;
+        /// <summary> prefix unary expressions `typeof x`, `!x`, `+x`, `-x`, `++x`, ... </summary>
+        public const byte UnaryPrefix = 16;
+        /// <summary> Multiplication, division or modulo binary expression </summary>
+        public const byte Multiplication = 15;
+        /// <summary> Plus or minus binary expression </summary>
+        public const byte Addition = 14;
+        /// <summary> int32 binary shift expressions `x >> 10`, `x &lt;&lt; 10`, `x >>> 10` </summary>
+        public const byte BinaryShifts = 13;
+        /// <summary> Comparison expressions `x > 10`, `x &lt; 10`, `x >= 10`, `x in y`, `x instanceof Y` </summary>
+        public const byte Comparison = 12;
+        /// <summary> expressions `x == 10`, `x != 10`, `x === 10`, `x !== y` </summary>
+        public const byte Equal = 11;
+        /// <summary> `x &amp; 0xff` </summary>
+        public const byte BitwiseAnd = 10;
+        /// <summary> `x ^ 0xff` </summary>
+        public const byte BitwiseXor = 9;
+        /// <summary> `x | 0xff` </summary>
+        public const byte BitwiseOr = 8;
+        /// <summary> `x == 1 &amp;&amp; y == 1` </summary>
+        public const byte ConditionalAnd = 7;
+        /// <summary> `x == 1 || y == 1` </summary>
+        public const byte ConditionalOr = 6;
+        /// <summary> `x ?? y` </summary>
+        public const byte NullishCoalescing = 5;
+        /// <summary> `x == 1 ? y : z` </summary>
+        public const byte Conditional = 4;
+        /// <summary> `x = 123` </summary>
+        public const byte Assignment = 3;
+        /// <summary> `x => x + 1` </summary>
+        public const byte ArrowFunction = 2;
+        /// <summary> `x, y` </summary>
+        public const byte Sequence = 1;
     }
 
+    /// <summary> Wraps nodes with <see cref="JsParenthesizedExpression" /> when needed to preserve semantics when the AST is stringified. </summary>
     public class JsParensFixingVisitor : JsNodeVisitor
     {
+        /// <summary> Returns the "inner operator precedence" of the parent node, as seen from the specified child node.
+        /// For example: binary expression have the same inner and outer precedence, <see cref="JsParenthesizedExpression" /> will return Atomic (20) from the outside, but 0 from the inside. Similarly, <see cref="JsInvocationExpression" /> is Atomic from the outside, but 1 (Sequence needs parens) from the argument position and 20 (needs to be Atomic) from the invocation target position. </summary>
+        public static byte GetParentLevel(JsExpression expression)
+        {
+            if (expression.Parent is JsParenthesizedExpression or JsReturnStatement or JsExpressionStatement or null)
+                return 0;
+            if (expression.Role == JsTreeRoles.Argument ||
+                expression.Role == JsTreeRoles.Expression && expression.Parent is JsObjectProperty or JsVariableDefStatement)
+                return 1;
+            return OperatorLevel(expression.Parent as JsExpression);
+        }
+
+        /// <summary> Returns the "outer operator precedence" of the <paramref name="expression" />.
+        /// For example, Sequence expression will return 1; <see cref="JsInvocationExpression" />, <see cref="JsParenthesizedExpression" />, ... will return Atomic (20). </summary> 
         public static byte OperatorLevel(JsExpression? expression)
         {
             switch (expression) {
@@ -74,63 +127,64 @@ namespace DotVVM.Framework.Compilation.Javascript
                 case JsObjectExpression _:
                 case JsArrayExpression _:
                 case JsNewExpression _:
-                    return 20;
+                    return OperatorPrecedence.Atomic; // 20
                 case JsBinaryExpression be:
                     switch (be.Operator) {
                         case BinaryOperatorType.Times:
                         case BinaryOperatorType.Divide:
                         case BinaryOperatorType.Modulo:
-                            return 14;
+                            return OperatorPrecedence.Multiplication; // 15
                         case BinaryOperatorType.Plus:
                         case BinaryOperatorType.Minus:
-                            return 13;
+                            return OperatorPrecedence.Addition; // 14
                         case BinaryOperatorType.LeftShift:
                         case BinaryOperatorType.RightShift:
                         case BinaryOperatorType.UnsignedRightShift:
-                            return 12;
+                            return OperatorPrecedence.BinaryShifts; // 13
                         case BinaryOperatorType.In:
                         case BinaryOperatorType.InstanceOf:
                         case BinaryOperatorType.Greater:
                         case BinaryOperatorType.GreaterOrEqual:
                         case BinaryOperatorType.Less:
                         case BinaryOperatorType.LessOrEqual:
-                            return 11;
+                            return OperatorPrecedence.Comparison; // 12
                         case BinaryOperatorType.Equal:
                         case BinaryOperatorType.NotEqual:
                         case BinaryOperatorType.StrictlyEqual:
                         case BinaryOperatorType.StrictlyNotEqual:
-                            return 10;
+                            return OperatorPrecedence.Equal; // 11
                         case BinaryOperatorType.BitwiseAnd:
-                            return 9;
+                            return OperatorPrecedence.BitwiseAnd; // 10
                         case BinaryOperatorType.BitwiseXOr:
-                            return 8;
+                            return OperatorPrecedence.BitwiseXor; // 9
                         case BinaryOperatorType.BitwiseOr:
-                            return 7;
+                            return OperatorPrecedence.BitwiseOr; // 8
                         case BinaryOperatorType.ConditionalAnd:
-                            return 6;
+                            return OperatorPrecedence.ConditionalAnd; // 7
                         case BinaryOperatorType.ConditionalOr:
-                            return 5;
+                            return OperatorPrecedence.ConditionalOr; // 6
                         case BinaryOperatorType.NullishCoalescing:
-                            return 4;
+                            return OperatorPrecedence.NullishCoalescing; // 5
                         case BinaryOperatorType.Sequence:
-                            return 0;
+                            return OperatorPrecedence.Sequence; // 1
                         default: throw new NotSupportedException();
                     }
                 case JsUnaryExpression ue:
-                    if (!ue.IsPrefix) return 17;
-                    else return 16;
+                    if (!ue.IsPrefix) return OperatorPrecedence.UnaryPostfix; // 17
+                    else return OperatorPrecedence.UnaryPrefix; // 16
                 case JsConditionalExpression ce:
-                    return 3;
+                    return OperatorPrecedence.Conditional; // 4
                 case JsAssignmentExpression ae:
-                    return 2;
+                    return OperatorPrecedence.Assignment; // 3
                 case JsArrowFunctionExpression arrowFunction:
-                    return 1;
+                    return OperatorPrecedence.ArrowFunction; // 2
                 case null:
                     return 0;
                 default: throw new NotSupportedException();
             }
         }
 
+        /// <summary> Returns true if the expression is in the more associative position of the parent node. For example `a + b` will return true for `a` and return false for `b`. For non-associative nodes (invocations, ...), always returns true.  </summary>
         public static bool IsPreferredSide(JsExpression expression)
         {
             switch (expression)
@@ -150,12 +204,9 @@ namespace DotVVM.Framework.Compilation.Javascript
             }
         }
 
+        /// <summary> Returns the "outer operator precedence" of the specified JS expression. </summary>
         public static OperatorPrecedence GetOperatorPrecedence(JsExpression expression)
         {
-            if (expression.Role == JsTreeRoles.Argument && expression is JsBinaryExpression binary && binary.Operator == BinaryOperatorType.Sequence)
-                return new OperatorPrecedence(1, true);
-            if (expression.Role == JsTreeRoles.Argument || expression.Parent is JsParenthesizedExpression)
-                return OperatorPrecedence.Max;
             return new OperatorPrecedence(OperatorLevel(expression), IsPreferredSide(expression));
         }
 
@@ -164,7 +215,7 @@ namespace DotVVM.Framework.Compilation.Javascript
         /// </summary>
         public bool NeedsParens(JsExpression expression)
         {
-            return GetOperatorPrecedence(expression).NeedsParens(OperatorLevel(expression.Parent as JsExpression));
+            return GetOperatorPrecedence(expression).NeedsParens(GetParentLevel(expression));
         }
 
         protected override void DefaultVisit(JsNode node)

--- a/src/Framework/Framework/Compilation/Javascript/ParametrizedCode.cs
+++ b/src/Framework/Framework/Compilation/Javascript/ParametrizedCode.cs
@@ -312,7 +312,7 @@ namespace DotVVM.Framework.Compilation.Javascript
 
         public static CodeParameterInfo FromExpression(JsSymbolicParameter expression)
         {
-            return new CodeParameterInfo(expression.Symbol, JsParensFixingVisitor.OperatorLevel(expression.Parent as JsExpression), expression.Parent is JsMemberAccessExpression, expression.DefaultAssignment);
+            return new CodeParameterInfo(expression.Symbol, JsParensFixingVisitor.GetParentLevel(expression), expression.Parent is JsMemberAccessExpression, expression.DefaultAssignment);
         }
     }
 

--- a/src/Framework/Framework/Controls/DotvvmControl.cs
+++ b/src/Framework/Framework/Controls/DotvvmControl.cs
@@ -494,7 +494,9 @@ namespace DotVVM.Framework.Controls
 
         private object JoinValuesOrBindings(IList<object?> fragments)
         {
-            if (fragments.All(f => f is string))
+            if (fragments.Count == 1)
+                return fragments[0] ?? "";
+            else if (fragments.All(f => f is string or null))
             {
                 return string.Join("_", fragments);
             }
@@ -510,12 +512,12 @@ namespace DotVVM.Framework.Controls
                     if (f is IValueBinding binding)
                     {
                         service = service ?? binding.GetProperty<BindingCompilationService>(ErrorHandlingMode.ReturnNull);
-                        result.Add(binding.GetParametrizedKnockoutExpression(this, unwrapped: true), 14);
+                        result.Add(binding.GetParametrizedKnockoutExpression(this, unwrapped: true), OperatorPrecedence.Addition);
                     }
                     else result.Add(JavascriptCompilationHelper.CompileConstant(f));
                 }
                 if (service == null) throw new NotSupportedException();
-                return ValueBindingExpression.CreateBinding<string?>(service.WithoutInitialization(), h => null, result.Build(new OperatorPrecedence()), this.GetDataContextType());
+                return ValueBindingExpression.CreateBinding<string?>(service.WithoutInitialization(), h => null, result.Build(new OperatorPrecedence(OperatorPrecedence.Addition, false)), this.GetDataContextType());
             }
         }
 

--- a/src/Framework/Framework/Controls/HtmlGenericControl.cs
+++ b/src/Framework/Framework/Controls/HtmlGenericControl.cs
@@ -12,6 +12,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Text;
 using DotVVM.Framework.Compilation.Javascript;
+using FastExpressionCompiler;
 
 namespace DotVVM.Framework.Controls
 {
@@ -359,13 +360,6 @@ namespace DotVVM.Framework.Controls
                     AddHtmlAttribute(writer, name, i.Value);
                 }
             }
-            else if (value is IEnumerable<string>)
-            {
-                foreach (var vv in (IEnumerable<string>)value)
-                {
-                    writer.AddAttribute(name, vv);
-                }
-            }
             else if (value is IStaticValueBinding)
             {
                 AddHtmlAttribute(writer, name, ((IStaticValueBinding)value).Evaluate(this));
@@ -390,13 +384,15 @@ namespace DotVVM.Framework.Controls
                 Enum enumValue => enumValue.ToEnumString(),
                 Guid guid => guid.ToString(),
                 _ when ReflectionUtils.IsNumericType(value.GetType()) => Convert.ToString(value, CultureInfo.InvariantCulture) ?? "",
+                System.Collections.IEnumerable =>
+                    throw new NotSupportedException($"Attribute value of type '{value.GetType().ToCode(stripNamespace: true)}' is not supported. Consider concatenating the values into a string or use the HtmlGenericControl.AttributeList if you need to pass multiple values."),
                 _ =>
 
                     // DateTime and related are not supported here intentionally.
                     // It is not clear in which format it should be rendered - on some places, the HTML specs requires just yyyy-MM-dd,
                     // but in case of Web Components, the users may want to pass the whole date, or use a specific format
 
-                    throw new NotSupportedException($"Attribute value of type '{value.GetType().FullName}' is not supported. Please convert the value to string, e. g. by using ToString()")
+                    throw new NotSupportedException($"Attribute value of type '{value.GetType().ToCode(stripNamespace: true)}' is not supported. Please convert the value to string, e. g. by using ToString()")
             };
 
         private void AddHtmlAttributesToRender(ref RenderState r, IHtmlWriter writer)

--- a/src/Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/Tests/Binding/JavascriptCompilationTests.cs
@@ -118,6 +118,25 @@ namespace DotVVM.Framework.Tests.Binding
             Assert.AreEqual("$parent+$parents[1]+$data+$parent+$parents[2]", js);
         }
 
+        [DataTestMethod]
+        [DataRow("2+2", "2+2", DisplayName = "2+2")]
+        [DataRow("2+2+2", "2+2+2", DisplayName = "2+2+2")]
+        [DataRow("(2+2)+2", "2+2+2", DisplayName = "(2+2)+2")]
+        [DataRow("2+(2+2)", "2+(2+2)", DisplayName = "2+(2+2)")]
+        [DataRow("2+(2*2)", "2+2*2", DisplayName = "2+(2*2)")]
+        [DataRow("2*(2+2)", "2*(2+2)", DisplayName = "2*(2+2)")]
+        [DataRow("IntProp & (2+2)", "IntProp()&2+2", DisplayName = "IntProp & (2+2)")]
+        [DataRow("IntProp & 2+2", "IntProp()&2+2", DisplayName = "IntProp & 2+2")]
+        [DataRow("IntProp & -1", "IntProp()&-1", DisplayName = "IntProp & -1")]
+        [DataRow("'a' + 'b'", "\"ab\"", DisplayName = "'a' + 'b'")]
+        [DataRow("'xx' + IntProp", "\"xx\"+IntProp()", DisplayName = "'xx' + IntProp")]
+        [DataRow("true == (IntProp == 1)", "true==(IntProp()==1)", DisplayName = "true == (IntProp == 1)")]
+        public void JavascriptCompilation_BinaryExpressions(string expr, string expectedJs)
+        {
+            var js = CompileBinding(expr, new [] { typeof(TestViewModel) });
+            Assert.AreEqual(expectedJs, js);
+        }
+
         [TestMethod]
         public void JavascriptCompilation_BindingPageInfo_IsPostbackRunning()
         {

--- a/src/Tests/ControlTests/testoutputs/CompositeControlTests.ControlWithMultipleEnumClasses.html
+++ b/src/Tests/ControlTests/testoutputs/CompositeControlTests.ControlWithMultipleEnumClasses.html
@@ -1,0 +1,20 @@
+<html>
+	<head></head>
+	<body>
+		
+		<!-- static value -->
+		<div class="class-a class-d"></div>
+		
+		<!-- value binding + resource binding -->
+		<div class="class-c class-d" data-bind="class: EnumForCssClasses()+&quot; class-d&quot;"></div>
+		
+		<!-- value binding + static -->
+		<div class="class-c class-d" data-bind="class: EnumForCssClasses()+&quot; class-d&quot;"></div>
+		
+		<!-- static + value binding -->
+		<div class="class-d class-c" data-bind="class: &quot;class-d &quot;+EnumForCssClasses()"></div>
+		
+		<!-- both value bindings -->
+		<div class="class-d class-c" data-bind="class: (TrueBool() ? &quot;class-d&quot; : &quot;class-a&quot;)+&quot; &quot;+EnumForCssClasses()"></div>
+	</body>
+</html>

--- a/src/Tests/Runtime/JavascriptCompilation/JsParensInsersionTests.cs
+++ b/src/Tests/Runtime/JavascriptCompilation/JsParensInsersionTests.cs
@@ -51,17 +51,31 @@ namespace DotVVM.Framework.Tests.Runtime.JavascriptCompilation
             AssertFormatting("(a??b)&&c", id("a").Binary(BinaryOperatorType.NullishCoalescing, id("b")).Binary(BinaryOperatorType.ConditionalAnd, id("c")));
         }
 
-        [TestMethod]
-        public void JsParens_OperatorPriority()
+        [DataTestMethod]
+        [DataRow(BinaryOperatorType.Times, BinaryOperatorType.Plus, "a*b+c")]
+        [DataRow(BinaryOperatorType.Plus, BinaryOperatorType.Times, "(a+b)*c")]
+        [DataRow(BinaryOperatorType.Plus, BinaryOperatorType.Plus, "a+b+c")]
+        [DataRow(BinaryOperatorType.Plus, BinaryOperatorType.Minus, "a+b-c")]
+        [DataRow(BinaryOperatorType.Minus, BinaryOperatorType.Plus, "a-b+c")]
+        [DataRow(BinaryOperatorType.ConditionalAnd, BinaryOperatorType.ConditionalOr, "a&&b||c")]
+        [DataRow(BinaryOperatorType.ConditionalOr, BinaryOperatorType.ConditionalAnd, "(a||b)&&c")]
+        [DataRow(BinaryOperatorType.BitwiseOr, BinaryOperatorType.ConditionalAnd, "a|b&&c")]
+        [DataRow(BinaryOperatorType.BitwiseOr, BinaryOperatorType.BitwiseAnd, "(a|b)&c")]
+        [DataRow(BinaryOperatorType.GreaterOrEqual, BinaryOperatorType.ConditionalAnd, "a>=b&&c")]
+        [DataRow(BinaryOperatorType.GreaterOrEqual, BinaryOperatorType.ConditionalOr, "a>=b||c")]
+        [DataRow(BinaryOperatorType.GreaterOrEqual, BinaryOperatorType.BitwiseAnd, "a>=b&c")]
+        [DataRow(BinaryOperatorType.LeftShift, BinaryOperatorType.Plus, "(a<<b)+c")]
+        [DataRow(BinaryOperatorType.LeftShift, BinaryOperatorType.Greater, "a<<b>c")]
+        [DataRow(BinaryOperatorType.Greater, BinaryOperatorType.Greater, "a>b>c")]
+        [DataRow(BinaryOperatorType.Greater, BinaryOperatorType.GreaterOrEqual, "a>b>=c")]
+        [DataRow(BinaryOperatorType.Plus, BinaryOperatorType.Sequence, "a+b,c")]
+        [DataRow(BinaryOperatorType.Sequence, BinaryOperatorType.Plus, "(a,b)+c")]
+        public void JsParens_OperatorPriority(BinaryOperatorType firstOp, BinaryOperatorType secondOp, string expectedJs)
         {
-            AssertFormatting("a*b+c", new JsBinaryExpression(
-                new JsBinaryExpression(new JsIdentifierExpression("a"), BinaryOperatorType.Times, new JsIdentifierExpression("b")),
-                BinaryOperatorType.Plus,
-                new JsIdentifierExpression("c")));
-            AssertFormatting("(a+b)*c", new JsBinaryExpression(
-                new JsBinaryExpression(new JsIdentifierExpression("a"), BinaryOperatorType.Plus, new JsIdentifierExpression("b")),
-                BinaryOperatorType.Times,
-                new JsIdentifierExpression("c")));
+            AssertFormatting(expectedJs,
+                new JsIdentifierExpression("a")
+                    .Binary(firstOp, new JsIdentifierExpression("b"))
+                    .Binary(secondOp, new JsIdentifierExpression("c")));
         }
 
         [TestMethod]
@@ -113,17 +127,34 @@ namespace DotVVM.Framework.Tests.Runtime.JavascriptCompilation
             );
         }
 
-        [TestMethod]
-        public void JsParent_ParametrizedCodeBuilder()
+        [DataTestMethod]
+        [DataRow(BinaryOperatorType.Times, "a+b+(a*b)", "a+b+a*b")]
+        [DataRow(BinaryOperatorType.Minus, "a+b+(a-b)", "a+b+(a-b)")]
+        [DataRow(BinaryOperatorType.BitwiseXOr, "a+b+(a^b)", "a+b+(a^b)")]
+        [DataRow(BinaryOperatorType.BitwiseOr, "a+b+(a|b)", "a+b+(a|b)")]
+        [DataRow(BinaryOperatorType.BitwiseAnd, "a+b+(a&b)", "a+b+(a&b)")]
+        [DataRow(BinaryOperatorType.NullishCoalescing, "a+b+(a??b)", "a+b+(a??b)")]
+        [DataRow(BinaryOperatorType.InstanceOf, "a+b+(a instanceof b)", "a+b+(a instanceof b)")]
+        public void JsParent_ParametrizedCodeBuilder(BinaryOperatorType binaryOp, string resultParanoidVersion, string resultOptimalVersion)
         {
-            Assert.AreEqual("a+b+(a*b)", new ParametrizedCode.Builder { 
+            Assert.AreEqual(resultParanoidVersion, new ParametrizedCode.Builder { 
                 new JsIdentifierExpression("a").FormatParametrizedScript(),
                 "+b+",
                 new JsBinaryExpression(
                     new JsIdentifierExpression("a"),
-                    BinaryOperatorType.Times,
+                    binaryOp,
                     new JsIdentifierExpression("b")
                 ).FormatParametrizedScript()
+            }.Build(default).ToDefaultString());
+
+            Assert.AreEqual(resultOptimalVersion, new ParametrizedCode.Builder { 
+                new JsIdentifierExpression("a").FormatParametrizedScript(),
+                "+b+",
+                { new JsBinaryExpression(
+                    new JsIdentifierExpression("a"),
+                    binaryOp,
+                    new JsIdentifierExpression("b")
+                ).FormatParametrizedScript(), OperatorPrecedence.Addition }
             }.Build(default).ToDefaultString());
         }
     }


### PR DESCRIPTION
Since it's nearly impossible to concatenate two bindings or
a binding and a constant value, this patch adds support for a list
of binding or values directly to HtmlGenericControl.AddAttributesToRender

I added AttributeList, a special linked list for this use case. The reason is
that we need to append efficiently in the MergePlainValues method
(or prepend, that doesn't matter). It's also far more efficient to typecheck
for sealed class than an generic interface like `IEnumerable<T>`
(the typecheck will be done for each value in HtmlGenericControl)

In order to generate reasonable code, I needed to fix some bugs in
OperatorPrecdence:

* distinguish between no parens needed ever (0) and sequence expression (1)
   - for this reason, all values were shifted by one. And I made constants
* some expressions (parenthized expr, invocation, ...) have a different
   precence from the inside than from the outside. This used to be worked
   around by checking the parent node in `GetOperatorPrecedence`, but that
   doesn't work well when the expression is treated as independent from the
   its parent. I changed this by adding the `GetParentLevel` which gives
   the inner precedence of the parent node as seen from the current
   expression.
* JoinValuesOrBindings should just return the original binding if there are no fragments for joining - it just resulted in unnecesary parenthesis being added


cc @Duzij, you have been asking for this for some time, so feel free to test it out.