### PR TITLE
Moved `ToEnumString` JS translation into binding helper namespace

### DIFF
--- a/src/Framework/Framework/Binding/HelperNamespace/Enums.cs
+++ b/src/Framework/Framework/Binding/HelperNamespace/Enums.cs
@@ -18,7 +18,7 @@ namespace DotVVM.Framework.Binding.HelperNamespace
 
         public static string ToEnumString<T>(this T instance) where T : struct, Enum
         {
-            return ReflectionUtils.ToEnumString(instance);
+            return ReflectionUtils.ToEnumString<T>(instance);
         }
     }
 }

--- a/src/Framework/Framework/Binding/HelperNamespace/Enums.cs
+++ b/src/Framework/Framework/Binding/HelperNamespace/Enums.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Binding.HelperNamespace
 {
@@ -8,6 +9,16 @@ namespace DotVVM.Framework.Binding.HelperNamespace
         public static string[] GetNames<TEnum>()
         {
             return Enum.GetNames(typeof(TEnum));
+        }
+
+        public static string? ToEnumString<T>(T? instance) where T : struct, Enum
+        {
+            return ReflectionUtils.ToEnumString(instance);
+        }
+
+        public static string ToEnumString<T>(this T instance) where T : struct, Enum
+        {
+            return ReflectionUtils.ToEnumString(instance);
         }
     }
 }

--- a/src/Framework/Framework/Compilation/Binding/TypeConversions.cs
+++ b/src/Framework/Framework/Compilation/Binding/TypeConversions.cs
@@ -10,6 +10,7 @@ using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Compilation.Javascript.Ast;
 using DotVVM.Framework.Compilation.ControlTree.Resolved;
 using DotVVM.Framework.Binding;
+using DotVVM.Framework.Binding.HelperNamespace;
 
 namespace DotVVM.Framework.Compilation.Binding
 {
@@ -195,7 +196,7 @@ namespace DotVVM.Framework.Compilation.Binding
         {
             if (src.Type.UnwrapNullableType().IsEnum)
             {
-                return Expression.Call(typeof(ReflectionUtils), "ToEnumString", new [] { src.Type.UnwrapNullableType() }, src);
+                return Expression.Call(typeof(Enums), "ToEnumString", new [] { src.Type.UnwrapNullableType() }, src);
             }
             var toStringMethod = src.Type.GetMethod("ToString", Type.EmptyTypes);
             if (toStringMethod?.DeclaringType == typeof(object))

--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -203,7 +203,7 @@ namespace DotVVM.Framework.Compilation.Javascript
         {
             AddMethodTranslator(typeof(object), "ToString", new PrimitiveToStringTranslator(), 0);
             AddMethodTranslator(typeof(Convert), "ToString", new PrimitiveToStringTranslator(), 1, true);
-            AddMethodTranslator(typeof(ReflectionUtils), "ToEnumString", parameterCount: 1, translator: new GenericMethodCompiler(
+            AddMethodTranslator(typeof(Enums), "ToEnumString", parameterCount: 1, translator: new GenericMethodCompiler(
                 args => args[1]
             ), allowMultipleMethods: true);
 

--- a/src/Framework/Framework/Utils/ReflectionUtils.cs
+++ b/src/Framework/Framework/Utils/ReflectionUtils.cs
@@ -472,15 +472,14 @@ namespace DotVVM.Framework.Utils
             member is TypeInfo type ? type.AsType() :
             throw new NotImplementedException($"Could not get return type of member {member.GetType().FullName}");
 
-        public static string ToEnumString<T>(this T instance) where T : struct, Enum
+        [return: NotNullIfNotNull("instance")]
+        public static string? ToEnumString<T>(T? instance) where T : struct, Enum
         {
             var name = instance.ToString();
             if (!EnumInfo<T>.HasEnumMemberField)
                 return name;
             return ToEnumString(typeof(T), name);
         }
-        public static string? ToEnumString<T>(T? instance) where T : struct, Enum =>
-            instance?.ToEnumString();
 
         public static string ToEnumString(Type enumType, string name)
         {

--- a/src/Framework/Framework/Utils/ReflectionUtils.cs
+++ b/src/Framework/Framework/Utils/ReflectionUtils.cs
@@ -475,7 +475,10 @@ namespace DotVVM.Framework.Utils
         [return: NotNullIfNotNull("instance")]
         public static string? ToEnumString<T>(T? instance) where T : struct, Enum
         {
-            var name = instance.ToString();
+            if (instance == null)
+                return null;
+
+            var name = instance.ToString()!;
             if (!EnumInfo<T>.HasEnumMemberField)
                 return name;
             return ToEnumString(typeof(T), name);


### PR DESCRIPTION
This PR moves the `ToEnumString` JS translation into the common binding helper namespace