### PR TITLE
Encrypted values serialization should use our default settings

### DIFF
--- a/src/Framework/Framework/ViewModel/Serialization/EncryptedValuesReader.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/EncryptedValuesReader.cs
@@ -10,7 +10,6 @@ namespace DotVVM.Framework.ViewModel.Serialization
 {
     public class EncryptedValuesReader
     {
-        JsonSerializer serializer;
         Stack<(int prop, JObject? obj)> stack = new();
         int virtualNests = 0;
         int lastPropertyIndex = -1;
@@ -19,7 +18,6 @@ namespace DotVVM.Framework.ViewModel.Serialization
         public EncryptedValuesReader(JObject json)
         {
             stack.Push((0, json));
-            this.serializer = new JsonSerializer();
         }
 
         private JObject? json => stack.Peek().obj;

--- a/src/Framework/Framework/ViewModel/Serialization/EncryptedValuesWriter.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/EncryptedValuesWriter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using DotVVM.Framework.Configuration;
 using Newtonsoft.Json;
 
 namespace DotVVM.Framework.ViewModel.Serialization
@@ -18,7 +19,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
         public EncryptedValuesWriter(JsonWriter jsonWriter)
         {
             this.writer = jsonWriter;
-            serializer = new JsonSerializer();
+            serializer = JsonSerializer.Create(DefaultSerializerSettingsProvider.Instance.Settings);
         }
 
         public void Nest() => Nest(lastPropertyIndex + 1);

--- a/src/Tests/ViewModel/SerializerTests.cs
+++ b/src/Tests/ViewModel/SerializerTests.cs
@@ -341,6 +341,23 @@ namespace DotVVM.Framework.Tests.ViewModel
             Assert.AreEqual(obj.Property1, (string)json["Property1"]);
             Assert.IsFalse(json.ContainsKey("Service"));
         }
+
+        [TestMethod]
+        public void SupportsSignedDictionary()
+        {
+            var obj = new TestViewModelWithSignedDictionary() {
+                SignedDictionary = {
+                    ["a"] = "x",
+                    ["b"] = "y"
+                }
+            };
+            var (obj2, json) = SerializeAndDeserialize(obj);
+
+            CollectionAssert.Contains(obj2.SignedDictionary, new KeyValuePair<string, string>("a", "x"));
+            CollectionAssert.Contains(obj2.SignedDictionary, new KeyValuePair<string, string>("b", "y"));
+            Assert.AreEqual(obj.SignedDictionary.Count, obj2.SignedDictionary.Count);
+            Assert.IsFalse(!json.ContainsKey("SignedDictionary"));
+        }
         public class ViewModelWithService
         {
             public string Property1 { get; }
@@ -466,5 +483,11 @@ namespace DotVVM.Framework.Tests.ViewModel
         }
 
         public record WithDataset(GridViewDataSet<string> Dataset);
+    }
+
+    public class TestViewModelWithSignedDictionary
+    {
+        [Protect(ProtectMode.SignData)]
+        public Dictionary<string, string> SignedDictionary { get; set; } = new();
     }
 }


### PR DESCRIPTION
This caused a problem when Dictionary<,> was serialized,
since Newtonsoft.Json serializes it as object by default, but we excepted
it to be the Key/Value array when deserializing.

Resolves  #1379