### PR TITLE
Added `MaxDepth` to default serialization settings

### DIFF
--- a/src/Framework/Framework/Configuration/DefaultSerializerSettingsProvider.cs
+++ b/src/Framework/Framework/Configuration/DefaultSerializerSettingsProvider.cs
@@ -11,6 +11,7 @@ namespace DotVVM.Framework.Configuration
 {
     public sealed class DefaultSerializerSettingsProvider
     {
+        private const int defaultMaxSerializationDepth = 64;
         internal readonly JsonSerializerSettings Settings;
 
         public JsonSerializerSettings GetSettingsCopy()
@@ -29,7 +30,8 @@ namespace DotVVM.Framework.Configuration
                     new StringEnumConverter(),
                     new DotvvmDictionaryConverter(),
                     new DotvvmByteArrayConverter()
-                }
+                },
+                MaxDepth = defaultMaxSerializationDepth
             };
         }
 
@@ -46,6 +48,7 @@ namespace DotVVM.Framework.Configuration
 
         private DefaultSerializerSettingsProvider()
         {
+            JsonConvert.DefaultSettings = () => new JsonSerializerSettings() { MaxDepth = defaultMaxSerializationDepth };
             Settings = CreateSettings();
         }
     }


### PR DESCRIPTION
This PR adds `MaxDepth` both to global Newtonsoft settings and also to DotVVM's `DefaultSerializerSettingsProvider`. We are using the same default as Newtonsoft. See: https://github.com/JamesNK/Newtonsoft.Json/blob/94ff24f815a777269920f5a7b13f60db50c5eeb7/Src/Newtonsoft.Json/JsonReader.cs#L332