### PR TITLE
Repeater calls templates with rooted parent

### DIFF
--- a/src/Framework/Framework/Controls/DotvvmControlCollection.cs
+++ b/src/Framework/Framework/Controls/DotvvmControlCollection.cs
@@ -272,6 +272,14 @@ namespace DotVVM.Framework.Controls
             Debug.Assert(parent.properties.Contains(Internal.UniqueIDProperty));
             Debug.Assert(!item.properties.Contains(Internal.UniqueIDProperty));
             Debug.Assert(parentId is string);
+
+            // if the parent is a naming container, we don't need to duplicate it's unique id into the control
+            // when we don't do this Repeater generates different ids in server-side and client-side mode, because the
+            // UniqueIDProperty of the parent DataItemContainer is different, but the ClientIdFragment is the same
+            if (item.Parent!.properties.Contains(Internal.IsNamingContainerProperty))
+            {
+                parentId = "";
+            }
             
             var id = parentId.ToString() + "a" + uniqueIdCounter.ToString();
             uniqueIdCounter++;

--- a/src/Framework/Framework/Controls/HierarchyRepeater.cs
+++ b/src/Framework/Framework/Controls/HierarchyRepeater.cs
@@ -149,7 +149,7 @@ namespace DotVVM.Framework.Controls
         {
             if (RenderOnServer)
             {
-                foreach (var child in Children.Except(new[] { emptyDataContainer! }))
+                foreach (var child in Children.Except(new[] { emptyDataContainer!, clientItemTemplate! }))
                 {
                     child.Render(writer, context);
                 }
@@ -168,7 +168,7 @@ namespace DotVVM.Framework.Controls
 
             if (DataSource is not null)
             {
-                this.AppendChildren(CreateServerLevel(context, GetIEnumerableFromDataSource()!));
+                CreateServerLevel(this.Children, context, GetIEnumerableFromDataSource()!);
             }
 
             if (renderClientTemplate)
@@ -177,12 +177,12 @@ namespace DotVVM.Framework.Controls
                 // we'd get a binding... so we just generate a random Guid, not ideal but it will work.
                 var uniqueId = GetDotvvmUniqueId() is string id ? id : Guid.NewGuid().ToString();
                 clientItemTemplateId = $"{uniqueId}-item";
-                clientItemTemplate = GetClientItemTemplate(context);
+                clientItemTemplate = AddClientItemTemplate(Children, context);
                 context.ResourceManager.AddTemplateResource(context, clientItemTemplate, clientItemTemplateId);
                 clientRootLevel = LevelWrapperCapability.GetWrapper();
 
                 Children.Add(clientRootLevel);
-                clientRootLevel.AppendChildren(new HierarchyRepeaterLevel {
+                clientRootLevel.Children.Add(new HierarchyRepeaterLevel {
                     IsRoot = true,
                     ForeachExpression = GetForeachDataBindExpression().GetKnockoutBindingExpression(this),
                     ItemTemplateId = clientItemTemplateId,
@@ -191,11 +191,12 @@ namespace DotVVM.Framework.Controls
 
             if (EmptyDataTemplate is not null)
             {
-                Children.Add(emptyDataContainer ??= GetEmptyItem(context));
+                emptyDataContainer ??= AddEmptyItem(Children, context);
             }
         }
 
         private DotvvmControl CreateServerLevel(
+            IList<DotvvmControl> c,
             IDotvvmRequestContext context,
             IEnumerable items,
             ImmutableArray<int> parentPath = default,
@@ -214,25 +215,33 @@ namespace DotVVM.Framework.Controls
             var dataContextLevelWrapper = new HierarchyRepeaterLevel {
                 ForeachExpression = foreachExpression
             };
+            if (parentPath.Length > 0)
+            {
+                dataContextLevelWrapper.SetValue(Internal.IsNamingContainerProperty, true);
+                dataContextLevelWrapper.SetValue(Internal.UniqueIDProperty, parentPath[^1].ToString());
+            }
+            c.Add(dataContextLevelWrapper);
             var levelWrapper = LevelWrapperCapability.GetWrapper();
             dataContextLevelWrapper.Children.Add(levelWrapper);
 
             var index = 0;
             foreach (var item in items)
             {
-                levelWrapper.AppendChildren(CreateServerItem(context, item, parentPath, index));
+                CreateServerItem(levelWrapper.Children, context, item, parentPath, index);
                 index++;
             }
             return dataContextLevelWrapper;
         }
 
         private DotvvmControl CreateServerItem(
+            IList<DotvvmControl> c,
             IDotvvmRequestContext context,
             object item,
             ImmutableArray<int> parentPath,
             int index)
         {
             var itemWrapper = ItemWrapperCapability.GetWrapper();
+            c.Add(itemWrapper);
             var dataItem = new DataItemContainer { DataItemIndex = index };
             itemWrapper.Children.Add(dataItem);
             dataItem.SetDataContextTypeFromDataSource(GetDataSourceBinding());
@@ -245,8 +254,9 @@ namespace DotVVM.Framework.Controls
             placeholder.SetValue(
                 Internal.PathFragmentProperty,
                 $"{GetPathFragmentExpression()}{parentSegment}/[{index}]");
-            ItemTemplate.BuildContent(context, placeholder);
+            placeholder.SetValue(Internal.UniqueIDProperty, "item");
             dataItem.Children.Add(placeholder);
+            ItemTemplate.BuildContent(context, placeholder);
 
             // if the item has children then recurse down
             var itemChildren = GetItemChildren(item);
@@ -263,19 +273,18 @@ namespace DotVVM.Framework.Controls
                         default
                     );
 
-                itemWrapper.AppendChildren(
-                    CreateServerLevel(context, itemChildren, parentPath.Add(index), foreachExpression)
-                );
+                CreateServerLevel(itemWrapper.Children, context, itemChildren, parentPath.Add(index), foreachExpression);
             }
             return itemWrapper;
         }
 
-        private DotvvmControl GetClientItemTemplate(IDotvvmRequestContext context)
+        private DotvvmControl AddClientItemTemplate(IList<DotvvmControl> c, IDotvvmRequestContext context)
         {
+            var bindingService = context.Services.GetRequiredService<BindingCompilationService>();
+
             var dataItem = new DataItemContainer();
             dataItem.DataContext = null;
             dataItem.SetValue(Internal.PathFragmentProperty, $"{GetPathFragmentExpression()}/[$indexPath]");
-            var bindingService = context.Services.GetRequiredService<BindingCompilationService>();
             dataItem.SetDataContextTypeFromDataSource(GetDataSourceBinding());
             var clientIdFragmentProperty = ValueBindingExpression.CreateBinding<string?>(
                 bindingService.WithoutInitialization(),
@@ -283,11 +292,13 @@ namespace DotVVM.Framework.Controls
                 new ParametrizedCode("$indexPath.map(ko.unwrap).join(\"_\")", OperatorPrecedence.Max),
                 dataItem.GetDataContextType());
             dataItem.SetValue(Internal.ClientIDFragmentProperty, clientIdFragmentProperty);
+            c.Add(dataItem);
 
             var itemWrapper = ItemWrapperCapability.GetWrapper();
             dataItem.Children.Add(itemWrapper);
 
             var dataContextChangeItemWrapper = new HierarchyRepeaterItem();
+            dataContextChangeItemWrapper.SetValue(Internal.UniqueIDProperty, "item");
             itemWrapper.Children.Add(dataContextChangeItemWrapper);
             ItemTemplate.BuildContent(context, dataContextChangeItemWrapper);
 
@@ -318,13 +329,14 @@ namespace DotVVM.Framework.Controls
             return dataItem;
         }
 
-        private EmptyData GetEmptyItem(IDotvvmRequestContext context)
+        private EmptyData AddEmptyItem(IList<DotvvmControl> c, IDotvvmRequestContext context)
         {
             var emptyDataContainer = new EmptyData();
             emptyDataContainer.SetValue(EmptyData.RenderWrapperTagProperty, GetValueRaw(RenderWrapperTagProperty));
             emptyDataContainer.SetValue(EmptyData.WrapperTagNameProperty, GetValueRaw(WrapperTagNameProperty));
             emptyDataContainer.SetValue(EmptyData.VisibleProperty, GetValueRaw(VisibleProperty));
             emptyDataContainer.SetBinding(DataSourceProperty, GetDataSourceBinding());
+            c.Add(emptyDataContainer);
             EmptyDataTemplate!.BuildContent(context, emptyDataContainer);
             return emptyDataContainer;
         }

--- a/src/Framework/Framework/Controls/HierarchyRepeater.cs
+++ b/src/Framework/Framework/Controls/HierarchyRepeater.cs
@@ -218,7 +218,7 @@ namespace DotVVM.Framework.Controls
             if (parentPath.Length > 0)
             {
                 dataContextLevelWrapper.SetValue(Internal.IsNamingContainerProperty, true);
-                dataContextLevelWrapper.SetValue(Internal.UniqueIDProperty, parentPath[^1].ToString());
+                dataContextLevelWrapper.SetValue(Internal.UniqueIDProperty, parentPath[parentPath.Length - 1].ToString());
             }
             c.Add(dataContextLevelWrapper);
             var levelWrapper = LevelWrapperCapability.GetWrapper();

--- a/src/Tests/ControlTests/CompositeControlTests.cs
+++ b/src/Tests/ControlTests/CompositeControlTests.cs
@@ -93,6 +93,27 @@ namespace DotVVM.Framework.Tests.ControlTests
         }
 
         [TestMethod]
+        public async Task WrappedHierarchyRepeaterControlWithGeneratedIds()
+        {
+            var r = await cth.RunPage(typeof(BasicTestViewModel), @"
+                <!-- SSR -->
+                <cc:HierarchyControlWhichUsesUniqueIds DataSource={value: Hierarchy} ItemChildrenBinding={value: Children} RenderSettings.Mode=Server />
+                <!-- CSR -->
+                <cc:HierarchyControlWhichUsesUniqueIds DataSource={value: Hierarchy} ItemChildrenBinding={value: Children} RenderSettings.Mode=Client />
+                ",
+                renderResources: true
+            );
+
+            foreach (var junkElement in r.Html.QuerySelectorAll("#__dot_viewmodel_root, script, head"))
+            {
+                junkElement.Remove();
+            }
+
+            check.CheckString(r.FormattedHtml, fileExtension: "html");
+        }
+
+
+        [TestMethod]
         public async Task BindingMapping()
         {
             var r = await cth.RunPage(typeof(BasicTestViewModel), @"
@@ -197,6 +218,11 @@ namespace DotVVM.Framework.Tests.ControlTests
 
             public List<string> List { get; set; } = new List<string> { "list-item1", "list-item2" };
 
+            public List<HierarchyVM> Hierarchy { get; set; } = new() {
+                new("A", new()),
+                new("B", new() { new("C", new() { new("D", new()) }) })
+            };
+
             public bool TrueBool { get; set; } = true;
 
             public EnumForCssClasses EnumForCssClasses { get; set; } = EnumForCssClasses.C;
@@ -206,6 +232,8 @@ namespace DotVVM.Framework.Tests.ControlTests
                 AfterPreRender = true;
                 return base.PreRender();
             }
+
+            public record HierarchyVM(string Label, List<HierarchyVM> Children);
         }
     }
 
@@ -375,7 +403,8 @@ namespace DotVVM.Framework.Tests.ControlTests
         }
         public DotvvmControl GetContents(
             IValueBinding<IEnumerable<string>> dataSource
-        )       {
+        )
+        {
             return new Repeater() {
                 WrapperTagName = "ul",
                 RenderAsNamedTemplate = false // for testing
@@ -392,6 +421,39 @@ namespace DotVVM.Framework.Tests.ControlTests
                 }));
         }
     }
+
+    public class HierarchyControlWhichUsesUniqueIds: CompositeControl
+    {
+        private readonly BindingCompilationService bindingService;
+
+        public HierarchyControlWhichUsesUniqueIds(BindingCompilationService bindingService)
+        {
+            this.bindingService = bindingService;
+        }
+        public DotvvmControl GetContents(
+            IValueBinding<System.Collections.IEnumerable> dataSource,
+            [CollectionElementDataContextChange(1)]
+            [ControlPropertyBindingDataContextChange("DataSource")]
+            IValueBinding<IEnumerable<object>> itemChildrenBinding
+        )
+        {
+            return new HierarchyRepeater() {
+                WrapperTagName = "ul"
+            }
+                .SetProperty(HierarchyRepeater.DataSourceProperty, dataSource)
+                .SetProperty(HierarchyRepeater.ItemChildrenBindingProperty, itemChildrenBinding)
+                .SetProperty(HierarchyRepeater.ItemTemplateProperty, new DelegateTemplate((_, container) => {
+                    var li = new HtmlGenericControl("li");
+                    container.Children.Add(li);
+                    // this won't work unless the <li> is rooted
+                    var id = li.GetDotvvmUniqueId();
+                    li.AddAttribute("data-id", id);
+
+                    li.SetProperty(c => c.InnerText, bindingService.Cache.CreateValueBinding<string>("_this.Label", li.GetDataContextType()));
+                }));
+        }
+    }
+
 
     public enum EnumForCssClasses
     {

--- a/src/Tests/ControlTests/testoutputs/CompositeControlTests.WrappedHierarchyRepeaterControlWithGeneratedIds.html
+++ b/src/Tests/ControlTests/testoutputs/CompositeControlTests.WrappedHierarchyRepeaterControlWithGeneratedIds.html
@@ -1,0 +1,41 @@
+<html>
+	<body>
+		
+		<!-- SSR -->
+		<ul>
+			<!-- ko dotvvm-SSR-foreach: { data: Hierarchy } -->
+			<!-- ko dotvvm-SSR-item: 0 -->
+			<li data-bind="text: Label" data-id="c8a0_0_itema0">A</li>
+			<!-- /ko -->
+			<!-- ko dotvvm-SSR-item: 1 -->
+			<li data-bind="text: Label" data-id="c8a0_1_itema0">B</li>
+			<!-- /ko -->
+			<!-- ko dotvvm-SSR-foreach: { data: ko.unwrap($foreachCollectionSymbol)[1]().Children } -->
+			<!-- ko dotvvm-SSR-item: 0 -->
+			<li data-bind="text: Label" data-id="c8a0_1_0_itema0">C</li>
+			<!-- /ko -->
+			<!-- ko dotvvm-SSR-foreach: { data: ko.unwrap($foreachCollectionSymbol)[0]().Children } -->
+			<!-- ko dotvvm-SSR-item: 0 -->
+			<li data-bind="text: Label" data-id="c8a0_1_0_0_itema0">D</li>
+			<!-- /ko -->
+			<!-- /ko -->
+			<!-- /ko -->
+			<!-- /ko -->
+		</ul>
+		
+		<!-- CSR -->
+		<ul>
+			<!-- ko template: { foreach: Hierarchy, name: "c12a0-item", hierarchyRole: "Root" } -->
+			<!-- /ko -->
+		</ul>
+		
+		<!-- Resource c12a0-item of type TemplateResource. -->
+		<template id="c12a0-item">
+			<!-- ko with: $item --><li data-bind="text: Label, attr: { &quot;data-id&quot;: &quot;c12a0&quot;+'_'+$indexPath.map(ko.unwrap).join(&quot;_&quot;)+'_'+&quot;itema0&quot; }"></li>
+			<!-- /ko -->
+			<!-- ko template: { foreach: $item().Children, name: "c12a0-item", hierarchyRole: "Child" } -->
+			<!-- ko if: Children()?.length -->
+			<!-- /ko -->
+			<!-- /ko --></template>
+	</body>
+</html>

--- a/src/Tests/ControlTests/testoutputs/CompositeControlTests.WrappedRepeaterControlWithGeneratedIds.html
+++ b/src/Tests/ControlTests/testoutputs/CompositeControlTests.WrappedRepeaterControlWithGeneratedIds.html
@@ -5,16 +5,16 @@
 		<!-- SSR -->
 		<ul data-bind="dotvvm-SSR-foreach: { data: List }">
 			<!-- ko dotvvm-SSR-item: 0 -->
-			<li data-bind="text: $rawData" data-id="c9a0_0_0a0">list-item1</li>
+			<li data-bind="text: $rawData" data-id="c9a0_0_a0">list-item1</li>
 			<!-- /ko -->
 			<!-- ko dotvvm-SSR-item: 1 -->
-			<li data-bind="text: $rawData" data-id="c9a0_1_1a0">list-item2</li>
+			<li data-bind="text: $rawData" data-id="c9a0_1_a0">list-item2</li>
 			<!-- /ko -->
 		</ul>
 		
 		<!-- CSR -->
 		<ul data-bind="foreach: { data: List }">
-			<li data-bind="text: $rawData, attr: { &quot;data-id&quot;: &quot;c13a0&quot;+'_'+$index()+'_'+&quot;c13a0a2a0&quot; }"></li>
+			<li data-bind="text: $rawData, attr: { &quot;data-id&quot;: &quot;c13a0&quot;+'_'+$index()+'_'+&quot;a0&quot; }"></li>
 		</ul>
 	</body>
 </html>

--- a/src/Tests/ControlTests/testoutputs/CompositeControlTests.WrappedRepeaterControlWithGeneratedIds.html
+++ b/src/Tests/ControlTests/testoutputs/CompositeControlTests.WrappedRepeaterControlWithGeneratedIds.html
@@ -1,0 +1,20 @@
+<html>
+	<head></head>
+	<body>
+		
+		<!-- SSR -->
+		<ul data-bind="dotvvm-SSR-foreach: { data: List }">
+			<!-- ko dotvvm-SSR-item: 0 -->
+			<li data-bind="text: $rawData" data-id="c9a0_0_0a0">list-item1</li>
+			<!-- /ko -->
+			<!-- ko dotvvm-SSR-item: 1 -->
+			<li data-bind="text: $rawData" data-id="c9a0_1_1a0">list-item2</li>
+			<!-- /ko -->
+		</ul>
+		
+		<!-- CSR -->
+		<ul data-bind="foreach: { data: List }">
+			<li data-bind="text: $rawData, attr: { &quot;data-id&quot;: &quot;c13a0&quot;+'_'+$index()+'_'+&quot;c13a0a2a0&quot; }"></li>
+		</ul>
+	</body>
+</html>


### PR DESCRIPTION
Usually it's not super important if the container control is rooted or not,
but when the DelegateTemplate contains some user code which calls
GetDotvvmUniqueId (or similar), it will fail in weird ways (the ids will be
generated but won't be unique). For components used only from markup,
this really does not matter, but Repeater is being used as a base component
for many composite controls.

Similar change is made in HierarchyRepeater, where few fixes were needed to make the ids actually unique.

Plus one slight change was made to make repeater generate the same ids client-side and server-side. 