### PR TITLE
Fixed an issue with parsing interpolated strings using dothtml tokenizer

### DIFF
--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Tokenizer/DothtmlTokenizer.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Tokenizer/DothtmlTokenizer.cs
@@ -633,9 +633,8 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
                         // -- we may need to ignore some curly brackets
                         // -- additionally also some quotes might be ignored
                         BindingTokenizer.ReadInterpolatedString(Peek, Read, out _);
-                        continue;
                     }
-                    if (current == '\'' || current == '"')
+                    else if (current == '\'' || current == '"')
                     {
                         // string literal - ignore curly braces inside
                         BindingTokenizer.ReadStringLiteral(Peek, Read, out _);

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Tokenizer/DothtmlTokenizer.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Tokenizer/DothtmlTokenizer.cs
@@ -623,15 +623,24 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
             }
             else
             {
-                char ch;
-                while ((ch = Peek()) != '}')
+                char current;
+                while ((current = Peek()) != '}')
                 {
-                    if (ch == '\'' || ch == '"')
+                    char next = Peek(delta: 1);
+                    if (current == '$' && (next == '"' || next == '\''))
+                    {
+                        // interpolated string
+                        // -- we may need to ignore some curly brackets
+                        // -- additionally also some quotes might be ignored
+                        BindingTokenizer.ReadInterpolatedString(Peek, Read, out _);
+                        continue;
+                    }
+                    if (current == '\'' || current == '"')
                     {
                         // string literal - ignore curly braces inside
                         BindingTokenizer.ReadStringLiteral(Peek, Read, out _);
                     }
-                    else if (ch == NullChar)
+                    else if (current == NullChar)
                     {
                         CreateToken(DothtmlTokenType.Text, errorProvider: t => CreateTokenError());
                         CreateToken(DothtmlTokenType.CloseBinding, errorProvider: t => CreateTokenError(t, DothtmlTokenType.OpenBinding, DothtmlTokenizerErrors.BindingNotClosed));

--- a/src/Tests/ControlTests/MarkupControlTests.cs
+++ b/src/Tests/ControlTests/MarkupControlTests.cs
@@ -20,6 +20,7 @@ namespace DotVVM.Framework.Tests.ControlTests
     public class MarkupControlTests
     {
         static readonly ControlTestHelper cth = new ControlTestHelper(config: config => {
+            _ = Repeater.RenderAsNamedTemplateProperty;
             config.Markup.AddMarkupControl("cc", "CustomControl", "CustomControl.dotcontrol");
             config.Markup.AddMarkupControl("cc", "CustomControlWithCommand", "CustomControlWithCommand.dotcontrol");
             config.Markup.AddMarkupControl("cc", "CustomControlWithProperty", "CustomControlWithProperty.dotcontrol");

--- a/src/Tests/Parser/Dothtml/DothtmlParserTests.cs
+++ b/src/Tests/Parser/Dothtml/DothtmlParserTests.cs
@@ -723,6 +723,15 @@ test";
         }
 
         [TestMethod]
+        public void DothtmlParser_BindingInnerInterpolatedExpression_BindingCorrectlyClosed()
+        {
+            var markup = "{{value: $'Hello {$'Innner {'Another interpolation'}'}'}}";
+            var root = ParseMarkup(markup);
+
+            Assert.AreEqual(1, root.Content.Count);
+        }
+
+        [TestMethod]
         public void DothtmlParser_AngleCharsInsideBinding()
         {
             var markup = "<div class-active='{value: Activity > 3 && Activity < 100}' />";


### PR DESCRIPTION
This PR fixes and issue with parsing interpolated strings. Right now the behaviour is broken in the following way:
* Consider an expression `$'Hello {$'Innner {'Another interpolation'}'}'`
* It would be parsed similar to the following:
   * `$'Hello {$'Innner {'Another interpolation'`
   * `}'}'`

This can be observed using Visual Studio Extension - artifacts will be completely broken