### PR TITLE
Fixed codegen for serialization maps on .NET Framework

### DIFF
--- a/src/Framework/Framework/ViewModel/Serialization/ViewModelSerializationMap.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/ViewModelSerializationMap.cs
@@ -324,15 +324,17 @@ namespace DotVVM.Framework.ViewModel.Serialization
 
             if (propertyVars.Length > 0)
             {
-                var setProperties = Expression.Block(
-                    Properties
-                        .Zip(propertyVars, (p, v) =>
-                            p is { PropertyInfo.SetMethod: not null, ConstructorParameter: null, TransferToServer: true }
-                                ? Expression.Assign(Expression.Property(value, p.PropertyInfo), v)
-                                : null)
-                        .Where(e => e != null)!
-                );
-                block.Add(setProperties);
+                var propertySettingExpressions = Properties
+                    .Zip(propertyVars, (p, v) =>
+                        p is { PropertyInfo.SetMethod: not null, ConstructorParameter: null, TransferToServer: true }
+                            ? Assign(Property(value, p.PropertyInfo), v)
+                            : null)
+                    .Where(e => e != null).ToList();
+
+                if (propertySettingExpressions.Any())
+                {
+                    block.Add(Block(propertySettingExpressions!));
+                }
             }
 
             // return value


### PR DESCRIPTION
This PR fixes failing tests on CI. It seems like the following is not supported on .NET Framework:
* Calling `Zip` using an empty collection
   * This issue occurred when generating serialization maps for viewmodels that do not define any properties
* Creating an empty `Expression.Block`

This issue affects only 4.1 and is not present in 4.0.3