### PR TITLE
Fix race conditions in startup tracer

### DIFF
--- a/src/Framework/Framework/Diagnostics/Models/DiagnosticsInformation.cs
+++ b/src/Framework/Framework/Diagnostics/Models/DiagnosticsInformation.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Text;
 using DotVVM.Framework.Hosting;
 

--- a/src/Framework/Framework/Diagnostics/Models/EventTiming.cs
+++ b/src/Framework/Framework/Diagnostics/Models/EventTiming.cs
@@ -1,17 +1,6 @@
 namespace DotVVM.Framework.Diagnostics.Models
 {
-    public class EventTiming
+    public record EventTiming(string EventName, long Duration, long TotalDuration, bool StartupComplete = false)
     {
-        public EventTiming(string eventName, long duration, long totalDuration)
-        {
-            EventName = eventName;
-            Duration = duration;
-            TotalDuration = totalDuration;
-        }
-
-        public string EventName { get; set; }
-        public long Duration { get; set; }
-        public long TotalDuration { get; set; }
     }
-
 }

--- a/src/Framework/Framework/Hosting/StartupTracingConstants.cs
+++ b/src/Framework/Framework/Hosting/StartupTracingConstants.cs
@@ -10,6 +10,7 @@ namespace DotVVM.Framework.Hosting
     public class StartupTracingConstants
     {
         public static readonly string AddDotvvmStarted = nameof(AddDotvvmStarted);
+        public static readonly string StartupComplete = nameof(StartupComplete);
 
         public static readonly string DotvvmConfigurationUserServicesRegistrationStarted = nameof(DotvvmConfigurationUserServicesRegistrationStarted);
         public static readonly string DotvvmConfigurationUserServicesRegistrationFinished = nameof(DotvvmConfigurationUserServicesRegistrationFinished);

--- a/src/Framework/Framework/Utils/ConcurrencyUtils.cs
+++ b/src/Framework/Framework/Utils/ConcurrencyUtils.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+
+namespace DotVVM.Framework.Utils
+{
+    static class ConcurrencyUtils
+	{
+		public static T CasChange<T>(ref T xRef, Func<T, T> f)
+			where T : class
+		{
+		Retry:
+			var x1 = xRef;
+			var x2 = f(x1);
+
+			var oldValue = Interlocked.CompareExchange(ref xRef, x2, x1);
+			if (oldValue != x1)
+			{
+				// unsuccessfully write
+				goto Retry;
+			}
+
+			return x2;
+		}
+	}
+}


### PR DESCRIPTION
hopefully without adding new ones...
the main point is the replacement of List with ImmutableList,
which is safe to read even when some other thread
is still reporting events