### PR TITLE
Allow Sec-Fetch-Site=none in returned files

### DIFF
--- a/src/Framework/Framework/Hosting/Middlewares/DotvvmReturnedFileMiddleware.cs
+++ b/src/Framework/Framework/Hosting/Middlewares/DotvvmReturnedFileMiddleware.cs
@@ -39,7 +39,7 @@ namespace DotVVM.Framework.Hosting.Middlewares
                 // the user may have control over contents of the file and it may served from a trusted domain.
                 // if you don't like this behavior, you can return the file from your own middleware,
                 // we'll not add an option to disable this check.
-                if (site != "same-origin" || dest != "document")
+                if (site == "cross-site" || dest != "document")
                     await c.RejectRequest("Returned file can only be used from same-site navigation.");
             }
         }


### PR DESCRIPTION
I have no idea why, but seems that Chrome sends site = none in some cases.
The point here was to disallow cross-origin usage of the
returned files, which you hopefully can't do
without sending `Sec-Fetch-Site: cross-site`.

The spec says the following about Sec-Fetch-Site: none

> This request is a user-originated operation. For example: entering a URL into the address bar, opening a bookmark, or dragging-and-dropping a file into the browser window.

I doubt anyone did enter the URL manually, so this just a workaround for
a Chrome bug.

I don't think it allows any potential attacks,
and anyway, we can allow users copying the file URL into a different browser