### PR TITLE
Compile time warning for uppercase atrributes (i.e. mistyped properties)

### DIFF
--- a/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
+++ b/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
@@ -285,14 +285,11 @@ namespace DotVVM.Framework.Binding
                     propertyName,
                     unwrappedType,
                     attributeProvider,
-                    boxedDefaultValue
+                    boxedDefaultValue,
+                    declaringCapability: declaringCapability
                 );
+                propertyGroup.AddUsedInCapability(declaringCapability);
 
-                if (declaringCapability is object)
-                {
-                    propertyGroup.OwningCapability = declaringCapability;
-                    propertyGroup.UsedInCapabilities = propertyGroup.UsedInCapabilities.Add(declaringCapability);
-                }
                 return propertyGroup;
             }
             // Control Capability

--- a/src/Framework/Framework/Binding/DotvvmProperty.cs
+++ b/src/Framework/Framework/Binding/DotvvmProperty.cs
@@ -105,6 +105,8 @@ namespace DotVVM.Framework.Binding
         public DotvvmCapabilityProperty? OwningCapability { get; internal set; }
         /// <summary> The capabilities which use this property. </summary>
         public ImmutableArray<DotvvmCapabilityProperty> UsedInCapabilities { get; internal set; } = ImmutableArray<DotvvmCapabilityProperty>.Empty;
+        IPropertyDescriptor? IControlAttributeDescriptor.OwningCapability => OwningCapability;
+        IEnumerable<IPropertyDescriptor> IControlAttributeDescriptor.UsedInCapabilities => UsedInCapabilities;
 
 
         internal void AddUsedInCapability(DotvvmCapabilityProperty? p)

--- a/src/Framework/Framework/Binding/GroupedDotvvmProperty.cs
+++ b/src/Framework/Framework/Binding/GroupedDotvvmProperty.cs
@@ -8,11 +8,13 @@ using System.Threading.Tasks;
 
 namespace DotVVM.Framework.Binding
 {
-    public sealed class GroupedDotvvmProperty : DotvvmProperty
+    public sealed class GroupedDotvvmProperty : DotvvmProperty, IGroupedPropertyDescriptor
     {
         public DotvvmPropertyGroup PropertyGroup { get; }
 
         public string GroupMemberName { get; }
+
+        IPropertyGroupDescriptor IGroupedPropertyDescriptor.PropertyGroup => PropertyGroup;
 
         public GroupedDotvvmProperty(string groupMemberName, DotvvmPropertyGroup propertyGroup)
         {
@@ -30,7 +32,9 @@ namespace DotVVM.Framework.Binding
                 DefaultValue = group.DefaultValue,
                 IsValueInherited = false,
                 Name = propname,
-                ObsoleteAttribute = group.ObsoleteAttribute
+                ObsoleteAttribute = group.ObsoleteAttribute,
+                OwningCapability = group.OwningCapability,
+                UsedInCapabilities = group.UsedInCapabilities
             };
 
             DotvvmProperty.InitializeProperty(prop, group.AttributeProvider);

--- a/src/Framework/Framework/Compilation/ControlTree/IControlResolverMetadata.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/IControlResolverMetadata.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using DotVVM.Framework.Binding;
+using DotVVM.Framework.Controls;
 
 namespace DotVVM.Framework.Compilation.ControlTree
 {
@@ -28,6 +29,8 @@ namespace DotVVM.Framework.Compilation.ControlTree
 		/// Gets property groups available on this control (list is ordered - longer prefix goes first)
 		/// </summary>
 		IReadOnlyList<PropertyGroupMatcher> PropertyGroups { get; }
+
+        ControlPrecompilationMode PrecompilationMode { get; }
 
         DataContextChangeAttribute[] DataContextChangeAttributes { get; }
 		DataContextStackManipulationAttribute? DataContextManipulationAttribute { get; }

--- a/src/Framework/Framework/Compilation/ControlTree/IPropertyDescriptor.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/IPropertyDescriptor.cs
@@ -8,4 +8,10 @@ namespace DotVVM.Framework.Compilation.ControlTree
         bool IsBindingProperty { get; }
         string FullName { get; }
     }
+
+    public interface IGroupedPropertyDescriptor: IPropertyDescriptor
+    {
+        string GroupMemberName { get; }
+        IPropertyGroupDescriptor PropertyGroup { get; }
+    }
 }

--- a/src/Framework/Framework/Compilation/ControlTree/ITypeDescriptor.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ITypeDescriptor.cs
@@ -1,3 +1,4 @@
+using System;
 using DotVVM.Framework.Controls;
 
 namespace DotVVM.Framework.Compilation.ControlTree
@@ -19,6 +20,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
         ControlMarkupOptionsAttribute? GetControlMarkupOptionsAttribute();
 
         bool IsEqualTo(ITypeDescriptor other);
+        bool IsEqualTo(Type other);
 
         ITypeDescriptor? TryGetArrayElementOrIEnumerableType();
 

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedTypeDescriptor.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedTypeDescriptor.cs
@@ -44,10 +44,24 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
             return Type.GetCustomAttribute<ControlMarkupOptionsAttribute>();
         }
 
+        public bool IsEqualTo(Type other)
+        {
+            return this.Type == other;
+        }
         public bool IsEqualTo(ITypeDescriptor other)
         {
+            if (other is ResolvedTypeDescriptor { Type: var otherType })
+                return this.IsEqualTo(otherType);
             return Name == other.Name && Namespace == other.Namespace && Assembly == other.Assembly;
         }
+
+        public override bool Equals(object? obj) =>
+            obj is null ? false :
+            obj is ResolvedTypeDescriptor { Type: var otherType } ? IsEqualTo(otherType) :
+            obj is Type otherType2 ? IsEqualTo(otherType2) :
+            obj is ITypeDescriptor typeD ? IsEqualTo(typeD) :
+            false;
+        public override int GetHashCode() => Type.GetHashCode();
 
         public ITypeDescriptor? TryGetArrayElementOrIEnumerableType()
         {

--- a/src/Framework/Framework/Compilation/IControlAttributeDescriptor.cs
+++ b/src/Framework/Framework/Compilation/IControlAttributeDescriptor.cs
@@ -19,5 +19,8 @@ namespace DotVVM.Framework.Compilation
         ObsoleteAttribute? ObsoleteAttribute { get; }
         ITypeDescriptor DeclaringType { get; }
         ITypeDescriptor PropertyType { get; }
+
+        IPropertyDescriptor? OwningCapability { get; }
+        IEnumerable<IPropertyDescriptor> UsedInCapabilities { get; }
     }
 }

--- a/src/Framework/Framework/Utils/StringSimilarity.cs
+++ b/src/Framework/Framework/Utils/StringSimilarity.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace DotVVM.Framework.Utils
+{
+    internal static class StringSimilarity
+    {
+        /// <summary> Edit distance with deletion (Visble), insertion (Visivble), substitution (Visine) and transposition (Visilbe) </summary>
+        public static int DamerauLevenshteinDistance(string a, string b)
+        {
+            // https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance
+
+            if (a.Length * b.Length > 100_000)
+                // avoid comparing long strings
+                return a.Length + b.Length;
+
+            var d = new int[a.Length + 1, b.Length + 1];
+
+            for (var i = 0; i <= a.Length; i++)
+                d[i, 0] = i;
+                
+            for (var j = 0; j <= b.Length; j++)
+                d[0, j] = j;
+            
+            for (var i = 0; i < a.Length; i ++)
+            {
+                for (var j = 0; j < b.Length; j++)
+                {
+                    var substitutionCost = a[i] == b[j] ? 0 : 1;
+                    var deletionCost = 1;
+                    var insertionCost = 1;
+                    d[i+1, j+1] = min(d[i, j+1] + deletionCost,
+                                  d[i+1, j] + insertionCost,
+                                  d[i, j] + substitutionCost);
+                    if (i > 1 && j > 1 && a[i] == b[j-1] && a[i-1] == b[j])
+                    {
+                        var transpositionCost = 1;
+                        d[i+1, j+1] = min(d[i+1, j+1],
+                                      d[i-1, j-1] + transpositionCost);
+                    }
+                }
+            }
+            return d[a.Length, b.Length];
+        }
+
+        static int min(int a, int b) => Math.Min(a, b);
+        static int min(int a, int b, int c) => min(min(a, b), c);
+    }
+}

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/DefaultControlTreeResolverTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/DefaultControlTreeResolverTests.cs
@@ -701,5 +701,26 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
             Assert.IsFalse(control3[1].DothtmlNode.HasNodeErrors);
             Assert.IsFalse(control3[2].DothtmlNode.HasNodeErrors);
         }
+
+        [TestMethod]
+        public void DefaultViewCompiler_NonExistenPropertyWarning()
+        {
+           var markup = $@"
+@viewModel System.Boolean
+<dot:Button TestProperty=AA Visble={{value: false}} normal-attribute=AA Click={{command: 0}} />
+";
+            var button = ParseSource(markup)
+                .Content.SelectRecursively(c => c.Content)
+                .Single(c => c.Metadata.Type == typeof(Button));
+
+            var elementNode = (DothtmlElementNode)button.DothtmlNode;
+            var attribute1 = elementNode.Attributes.Single(a => a.AttributeName == "TestProperty");
+            var attribute2 = elementNode.Attributes.Single(a => a.AttributeName == "normal-attribute");
+            var attribute3 = elementNode.Attributes.Single(a => a.AttributeName == "Visble");
+
+            Assert.AreEqual(0, attribute2.AttributeNameNode.NodeWarnings.Count(), attribute2.AttributeNameNode.NodeWarnings.StringJoin(", "));
+            Assert.AreEqual("HTML attribute name 'TestProperty' should not contain uppercase letters. Did you intent to use a DotVVM property instead?", attribute1.AttributeNameNode.NodeWarnings.Single());
+            Assert.AreEqual("HTML attribute name 'Visble' should not contain uppercase letters. Did you mean Visible, or another DotVVM property?", attribute3.AttributeNameNode.NodeWarnings.Single());
+        }
     }
 }

--- a/src/Tests/Runtime/DotvvmControlErrorsTests.cs
+++ b/src/Tests/Runtime/DotvvmControlErrorsTests.cs
@@ -16,7 +16,7 @@ namespace DotVVM.Framework.Tests.Runtime
             var dotvvmBuilder = CreateControlRenderer(div, new object());
 
             var exc = Assert.ThrowsException<DotvvmCompilationException>(() => dotvvmBuilder());
-            StringAssert.Contains(exc.Message, "The property 'DotvvmBindableObject.DataContext' cannot contain hard coded value");
+            StringAssert.Contains(exc.Message, "The property DotvvmBindableObject.DataContext cannot contain hard coded value");
         }
 
         [TestMethod]
@@ -26,7 +26,7 @@ namespace DotVVM.Framework.Tests.Runtime
             var dotvvmBuilder = CreateControlRenderer(checkbox, new object());
 
             var exc = Assert.ThrowsException<DotvvmCompilationException>(() => dotvvmBuilder()); 
-            StringAssert.Contains(exc.Message, "The property 'CheckBox.Checked' cannot contain hard coded value");
+            StringAssert.Contains(exc.Message, "The property CheckBox.Checked cannot contain hard coded value");
         }
 
         [TestMethod]

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -1377,18 +1377,15 @@
           "",
           "html:"
         ],
-        "type": "System.Object",
-        "fromCapability": "HtmlCapability"
+        "type": "System.Object"
       },
       "CssClasses": {
         "prefix": "Class-",
-        "type": "System.Boolean",
-        "fromCapability": "HtmlCapability"
+        "type": "System.Boolean"
       },
       "CssStyles": {
         "prefix": "Style-",
-        "type": "System.Object",
-        "fromCapability": "HtmlCapability"
+        "type": "System.Object"
       }
     },
     "DotVVM.Framework.Controls.JsComponent": {


### PR DESCRIPTION
We have this warning at runtime, so people can see it in the dev console,
or in ASP.NET Core logs. With this change, the error should be also
displayed in VS Extension (we currently don't display warnings with DotVVM itself)