### PR TITLE
Use case insensitive comparisons for attributes

### DIFF
--- a/src/Framework/Framework/Compilation/ControlTree/DotvvmPropertyGroup.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/DotvvmPropertyGroup.cs
@@ -38,7 +38,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
         ITypeDescriptor IControlAttributeDescriptor.PropertyType => new ResolvedTypeDescriptor(PropertyType);
         public IAttributeValueMerger? ValueMerger { get; }
 
-        private ConcurrentDictionary<string, GroupedDotvvmProperty> generatedProperties = new();
+        private ConcurrentDictionary<string, GroupedDotvvmProperty> generatedProperties = new(StringComparer.OrdinalIgnoreCase);
 
         /// <summary> The capability which declared this property. When the property is declared by an capability, it can only be used by this capability. </summary>
         public DotvvmCapabilityProperty? OwningCapability { get; internal set; }

--- a/src/Framework/Framework/Controls/HtmlGenericControl.cs
+++ b/src/Framework/Framework/Controls/HtmlGenericControl.cs
@@ -413,7 +413,7 @@ namespace DotVVM.Framework.Controls
 
                 if (knockoutExpression is {})
                 {
-                    if (attributeName == "class")
+                    if (attributeName.Equals("class", StringComparison.OrdinalIgnoreCase))
                     {
                         writer.AddKnockoutDataBind("class", knockoutExpression);
                     }

--- a/src/Tests/ControlTests/CompositeControlTests.cs
+++ b/src/Tests/ControlTests/CompositeControlTests.cs
@@ -210,6 +210,29 @@ namespace DotVVM.Framework.Tests.ControlTests
             check.CheckString(r.FormattedHtml, fileExtension: "html");
         }
 
+        [TestMethod]
+        public async Task AttributeComparisonsAreCaseInsensitive()
+        {
+            var r = await cth.RunPage(typeof(BasicTestViewModel), @"
+                <dot:Placeholder RenderSettings.Mode=Server>
+
+
+                    <!-- static value -->
+                    <cc:MessedUpControlWhichUsesUppercaseAttributes CssClass1=A CssClass2=D />
+                    <!-- value binding + resource binding -->
+                    <cc:MessedUpControlWhichUsesUppercaseAttributes CssClass1={value: 'A'} CssClass2={resource: 'D'} />
+                    <!-- value binding + static -->
+                    <cc:MessedUpControlWhichUsesUppercaseAttributes CssClass1={value: EnumForCssClasses} CssClass2=D />
+                    <!-- both value bindings -->
+                    <cc:MessedUpControlWhichUsesUppercaseAttributes CssClass1={value: TrueBool ? 'D' : 'A'} CssClass2={value: EnumForCssClasses} />
+
+                </dot:Placeholder>
+                "
+            );
+
+            check.CheckString(r.FormattedHtml, fileExtension: "html");
+        }
+
         public class BasicTestViewModel: DotvvmViewModelBase
         {
             [Bind(Name = "int")]
@@ -464,6 +487,20 @@ namespace DotVVM.Framework.Tests.ControlTests
 
                     li.SetProperty(c => c.InnerText, bindingService.Cache.CreateValueBinding<string>("_this.Label", li.GetDataContextType()));
                 }));
+        }
+    }
+
+    public class MessedUpControlWhichUsesUppercaseAttributes: CompositeControl
+    {
+        public static DotvvmControl GetContents(
+            ValueOrBinding<string> cssClass1,
+            ValueOrBinding<string> cssClass2
+        )
+        {
+            return new HtmlGenericControl("div")
+                .AddAttribute("ClaSS", cssClass1)
+                .AddAttribute("class", cssClass2)
+                .AddAttribute("CLASS", "one-more-class");
         }
     }
 

--- a/src/Tests/ControlTests/testoutputs/CompositeControlTests.AttributeComparisonsAreCaseInsensitive.html
+++ b/src/Tests/ControlTests/testoutputs/CompositeControlTests.AttributeComparisonsAreCaseInsensitive.html
@@ -1,0 +1,17 @@
+<html>
+	<head></head>
+	<body>
+		
+		<!-- static value -->
+		<div class="A D one-more-class"></div>
+		
+		<!-- value binding + resource binding -->
+		<div class="one-more-class A D" data-bind="class: &quot;one-more-class &quot;+&quot;A&quot;+&quot; D&quot;"></div>
+		
+		<!-- value binding + static -->
+		<div class="one-more-class class-c D" data-bind="class: &quot;one-more-class &quot;+EnumForCssClasses()+&quot; D&quot;"></div>
+		
+		<!-- both value bindings -->
+		<div class="one-more-class D class-c" data-bind="class: &quot;one-more-class &quot;+(TrueBool() ? &quot;D&quot; : &quot;A&quot;)+&quot; &quot;+EnumForCssClasses()"></div>
+	</body>
+</html>


### PR DESCRIPTION
Use OrdinalIgnoreCase comparer for all PropertyGroups - in general most things
in dothtml is case insensitive, all of our uses for property groups are
case insensitive. I think it's not worth it to add another config option.

resolves #1395