### PR TITLE
parser: fix CDATA parsing

### DIFF
--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlLiteralNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlLiteralNode.cs
@@ -1,13 +1,15 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer;
 
 namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
 {
     [DebuggerDisplay("{Value}")]
-    public class DothtmlLiteralNode : DothtmlNode
+    public sealed class DothtmlLiteralNode : DothtmlNode
     {
-        public string Value => Tokens.ConcatTokenText();
+        public DothtmlToken? MainValueToken { get; set; }
+        public string Value => MainValueToken is {} ? MainValueToken.Text : Tokens.ConcatTokenText();
         public bool Escape { get; set; } = false;
 
         public override IEnumerable<DothtmlNode> EnumerateChildNodes()

--- a/src/Tests/ControlTests/SimpleControlTests.cs
+++ b/src/Tests/ControlTests/SimpleControlTests.cs
@@ -407,6 +407,24 @@ namespace DotVVM.Framework.Tests.ControlTests
             check.CheckString(r.FormattedHtml, fileExtension: "html");
         }
 
+        [TestMethod]
+        public async Task CurlyBraceEscaping()
+        {
+            var r = await cth.RunPage(typeof(BasicTestViewModel), @"
+                CDATA: <![CDATA[ <span>{{value: Label}}</span> ]]>
+
+                <br>
+
+                Escape sequence: &#123;&#123;value: Label&#125;&#125;
+
+                <br>
+
+                Lazy escaping: {&#123;value: Label}}
+            ");
+            check.CheckString(r.OutputString, fileExtension: "raw.html");
+            check.CheckString(r.FormattedHtml, fileExtension: "reparsed.html");
+        }
+
         public class BasicTestViewModel: DotvvmViewModelBase
         {
             [Bind(Name = "int")]

--- a/src/Tests/ControlTests/testoutputs/SimpleControlTests.CurlyBraceEscaping.raw.html
+++ b/src/Tests/ControlTests/testoutputs/SimpleControlTests.CurlyBraceEscaping.raw.html
@@ -1,0 +1,18 @@
+
+
+<head></head>
+<body>
+
+                CDATA:  &lt;span&gt;{{value: Label}}&lt;/span&gt; 
+
+                <br />
+
+                Escape sequence: &#123;&#123;value: Label&#125;&#125;
+
+                <br />
+
+                Lazy escaping: {&#123;value: Label}}
+            
+
+
+</body>

--- a/src/Tests/ControlTests/testoutputs/SimpleControlTests.CurlyBraceEscaping.reparsed.html
+++ b/src/Tests/ControlTests/testoutputs/SimpleControlTests.CurlyBraceEscaping.reparsed.html
@@ -1,0 +1,10 @@
+<html>
+	<head></head>
+	<body>
+		CDATA:  &lt;span&gt;{{value: Label}}&lt;/span&gt;
+		<br>
+		Escape sequence: {{value: Label}}
+		<br>
+		Lazy escaping: {{value: Label}}
+	</body>
+</html>

--- a/src/Tests/Parser/Dothtml/DothtmlParserTests.cs
+++ b/src/Tests/Parser/Dothtml/DothtmlParserTests.cs
@@ -425,7 +425,7 @@ test";
             Assert.AreEqual("test ", ((DothtmlLiteralNode)nodes[0]).Value);
 
             Assert.IsInstanceOfType(nodes[1], typeof(DothtmlLiteralNode));
-            Assert.AreEqual(@"<![CDATA[<a href=""test1"">test2</a>]]>", ((DothtmlLiteralNode)nodes[1]).Value);
+            Assert.AreEqual(@"<a href=""test1"">test2</a>", ((DothtmlLiteralNode)nodes[1]).Value);
 
             Assert.IsInstanceOfType(nodes[2], typeof(DothtmlLiteralNode));
             Assert.AreEqual(" test3 ", ((DothtmlLiteralNode)nodes[2]).Value);


### PR DESCRIPTION
We used to both include the `<![CDATA[` string and
encode the literal. Now it removes the CDATA prefix and suffix,
and HTML encodes the string in between.