### PR TITLE
Svelte bridge: support hosting knockout templates

### DIFF
--- a/src/Framework/JsComponent.React/dotvvm-react.tsx
+++ b/src/Framework/JsComponent.React/dotvvm-react.tsx
@@ -4,12 +4,27 @@ import * as ReactDOM from 'react-dom';
 import type { StateManager } from 'state-manager';
 
 export type KnockoutTemplateReactComponent_Props = {
+    /** HTML element name which will contain the knockout template. By default a `<div>` wrapper tag is used. */
     wrapperTag: string
+
+    /** ID of the knockout template to be rendered, knockout will search for a matching `<template id="...">` element.
+     * You can get this ID in a DotVVM JsComponent as a property when you use inner element in the dothtml markup. */
     templateName: string
+
+    /** A function which returns the knockout context for the rendered template. This property can not be updated after initialization
+     *  @example getChildContext={c => c.extend({ $myTag: 1234 })} */
     getChildContext?: (context: KnockoutBindingContext) => KnockoutBindingContext
+
+    /** When set, a new knockout binding context with `$this` being the specified viewModel.
+     * Parent context will be the context of the parent element.
+     * Note that this viewModel is expected to be a plain JS object, not wrapped in knockout observables.
+     * Upading this property will update the template's data context. */
     viewModel?: any
 }
 
+/** React wrapper for knockout `ko.renderTemplate` function.
+ * Specify the `templateName` property to select which template should be rendered.
+ * Optionally, you can use the `viewModel` or `getChildContext` property to set a data context for the template. */
 export class KnockoutTemplateReactComponent extends React.Component<KnockoutTemplateReactComponent_Props> {
     static defaultProps = {
         wrapperTag: "div"

--- a/src/Samples/Common/Scripts/react/react-app.tsx
+++ b/src/Samples/Common/Scripts/react/react-app.tsx
@@ -1,9 +1,7 @@
-﻿/// <reference path="../../../../Framework/Framework/obj/typescript-types/dotvvm.d.ts" />
-import * as React from 'react';
+﻿import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { KnockoutTemplateReactComponent, registerReactControl } from 'dotvvm-jscomponent-react';
 import { LineChart, XAxis, Tooltip, CartesianGrid, Line, Dot } from 'recharts';
-import type { StateManager } from 'state-manager';
 
 // react component
 function RechartComponent(props: any) {

--- a/src/Samples/Common/Scripts/svelte/KnockoutTemplateSvelteComponent.svelte
+++ b/src/Samples/Common/Scripts/svelte/KnockoutTemplateSvelteComponent.svelte
@@ -1,0 +1,66 @@
+<!--
+@component
+Svelte wrapper for knockout `ko.renderTemplate` function.
+Specify the `templateName` property to select which template should be rendered.
+Optionally, you can use the `viewModel` or `getChildContext` property to set a data context for the template.
+-->
+
+<script lang="ts">
+    import { onMount } from "svelte";
+
+
+    /** HTML element name which will contain the knockout template. By default a `<div>` wrapper tag is used. */
+    export let wrapperTag: string = "div"
+
+    /** ID of the knockout template to be rendered, knockout will search for a matching `<template id="...">` element.
+     * You can get this ID in a DotVVM JsComponent as a property when you use inner element in the dothtml markup. */
+    export let templateName: string
+
+    /** A function which returns the knockout context for the rendered template. This property can not be updated after initialization
+     *  @example getChildContext={c => c.extend({ $myTag: 1234 })} */
+    export let getChildContext: (context: KnockoutBindingContext) => KnockoutBindingContext | undefined = undefined
+    
+    /** When set, a new knockout binding context with `$this` being the specified viewModel.
+     * Parent context will be the context of the parent element.
+     * Note that this viewModel is expected to be a plain JS object, not wrapped in knockout observables.
+     * Upading this property will update the template's data context. */
+    export let viewModel: any | undefined = undefined
+
+    let wrapperElement: HTMLElement
+    let viewModelStateManager
+    let templateNameObservable: KnockoutObservable<string> = ko.observable()
+
+    $: templateNameObservable(templateName)
+
+    function setNewViewModel(vm) {
+        if (viewModelStateManager) {
+            viewModelStateManager.setState(vm)
+        }
+    }
+    $: setNewViewModel(viewModel)
+
+
+    function initializeTemplate() {
+        const e = wrapperElement
+        let context: KnockoutBindingContext = ko.contextFor(e)
+        if (getChildContext) {
+            context = getChildContext(context)
+        }
+        else if (viewModel !== undefined) {
+            const updateEvent = new dotvvm.DotvvmEvent("templateInSvelte.newState")
+            viewModelStateManager = new dotvvm.StateManager(viewModel, updateEvent)
+            context = context.createChildContext(viewModelStateManager.stateObservable)
+        }
+        ko.renderTemplate(templateNameObservable, context, {}, e)
+    }
+
+    onMount(() => {
+        // we need to delay the template initialization, because knockout data context does not exist at the time when onMount is invoked
+        // it's added some moments later
+        setTimeout(() => initializeTemplate(), 5)
+    })
+</script>
+
+
+<svelte:element this={wrapperTag} bind:this={wrapperElement}>
+</svelte:element>

--- a/src/Samples/Common/Scripts/svelte/TemplateSelector.svelte
+++ b/src/Samples/Common/Scripts/svelte/TemplateSelector.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import KoTemplate from './KnockoutTemplateSvelteComponent.svelte'
+
+	export let condition
+	export let template1
+	export let template2
+</script>
+
+<div>
+	<KoTemplate
+		wrapperTag="p"
+		templateName={condition ? template1 : template2}
+		getChildContext={c => c.extend({ $kokos: 1 })} />
+
+</div>

--- a/src/Samples/Common/Scripts/svelte/svelte-app.ts
+++ b/src/Samples/Common/Scripts/svelte/svelte-app.ts
@@ -1,8 +1,9 @@
-﻿/// <reference path="../../../../Framework/Framework/obj/typescript-types/dotvvm.d.ts" />
-
-import Chart from './Chart.svelte'
+﻿import Chart from './Chart.svelte'
 import Incrementer from './Incrementer2.svelte'
+import TemplateSelector from './TemplateSelector.svelte'
 
+// copy pasted from generated svelte code,
+// they don't currently have a public API for two way data bindings
 function svelte_bind(component, name, callback) {
     const index = component.$$.props[name];
     if (index !== undefined) {
@@ -14,7 +15,7 @@ function svelte_bind(component, name, callback) {
 export const registerSvelteControl = (Control, defaultProps = {}) => ({
     create: (elm, props, commands, templates, setProps) => {
         const initialProps = { ...defaultProps, ...commands, ...templates }
-        let currentProps = { ...initialProps, ...props };
+        let currentProps = { ...initialProps, ...props }
 
         const c = new Control({
             target: elm,
@@ -28,7 +29,6 @@ export const registerSvelteControl = (Control, defaultProps = {}) => ({
                 setProps(updateObj)
             }
         }
-
         for (const p of Object.keys(props)) {
             svelte_bind(c, p, propertyUpdated(p))
         }
@@ -42,11 +42,8 @@ export const registerSvelteControl = (Control, defaultProps = {}) => ({
         }
 
 
-        // ReactDOM.render(<ReactControl {...currentProps} />, elm);
         return {
             updateProps(updatedProps) {
-                // currentProps = { ...currentProps, ...updatedProps }
-                // ReactDOM.render(<ReactControl {...currentProps} />, elm)
                 currentProps = { ...currentProps, ...updatedProps }
                 c.$set(updatedProps)
             },
@@ -62,6 +59,7 @@ export const registerSvelteControl = (Control, defaultProps = {}) => ({
 export default (context) => ({
     $controls: {
         chart: registerSvelteControl(Chart, { context, onMouse() { /* default empty method */ } }),
-        incrementer: registerSvelteControl(Incrementer)
+        incrementer: registerSvelteControl(Incrementer),
+        TemplateSelector: registerSvelteControl(TemplateSelector)
     }
 })

--- a/src/Samples/Common/Views/FeatureSamples/JsComponentIntegration/SvelteComponentIntegration.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/JsComponentIntegration/SvelteComponentIntegration.dothtml
@@ -38,6 +38,35 @@
         </div>
 
     </div>
+
+    <h3> Knockout templates rendered from Svelte component </h3>
+
+    <dot:CheckBox Checked="{value: Condition}" data-ui="template-condition" Text="Condition for template selector" />
+
+    <js:TemplateSelector condition={value: Condition}>
+        <template1>
+            <span data-ui="template1">
+                Condition == true (and IncludeInPage = {{value: IncludeInPage}})
+            </span>
+        </template1>
+        <template2>
+            <span data-ui="template2">
+                Condition == false
+            </span>
+            <ul data-ui="template2-commandSection">
+                <li>
+                    <dot:Button Text="Test command" data-ui="template2-command" Click="{command: ChangeCurrentThing()}" />
+                </li>
+                <li>
+                    <dot:Button Text="Test static command" data-ui="template2-clientStaticCommand" Click="{staticCommand:  CurrentThing = "StaticCommandInvoked"}" />
+                </li>
+                <li>
+                    <dot:Button Text="Test server static command" data-ui="template2-serverStaticCommand" Click="{staticCommand: CurrentThing = viewModelType.GetCurrentThing() }" />
+                </li>
+            </ul>
+        </template2>
+    </js:TemplateSelector>
+
 </body>
 </html>
 


### PR DESCRIPTION
The implementation and API of KnockoutTemplateSvelteComponent
is mostly similar to the corresponding React component.