### PR TITLE
Allow control interfaces in composite control properties

### DIFF
--- a/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
+++ b/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
@@ -331,9 +331,9 @@ namespace DotVVM.Framework.Binding
                     else if (!typeof(ValueOrBinding).IsAssignableFrom(propertyType.UnwrapNullableType()))
                         dotvvmProperty.MarkupOptions.AllowBinding = false;
 
-                    if (typeof(DotvvmBindableObject).IsAssignableFrom(type) ||
+                    if (typeof(IDotvvmObjectLike).IsAssignableFrom(type) ||
                         typeof(ITemplate).IsAssignableFrom(type) ||
-                        typeof(IEnumerable<DotvvmBindableObject>).IsAssignableFrom(type))
+                        typeof(IEnumerable<IDotvvmObjectLike>).IsAssignableFrom(type))
                         dotvvmProperty.MarkupOptions.MappingMode = MappingMode.Both;
 
                     DotvvmProperty.Register(dotvvmProperty);


### PR DESCRIPTION
CompositeControl automatically infers if a property
should be mapped to an attribute or to a inner element
from the property type. It used to check if the type is
assignable to DotvvmBindableObject, which didn't work
with control interfaces.