### PR TITLE
Fix generated in Repeater created from code

### DIFF
--- a/src/Framework/Framework/Controls/GridView.cs
+++ b/src/Framework/Framework/Controls/GridView.cs
@@ -461,7 +461,7 @@ namespace DotVVM.Framework.Controls
                     var placeholder = new DataItemContainer { DataContext = null };
                     placeholder.SetDataContextTypeFromDataSource(GetBinding(DataSourceProperty).NotNull());
                     placeholder.SetValue(Internal.PathFragmentProperty, GetPathFragmentExpression() + "/[$index]");
-                    placeholder.SetValue(Internal.ClientIDFragmentProperty, GetValueRaw(Internal.CurrentIndexBindingProperty));
+                    placeholder.SetValue(Internal.ClientIDFragmentProperty, this.GetIndexBinding(context));
                     writer.WriteKnockoutDataBindComment("if", "!$gridViewDataSetHelper.isInEditMode($context)");
                     CreateTemplates(context, placeholder);
                     Children.Add(placeholder);
@@ -471,7 +471,7 @@ namespace DotVVM.Framework.Controls
                     var placeholderEdit = new DataItemContainer { DataContext = null };
                     placeholderEdit.SetDataContextTypeFromDataSource(GetBinding(DataSourceProperty).NotNull());
                     placeholderEdit.SetValue(Internal.PathFragmentProperty, GetPathFragmentExpression() + "/[$index]");
-                    placeholderEdit.SetValue(Internal.ClientIDFragmentProperty, GetValueRaw(Internal.CurrentIndexBindingProperty));
+                    placeholderEdit.SetValue(Internal.ClientIDFragmentProperty, this.GetIndexBinding(context));
                     writer.WriteKnockoutDataBindComment("if", "$gridViewDataSetHelper.isInEditMode($context)");
                     CreateTemplates(context, placeholderEdit, true);
                     Children.Add(placeholderEdit);
@@ -483,7 +483,7 @@ namespace DotVVM.Framework.Controls
                     var placeholder = new DataItemContainer { DataContext = null };
                     placeholder.SetDataContextTypeFromDataSource(GetBinding(DataSourceProperty).NotNull());
                     placeholder.SetValue(Internal.PathFragmentProperty, GetPathFragmentExpression() + "/[$index]");
-                    placeholder.SetValue(Internal.ClientIDFragmentProperty, GetValueRaw(Internal.CurrentIndexBindingProperty));
+                    placeholder.SetValue(Internal.ClientIDFragmentProperty, this.GetIndexBinding(context));
                     Children.Add(placeholder);
                     CreateRowWithCells(context, placeholder);
                     placeholder.Render(writer, context);

--- a/src/Framework/Framework/Controls/ItemsControl.cs
+++ b/src/Framework/Framework/Controls/ItemsControl.cs
@@ -12,6 +12,8 @@ using DotVVM.Framework.Compilation.ControlTree.Resolved;
 using DotVVM.Framework.Compilation.Styles;
 using DotVVM.Framework.Compilation.ControlTree;
 using System.Linq.Expressions;
+using DotVVM.Framework.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DotVVM.Framework.Controls
 {
@@ -90,6 +92,30 @@ namespace DotVVM.Framework.Controls
                 new ResolvedBinding(bindingService, new Compilation.BindingParserOptions(typeof(ValueBindingExpression)), dataContext,
                 parsedExpression: Expression.Parameter(typeof(int), "_index").AddParameterAnnotation(
                     new BindingParameterAnnotation(dataContext, new CurrentCollectionIndexExtensionParameter())))));
+        }
+
+        protected IBinding GetIndexBinding(IDotvvmRequestContext context)
+        {
+            var result = GetValueRaw(Internal.CurrentIndexBindingProperty) as IBinding;
+            if (result is {})
+            {
+                return result;
+            }
+            else
+            {
+                // slower path: create the _index binding at runtime
+                var bindingService = context.Services.GetRequiredService<BindingCompilationService>();
+                var dataContext = GetDataSourceBinding().GetProperty<CollectionElementDataContextBindingProperty>().DataContext;
+                return bindingService.Cache.CreateCachedBinding("_index", new object[] { dataContext }, () =>
+                    new ValueBindingExpression<int>(bindingService, new object?[] {
+                        dataContext,
+                        new ParsedExpressionBindingProperty(
+                            Expression.Parameter(typeof(int), "_index").AddParameterAnnotation(
+                                new BindingParameterAnnotation(dataContext, new CurrentCollectionIndexExtensionParameter()))
+                        )
+                    }
+                ));
+            }
         }
     }
 }

--- a/src/Framework/Framework/Controls/Repeater.cs
+++ b/src/Framework/Framework/Controls/Repeater.cs
@@ -260,7 +260,7 @@ namespace DotVVM.Framework.Controls
             container.SetDataContextTypeFromDataSource(GetBinding(DataSourceProperty)!);
             if (item == null && index == null)
             {
-                SetUpClientItem(container);
+                SetUpClientItem(context, container);
             }
             else
             {
@@ -330,11 +330,11 @@ namespace DotVVM.Framework.Controls
             }
         }
 
-        private void SetUpClientItem(DataItemContainer container)
+        private void SetUpClientItem(IDotvvmRequestContext context, DataItemContainer container)
         {
             container.DataContext = null;
             container.SetValue(Internal.PathFragmentProperty, GetPathFragmentExpression() + "/[$index]");
-            container.SetValue(Internal.ClientIDFragmentProperty, GetValueRaw(Internal.CurrentIndexBindingProperty));
+            container.SetValue(Internal.ClientIDFragmentProperty, this.GetIndexBinding(context));
         }
 
         private void SetUpServerItem(IDotvvmRequestContext context, object item, int index, DataItemContainer container)

--- a/src/Tests/ControlTests/testoutputs/CompositeControlTests.WrappedRepeaterControl.html
+++ b/src/Tests/ControlTests/testoutputs/CompositeControlTests.WrappedRepeaterControl.html
@@ -4,7 +4,7 @@
 		
 		<!-- simple list -->
 		<p class="css-class-from-markup my-repeated-button" data-bind="foreach: { data: List }" id="test-id">
-			<button class="the-only-class-for-button-element" data-bind="text: ($parent.Label() ?? &quot;&quot;) + $data" id="test-id_c9a0_c9a0a0_inner-button" onclick="dotvvm.postBack(this,[&quot;List/[$index]&quot;],&quot;WHRHt9Mi4BuLdRIz&quot;,&quot;&quot;,null,[],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button"></button>
+			<button class="the-only-class-for-button-element" data-bind="text: ($parent.Label() ?? &quot;&quot;) + $data, attr: { id: &quot;test-id&quot;+'_'+$index()+'_'+&quot;inner-button&quot; }" onclick="dotvvm.postBack(this,[&quot;List/[$index]&quot;],&quot;WHRHt9Mi4BuLdRIz&quot;,&quot;&quot;,null,[],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button"></button>
 		</p>
 	</body>
 </html>


### PR DESCRIPTION
Repeater used to rely on Internal.CurrentIndexBindingProperty being set
during view compilation, this patch adds a fallback path
for when the repeater is created at runtime.

resolves #1363

Turns out we already had a test covering this, but nobody
noticed that the test is also wrong :]