### PR TITLE
Added support for primary names and alternative names for controls

### DIFF
--- a/src/Framework/Framework/Compilation/CompiledAssemblyCache.cs
+++ b/src/Framework/Framework/Compilation/CompiledAssemblyCache.cs
@@ -220,5 +220,10 @@ namespace DotVVM.Framework.Compilation
             return assemblies.Select(a => a.GetType(name, false, ignoreCase)).FirstOrDefault(t => t != null);
         }
 
+        public Assembly? GetAssembly(string assemblyName)
+        {
+            return GetAllAssemblies()
+                .FirstOrDefault(a => a.GetName().Name == new AssemblyName(assemblyName).Name);
+        }
     }
 }

--- a/src/Framework/Framework/Compilation/ControlTree/ControlResolverBase.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ControlResolverBase.cs
@@ -135,7 +135,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
 			{
 				if (string.IsNullOrEmpty(rule.TagName))
 				{
-					var compiledControl = FindCompiledControl(tagName, rule.Namespace.NotNull(), rule.Assembly.NotNull());
+					var compiledControl = FindCompiledControl(rule.TagPrefix!, tagName, rule.Namespace.NotNull(), rule.Assembly.NotNull());
 					if (compiledControl != null)
 					{
 						return compiledControl;
@@ -193,7 +193,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
         /// <summary>
         /// Finds the compiled control.
         /// </summary>
-        protected abstract IControlType? FindCompiledControl(string tagName, string namespaceName, string assemblyName);
+        protected abstract IControlType? FindCompiledControl(string tagPrefix, string tagName, string namespaceName, string assemblyName);
 
 		/// <summary>
 		/// Finds the markup control.

--- a/src/Framework/Framework/Compilation/ControlTree/ControlResolverMetadataBase.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ControlResolverMetadataBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using DotVVM.Framework.Binding;
 using DotVVM.Framework.Compilation.ControlTree.Resolved;
 using DotVVM.Framework.Controls;
@@ -23,6 +24,10 @@ namespace DotVVM.Framework.Compilation.ControlTree
         public string? Namespace => controlType.Type.Namespace;
 
         public string Name => controlType.Type.Name;
+
+        public string? PrimaryName { get; }
+
+        public HashSet<string>? AlternativeNames { get; }
 
         [JsonIgnore]
         public ITypeDescriptor Type => controlType.Type;
@@ -104,6 +109,9 @@ namespace DotVVM.Framework.Compilation.ControlTree
                 LoadPropertyGroups(propertyGroups);
                 return propertyGroups;
             });
+
+            PrimaryName = attribute?.PrimaryName;
+            AlternativeNames = attribute?.AlternativeNames?.ToHashSet(StringComparer.OrdinalIgnoreCase);
         }
 
         protected abstract void LoadProperties(Dictionary<string, IPropertyDescriptor> result);

--- a/src/Framework/Framework/Compilation/Directives/BaseTypeDirectiveCompiler.cs
+++ b/src/Framework/Framework/Compilation/Directives/BaseTypeDirectiveCompiler.cs
@@ -51,6 +51,12 @@ namespace DotVVM.Framework.Compilation.Directives
                     baseControlDirective.DothtmlNode!.AddError("Markup controls must derive from DotvvmMarkupControl class!");
                     wrapperType = baseType;
                 }
+                else if (baseType.GetControlMarkupOptionsAttribute() is { } attribute
+                         && (!string.IsNullOrEmpty(attribute.PrimaryName) || attribute.AlternativeNames?.Any() == true))
+                {
+                    baseControlDirective.DothtmlNode!.AddError("Markup controls cannot use the PrimaryName or AlternativeNames properties in the ControlMarkupOptions attribute!");
+                    wrapperType = baseType;
+                }
                 else
                 {
                     wrapperType = baseType;

--- a/src/Framework/Framework/Controls/ControlMarkupOptionsAttribute.cs
+++ b/src/Framework/Framework/Controls/ControlMarkupOptionsAttribute.cs
@@ -18,7 +18,8 @@ namespace DotVVM.Framework.Controls
         public ControlPrecompilationMode Precompile { get; set; } = ControlPrecompilationMode.Never;
 
         /// <summary>
-        /// When set, the control will be referenced by this name in the markup and the primary name will appear in the Visual Studio IntelliSense.
+        /// If set, the control will be referenced by this name in the markup and the primary name will appear in the Visual Studio IntelliSense.
+        /// If not set, the control class name will be used as a primary name.
         /// </summary>
         public string? PrimaryName { get; set; } = null;
 
@@ -26,19 +27,5 @@ namespace DotVVM.Framework.Controls
         /// Represents a set of alternative names that are possible to use in the markup.
         /// </summary>
         public string[]? AlternativeNames { get; set; } = null;
-    }
-
-    public enum ControlPrecompilationMode
-    {
-        /// <summary> Never attempt precompilation. </summary>
-        Never,
-        /// <summary> Attempt precompilation whenever it's possible (the control is CompositeControl and there are no resource bindings in properties which can't handle bindings). If exception is thrown by the control, it is ignored and precompilation is skipped. </summary>
-        IfPossibleAndIgnoreExceptions,
-        /// <summary> Attempt precompilation whenever it's possible (the control is CompositeControl and there are no resource bindings in properties which can't handle bindings). If exception is thrown by the control, compilation fails. </summary>
-        IfPossible,
-        /// <summary> Always try to precompile the control and fail compilation when it's not possible. </summary>
-        Always,
-        /// <summary> Always precompile this controls and do that while styles are being processed. This will allow other styles to match onto the generated controls. </summary>
-        InServerSideStyles
     }
 }

--- a/src/Framework/Framework/Controls/ControlMarkupOptionsAttribute.cs
+++ b/src/Framework/Framework/Controls/ControlMarkupOptionsAttribute.cs
@@ -16,6 +16,16 @@ namespace DotVVM.Framework.Controls
 
         /// <summary> When set, the control will be evaluated only once during view compilation, instead of execting it for every request. It only work for <see cref="CompositeControl" />s. </summary>
         public ControlPrecompilationMode Precompile { get; set; } = ControlPrecompilationMode.Never;
+
+        /// <summary>
+        /// When set, the control will be referenced by this name in the markup and the primary name will appear in the Visual Studio IntelliSense.
+        /// </summary>
+        public string? PrimaryName { get; set; } = null;
+
+        /// <summary>
+        /// Represents a set of alternative names that are possible to use in the markup.
+        /// </summary>
+        public string[]? AlternativeNames { get; set; } = null;
     }
 
     public enum ControlPrecompilationMode

--- a/src/Framework/Framework/Controls/ControlPrecompilationMode.cs
+++ b/src/Framework/Framework/Controls/ControlPrecompilationMode.cs
@@ -1,0 +1,15 @@
+namespace DotVVM.Framework.Controls;
+
+public enum ControlPrecompilationMode
+{
+    /// <summary> Never attempt precompilation. </summary>
+    Never,
+    /// <summary> Attempt precompilation whenever it's possible (the control is CompositeControl and there are no resource bindings in properties which can't handle bindings). If exception is thrown by the control, it is ignored and precompilation is skipped. </summary>
+    IfPossibleAndIgnoreExceptions,
+    /// <summary> Attempt precompilation whenever it's possible (the control is CompositeControl and there are no resource bindings in properties which can't handle bindings). If exception is thrown by the control, compilation fails. </summary>
+    IfPossible,
+    /// <summary> Always try to precompile the control and fail compilation when it's not possible. </summary>
+    Always,
+    /// <summary> Always precompile this controls and do that while styles are being processed. This will allow other styles to match onto the generated controls. </summary>
+    InServerSideStyles
+}

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/ControlWithOverriddenRules.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/ControlWithOverriddenRules.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using DotVVM.Framework.Compilation.ControlTree.Resolved;
 using DotVVM.Framework.Compilation.Validation;
+using DotVVM.Framework.Controls;
 
 namespace DotVVM.Framework.Tests.Runtime.ControlTree.DefaultControlTreeResolver
 {
@@ -11,6 +12,16 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree.DefaultControlTreeResolver
         {
             yield break;
         }
+    }
+    
+    [ControlMarkupOptions(PrimaryName = "PrimaryNameControl")]
+    public class ControlWithPrimaryName : DotvvmControl
+    {
+    }
+
+    [ControlMarkupOptions(AlternativeNames = new [] { "AlternativeNameControl", "AlternativeNameControl2" })]
+    public class ControlWithAlternativeNames : DotvvmControl
+    {
     }
 }
 

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/DefaultControlTreeResolverTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/DefaultControlTreeResolverTests.cs
@@ -722,5 +722,33 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
             Assert.AreEqual("HTML attribute name 'TestProperty' should not contain uppercase letters. Did you intent to use a DotVVM property instead?", attribute1.AttributeNameNode.NodeWarnings.Single());
             Assert.AreEqual("HTML attribute name 'Visble' should not contain uppercase letters. Did you mean Visible, or another DotVVM property?", attribute3.AttributeNameNode.NodeWarnings.Single());
         }
+
+        [TestMethod]
+        public void DefaultViewCompiler_DifferentControlPrimaryName()
+        {
+            var root = ParseSource(@"@viewModel System.String
+<cc:PrimaryNameControl />
+<cc:ControlWithPrimaryName />");
+            var nonLiterals = root.Content.Where(c => !c.IsOnlyWhitespace()).ToList();
+            Assert.AreEqual(2, nonLiterals.Count);
+            Assert.AreEqual(typeof(ControlWithPrimaryName), nonLiterals[0].Metadata.Type);
+            Assert.AreEqual(typeof(ControlWithPrimaryName), nonLiterals[1].Metadata.Type);
+            Assert.AreEqual("PrimaryNameControl", nonLiterals[0].Metadata.PrimaryName);
+        }
+
+        [TestMethod]
+        public void DefaultViewCompiler_DifferentControlAlternativeNames()
+        {
+            var root = ParseSource(@"@viewModel System.String
+<cc:ControlWithAlternativeNames />
+<cc:AlternativeNameControl />
+<cc:AlternativeNameControl2 />");
+            var nonLiterals = root.Content.Where(c => !c.IsOnlyWhitespace()).ToList();
+            Assert.AreEqual(3, nonLiterals.Count);
+            Assert.AreEqual(typeof(ControlWithAlternativeNames), nonLiterals[0].Metadata.Type);
+            Assert.AreEqual(typeof(ControlWithAlternativeNames), nonLiterals[1].Metadata.Type);
+            Assert.AreEqual(typeof(ControlWithAlternativeNames), nonLiterals[2].Metadata.Type);
+            Assert.AreEqual(2, nonLiterals[0].Metadata.AlternativeNames!.Count);
+        }
     }
 }


### PR DESCRIPTION
I've added an option to specify aliases for controls in markup. 
We'll need this in the AutoUI package where we want the control in markup would be named `auto:Editor`, but the underlying class name would be `AutoEditor`.

I've added the `PrimaryName` property in the `ControlMarkupOptions` - this will be important for the VS extension as this should be the name that the extension will suggest in IntelliSense. If this property is not specified, the primary name would be the name of the control class (current behavior).
Also, I've added the `AlternativeName` collection which allows specifying other aliases. This can be used for renaming controls.