### PR TITLE
ToSystemType will try finding the type without assembly name

### DIFF
--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedTypeDescriptor.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedTypeDescriptor.cs
@@ -125,15 +125,23 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
         public static Type? ToSystemType(ITypeDescriptor? typeDescriptor)
         {
             if (typeDescriptor == null) return null;
-            else if (typeDescriptor is ResolvedTypeDescriptor)
+            
+            return TryToSystemType(typeDescriptor) ??
+                    throw new InvalidOperationException($"Type {typeDescriptor.FullName}, {typeDescriptor.Assembly} could not be found using reflection.");
+        }
+
+        public static Type? TryToSystemType(ITypeDescriptor? typeDescriptor)
+        {
+            if (typeDescriptor == null) return null;
+            else if (typeDescriptor is ResolvedTypeDescriptor { Type: var type })
             {
-                return ((ResolvedTypeDescriptor)typeDescriptor).Type;
+                return type;
             }
             else
             {
                 return
-                    Type.GetType(typeDescriptor.FullName + ", " + typeDescriptor.Assembly)
-                    ?? throw new InvalidOperationException($"Type {typeDescriptor.FullName} could not be found using reflection.");
+                    Type.GetType(typeDescriptor.FullName + ", " + typeDescriptor.Assembly) ??
+                    Type.GetType(typeDescriptor.FullName);
             }
         }
 


### PR DESCRIPTION
This caused problems for VS extension where it was provided
with `System.Boolean, netstandard`, but we would need to
use mscorlib for it to be found. Way around this is that
core types can be found without the assembly name,
which allows us to not rely on specific core assembly name.

Also added TryToSystemType which won't throw an exception