### PR TITLE
Fix implicit ToEnumString on nullable enum

### DIFF
--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -205,7 +205,7 @@ namespace DotVVM.Framework.Compilation.Javascript
             AddMethodTranslator(typeof(Convert), "ToString", new PrimitiveToStringTranslator(), 1, true);
             AddMethodTranslator(typeof(ReflectionUtils), "ToEnumString", parameterCount: 1, translator: new GenericMethodCompiler(
                 args => args[1]
-            ));
+            ), allowMultipleMethods: true);
 
             AddMethodTranslator(typeof(DateTime).GetMethod("ToString", Type.EmptyTypes), new GenericMethodCompiler(
                 args => new JsIdentifierExpression("dotvvm").Member("globalize").Member("bindingDateToString")

--- a/src/Framework/Framework/Utils/ReflectionUtils.cs
+++ b/src/Framework/Framework/Utils/ReflectionUtils.cs
@@ -479,6 +479,8 @@ namespace DotVVM.Framework.Utils
                 return name;
             return ToEnumString(typeof(T), name);
         }
+        public static string? ToEnumString<T>(T? instance) where T : struct, Enum =>
+            instance?.ToEnumString();
 
         public static string ToEnumString(Type enumType, string name)
         {


### PR DESCRIPTION
Problem was that we removed the ToEnumString(T?) overload,
this adds it back
(it's not extension method on purpose to avoid ambiguity)

It should fix the failing tests in main