### PR TITLE
Added support for more operators in data-bindings

### DIFF
--- a/src/Framework/Framework/Compilation/Binding/ExpressionBuildingVisitor.cs
+++ b/src/Framework/Framework/Compilation/Binding/ExpressionBuildingVisitor.cs
@@ -212,6 +212,9 @@ namespace DotVVM.Framework.Compilation.Binding
                 case BindingTokenType.OrElseOperator:
                     eop = ExpressionType.OrElse;
                     break;
+                case BindingTokenType.ExclusiveOrOperator:
+                    eop = ExpressionType.ExclusiveOr;
+                    break;
                 case BindingTokenType.AssignOperator:
                     eop = ExpressionType.Assign;
                     break;

--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslationVisitor.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslationVisitor.cs
@@ -309,6 +309,14 @@ namespace DotVVM.Framework.Compilation.Javascript
                 ReplaceNullValue(result.Left, expression.Left, new JsLiteral(""));
                 ReplaceNullValue(result.Right, expression.Right, new JsLiteral(""));
             }
+            if (expression.NodeType == ExpressionType.ExclusiveOr && expression.Left.Type == typeof(bool) && expression.Right.Type == typeof(bool))
+            {
+                // Whenever operator ^ is applied on two booleans in .NET, the result is also boolean
+                // Convert to "!!result" - the first negation coerces the value to boolean and inverts it. The second negation returns the correct value
+
+                return new JsUnaryExpression(UnaryOperatorType.LogicalNot,
+                    new JsUnaryExpression(UnaryOperatorType.LogicalNot, result));
+            }
             
             return result;
         }

--- a/src/Framework/Framework/Compilation/Parser/Binding/Parser/BindingParser.cs
+++ b/src/Framework/Framework/Compilation/Parser/Binding/Parser/BindingParser.cs
@@ -322,12 +322,25 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
         private BindingParserNode ReadOrExpression()
         {
             var startIndex = CurrentIndex;
-            var first = ReadAndExpression();
+            var first = ReadExclusiveOrExpression();
             while (Peek() is BindingToken operatorToken && operatorToken.Type == BindingTokenType.OrOperator)
             {
                 Read();
-                var second = ReadAndExpression();
+                var second = ReadExclusiveOrExpression();
                 first = CreateNode(new BinaryOperatorBindingParserNode(first, second, BindingTokenType.OrOperator), startIndex);
+            }
+            return first;
+        }
+
+        private BindingParserNode ReadExclusiveOrExpression()
+        {
+            var startIndex = CurrentIndex;
+            var first = ReadAndExpression();
+            while (Peek() is BindingToken operatorToken && operatorToken.Type == BindingTokenType.ExclusiveOrOperator)
+            {
+                Read();
+                var second = ReadAndExpression();
+                first = CreateNode(new BinaryOperatorBindingParserNode(first, second, BindingTokenType.ExclusiveOrOperator), startIndex);
             }
             return first;
         }

--- a/src/Framework/Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenType.cs
+++ b/src/Framework/Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenType.cs
@@ -40,6 +40,7 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Tokenizer
         AndAlsoOperator,
         OrOperator,
         OrElseOperator,
+        ExclusiveOrOperator,
 
         AssignOperator,
 

--- a/src/Framework/Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenizer.cs
+++ b/src/Framework/Framework/Compilation/Parser/Binding/Tokenizer/BindingTokenizer.cs
@@ -115,7 +115,7 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Tokenizer
                     case '^':
                         FinishIncompleteIdentifier();
                         Read();
-                        EnsureUnsupportedOperator(BindingTokenType.UnsupportedOperator);
+                        EnsureUnsupportedOperator(BindingTokenType.ExclusiveOrOperator);
                         break;
 
                     case ':':

--- a/src/Tests/Binding/BindingCompilationTests.cs
+++ b/src/Tests/Binding/BindingCompilationTests.cs
@@ -996,9 +996,17 @@ namespace DotVVM.Framework.Tests.Binding
             var ex = aggEx.GetBaseException();
             StringAssert.Contains(ex.Message, "cannot be assigned into");
         }
+
+        [TestMethod]
+        public void BindingCompiler_ExclusiveOrOperator()
+        {
+            Assert.AreEqual(true, ExecuteBinding("var boolVariable = BoolProp ^ true; boolVariable", new TestViewModel { BoolProp = false }));
+            Assert.AreEqual(false, ExecuteBinding("var boolVariable = BoolProp ^ true; boolVariable", new TestViewModel { BoolProp = true }));
+        }
     }
     class TestViewModel
     {
+        public bool BoolProp { get; set; }
         public string StringProp { get; set; }
         public int IntProp { get; set; }
         public int? NullableIntProp { get; set; }

--- a/src/Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/Tests/Binding/JavascriptCompilationTests.cs
@@ -129,12 +129,20 @@ namespace DotVVM.Framework.Tests.Binding
         [DataRow("IntProp & 2+2", "IntProp()&2+2", DisplayName = "IntProp & 2+2")]
         [DataRow("IntProp & -1", "IntProp()&-1", DisplayName = "IntProp & -1")]
         [DataRow("'a' + 'b'", "\"ab\"", DisplayName = "'a' + 'b'")]
+        [DataRow("IntProp ^ 1", "IntProp()^1", DisplayName = "IntProp ^ 1")]
         [DataRow("'xx' + IntProp", "\"xx\"+IntProp()", DisplayName = "'xx' + IntProp")]
         [DataRow("true == (IntProp == 1)", "true==(IntProp()==1)", DisplayName = "true == (IntProp == 1)")]
         public void JavascriptCompilation_BinaryExpressions(string expr, string expectedJs)
         {
             var js = CompileBinding(expr, new [] { typeof(TestViewModel) });
             Assert.AreEqual(expectedJs, js);
+        }
+
+        [TestMethod]
+        public void JavascriptCompilation_ExclusiveOr_ReturnsBooleanIfOperandsAreBooleans()
+        {
+            var js = CompileBinding("BoolProp = BoolProp ^ true", new[] { typeof(TestViewModel) });
+            Assert.AreEqual("BoolProp(!!(BoolProp()^true)).BoolProp", js);
         }
 
         [TestMethod]

--- a/src/Tests/Parser/Binding/BindingParserTests.cs
+++ b/src/Tests/Parser/Binding/BindingParserTests.cs
@@ -140,6 +140,20 @@ namespace DotVVM.Framework.Tests.Parser.Binding
             Assert.AreEqual("b", ((IdentifierNameBindingParserNode)add.SecondExpression).Name);
         }
 
+        [TestMethod]
+        public void BindingParser_BinaryOperatorExclusiveOr_Valid()
+        {
+            var result = bindingParserNodeFactory.Parse("a ^ b");
+
+            var root = (BinaryOperatorBindingParserNode)result;
+            Assert.AreEqual(BindingTokenType.ExclusiveOrOperator, root.Operator);
+
+            var a = (IdentifierNameBindingParserNode)root.FirstExpression;
+            var b = (IdentifierNameBindingParserNode)root.SecondExpression;
+            Assert.AreEqual("a", a.Name);
+            Assert.AreEqual("b", b.Name);
+        }
+
 
         [TestMethod]
         public void BindingParser_MemberAccess_ArrayIndexer_Chain_Valid()
@@ -442,9 +456,9 @@ namespace DotVVM.Framework.Tests.Parser.Binding
         }
 
         [TestMethod]
-        public void BindingParser_MultipleUnsupportedBinaryOperators_Valid()
+        public void BindingParser_UnsupportedBinaryOperator_Valid()
         {
-            var parser = bindingParserNodeFactory.SetupParser("_root.MyCoolProperty += _this.Number1 + Number2^_parent0.Exponent * Multiplikator");
+            var parser = bindingParserNodeFactory.SetupParser("_root.MyCoolProperty += _this.Number1 * Multiplikator");
             var node = parser.ReadExpression();
 
             Assert.IsTrue(parser.OnEnd());
@@ -454,19 +468,10 @@ namespace DotVVM.Framework.Tests.Parser.Binding
 
             CheckBinaryOperatorNodeType<MemberAccessBindingParserNode, BinaryOperatorBindingParserNode>(plusAssignNode, BindingTokenType.UnsupportedOperator);
 
-            var caretNode = plusAssignNode.SecondExpression as BinaryOperatorBindingParserNode;
-
-            CheckBinaryOperatorNodeType<BinaryOperatorBindingParserNode, BinaryOperatorBindingParserNode>(caretNode, BindingTokenType.UnsupportedOperator);
-
-            var plusNode = caretNode.FirstExpression as BinaryOperatorBindingParserNode;
-
-            CheckBinaryOperatorNodeType<MemberAccessBindingParserNode, IdentifierNameBindingParserNode>(plusNode, BindingTokenType.AddOperator);
-
-            var multiplyNode = caretNode.SecondExpression as BinaryOperatorBindingParserNode;
+            var multiplyNode = plusAssignNode.SecondExpression as BinaryOperatorBindingParserNode;
 
             CheckBinaryOperatorNodeType<MemberAccessBindingParserNode, IdentifierNameBindingParserNode>(multiplyNode, BindingTokenType.MultiplyOperator);
 
-            Assert.IsTrue(caretNode.NodeErrors.Any());
             Assert.IsTrue(plusAssignNode.NodeErrors.Any());
         }
 

--- a/src/Tests/Parser/Binding/BindingTokenizerTests.cs
+++ b/src/Tests/Parser/Binding/BindingTokenizerTests.cs
@@ -211,17 +211,6 @@ namespace DotVVM.Framework.Tests.Parser.Binding
             Assert.AreEqual(BindingTokenType.Identifier, tokens[2].Type);
         }
 
-        [TestMethod]
-        public void BindingTokenizer_UnsupportedOperator_Carret()
-        {
-            var tokens = Tokenize("Test^3");
-
-            Assert.AreEqual(3, tokens.Count);
-            Assert.AreEqual(BindingTokenType.Identifier, tokens[0].Type);
-            Assert.AreEqual(BindingTokenType.UnsupportedOperator, tokens[1].Type);
-            Assert.AreEqual(BindingTokenType.Identifier, tokens[2].Type);
-        }
-
         [DataTestMethod]
         [DataRow("StringProp = StringProp + 1;;test", false)]
         [DataRow("StringProp = StringProp + 1; ;test", true)]


### PR DESCRIPTION
This PR adds support for the following operators:
* `^` - exclusive or
   * This operator is behaving a bit differently as compared to plain JS (in order to better capture the behaviour of .NET)
   * Whenever applied to two `bool`s, the result is also a `bool` as compared to `1` or `0`
* `~` - binary negation
   * TODO
* ...