### PR TITLE
Added support for running unit tests on .NET Framework

### DIFF
--- a/src/Framework/Testing/DotVVM.Framework.Testing.csproj
+++ b/src/Framework/Testing/DotVVM.Framework.Testing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <PackageId>DotVVM.Testing</PackageId>
     <Description>

--- a/src/Framework/Testing/DotVVM.Framework.Testing.csproj
+++ b/src/Framework/Testing/DotVVM.Framework.Testing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0;net472</TargetFrameworks>
     <Nullable>enable</Nullable>
     <PackageId>DotVVM.Testing</PackageId>
     <Description>

--- a/src/Tests/Binding/ExpressionHelperTests.cs
+++ b/src/Tests/Binding/ExpressionHelperTests.cs
@@ -9,7 +9,6 @@ using DotVVM.Framework.Compilation.Binding;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.Utils;
 using DotVVM.Framework.Testing;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CSharp.RuntimeBinder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/Tests/DotVVM.Framework.Tests.csproj
+++ b/src/Tests/DotVVM.Framework.Tests.csproj
@@ -13,7 +13,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net6.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <PublicSign>True</PublicSign>
@@ -31,7 +32,7 @@
     <ProjectReference Include="../Framework/Hosting.Owin/DotVVM.Framework.Hosting.Owin.csproj" />
     <PackageReference Include="CheckTestOutput" Version="0.4.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <Compile Remove="AspCore/CachingTests.cs"/>
+    <Compile Remove="AspCore/CachingTests.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <ProjectReference Include="../Framework/Hosting.AspNetCore/DotVVM.Framework.Hosting.AspNetCore.csproj" />

--- a/src/Tests/DotVVM.Framework.Tests.csproj
+++ b/src/Tests/DotVVM.Framework.Tests.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <PublicSign>True</PublicSign>
@@ -25,14 +25,22 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Framework/Framework/DotVVM.Framework.csproj" />
-    <ProjectReference Include="../Framework/Hosting.AspNetCore/DotVVM.Framework.Hosting.AspNetCore.csproj" />
     <ProjectReference Include="../Framework/Testing/DotVVM.Framework.Testing.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <ProjectReference Include="../Framework/Hosting.Owin/DotVVM.Framework.Hosting.Owin.csproj" />
+    <PackageReference Include="CheckTestOutput" Version="0.4.3" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <Compile Remove="AspCore/CachingTests.cs"/>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <ProjectReference Include="../Framework/Hosting.AspNetCore/DotVVM.Framework.Hosting.AspNetCore.csproj" />
+    <PackageReference Include="CheckTestOutput" Version="0.5.1" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.17.0" />
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-    <PackageReference Include="CheckTestOutput" Version="0.5.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.*" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.*" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Tests/DotVVM.Framework.Tests.csproj
+++ b/src/Tests/DotVVM.Framework.Tests.csproj
@@ -32,6 +32,7 @@
     <ProjectReference Include="../Framework/Hosting.Owin/DotVVM.Framework.Hosting.Owin.csproj" />
     <PackageReference Include="CheckTestOutput" Version="0.4.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
     <Compile Remove="AspCore/CachingTests.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/src/Tests/ViewModel/SerializerTests.cs
+++ b/src/Tests/ViewModel/SerializerTests.cs
@@ -165,7 +165,7 @@ namespace DotVVM.Framework.Tests.ViewModel
         {
             using var stream = new MemoryStream();
             // Serialize array
-            using (var writer = new JsonTextWriter(new StreamWriter(stream, Encoding.UTF8, leaveOpen: true)))
+            using (var writer = new JsonTextWriter(new StreamWriter(stream, Encoding.UTF8, 4096, leaveOpen: true)))
             {
                 new DotvvmByteArrayConverter().WriteJson(writer, array, new JsonSerializer());
                 writer.Flush();


### PR DESCRIPTION
This PR adds the possibility to run tests also on .NET Framework. Over the past few months, there have been a couple of issues manifesting only on .NET Framework. Therefore, we should always run unit tests also on .NET Framework as it seems to have discovered multiple issues (see the tests report).

- This change should not affect people on Linux/Mac as we are using conditional `TargetFrameworks`
- It also works on CI (`windows-2022` run has two reporting platforms - `net6` and `net472`)

Failing tests on .NET Framework will be fixed within a separate PR