### PR TITLE
deserializer: fix root viewmodels with constructor properties

### DIFF
--- a/src/Framework/Framework/ViewModel/Serialization/DefaultViewModelSerializer.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/DefaultViewModelSerializer.cs
@@ -345,7 +345,13 @@ namespace DotVVM.Framework.ViewModel.Serialization
             var reader = viewModelToken.CreateReader();
             try
             {
-                viewModelConverter.Populate(reader, serializer, context.ViewModel!);
+                var newVM = viewModelConverter.Populate(reader, serializer, context.ViewModel!);
+                if (newVM != context.ViewModel)
+                {
+                    context.ViewModel = newVM;
+                    if (context.View is not null)
+                        context.View.DataContext = newVM;
+                }
             }
             catch (Exception ex)
             {

--- a/src/Framework/Framework/ViewModel/Serialization/ViewModelSerializationMap.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/ViewModelSerializationMap.cs
@@ -388,7 +388,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
             }
         }
 
-        private static object? Deserialize(JsonSerializer serializer, JsonReader reader, ViewModelPropertyMap property, object existingValue)
+        private static object? Deserialize(JsonSerializer serializer, JsonReader reader, ViewModelPropertyMap property, object? existingValue)
         {
             if (property.JsonConverter != null && property.JsonConverter.CanRead && property.JsonConverter.CanConvert(property.Type))
             {

--- a/src/Tests/ControlTests/CommandTests.cs
+++ b/src/Tests/ControlTests/CommandTests.cs
@@ -1,0 +1,58 @@
+using CheckTestOutput;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DotVVM.Framework.Testing;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DotVVM.Framework.Tests.ControlTests
+{
+    [TestClass]
+    public class CommandTests
+    {
+        static readonly ControlTestHelper cth = new ControlTestHelper(config: config => {
+
+        }, services: services => {
+            services.AddTransient<OmgViewModelWithIsAlsoAService>();
+        });
+        OutputChecker check = new OutputChecker("testoutputs");
+
+
+        [TestMethod]
+        public async Task RootViewModelIsRecord()
+        {
+            var r = await cth.RunPage(typeof(ViewModel1), " <dot:Button Text=Click Click={command: Text = NestedVM.TestProp} /> ");
+
+            Assert.AreEqual("Text1", (string)r.ViewModel.Text);
+            Assert.AreEqual("Text2", (string)r.ViewModel.NestedVM.TestProp);
+
+            await r.RunCommand("Text = NestedVM.TestProp");
+
+            Assert.AreEqual("Text2", (string)r.ViewModel.Text);
+        }
+
+        
+        public class ViewModel1
+        {
+            // don't ask me why people do this...
+            // on one project, 4.1 upgrade did not work, because they try to inject
+            // a service into viewmodel which is also a nested viewmodel property 🤦
+            // DotVVM obviously thinks it's a viewmodel, not a service, so it
+            // re-creates the object after deserialization, which broke other things if it's a root viewmodel
+            public ViewModel1(OmgViewModelWithIsAlsoAService nestedVM)
+            {
+                NestedVM = nestedVM;
+            }
+
+            public OmgViewModelWithIsAlsoAService NestedVM { get; }
+
+            public string Text { get; set; } = "Text1";
+        }
+
+        public class OmgViewModelWithIsAlsoAService
+        {
+            public string TestProp { get; set; } = "Text2";
+        }
+        
+    }
+}


### PR DESCRIPTION
Problem was that we re-created the root viewmodel without setting it back to context.ViewModel and view.DataContext

cc @Ropack 