### PR TITLE
Add JS API for modifying the client-side error collection

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/tests/observableHierarchies.ts
+++ b/src/Framework/Framework/Resources/Scripts/tests/observableHierarchies.ts
@@ -1,0 +1,41 @@
+﻿export interface ObservableHierarchy {
+    $type: string | KnockoutObservable<string>
+    Prop1: KnockoutObservable<string>
+    Prop2: null | KnockoutObservable<ObservableSubHierarchy>
+}
+
+export interface ObservableSubHierarchy {
+    $type: string | KnockoutObservable<string>
+    Prop21: KnockoutObservable<string>
+    Prop22: KnockoutObservable<string>
+    Prop23: KnockoutObservableArray<null | KnockoutObservable<{
+        Prop231: null | KnockoutObservable<null | string>,
+        $type: string | KnockoutObservable<string>
+    }>>
+}
+
+export function createComplexObservableViewmodel(): ObservableHierarchy {
+    return {
+        $type: ko.observable("t5"),
+        Prop1: ko.observable("aa"),
+        Prop2: ko.observable(createComplexObservableSubViewmodel())
+    }
+}
+
+export function createComplexObservableSubViewmodel(): ObservableSubHierarchy {
+    return {
+        $type: ko.observable("t5_a"),
+        Prop21: ko.observable("bb"),
+        Prop22: ko.observable("cc"),
+        Prop23: ko.observableArray([
+            ko.observable({
+                $type: ko.observable("t5_a_a"),
+                Prop231: ko.observable("dd")
+            }),
+            ko.observable({
+                $type: ko.observable("t5_a_a"),
+                Prop231: ko.observable("ee")
+            })
+        ])
+    }
+}

--- a/src/Framework/Framework/Resources/Scripts/tests/serialization.test.ts
+++ b/src/Framework/Framework/Resources/Scripts/tests/serialization.test.ts
@@ -3,6 +3,7 @@ import { deserialize } from '../serialization/deserialize'
 import { serialize } from '../serialization/serialize'
 import { serializeDate } from '../serialization/date'
 import { tryCoerce } from '../metadata/coercer';
+import { createComplexObservableSubViewmodel, createComplexObservableViewmodel, ObservableHierarchy, ObservableSubHierarchy } from "./observableHierarchies"
 
 jest.mock("../metadata/typeMap", () => ({
     getTypeInfo(typeId: string) {
@@ -1249,32 +1250,6 @@ function createComplexObservableTargetWithMissingSubHierarchy(): KnockoutObserva
     })
 }
 
-function createComplexObservableViewmodel(): ObservableHierarchy {
-    return {
-        $type: ko.observable("t5"),
-        Prop1: ko.observable("aa"),
-        Prop2: ko.observable(createComplexObservableSubViewmodel())
-    }
-}
-
-function createComplexObservableSubViewmodel(): ObservableSubHierarchy {
-    return {
-        $type: ko.observable("t5_a"),
-        Prop21: ko.observable("bb"),
-        Prop22: ko.observable("cc"),
-        Prop23: ko.observableArray([
-            ko.observable({
-                $type: ko.observable("t5_a_a"),
-                Prop231: ko.observable("dd")
-            }),
-            ko.observable({
-                $type: ko.observable("t5_a_a"),
-                Prop231: ko.observable("ee")
-            })
-        ])
-    }
-}
-
 function createComplexNonObservableViewmodel() {
     return {
         $type: "t5",
@@ -1365,22 +1340,6 @@ class TestData {
         const prop2 = assertObservable(object.Prop2)
         expect(prop2).toBe("bb")
     }
-}
-
-interface ObservableHierarchy {
-    $type: string | KnockoutObservable<string>
-    Prop1: KnockoutObservable<string>
-    Prop2: null | KnockoutObservable<ObservableSubHierarchy>
-}
-
-interface ObservableSubHierarchy {
-    $type: string | KnockoutObservable<string>
-    Prop21: KnockoutObservable<string>
-    Prop22: KnockoutObservable<string>
-    Prop23: KnockoutObservableArray<null | KnockoutObservable<{ 
-        Prop231: null | KnockoutObservable<null | string>,
-        $type: string | KnockoutObservable<string>
-    }>>
 }
 
 const testTypeMap: TypeMap = {

--- a/src/Framework/Framework/Resources/Scripts/tests/validation.test.ts
+++ b/src/Framework/Framework/Resources/Scripts/tests/validation.test.ts
@@ -88,6 +88,35 @@ describe("DotVVM.Validation - public API", () => {
         expect(errorsFromRoot[1].errorMessage).toBe("Everything is wrong.");
     })
 
+    test("addErrors - on array element", () => {
+        //Setup
+        validation.removeErrors("/");
+        const vm = ko.observable(createComplexObservableViewmodel());
+
+        //Act
+        validation.addErrors(
+            [
+                { errorMessage: "Element 0 is invalid.", propertyPath: "/Prop2/Prop23/0/" },
+                { errorMessage: "Element 1 is wrong.", propertyPath: "/Prop2/Prop23/1" }
+            ],
+            { root: vm }
+        )
+
+        //Check
+        expect(validation.errors.length).toBe(2);
+        expect(validation.errors[0].errorMessage).toBe("Element 0 is invalid.");
+        expect(validation.errors[1].errorMessage).toBe("Element 1 is wrong.");
+
+        const errorsFromElement0 = getErrors((vm().Prop2 as KnockoutObservable<ObservableSubHierarchy>)().Prop23()[0]);
+        const errorsFromElement1 = getErrors((vm().Prop2 as KnockoutObservable<ObservableSubHierarchy>)().Prop23()[1]);
+
+        expect(errorsFromElement0.length).toBe(1);
+        expect(errorsFromElement1.length).toBe(1);
+
+        expect(errorsFromElement0[0].errorMessage).toBe("Element 0 is invalid.");
+        expect(errorsFromElement1[0].errorMessage).toBe("Element 1 is wrong.");
+    })
+
     test("addErrors - second level nonexistent property", () => {
         //Setup
         const vm = createComplexObservableViewmodel();
@@ -169,6 +198,81 @@ describe("DotVVM.Validation - public API", () => {
 
         expect(errorsFromProp1.length).toBe(1);
         expect(errorsFromProp21.length).toBe(0);
+    })
+
+    test("removeErrors - remove from 2 different properties in subhierarchy", () => {
+        //Setup
+        validation.removeErrors("/");
+        const vm = createComplexObservableViewmodel();
+
+        validation.addErrors(
+            [
+                { errorMessage: "Prop1 is too short.", propertyPath: "/Prop1" },
+                { errorMessage: "Prop21 is too long.", propertyPath: "/Prop2/Prop21" },
+                { errorMessage: "Prop21 is too large.", propertyPath: "/Prop2/Prop22" }
+
+            ],
+            { root: ko.observable(vm) }
+        );
+
+        //Act
+        validation.removeErrors("/Prop2");
+
+        //Check
+        expect(validation.errors.length).toBe(1);
+
+        const errorsFromProp1 = getErrors(vm.Prop1);
+        const errorsFromProp21 = getErrors((vm.Prop2 as KnockoutObservable<ObservableSubHierarchy>)().Prop21);
+        const errorsFromProp22 = getErrors((vm.Prop2 as KnockoutObservable<ObservableSubHierarchy>)().Prop22);
+
+        expect(errorsFromProp1.length).toBe(1);
+        expect(errorsFromProp21.length).toBe(0);
+        expect(errorsFromProp22.length).toBe(0);
+    })
+
+    test("validationErrorsChanged - gets called on error added.", () => {
+        //Setup
+        validation.removeErrors("/");
+        const vm = createComplexObservableViewmodel();
+
+        const onErrorsCallback = jest.fn();
+
+        validation.events.validationErrorsChanged.subscribe(onErrorsCallback);
+
+        //Act
+        validation.addErrors(
+            [{ errorMessage: "Prop1 is too short.", propertyPath: "/Prop1" }],
+            { root: ko.observable(vm) }
+        )
+
+        validation.addErrors(
+            [{ errorMessage: "Prop1 is too long.", propertyPath: "/Prop2" }],
+            { root: ko.observable(vm) }
+        )
+
+        //Check
+        expect(onErrorsCallback).toHaveBeenCalledTimes(2);
+    })
+
+    test("validationErrorsChanged - gets called on existing error removed.", () => {
+        //Setup
+        validation.removeErrors("/");
+        const vm = createComplexObservableViewmodel();
+
+        const onErrorsCallback = jest.fn();
+
+        validation.events.validationErrorsChanged.subscribe(onErrorsCallback);
+
+        //Act
+        validation.addErrors(
+            [{ errorMessage: "Prop1 is too short.", propertyPath: "/Prop1" }],
+            { root: ko.observable(vm) }
+        )
+
+        validation.removeErrors("/Prop1")
+
+        //Check
+        expect(onErrorsCallback).toHaveBeenCalledTimes(2);
     })
 });
 

--- a/src/Framework/Framework/Resources/Scripts/tests/validation.test.ts
+++ b/src/Framework/Framework/Resources/Scripts/tests/validation.test.ts
@@ -1,0 +1,187 @@
+﻿import { error } from "../events";
+import { globalValidationObject as validation, ValidationErrorDescriptor } from "../validation/validation"
+import { createComplexObservableSubViewmodel, createComplexObservableViewmodel, ObservableHierarchy, ObservableSubHierarchy } from "./observableHierarchies"
+import { getErrors } from "../validation/error"
+
+
+describe("DotVVM.Validation - public API", () => {
+
+    test("addErrors - single first level property", () => {
+        //Setup
+        validation.removeErrors("/");
+        const vm = createComplexObservableViewmodel();
+
+        //Act
+        validation.addErrors(
+            [
+                { errorMessage: "Prop1 is too short.", propertyPath: "/Prop1" },
+                { errorMessage: "Prop1 is too long.", propertyPath: "/Prop1/" }
+            ],
+            { root: ko.observable(vm) }
+        )
+
+        //Check
+        expect(validation.errors.length).toBe(2);
+        expect(validation.errors[0].errorMessage).toBe("Prop1 is too short.");
+        expect(validation.errors[1].errorMessage).toBe("Prop1 is too long.");
+
+        const errorsFromObservable = getErrors(vm.Prop1);
+
+        expect(errorsFromObservable.length).toBe(2);
+        expect(errorsFromObservable[0].errorMessage).toBe("Prop1 is too short.");
+        expect(errorsFromObservable[1].errorMessage).toBe("Prop1 is too long.");
+    })
+
+    test("addErrors - two different properties", () => {
+        //Setup
+        validation.removeErrors("/");
+        const vm = createComplexObservableViewmodel();
+
+        //Act
+        validation.addErrors(
+            [
+                { errorMessage: "Prop1 is too short.", propertyPath: "/Prop1" },
+                { errorMessage: "Prop21 is too long.", propertyPath: "/Prop2/Prop21" }
+            ],
+            { root: ko.observable(vm) }
+        )
+
+        //Check
+        expect(validation.errors.length).toBe(2);
+        expect(validation.errors[0].errorMessage).toBe("Prop1 is too short.");
+        expect(validation.errors[1].errorMessage).toBe("Prop21 is too long.");
+
+        const errorsFromProp1 = getErrors(vm.Prop1);
+        const errorsFromProp21 = getErrors((vm.Prop2 as KnockoutObservable<ObservableSubHierarchy>)().Prop21);
+
+        expect(errorsFromProp1.length).toBe(1);
+        expect(errorsFromProp21.length).toBe(1);
+
+        expect(errorsFromProp1[0].errorMessage).toBe("Prop1 is too short.");
+        expect(errorsFromProp21[0].errorMessage).toBe("Prop21 is too long.");
+    })
+
+    test("addErrors - on root", () => {
+        //Setup
+        validation.removeErrors("/");
+        const vm = ko.observable(createComplexObservableViewmodel());
+
+        //Act
+        validation.addErrors(
+            [
+                { errorMessage: "Everything is invalid.", propertyPath: "/" },
+                { errorMessage: "Everything is wrong.", propertyPath: "/" }
+            ],
+            { root: vm }
+        )
+
+        //Check
+        expect(validation.errors.length).toBe(2);
+        expect(validation.errors[0].errorMessage).toBe("Everything is invalid.");
+        expect(validation.errors[1].errorMessage).toBe("Everything is wrong.");
+
+        const errorsFromRoot = getErrors(vm);
+
+        expect(errorsFromRoot.length).toBe(2);
+
+        expect(errorsFromRoot[0].errorMessage).toBe("Everything is invalid.");
+        expect(errorsFromRoot[1].errorMessage).toBe("Everything is wrong.");
+    })
+
+    test("addErrors - second level nonexistent property", () => {
+        //Setup
+        const vm = createComplexObservableViewmodel();
+
+        //Act
+        const act = () => validation.addErrors(
+            [
+                { errorMessage: "Does not matter", propertyPath: "/Prop1/NonExistent" },
+            ],
+            { root: ko.observable(vm) }
+        )
+
+        //Check
+        expect(act).toThrowError("Validation error could not been applied to property specified by propertyPath /Prop1/NonExistent. Property with name NonExistent does not exist on /Prop1.");
+    })
+
+    test("addErrors - root level nonexistent property", () => {
+        //Setup
+        const vm = createComplexObservableViewmodel();
+
+        //Act
+        const act = () => validation.addErrors(
+            [
+                { errorMessage: "Does not matter", propertyPath: "/NonExistent" },
+            ],
+            { root: ko.observable(vm) }
+        )
+
+        //Check
+        expect(act).toThrowError("Validation error could not been applied to property specified by propertyPath /NonExistent. Property with name NonExistent does not exist on root.");
+    })
+
+    test("removeErrors - remove everything from root up", () => {
+        //Setup
+        const vm = SetupComplexObservableViewmodelWithErrorsOnProp1AndProp21();
+
+        //Act
+        validation.removeErrors("/");
+
+        //Check
+        expect(validation.errors.length).toBe(0);
+
+        const errorsFromProp1 = getErrors(vm.Prop1);
+        const errorsFromProp21 = getErrors((vm.Prop2 as KnockoutObservable<ObservableSubHierarchy>)().Prop21);
+
+        expect(errorsFromProp1.length).toBe(0);
+        expect(errorsFromProp21.length).toBe(0);
+    })
+
+    test("removeErrors - remove only on specific property", () => {
+        //Setup
+        const vm = SetupComplexObservableViewmodelWithErrorsOnProp1AndProp21();
+
+        //Act
+        validation.removeErrors("/Prop2/Prop21");
+
+        //Check
+        expect(validation.errors.length).toBe(1);
+
+        const errorsFromProp1 = getErrors(vm.Prop1);
+        const errorsFromProp21 = getErrors((vm.Prop2 as KnockoutObservable<ObservableSubHierarchy>)().Prop21);
+
+        expect(errorsFromProp1.length).toBe(1);
+        expect(errorsFromProp21.length).toBe(0);
+    })
+
+    test("removeErrors - remove only on property in subhierarchy", () => {
+        //Setup
+        const vm = SetupComplexObservableViewmodelWithErrorsOnProp1AndProp21();
+
+        //Act
+        validation.removeErrors("/Prop2");
+
+        //Check
+        expect(validation.errors.length).toBe(1);
+
+        const errorsFromProp1 = getErrors(vm.Prop1);
+        const errorsFromProp21 = getErrors((vm.Prop2 as KnockoutObservable<ObservableSubHierarchy>)().Prop21);
+
+        expect(errorsFromProp1.length).toBe(1);
+        expect(errorsFromProp21.length).toBe(0);
+    })
+});
+
+function SetupComplexObservableViewmodelWithErrorsOnProp1AndProp21() {
+    validation.removeErrors("/");
+    const vm = createComplexObservableViewmodel();
+
+    validation.addErrors(
+        [
+            { errorMessage: "Prop1 is too short.", propertyPath: "/Prop1" },
+            { errorMessage: "Prop21 is too long.", propertyPath: "/Prop2/Prop21" }
+        ],
+        { root: ko.observable(vm) }
+    );
+    return vm;
+}

--- a/src/Framework/Framework/Resources/Scripts/utils/evaluator.ts
+++ b/src/Framework/Framework/Resources/Scripts/utils/evaluator.ts
@@ -25,7 +25,7 @@ export function traverseContext(context: any, path: string): any {
 
         var nextNode = ko.unwrap(currentLevel)[expressionPart];
         if (nextNode == undefined) {
-            throw `Validation error could not been applied to property specified by propertyPath ${path}. Property with name ${expressionPart} does not exist on ${currentPath}.`;
+            throw `Validation error could not been applied to property specified by propertyPath ${path}. Property with name ${expressionPart} does not exist on ${!currentPath ? "root" : currentPath}.`;
         }
         currentPath += `/${expressionPart}`;
         currentLevel = nextNode;

--- a/src/Framework/Framework/Resources/Scripts/validation/error.ts
+++ b/src/Framework/Framework/Resources/Scripts/validation/error.ts
@@ -66,9 +66,6 @@ export class ValidationError {
         errors.splice(observableIndex, 1);
 
         const arrayIndex = allErrors.indexOf(this);
-
-
-
         allErrors.splice(arrayIndex, 1);
     }
 }

--- a/src/Framework/Framework/Resources/Scripts/validation/error.ts
+++ b/src/Framework/Framework/Resources/Scripts/validation/error.ts
@@ -14,12 +14,11 @@ export function detachErrors(...paths: string[]) {
         return prefixPath == path || path.startsWith(prefixPath)
     }
 
-
     const errorsCopy = Array.from(allErrors)
     errorsCopy.reverse()
     for (const e of errorsCopy) {
-        if (paths.some(p => pathStartsWith(e.propertyPath, p))) {
-            e.detach()
+        if (paths.some(p => pathStartsWith(p, e.propertyPath))) {
+            e.detach();
         }
     }
 }
@@ -67,6 +66,9 @@ export class ValidationError {
         errors.splice(observableIndex, 1);
 
         const arrayIndex = allErrors.indexOf(this);
+
+
+
         allErrors.splice(arrayIndex, 1);
     }
 }

--- a/src/Framework/Framework/Resources/Scripts/validation/error.ts
+++ b/src/Framework/Framework/Resources/Scripts/validation/error.ts
@@ -4,25 +4,6 @@ import { unwrapComputedProperty } from "../utils/evaluator";
 
 export const allErrors: ValidationError[] = []
 
-export function detachErrors(...paths: string[]) {
-    function pathStartsWith(prefixPath: string, path: string) {
-        // normalize paths = append / to each path and remove duplicated slashes
-        const normRegex = /(\/+)/g
-        prefixPath = prefixPath.replace(normRegex + "/", "/")
-        path = path.replace(normRegex + "/", "/")
-
-        return prefixPath == path || path.startsWith(prefixPath)
-    }
-
-    const errorsCopy = Array.from(allErrors)
-    errorsCopy.reverse()
-    for (const e of errorsCopy) {
-        if (paths.some(p => pathStartsWith(p, e.propertyPath))) {
-            e.detach();
-        }
-    }
-}
-
 export function detachAllErrors() {
     while (allErrors.length > 0) {
         allErrors[allErrors.length - 1].detach();

--- a/src/Framework/Framework/Resources/Scripts/validation/error.ts
+++ b/src/Framework/Framework/Resources/Scripts/validation/error.ts
@@ -4,6 +4,26 @@ import { unwrapComputedProperty } from "../utils/evaluator";
 
 export const allErrors: ValidationError[] = []
 
+export function detachErrors(...paths: string[]) {
+    function pathStartsWith(prefixPath: string, path: string) {
+        // normalize paths = append / to each path and remove duplicated slashes
+        const normRegex = /(\/+)/g
+        prefixPath = prefixPath.replace(normRegex + "/", "/")
+        path = path.replace(normRegex + "/", "/")
+
+        return prefixPath == path || path.startsWith(prefixPath)
+    }
+
+
+    const errorsCopy = Array.from(allErrors)
+    errorsCopy.reverse()
+    for (const e of errorsCopy) {
+        if (paths.some(p => pathStartsWith(e.propertyPath, p))) {
+            e.detach()
+        }
+    }
+}
+
 export function detachAllErrors() {
     while (allErrors.length > 0) {
         allErrors[allErrors.length - 1].detach();

--- a/src/Framework/Framework/Resources/Scripts/validation/validation.ts
+++ b/src/Framework/Framework/Resources/Scripts/validation/validation.ts
@@ -313,15 +313,19 @@ export function removeErrors(...paths: string[]) {
         return prefixPath == path || path.startsWith(prefixPath)
     }
 
+    let changed = false;
+
     const errorsCopy = Array.from(allErrors)
     errorsCopy.reverse()
     for (const e of errorsCopy) {
         if (paths.some(p => pathStartsWith(p, e.propertyPath))) {
             e.detach();
+            changed = true;
         }
     }
 
-    validationErrorsChanged.trigger({ allErrors })
+    if (changed)
+        validationErrorsChanged.trigger({ allErrors })
 }
 
 
@@ -335,7 +339,7 @@ export function addErrors(errors: ValidationErrorDescriptor[], options: AddError
         ValidationError.attach(prop.errorMessage, propertyPath, property);
     }
 
-    if (options.triggerErrorsChanged !== false) {
+    if (options.triggerErrorsChanged !== false && errors.length > 0) {
         validationErrorsChanged.trigger({ allErrors });
     }
 }

--- a/src/Framework/Framework/Resources/Scripts/validation/validation.ts
+++ b/src/Framework/Framework/Resources/Scripts/validation/validation.ts
@@ -307,8 +307,8 @@ export function removeErrors(...paths: string[]) {
     function pathStartsWith(prefixPath: string, path: string) {
         // normalize paths = append / to each path and remove duplicated slashes
         const normRegex = /(\/+)/g
-        prefixPath = prefixPath.replace(normRegex + "/", "/")
-        path = path.replace(normRegex + "/", "/")
+        prefixPath = (prefixPath + "/").replace(normRegex, "/")
+        path = (path + "/").replace(normRegex, "/")
 
         return prefixPath == path || path.startsWith(prefixPath)
     }

--- a/src/Framework/Framework/Resources/Scripts/validation/validation.ts
+++ b/src/Framework/Framework/Resources/Scripts/validation/validation.ts
@@ -1,6 +1,6 @@
 import * as evaluator from "../utils/evaluator"
 import { validators } from './validators'
-import { allErrors, detachAllErrors, detachErrors, ValidationError, getErrors } from "./error"
+import { allErrors, detachAllErrors, ValidationError, getErrors } from "./error"
 import { DotvvmEvent } from '../events'
 import * as spaEvents from '../spa/events'
 import { postbackHandlers } from "../postback/handlers"

--- a/src/Framework/Framework/Resources/Scripts/validation/validation.ts
+++ b/src/Framework/Framework/Resources/Scripts/validation/validation.ts
@@ -42,7 +42,7 @@ export const globalValidationObject = {
     /** Removes errors from the specified properties.
      *  The errors are removed recursively, so calling `dotvvm.validation.removeErrors("/")` removes all errors in the page,
      *  `dotvvm.validation.removeErrors("/Detail")` removes all errors from the object in property root.Detail */
-    removeErrors: detachErrors
+    removeErrors
 }
 
 const createValidationHandler = (path: string) => ({
@@ -302,6 +302,28 @@ export type AddErrorsOptions = {
      *  The validationErrorsChanged event controls the `Validator`s in the DotHTML page, so when it's not triggered, the change won't be visible. */
     triggerErrorsChanged?: false
 }
+
+export function removeErrors(...paths: string[]) {
+    function pathStartsWith(prefixPath: string, path: string) {
+        // normalize paths = append / to each path and remove duplicated slashes
+        const normRegex = /(\/+)/g
+        prefixPath = prefixPath.replace(normRegex + "/", "/")
+        path = path.replace(normRegex + "/", "/")
+
+        return prefixPath == path || path.startsWith(prefixPath)
+    }
+
+    const errorsCopy = Array.from(allErrors)
+    errorsCopy.reverse()
+    for (const e of errorsCopy) {
+        if (paths.some(p => pathStartsWith(p, e.propertyPath))) {
+            e.detach();
+        }
+    }
+
+    validationErrorsChanged.trigger({ allErrors })
+}
+
 
 export function addErrors(errors: ValidationErrorDescriptor[], options: AddErrorsOptions = {}): void {
     const root = options.root ?? dotvvm.viewModelObservables.root


### PR DESCRIPTION
The new API has 2 new functions:
* `dotvvm.validation.addErrors([{ errorMessage: "Test", propertyPath: "/X/Y/Z" }])`
* `dotvvm.validation.removeErrors("/FirstName", "/LastName")`