### PR TITLE
markup control: Basic support for property groups

### DIFF
--- a/src/Framework/Framework/Controls/DotvvmMarkupControl.cs
+++ b/src/Framework/Framework/Controls/DotvvmMarkupControl.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using DotVVM.Framework.Binding;
 using DotVVM.Framework.Binding.Expressions;
 using DotVVM.Framework.Compilation;
+using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Compilation.Javascript;
 using DotVVM.Framework.Compilation.Parser;
 using DotVVM.Framework.Configuration;
@@ -71,10 +73,8 @@ namespace DotVVM.Framework.Controls
         protected override void AddAttributesToRender(IHtmlWriter writer, IDotvvmRequestContext context)
         {
             var properties = new KnockoutBindingGroup();
-            var usedProperties =
-                GetValue<ControlUsedPropertiesInfo>(Internal.UsedPropertiesInfoProperty)?.ClientSideUsedProperties
-                    ?? GetDeclaredProperties();
-            foreach (var p in usedProperties)
+            var usedProperties = GetValue<ControlUsedPropertiesInfo>(Internal.UsedPropertiesInfoProperty);
+            foreach (var p in usedProperties?.ClientSideUsedProperties ?? GetDeclaredProperties())
             {
                 if (p.DeclaringType.IsAssignableFrom(typeof(DotvvmMarkupControl)))
                     continue;
@@ -84,6 +84,30 @@ namespace DotVVM.Framework.Controls
                 {
                     properties.Add(p.Name, pinfo.Js);
                 }
+            }
+
+            foreach (var pg in usedProperties?.ClientSideUsedPropertyGroups ?? DotvvmPropertyGroup.GetPropertyGroups(this.GetType()))
+            {
+                if (pg.DeclaringType.IsAssignableFrom(typeof(DotvvmMarkupControl)))
+                    continue;
+
+                var js = new StringBuilder().Append("[");
+                
+                var values = new VirtualPropertyGroupDictionary<object>(this, pg);
+                foreach (var p in values.Properties.OrderBy(p => p.GroupMemberName))
+                {
+                    var pinfo = GetPropertySerializationInfo(p); // migrate to use the KnockoutBindingGroup helpers
+                    if (pinfo.Js is object)
+                    {
+                        js.Append("{Key: ")
+                          .Append(JsonConvert.ToString(p.GroupMemberName, '"', StringEscapeHandling.EscapeHtml))
+                          .Append(", Value: ")
+                          .Append(pinfo.Js)
+                          .Append("},");
+                    }
+                }
+                js.Append("]");
+                properties.Add(pg.Name, js.ToString());
             }
 
             if (!properties.IsEmpty)

--- a/src/Framework/Framework/Controls/DotvvmMarkupControl.cs
+++ b/src/Framework/Framework/Controls/DotvvmMarkupControl.cs
@@ -59,7 +59,7 @@ namespace DotVVM.Framework.Controls
             }
 
             var viewModule = GetValue<ViewModuleReferenceInfo>(Internal.ReferencedViewModuleInfoProperty);
-            if (viewModule is object)
+            if (viewModule is {})
             {
                 Debug.Assert(viewModule.IsMarkupControl);
                 context.ResourceManager.AddRequiredResource(viewModule.ImportResourceName);
@@ -80,7 +80,7 @@ namespace DotVVM.Framework.Controls
                     continue;
 
                 var pinfo = GetPropertySerializationInfo(p); // migrate to use the KnockoutBindingGroup helpers
-                if (pinfo.Js is object)
+                if (pinfo.Js is {})
                 {
                     properties.Add(p.Name, pinfo.Js);
                 }
@@ -97,7 +97,7 @@ namespace DotVVM.Framework.Controls
                 foreach (var p in values.Properties.OrderBy(p => p.GroupMemberName))
                 {
                     var pinfo = GetPropertySerializationInfo(p); // migrate to use the KnockoutBindingGroup helpers
-                    if (pinfo.Js is object)
+                    if (pinfo.Js is {})
                     {
                         js.Append("{Key: ")
                           .Append(JsonConvert.ToString(p.GroupMemberName, '"', StringEscapeHandling.EscapeHtml))
@@ -122,7 +122,7 @@ namespace DotVVM.Framework.Controls
             }
 
             var viewModule = this.GetValue<ViewModuleReferenceInfo>(Internal.ReferencedViewModuleInfoProperty);
-            if (viewModule is object)
+            if (viewModule is {})
             {
                 var settings = DefaultSerializerSettingsProvider.Instance.GetSettingsCopy();
                 settings.StringEscapeHandling = StringEscapeHandling.EscapeHtml;

--- a/src/Tests/ControlTests/testoutputs/MarkupControlTests.MarkupControl_InternalProperty.html
+++ b/src/Tests/ControlTests/testoutputs/MarkupControlTests.MarkupControl_InternalProperty.html
@@ -1,0 +1,16 @@
+<html>
+	<head></head>
+	<body>
+		<div data-bind="dotvvm-with-control-properties: { Something: [{&quot;Key&quot;:&quot;test&quot;,&quot;Value&quot;:&quot;test&quot;},{&quot;Key&quot;:&quot;x&quot;,&quot;Value&quot;:&quot;y&quot;}], PropGroup: [{Key: &quot;const&quot;, Value: &quot;AA&quot;},{Key: &quot;resource&quot;, Value: &quot;XX10000000&quot;},{Key: &quot;value&quot;, Value: dotvvm.globalize.bindingNumberToString(int)},] }, dotvvm-with-view-modules: { modules: [&quot;somemodule&quot;] }">
+			<input onclick="dotvvm.applyPostbackHandlers((options) => {
+	dotvvm.viewModules.call(this, &quot;xx&quot;, [options.knockoutContext.$control.Something.state], false);
+},this).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
+			<input onclick="dotvvm.applyPostbackHandlers((options) => {
+	dotvvm.viewModules.call(this, &quot;xx&quot;, [options.knockoutContext.$control.PropGroup.state], false);
+},this).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
+			
+			<!-- ko text: dotvvm.translations.dictionary.containsKey($control.PropGroup(), "test") -->
+			<!-- /ko -->
+		</div>
+	</body>
+</html>

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -1418,6 +1418,12 @@
         "type": "System.Object"
       }
     },
+    "DotVVM.Framework.Tests.ControlTests.CustomControlWithInternalProperty": {
+      "PropGroup": {
+        "prefix": "PropGroup-",
+        "type": "System.String"
+      }
+    },
     "DotVVM.Framework.Tests.ControlTests.RepeatedButton": {
       "Attributes": {
         "prefixes": [


### PR DESCRIPTION
If the property group is used in the markup,
it will be serialized among the other control properties as a dictionary.
This approach should allow any operations on the dictionary.

The main use case is for passing all the properties into a JS function