### PR TITLE
More predictable dateParse

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/serialization/date.ts
+++ b/src/Framework/Framework/Resources/Scripts/serialization/date.ts
@@ -4,8 +4,29 @@ export function parseDate(value: string | null, convertFromUtc: boolean = false)
     if (value == null) return null;
     const match = value.match("^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})(\\.[0-9]{1,7})$");
     if (match) {
-        const date = new Date(parseInt(match[1], 10), parseInt(match[2], 10) - 1, parseInt(match[3], 10),
-            parseInt(match[4], 10), parseInt(match[5], 10), parseInt(match[6], 10), match.length > 7 ? parseInt(match[7].substring(1, 4), 10) : 0);
+        const date = new Date();
+        let month = parseInt(match[2], 10) - 1;
+        let day = parseInt(match[3], 10);
+
+         //Javascript date object does not support month 00 and rolls to december.
+        //In case of user input of 00 we correct it to january.
+        //This is more user friendly than suddendly having december.
+        month = month < 0 ? 0 : month;
+
+        //Javascript date object does not support day 0 and rolls to 30 or 31 and rolls the month value to previous month.
+        //This results in unpredictable behaviour if user inputs 00 into date input field for instance
+        //We sanitize it to 1st of the same month to avoid this unpredictability
+        day = day < 1 ? 1 : day;
+
+        //We set components of the date by hand, this prevents JS from 'corecting' years 00XX to 19XX
+        date.setMilliseconds(date.setMilliseconds(match.length > 7 ? parseInt(match[7].substring(1, 4), 10) : 0));
+        date.setSeconds(parseInt(match[6], 10));
+        date.setMinutes(parseInt(match[5], 10));
+        date.setHours(parseInt(match[4], 10));
+        date.setDate(day);
+        date.setMonth(month);
+        date.setFullYear(parseInt(match[1], 10));
+
         if (convertFromUtc) {
             date.setMinutes(date.getMinutes() - date.getTimezoneOffset());
         }

--- a/src/Framework/Framework/Resources/Scripts/serialization/date.ts
+++ b/src/Framework/Framework/Resources/Scripts/serialization/date.ts
@@ -4,7 +4,7 @@ export function parseDate(value: string | null, convertFromUtc: boolean = false)
     if (value == null) return null;
     const match = value.match("^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})(\\.[0-9]{1,7})$");
     if (match) {
-        const date = new Date();
+        const date = new Date(0);
         let month = parseInt(match[2], 10) - 1;
         let day = parseInt(match[3], 10);
 
@@ -19,7 +19,7 @@ export function parseDate(value: string | null, convertFromUtc: boolean = false)
         day = day < 1 ? 1 : day;
 
         //We set components of the date by hand, this prevents JS from 'corecting' years 00XX to 19XX
-        date.setMilliseconds(date.setMilliseconds(match.length > 7 ? parseInt(match[7].substring(1, 4), 10) : 0));
+        date.setMilliseconds(match.length > 7 ? parseInt(match[7].substring(1, 4), 10) : 0);
         date.setSeconds(parseInt(match[6], 10));
         date.setMinutes(parseInt(match[5], 10));
         date.setHours(parseInt(match[4], 10));

--- a/src/Framework/Framework/Resources/Scripts/tests/date.test.ts
+++ b/src/Framework/Framework/Resources/Scripts/tests/date.test.ts
@@ -13,15 +13,18 @@ test("Date 01:01:01.1 01/01/1901", () => {
 });
 
 test("Date 6:58:10 PM 0/10/2022 - Zero month", () => {
-    testDateIsSameAfterParse("2022-00-10T18:58:10.000000");
+    //No practical way to set day 0 and month 0 to JS date object
+    testDateIsSameAfterParse("2022-00-10T18:58:10.000000", "2022-01-10T18:58:10.000000");
 });
 
 test("Date 6:58:10 PM 5/0/2022 - Zero day", () => {
-    testDateIsSameAfterParse("2022-05-00T18:58:10.000000");
+    //No practical way to set day 0 and month 0 to JS date object
+    testDateIsSameAfterParse("2022-05-00T18:58:10.000000", "2022-05-01T18:58:10.000000");
 });
 
 test("Date 6:58:10 PM 0/0/2022 - Zero day and month", () => {
-    testDateIsSameAfterParse("2022-00-00T18:58:10.000000");
+    //No practical way to set day 0 and month 0 to JS date object
+    testDateIsSameAfterParse("2022-00-00T18:58:10.000000", "2022-01-01T18:58:10.000000");
 });
 
 test("Date 6:58:10 PM 1/1/0 - Zero year", () => {
@@ -29,7 +32,8 @@ test("Date 6:58:10 PM 1/1/0 - Zero year", () => {
 });
 
 test("Date 0:00:00 PM 0/0/0 - Zero all", () => {
-    testDateIsSameAfterParse("0000-00-00T00:00:00.000000");
+    //No practical way to set day 0 and month 0 to JS date object
+    testDateIsSameAfterParse("0000-00-00T00:00:00.000000", "0000-01-01T00:00:00.000000"); 
 });
 
 test("Date 0:00:00 PM 1/1/1 - Year one", () => {
@@ -52,9 +56,10 @@ test("Date 0:00:00 PM 1/1/9999 - Year 9999", () => {
     testDateIsSameAfterParse("9999-01-01T00:00:00.000000");
 });
 
-function testDateIsSameAfterParse(dateInputString: string) {
+function testDateIsSameAfterParse(dateInputString: string, expectedOutputDateString: string|null = null) {
     const date = parseDate(dateInputString) ?? new Date();
-    const outputDateString = dotvvm_Globalize.format(date, "yyyy-MM-ddTHH:mm:ss.fff000")
+    const outputDateString = dotvvm_Globalize.format(date, "yyyy-MM-ddTHH:mm:ss.fff000");
+    expectedOutputDateString = expectedOutputDateString ?? dateInputString;
 
-    expect(dateInputString).toBe(outputDateString);
+    expect(outputDateString).toBe(expectedOutputDateString);
 }

--- a/src/Framework/Framework/Resources/Scripts/tests/date.test.ts
+++ b/src/Framework/Framework/Resources/Scripts/tests/date.test.ts
@@ -56,9 +56,14 @@ test("Date 0:00:00 PM 1/1/9999 - Year 9999", () => {
     testDateIsSameAfterParse("9999-01-01T00:00:00.000000");
 });
 
+test("Date 6/28/2021 3:28:31 PM", () => {
+    testDateIsSameAfterParse("2021-06-28T15:28:31.000000");
+});
+
 function testDateIsSameAfterParse(dateInputString: string, expectedOutputDateString: string|null = null) {
-    const date = parseDate(dateInputString) ?? new Date();
-    const outputDateString = dotvvm_Globalize.format(date, "yyyy-MM-ddTHH:mm:ss.fff000");
+    const date = parseDate(dateInputString);
+
+    const outputDateString = date ? dotvvm_Globalize.format(date, "yyyy-MM-ddTHH:mm:ss.fff000") : null;
     expectedOutputDateString = expectedOutputDateString ?? dateInputString;
 
     expect(outputDateString).toBe(expectedOutputDateString);

--- a/src/Framework/Framework/Resources/Scripts/tests/date.test.ts
+++ b/src/Framework/Framework/Resources/Scripts/tests/date.test.ts
@@ -1,0 +1,60 @@
+﻿import { parseDate } from "../serialization/date"
+
+test("Date 6:58:10.500001 PM 8/10/2022", () => {
+    testDateIsSameAfterParse("2022-08-10T18:58:10.501000");
+});
+
+test("Date 8/10/2022 - date only", () => {
+    testDateIsSameAfterParse("2022-08-10T00:00:00.000000");
+});
+
+test("Date 01:01:01.1 01/01/1901", () => {
+    testDateIsSameAfterParse("1901-01-01T01:01:01.100000");
+});
+
+test("Date 6:58:10 PM 0/10/2022 - Zero month", () => {
+    testDateIsSameAfterParse("2022-00-10T18:58:10.000000");
+});
+
+test("Date 6:58:10 PM 5/0/2022 - Zero day", () => {
+    testDateIsSameAfterParse("2022-05-00T18:58:10.000000");
+});
+
+test("Date 6:58:10 PM 0/0/2022 - Zero day and month", () => {
+    testDateIsSameAfterParse("2022-00-00T18:58:10.000000");
+});
+
+test("Date 6:58:10 PM 1/1/0 - Zero year", () => {
+    testDateIsSameAfterParse("0000-01-01T18:58:10.000000");
+});
+
+test("Date 0:00:00 PM 0/0/0 - Zero all", () => {
+    testDateIsSameAfterParse("0000-00-00T00:00:00.000000");
+});
+
+test("Date 0:00:00 PM 1/1/1 - Year one", () => {
+    testDateIsSameAfterParse("0001-01-01T00:00:00.000000");
+});
+
+test("Date 0:00:00 PM 1/1/10 - Year ten", () => {
+    testDateIsSameAfterParse("0010-01-01T00:00:00.000000");
+});
+
+test("Date 0:00:00 PM 1/1/100 - Year hunderd", () => {
+    testDateIsSameAfterParse("0100-01-01T00:00:00.000000");
+});
+
+test("Date 0:00:00 PM 1/1/1000 - Year thousand", () => {
+    testDateIsSameAfterParse("1000-01-01T00:00:00.000000");
+});
+
+test("Date 0:00:00 PM 1/1/9999 - Year 9999", () => {
+    testDateIsSameAfterParse("9999-01-01T00:00:00.000000");
+});
+
+function testDateIsSameAfterParse(dateInputString: string) {
+    const date = parseDate(dateInputString) ?? new Date();
+    const outputDateString = dotvvm_Globalize.format(date, "yyyy-MM-ddTHH:mm:ss.fff000")
+
+    expect(dateInputString).toBe(outputDateString);
+}

--- a/src/Framework/Framework/tsconfig.json
+++ b/src/Framework/Framework/tsconfig.json
@@ -16,6 +16,6 @@
     "module": "ES2015"
   },
   // "include": ["Resources/Scripts/global-declarations.ts", "Resources/Scripts/**.ts", "Resources/Scripts/typings/knockout/knockout.d.ts"],
-  "exclude": ["obj/**", "Resources/Scripts/tests", "node_modules/**"],
+  "exclude": ["obj/**", "node_modules/**"],
   "compileOnSave": false
 }

--- a/src/Framework/Framework/tsconfig.json
+++ b/src/Framework/Framework/tsconfig.json
@@ -16,6 +16,6 @@
     "module": "ES2015"
   },
   // "include": ["Resources/Scripts/global-declarations.ts", "Resources/Scripts/**.ts", "Resources/Scripts/typings/knockout/knockout.d.ts"],
-  "exclude": ["obj/**", "node_modules/**"],
+  "exclude": ["obj/**", "Resources/Scripts/tests", "node_modules/**"],
   "compileOnSave": false
 }


### PR DESCRIPTION
This solves #1438.
Previously when user was in the middle of filling in a date the resulting date was very unpredictable.
This was because `Date` object created `dateParse` auto-corrected to some date values in unexpected ways.
Having `Date` object limitations in mind this PR aims to make resulting date object more predictable in these corner cases.