### PR TITLE
Fixed unary operator parsing precedence

### DIFF
--- a/src/Framework/Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenizer.cs
+++ b/src/Framework/Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenizer.cs
@@ -8,6 +8,7 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Tokenizer
     public class BindingTokenizer : TokenizerBase<BindingToken, BindingTokenType>
     {
         private static readonly HashSet<char> operatorCharacters = new HashSet<char> { '+', '-', '*', '/', '^', '\\', '%', '<', '>', '=', '&', '|', '~', '!', ';' };
+        private static readonly HashSet<char> unaryOperatorCharacters = new HashSet<char> { '~', '!' };
         internal readonly int bindingPositionOffset;
 
         public BindingTokenizer(int bindingPositionOffset = 0) : base(BindingTokenType.Identifier, BindingTokenType.WhiteSpace)
@@ -16,6 +17,8 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Tokenizer
         }
 
         public bool IsOperator(char c) => operatorCharacters.Contains(c);
+
+        public bool IsUnaryOperator(char c) => unaryOperatorCharacters.Contains(c);
 
         public override void Tokenize(string sourceText)
         {
@@ -287,17 +290,17 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Tokenizer
 
         internal void EnsureUnsupportedOperator(BindingTokenType preferredOperatorToken)
         {
-            if (IsOperator(Peek()))
+            if (IsUnaryOperator(Peek()) || !IsOperator(Peek()))
+            {
+                CreateToken(preferredOperatorToken);
+            }
+            else
             {
                 while (IsOperator(Peek()))
                 {
                     Read();
                 }
                 CreateToken(BindingTokenType.UnsupportedOperator);
-            }
-            else
-            {
-                CreateToken(preferredOperatorToken);
             }
         }
 

--- a/src/Framework/Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenizer.cs
+++ b/src/Framework/Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenizer.cs
@@ -8,7 +8,7 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Tokenizer
     public class BindingTokenizer : TokenizerBase<BindingToken, BindingTokenType>
     {
         private static readonly HashSet<char> operatorCharacters = new HashSet<char> { '+', '-', '*', '/', '^', '\\', '%', '<', '>', '=', '&', '|', '~', '!', ';' };
-        private static readonly HashSet<char> unaryOperatorCharacters = new HashSet<char> { '~', '!' };
+        private static readonly HashSet<char> unaryOperatorCharacters = new HashSet<char> { '+', '-', '~', '!' };
         internal readonly int bindingPositionOffset;
 
         public BindingTokenizer(int bindingPositionOffset = 0) : base(BindingTokenType.Identifier, BindingTokenType.WhiteSpace)

--- a/src/Tests/Binding/BindingCompilationTests.cs
+++ b/src/Tests/Binding/BindingCompilationTests.cs
@@ -617,6 +617,22 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        public void BindingCompiler_Valid_MemberAssignmentWithUnaryMinus()
+        {
+            var vm = new TestViewModel();
+            var result = ExecuteBinding($"IntProp=-42", vm);
+            Assert.AreEqual(-42, vm.IntProp);
+        }
+
+        [TestMethod]
+        public void BindingCompiler_Valid_MemberAssignmentWithUnaryNegation()
+        {
+            var vm = new TestViewModel();
+            var result = ExecuteBinding($"true==!false", vm);
+            Assert.IsTrue((bool)result);
+        }
+
+        [TestMethod]
         public void BindingCompiler_Valid_NamespaceAlias()
         {
             var result = ExecuteBinding("Alias.TestClass2.Property", new object[0], null, new NamespaceImport[] { new NamespaceImport("DotVVM.Framework.Tests.Binding.TestNamespace2", "Alias") });

--- a/src/Tests/Parser/Binding/BindingParserTests.cs
+++ b/src/Tests/Parser/Binding/BindingParserTests.cs
@@ -367,6 +367,38 @@ namespace DotVVM.Framework.Tests.Parser.Binding
         }
 
         [TestMethod]
+        public void BindingParser_AssignOperator_ValueWithUnaryMinus()
+        {
+            var result = (BinaryOperatorBindingParserNode)bindingParserNodeFactory.Parse("a=-5");
+            Assert.AreEqual(BindingTokenType.AssignOperator, result.Operator);
+
+            var first = (IdentifierNameBindingParserNode)result.FirstExpression;
+            Assert.AreEqual("a", first.Name);
+
+            var second = (UnaryOperatorBindingParserNode)result.SecondExpression;
+            Assert.AreEqual(BindingTokenType.SubtractOperator, second.Operator);
+
+            var literal = (LiteralExpressionBindingParserNode)second.InnerExpression;
+            Assert.AreEqual(5, (int)literal.Value);
+        }
+
+        [TestMethod]
+        public void BindingParser_AssignOperator_ValueWithUnaryNegation()
+        {
+            var result = (BinaryOperatorBindingParserNode)bindingParserNodeFactory.Parse("a=!b");
+            Assert.AreEqual(BindingTokenType.AssignOperator, result.Operator);
+
+            var first = (IdentifierNameBindingParserNode)result.FirstExpression;
+            Assert.AreEqual("a", first.Name);
+
+            var second = (UnaryOperatorBindingParserNode)result.SecondExpression;
+            Assert.AreEqual(BindingTokenType.NotOperator, second.Operator);
+
+            var identifier = (IdentifierNameBindingParserNode)second.InnerExpression;
+            Assert.AreEqual("b", identifier.Name);
+        }
+
+        [TestMethod]
         public void BindingParser_AssignOperator_Incomplete()
         {
             var result = (BinaryOperatorBindingParserNode)bindingParserNodeFactory.Parse("a = ");

--- a/src/Tests/Parser/Binding/BindingTokenizerTests.cs
+++ b/src/Tests/Parser/Binding/BindingTokenizerTests.cs
@@ -64,6 +64,19 @@ namespace DotVVM.Framework.Tests.Parser.Binding
         }
 
         [TestMethod]
+        public void BindingTokenizer_OperatorPrecedence_MinusAfterAssignment()
+        {
+            var tokens = Tokenize("a=-5");
+
+            var index = 0;
+            Assert.AreEqual(4, tokens.Count);
+            Assert.AreEqual(BindingTokenType.Identifier, tokens[index++].Type);
+            Assert.AreEqual(BindingTokenType.AssignOperator, tokens[index++].Type);
+            Assert.AreEqual(BindingTokenType.SubtractOperator, tokens[index++].Type);
+            Assert.AreEqual(BindingTokenType.Identifier, tokens[index++].Type);
+        }
+
+        [TestMethod]
         public void BindingTokenizer_AllOperators_Valid()
         {
             var tokens = Tokenize("+ - * / % < > <= >= == != ! & && | || ? : ?? . , =>");

--- a/src/Tests/Parser/Binding/BindingTokenizerTests.cs
+++ b/src/Tests/Parser/Binding/BindingTokenizerTests.cs
@@ -51,6 +51,19 @@ namespace DotVVM.Framework.Tests.Parser.Binding
         }
 
         [TestMethod]
+        public void BindingTokenizer_OperatorPrecedence_NegationAfterAssignment()
+        {
+            var tokens = Tokenize("a=!a");
+
+            var index = 0;
+            Assert.AreEqual(4, tokens.Count);
+            Assert.AreEqual(BindingTokenType.Identifier, tokens[index++].Type);
+            Assert.AreEqual(BindingTokenType.AssignOperator, tokens[index++].Type);
+            Assert.AreEqual(BindingTokenType.NotOperator, tokens[index++].Type);
+            Assert.AreEqual(BindingTokenType.Identifier, tokens[index++].Type);
+        }
+
+        [TestMethod]
         public void BindingTokenizer_AllOperators_Valid()
         {
             var tokens = Tokenize("+ - * / % < > <= >= == != ! & && | || ? : ?? . , =>");


### PR DESCRIPTION
This PR fixes a small bug due to which it was unable to compile expressions such as the following: `MyBoolProperty=!OtherBoolProperty`. Users received an error that the operator `=!` does not exist / is not supported.