### PR TITLE
Fixed culture issues and random crashes in unit tests

### DIFF
--- a/src/Framework/Framework/Utils/JsonUtils.cs
+++ b/src/Framework/Framework/Utils/JsonUtils.cs
@@ -64,7 +64,11 @@ namespace DotVVM.Framework.Utils
                                 diff[item.Key] = item.Value;
                             }
                         }
-                        catch(FormatException)
+                        catch (FormatException)
+                        {
+                            diff[item.Key] = item.Value;
+                        }
+                        catch (JsonReaderException)
                         {
                             diff[item.Key] = item.Value;
                         }

--- a/src/Tests/CultureUtils.cs
+++ b/src/Tests/CultureUtils.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.Routing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotVVM.Framework.Tests
+{
+    public static class CultureUtils
+    {
+
+        public static void RunWithCulture(string culture, Action action)
+        {
+            var originalCulture = CultureInfo.CurrentCulture;
+            var originalUICulture = CultureInfo.CurrentUICulture;
+
+            CultureInfo.CurrentCulture = CultureInfo.CurrentUICulture = new CultureInfo(culture);
+            try
+            {
+                action();
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+                CultureInfo.CurrentUICulture = originalUICulture;
+            }
+        }
+
+    }
+}

--- a/src/Tests/Routing/DotvvmRouteTests.cs
+++ b/src/Tests/Routing/DotvvmRouteTests.cs
@@ -367,23 +367,26 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_InvariantCulture()
         {
-            CultureInfo.CurrentCulture = CultureInfo.CurrentUICulture = new CultureInfo("cs-CZ");
-            var route = new DotvvmRoute("RR-{p}", null, null, null, configuration);
+            CultureUtils.RunWithCulture("cs-CZ", () =>
+            {
+                var route = new DotvvmRoute("RR-{p}", null, null, null, configuration);
 
-            var result = route.BuildUrl(new { p = 1.1});
+                var result = route.BuildUrl(new { p = 1.1 });
 
-            Assert.AreEqual("~/RR-1.1", result);
+                Assert.AreEqual("~/RR-1.1", result);
+            });
         }
 
         [TestMethod]
         public void DotvvmRoute_BuildUrl_UrlEncode()
         {
-            CultureInfo.CurrentCulture = CultureInfo.CurrentUICulture = new CultureInfo("cs-CZ");
-            var route = new DotvvmRoute("RR-{p}", null, null, null, configuration);
+            CultureUtils.RunWithCulture("cs-CZ", () => {
+                var route = new DotvvmRoute("RR-{p}", null, null, null, configuration);
 
-            var result = route.BuildUrl(new { p = 1.1});
+                var result = route.BuildUrl(new { p = 1.1});
 
-            Assert.AreEqual("~/RR-1.1", result);
+                Assert.AreEqual("~/RR-1.1", result);
+            });
         }
 
         [TestMethod]

--- a/src/Tests/ViewModel/ViewModelTypeMetadataSerializerTests.cs
+++ b/src/Tests/ViewModel/ViewModelTypeMetadataSerializerTests.cs
@@ -58,17 +58,20 @@ namespace DotVVM.Framework.Tests.ViewModel
         }
 #endif
 
-        [TestMethod]        
+        [TestMethod]
         public void ViewModelTypeMetadata_TypeMetadata()
         {
-            var typeMetadataSerializer = new ViewModelTypeMetadataSerializer(mapper);
-            var result = typeMetadataSerializer.SerializeTypeMetadata(new[]
+            CultureUtils.RunWithCulture("en-US", () =>
             {
-                mapper.GetMap(typeof(TestViewModel))
-            });
+                var typeMetadataSerializer = new ViewModelTypeMetadataSerializer(mapper);
+                var result = typeMetadataSerializer.SerializeTypeMetadata(new[]
+                {
+                    mapper.GetMap(typeof(TestViewModel))
+                });
 
-            var checker = new OutputChecker("testoutputs");
-            checker.CheckJsonObject(result);
+                var checker = new OutputChecker("testoutputs");
+                checker.CheckJsonObject(result);
+            });
         }
 
         [Flags]


### PR DESCRIPTION
Some tests were crashing when executed from Visual Studio as they were changing the culture and not changing it back.
Another test was crashing if the `JsonConvert.DefaultSettings` were set before the test is run - I don't know why but I've fixed error handling there. 