### PR TITLE
jscomponent: Fix plain command in JsComponent props

### DIFF
--- a/src/Framework/Framework/Binding/Expressions/CommandBindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/CommandBindingExpression.cs
@@ -13,6 +13,7 @@ using DotVVM.Framework.Compilation.Javascript.Ast;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.Runtime.Filters;
 using DotVVM.Framework.Utils;
+using FastExpressionCompiler;
 using Newtonsoft.Json;
 
 namespace DotVVM.Framework.Binding.Expressions
@@ -93,9 +94,22 @@ namespace DotVVM.Framework.Binding.Expressions
                 public ExpectedTypeBindingProperty GetExpectedType(AssignedPropertyBindingProperty? property = null)
                 {
                     var prop = property?.DotvvmProperty;
-                    if (prop == null) return new ExpectedTypeBindingProperty(typeof(Command));
 
-                    return new ExpectedTypeBindingProperty(prop.IsBindingProperty ? (prop.PropertyType.GenericTypeArguments.SingleOrDefault() ?? typeof(Command)) : prop.PropertyType);
+                    var type = prop is null ? null :
+                               prop.IsBindingProperty ? prop.PropertyType.GenericTypeArguments.SingleOrDefault() :
+                               prop.PropertyType;
+
+                    // replace object with Command, we can't produce anything else than a delegate from a command binding
+                    if (type is null || type == typeof(object))
+                        type = typeof(Command);
+                    
+                    if (!type.IsDelegate())
+                    {
+                        // can I just throw an exception here?
+                        throw new Exception($"Command binding can only be used in properties of a delegate type (or ICommandBinding). Property {prop} has type {prop?.PropertyType.ToCode()}.");
+                    }
+
+                    return new ExpectedTypeBindingProperty(type);
                 }
             }
         }

--- a/src/Samples/Common/Scripts/react/react-app.tsx
+++ b/src/Samples/Common/Scripts/react/react-app.tsx
@@ -35,10 +35,14 @@ function TemplateSelector(props) {
     </div>
 }
 
+const Button = ({ text, click, dataUI }) =>
+    <button onClick={e => click()} data-ui={dataUI}>{text}</button>
+
 // DotVVM Context importer 
 export default (context) => ({
     $controls: {
         recharts: registerReactControl(RechartComponent, { context, onMouse() { /* default empty method */ } }),
-        TemplateSelector: registerReactControl(TemplateSelector)
+        TemplateSelector: registerReactControl(TemplateSelector),
+        Button: registerReactControl(Button)
     }
 })

--- a/src/Samples/Common/Scripts/svelte/Button.svelte
+++ b/src/Samples/Common/Scripts/svelte/Button.svelte
@@ -1,0 +1,7 @@
+<script>
+	export let text
+	export let click
+	export let dataUI
+</script>
+
+<button data-ui={dataUI} on:click={e => click()}>{text}</button>

--- a/src/Samples/Common/Scripts/svelte/svelte-app.ts
+++ b/src/Samples/Common/Scripts/svelte/svelte-app.ts
@@ -1,6 +1,7 @@
 ﻿import Chart from './Chart.svelte'
 import Incrementer from './Incrementer2.svelte'
 import TemplateSelector from './TemplateSelector.svelte'
+import Button from './Button.svelte'
 
 // copy pasted from generated svelte code,
 // they don't currently have a public API for two way data bindings
@@ -60,6 +61,7 @@ export default (context) => ({
     $controls: {
         chart: registerSvelteControl(Chart, { context, onMouse() { /* default empty method */ } }),
         incrementer: registerSvelteControl(Incrementer),
-        TemplateSelector: registerSvelteControl(TemplateSelector)
+        TemplateSelector: registerSvelteControl(TemplateSelector),
+        Button: registerSvelteControl(Button),
     }
 })

--- a/src/Samples/Common/Views/FeatureSamples/JsComponentIntegration/ReactComponentIntegration.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/JsComponentIntegration/ReactComponentIntegration.dothtml
@@ -18,9 +18,9 @@
     </div>
 
 
-    <dot:Button data-ui="command-regenerate" Click={command: Regenerate()} Text="Regenerate chart"></dot:Button>
-    <dot:Button data-ui="command-removeDOM" Click={staticCommand: IncludeInPage = false} Text="Remove from DOM"></dot:Button>
-    <dot:Button data-ui="command-addDOM" Click={staticCommand: IncludeInPage = true} Text="Add to DOM"></dot:Button>
+    <js:Button dataUI="command-regenerate" click={command: Regenerate()} text="Regenerate chart" />
+    <js:Button dataUI="command-removeDOM" click={staticCommand: IncludeInPage = false} text="Remove from DOM"  />
+    <js:Button dataUI="command-addDOM" click={staticCommand: IncludeInPage = true} text="Add to DOM" />
 
     <p>
         CurrentThing:<span data-ui="result">{{value: CurrentThing}}</span>
@@ -41,7 +41,7 @@
             </span>
             <ul data-ui="template2-commandSection">
                 <li>
-                    <dot:Button Text="Test command" data-ui="template2-command" Click="{command: ChangeCurrentThing()}" />
+                    <js:Button text="Test command" dataUI="template2-command" click="{command: ChangeCurrentThing()}" />
                 </li>
                 <li>
                     <dot:Button Text="Test static command" data-ui="template2-clientStaticCommand" Click="{staticCommand:  CurrentThing = "StaticCommandInvoked"}" />

--- a/src/Samples/Common/Views/FeatureSamples/JsComponentIntegration/SvelteComponentIntegration.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/JsComponentIntegration/SvelteComponentIntegration.dothtml
@@ -17,9 +17,9 @@
     </div>
 
 
-    <dot:Button data-ui="command-regenerate" Click={command: Regenerate()} Text="Regenerate chart"></dot:Button>
-    <dot:Button data-ui="command-removeDOM" Click={staticCommand: IncludeInPage = false} Text="Remove from DOM"></dot:Button>
-    <dot:Button data-ui="command-addDOM" Click={staticCommand: IncludeInPage = true} Text="Add to DOM"></dot:Button>
+    <js:Button dataUI="command-regenerate" click={command: Regenerate()} text="Regenerate chart"/>
+    <js:Button dataUI="command-removeDOM" click={staticCommand: IncludeInPage = false} text="Remove from DOM"/>
+    <js:Button dataUI="command-addDOM" click={staticCommand: IncludeInPage = true} text="Add to DOM" />
 
     <p>
         CurrentThing:<span data-ui="result">{{value: CurrentThing}}</span>
@@ -55,7 +55,7 @@
             </span>
             <ul data-ui="template2-commandSection">
                 <li>
-                    <dot:Button Text="Test command" data-ui="template2-command" Click="{command: ChangeCurrentThing()}" />
+                    <js:Button text="Test command" dataUI="template2-command" click="{command: ChangeCurrentThing()}" />
                 </li>
                 <li>
                     <dot:Button Text="Test static command" data-ui="template2-clientStaticCommand" Click="{staticCommand:  CurrentThing = "StaticCommandInvoked"}" />


### PR DESCRIPTION
We only ever tested lambda functions in the command,
but plain command expressions didn't work.