### PR TITLE
Include a list of controls in the serialized config

### DIFF
--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedTypeDescriptor.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedTypeDescriptor.cs
@@ -9,9 +9,11 @@ using System.Reflection;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.Utils;
 using FastExpressionCompiler;
+using Newtonsoft.Json;
 
 namespace DotVVM.Framework.Compilation.ControlTree.Resolved
 {
+    [JsonConverter(typeof(ResourceManagement.DotvvmTypeDescriptorJsonConverter))]
     public sealed class ResolvedTypeDescriptor : ITypeDescriptor
     {
         private static ConcurrentDictionary<(Type, string), ResolvedTypeDescriptor?> cache = new ConcurrentDictionary<(Type, string), ResolvedTypeDescriptor?>();

--- a/src/Framework/Framework/Controls/Styles.cs
+++ b/src/Framework/Framework/Controls/Styles.cs
@@ -10,33 +10,41 @@ namespace DotVVM.Framework.Controls
     {
         /// <summary> List of controls that will placed as wrappers to this component (the last will be top-most) </summary> 
         [MarkupOptions(MappingMode = MappingMode.InnerElement)]
+        [AttachedProperty(typeof(IEnumerable<DotvvmBindableObject>))]
         public static CompileTimeOnlyDotvvmProperty WrappersProperty =
             CompileTimeOnlyDotvvmProperty.Register<IEnumerable<DotvvmBindableObject>, Styles>("Wrappers");
         /// <summary> List of controls that will be placed after this control (if possible) </summary> 
         [MarkupOptions(MappingMode = MappingMode.InnerElement)]
+        [AttachedProperty(typeof(IEnumerable<DotvvmBindableObject>))]
         public static CompileTimeOnlyDotvvmProperty AppendProperty =
             CompileTimeOnlyDotvvmProperty.Register<IEnumerable<DotvvmBindableObject>, Styles>("Append");
         /// <summary> List of controls that will be placed before this control in reverse order (if possible) </summary> 
         [MarkupOptions(MappingMode = MappingMode.InnerElement)]
+        [AttachedProperty(typeof(IEnumerable<DotvvmBindableObject>))]
         public static CompileTimeOnlyDotvvmProperty PrependProperty =
             CompileTimeOnlyDotvvmProperty.Register<IEnumerable<DotvvmBindableObject>, Styles>("Prepend");
         /// <summary> A control which will be used instead of the specified control. Properties will be translated to the properties of the new control when possible or added as attached properties when not directly translatable. </summary> 
         [MarkupOptions(MappingMode = MappingMode.InnerElement)]
+        [AttachedProperty(typeof(DotvvmBindableObject))]
         public static CompileTimeOnlyDotvvmProperty ReplaceWithProperty =
             CompileTimeOnlyDotvvmProperty.Register<DotvvmBindableObject, Styles>("ReplaceWith");
         /// <summary> No Server Side Styles will be applied to this control. When set by a style, this will be the last style to be applied to this control (although when the style contains multiple applicators, all of them will be applied) </summary> 
+        [AttachedProperty(typeof(bool))]
         public static CompileTimeOnlyDotvvmProperty ExcludeProperty =
             CompileTimeOnlyDotvvmProperty.Register<bool, Styles>("Exclude");
         /// <summary> A tag which can be used to selectively style certain controls. </summary> 
+        [AttachedProperty(typeof(string[]))]
         public static CompileTimeOnlyDotvvmProperty TagProperty =
             CompileTimeOnlyDotvvmProperty.Register<string[], Styles>("Tag");
 
         /// <summary> Append to this property to add a required resource somewhere to the page. </summary> 
         [MarkupOptions(MappingMode = MappingMode.Exclude)]
+        [AttachedProperty(typeof(string[]))]
         public static CompileTimeOnlyDotvvmProperty RequiredResourcesProperty =
             CompileTimeOnlyDotvvmProperty.Register<string[], Styles>("RequiredResources");
 
         /// <summary> If true, the control will be removed from the control tree. Note that all appended, prepended and wrapper controls will be preserved. </summary>
+        [AttachedProperty(typeof(bool))]
         public static CompileTimeOnlyDotvvmProperty RemoveProperty =
             CompileTimeOnlyDotvvmProperty.Register<bool, Styles>("Remove");
     }

--- a/src/Framework/Framework/Hosting/AssemblySerializableList.cs
+++ b/src/Framework/Framework/Hosting/AssemblySerializableList.cs
@@ -1,0 +1,32 @@
+using DotVVM.Framework.Compilation;
+using Microsoft.Extensions.DependencyModel;
+using System.Linq;
+using System.Reflection;
+using IO=System.IO;
+
+namespace DotVVM.Framework.Hosting
+{
+    record AssemblySerializableList(
+        string[] assemblyDirs,
+        string[] assemblyNames,
+        string mainAssembly
+    )
+    {
+        public static AssemblySerializableList CreateFromCache(CompiledAssemblyCache cache)
+        {
+            string getName(Assembly a)
+            {
+                var n = a.GetName();
+                return $"{n.Name}, Version={n.Version}";
+            }
+            var mainAssembly = Assembly.GetEntryAssembly();
+
+            var assemblies = cache.GetReferencedAssemblies();
+            return new AssemblySerializableList(
+                assemblyDirs: assemblies.Append(mainAssembly).Select(a => IO.Path.GetDirectoryName(a.Location)).Distinct().OrderBy(x => x).ToArray(),
+                assemblyNames: assemblies.Select(getName).OrderBy(x => x).ToArray(),
+                mainAssembly: getName(mainAssembly)
+            );
+        }
+    }
+}

--- a/src/Framework/Framework/Hosting/AssemblySerializableList.cs
+++ b/src/Framework/Framework/Hosting/AssemblySerializableList.cs
@@ -1,5 +1,6 @@
 using DotVVM.Framework.Compilation;
 using Microsoft.Extensions.DependencyModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using IO=System.IO;
@@ -9,21 +10,25 @@ namespace DotVVM.Framework.Hosting
     record AssemblySerializableList(
         string[] assemblyDirs,
         string[] assemblyNames,
-        string mainAssembly
+        string? mainAssembly
     )
     {
         public static AssemblySerializableList CreateFromCache(CompiledAssemblyCache cache)
         {
-            string getName(Assembly a)
+            [return: NotNullIfNotNull("a")]
+            string? getName(Assembly? a)
             {
+                if (a == null) return null;
                 var n = a.GetName();
                 return $"{n.Name}, Version={n.Version}";
             }
             var mainAssembly = Assembly.GetEntryAssembly();
 
-            var assemblies = cache.GetReferencedAssemblies();
+            var assemblies = cache.GetReferencedAssemblies().ToList();
+            if (mainAssembly is {})
+                assemblies.Add(mainAssembly);
             return new AssemblySerializableList(
-                assemblyDirs: assemblies.Append(mainAssembly).Select(a => IO.Path.GetDirectoryName(a.Location)).Distinct().OrderBy(x => x).ToArray(),
+                assemblyDirs: assemblies.Select(a => IO.Path.GetDirectoryName(a.Location)).OfType<string>().Distinct().OrderBy(x => x).ToArray(),
                 assemblyNames: assemblies.Select(getName).OrderBy(x => x).ToArray(),
                 mainAssembly: getName(mainAssembly)
             );

--- a/src/Framework/Framework/Hosting/AssemblySerializableList.cs
+++ b/src/Framework/Framework/Hosting/AssemblySerializableList.cs
@@ -29,7 +29,7 @@ namespace DotVVM.Framework.Hosting
                 assemblies.Add(mainAssembly);
             return new AssemblySerializableList(
                 assemblyDirs: assemblies.Select(a => IO.Path.GetDirectoryName(a.Location)).OfType<string>().Distinct().OrderBy(x => x).ToArray(),
-                assemblyNames: assemblies.Select(getName).OrderBy(x => x).ToArray(),
+                assemblyNames: assemblies.Select(getName).OrderBy(x => x).ToArray()!,
                 mainAssembly: getName(mainAssembly)
             );
         }

--- a/src/Framework/Framework/Hosting/DotvvmPresenter.cs
+++ b/src/Framework/Framework/Hosting/DotvvmPresenter.cs
@@ -505,7 +505,7 @@ namespace DotVVM.Framework.Hosting
                 else if (dest is "empty")
                 {
                     if (!DetermineSpaRequest(context.HttpContext))
-                        await context.RejectRequest($"Pages can not be loaded using Javascript for security reasons. If you are the developer, you can disable this check by setting DotvvmConfiguration.Security.VerifySecFetchForPages.DisableForRoute(\"{route}\")");
+                        await context.RejectRequest($"Pages can not be loaded using Javascript for security reasons. If you are the developer, you can disable this check by setting DotvvmConfiguration.Security.VerifySecFetchForPages.DisableForRoute(\"{route}\"). [dest: {dest}, site: {site}]");
                     if (site != "same-origin")
                         await context.RejectRequest($"Cross site SPA requests are disabled.");
                 }

--- a/src/Framework/Framework/Hosting/DotvvmPropertySerializableList.cs
+++ b/src/Framework/Framework/Hosting/DotvvmPropertySerializableList.cs
@@ -95,12 +95,13 @@ namespace DotVVM.Framework.Hosting
             {
                 foreach (var c in a.GetLoadableTypes())
                 {
+                    if (c.FullName is null) continue;
                     if (!typeof(DotvvmBindableObject).IsAssignableFrom(c)) continue;
 
                     var markupOptions = c.GetCustomAttribute<ControlMarkupOptionsAttribute>();
                     var interfaces = c.GetInterfaces().Except(c.BaseType?.GetInterfaces() ?? Array.Empty<Type>()).ToArray();
                     var control = new DotvvmControlInfo(
-                        c.Assembly.GetName().Name,
+                        c.Assembly?.GetName()?.Name,
                         c.BaseType,
                         interfaces: interfaces.Length > 0 ? interfaces : null,
                         isAbstract: c.IsAbstract || c.IsGenericType,
@@ -117,7 +118,7 @@ namespace DotVVM.Framework.Hosting
         static CommandArgumentInfo[]? GetCommandArguments(Type commandType)
         {
             if (commandType.IsDelegate(out var invoke) && invoke.GetParameters().Length > 0)
-                return invoke.GetParameters().Select(p => new CommandArgumentInfo(p.Name, p.ParameterType)).ToArray();
+                return invoke.GetParameters().Select(p => new CommandArgumentInfo(p.Name ?? "__no_name", p.ParameterType)).ToArray();
             else
                 return null;
         }
@@ -162,7 +163,7 @@ namespace DotVVM.Framework.Hosting
 
 
         public record DotvvmControlInfo(
-            string assembly,
+            string? assembly,
             Type? baseType,
             Type[]? interfaces,
             bool isAbstract,

--- a/src/Framework/Framework/Hosting/DotvvmPropertySerializableList.cs
+++ b/src/Framework/Framework/Hosting/DotvvmPropertySerializableList.cs
@@ -28,6 +28,12 @@ namespace DotVVM.Framework.Hosting
                         p.MarkupOptions.Name != p.Name ? p.MarkupOptions.Name : null,
                         p.MarkupOptions.MappingMode,
                         p.MarkupOptions.Required,
+                        onlyBindings: !p.MarkupOptions.AllowHardCodedValue,
+                        onlyHardcoded: !p.MarkupOptions.AllowBinding,
+                        isCommand: p.PropertyType.IsDelegate(),
+                        commandArguments: p.PropertyType.IsDelegate(out var invoke) && invoke.GetParameters().Length > 0
+                                          ? invoke.GetParameters().Select(p => new CommandArgumentInfo(p.Name, p.ParameterType)).ToArray()
+                                          : null,
                         p is ActiveDotvvmProperty,
                         p is CompileTimeOnlyDotvvmProperty,
                         fromCapability: p.OwningCapability?.Name,
@@ -112,6 +118,10 @@ namespace DotVVM.Framework.Hosting
             [property: DefaultValue(MappingMode.Attribute)]
             MappingMode mappingMode = MappingMode.Attribute,
             bool required = false,
+            bool onlyBindings = false,
+            bool onlyHardcoded = false,
+            bool isCommand = false,
+            CommandArgumentInfo[]? commandArguments = null,
             bool isActive = false,
             bool isCompileTimeOnly = false,
             string? fromCapability = null,
@@ -139,6 +149,12 @@ namespace DotVVM.Framework.Hosting
             bool isAbstract,
             string? defaultContentProperty,
             bool withoutContent
+        ) { }
+
+
+        public record CommandArgumentInfo(
+            string name,
+            Type type
         ) { }
 
 

--- a/src/Framework/Framework/Hosting/DotvvmPropertySerializableList.cs
+++ b/src/Framework/Framework/Hosting/DotvvmPropertySerializableList.cs
@@ -98,7 +98,7 @@ namespace DotVVM.Framework.Hosting
                     if (!typeof(DotvvmBindableObject).IsAssignableFrom(c)) continue;
 
                     var markupOptions = c.GetCustomAttribute<ControlMarkupOptionsAttribute>();
-                    var interfaces = c.GetInterfaces().Except(c.BaseType.GetInterfaces()).ToArray();
+                    var interfaces = c.GetInterfaces().Except(c.BaseType?.GetInterfaces() ?? Array.Empty<Type>()).ToArray();
                     var control = new DotvvmControlInfo(
                         c.Assembly.GetName().Name,
                         c.BaseType,
@@ -163,7 +163,7 @@ namespace DotVVM.Framework.Hosting
 
         public record DotvvmControlInfo(
             string assembly,
-            Type baseType,
+            Type? baseType,
             Type[]? interfaces,
             bool isAbstract,
             string? defaultContentProperty,

--- a/src/Framework/Framework/Hosting/DotvvmPropertySerializableList.cs
+++ b/src/Framework/Framework/Hosting/DotvvmPropertySerializableList.cs
@@ -27,6 +27,7 @@ namespace DotVVM.Framework.Hosting
                         p.IsValueInherited,
                         p.MarkupOptions.Name != p.Name ? p.MarkupOptions.Name : null,
                         p.MarkupOptions.MappingMode,
+                        p.DefaultValue,
                         p.MarkupOptions.Required,
                         onlyBindings: !p.MarkupOptions.AllowHardCodedValue,
                         onlyHardcoded: !p.MarkupOptions.AllowBinding,
@@ -129,6 +130,7 @@ namespace DotVVM.Framework.Hosting
             string? mappingName = null,
             [property: DefaultValue(MappingMode.Attribute)]
             MappingMode mappingMode = MappingMode.Attribute,
+            object? defaultValue = null,
             bool required = false,
             bool onlyBindings = false,
             bool onlyHardcoded = false,

--- a/src/Framework/Framework/Hosting/DotvvmPropertySerializableList.cs
+++ b/src/Framework/Framework/Hosting/DotvvmPropertySerializableList.cs
@@ -95,9 +95,11 @@ namespace DotVVM.Framework.Hosting
                     if (!typeof(DotvvmBindableObject).IsAssignableFrom(c)) continue;
 
                     var markupOptions = c.GetCustomAttribute<ControlMarkupOptionsAttribute>();
+                    var interfaces = c.GetInterfaces().Except(c.BaseType.GetInterfaces()).ToArray();
                     var control = new DotvvmControlInfo(
                         c.Assembly.GetName().Name,
                         c.BaseType,
+                        interfaces: interfaces.Length > 0 ? interfaces : null,
                         isAbstract: c.IsAbstract || c.IsGenericType,
                         markupOptions?.DefaultContentProperty,
                         !markupOptions?.AllowContent ?? false
@@ -146,6 +148,7 @@ namespace DotVVM.Framework.Hosting
         public record DotvvmControlInfo(
             string assembly,
             Type baseType,
+            Type[]? interfaces,
             bool isAbstract,
             string? defaultContentProperty,
             bool withoutContent

--- a/src/Framework/Framework/Hosting/DotvvmPropertySerializableList.cs
+++ b/src/Framework/Framework/Hosting/DotvvmPropertySerializableList.cs
@@ -100,13 +100,22 @@ namespace DotVVM.Framework.Hosting
 
                     var markupOptions = c.GetCustomAttribute<ControlMarkupOptionsAttribute>();
                     var interfaces = c.GetInterfaces().Except(c.BaseType?.GetInterfaces() ?? Array.Empty<Type>()).ToArray();
+                    var isComposite = typeof(CompositeControl).IsAssignableFrom(c) && typeof(CompositeControl) != c;
                     var control = new DotvvmControlInfo(
                         c.Assembly?.GetName()?.Name,
                         c.BaseType,
                         interfaces: interfaces.Length > 0 ? interfaces : null,
                         isAbstract: c.IsAbstract || c.IsGenericType,
                         markupOptions?.DefaultContentProperty,
-                        !markupOptions?.AllowContent ?? false
+                        withoutContent:
+                            !markupOptions?.AllowContent ?? false,
+                        markupPrimaryName:
+                            c.Name != markupOptions?.PrimaryName ? markupOptions?.PrimaryName : null,
+                        markupAlternativeNames:
+                            markupOptions?.AlternativeNames?.Length > 0 ? markupOptions?.AlternativeNames : null,
+                        isComposite: isComposite,
+                        precompilationMode:
+                            isComposite && markupOptions?.Precompile != ControlPrecompilationMode.Never ? markupOptions?.Precompile : null
                     );
                     result[c.FullName] = control;
                 }
@@ -168,7 +177,11 @@ namespace DotVVM.Framework.Hosting
             Type[]? interfaces,
             bool isAbstract,
             string? defaultContentProperty,
-            bool withoutContent
+            bool withoutContent,
+            string? markupPrimaryName,
+            string[]? markupAlternativeNames,
+            bool isComposite,
+            ControlPrecompilationMode? precompilationMode
         ) { }
 
 

--- a/src/Framework/Framework/Hosting/DotvvmPropertySerializableList.cs
+++ b/src/Framework/Framework/Hosting/DotvvmPropertySerializableList.cs
@@ -31,9 +31,7 @@ namespace DotVVM.Framework.Hosting
                         onlyBindings: !p.MarkupOptions.AllowHardCodedValue,
                         onlyHardcoded: !p.MarkupOptions.AllowBinding,
                         isCommand: p.PropertyType.IsDelegate(),
-                        commandArguments: p.PropertyType.IsDelegate(out var invoke) && invoke.GetParameters().Length > 0
-                                          ? invoke.GetParameters().Select(p => new CommandArgumentInfo(p.Name, p.ParameterType)).ToArray()
-                                          : null,
+                        commandArguments: GetCommandArguments(p.PropertyType),
                         p is ActiveDotvvmProperty,
                         p is CompileTimeOnlyDotvvmProperty,
                         fromCapability: p.OwningCapability?.Name,
@@ -77,6 +75,10 @@ namespace DotVVM.Framework.Hosting
                         p.DataContextChangeAttributes.Length > 0 ? p.DataContextChangeAttributes : null,
                         p.DataContextManipulationAttribute,
                         p.MarkupOptions.MappingMode,
+                        onlyBindings: !p.MarkupOptions.AllowHardCodedValue,
+                        onlyHardcoded: !p.MarkupOptions.AllowBinding,
+                        isCommand: p.PropertyType.IsDelegate(),
+                        commandArguments: GetCommandArguments(p.PropertyType),
                         fromCapability: p.OwningCapability?.Name,
                         isAttached: p.AttributeProvider?.IsDefined(typeof(AttachedPropertyAttribute), true) == true
                     )
@@ -111,6 +113,14 @@ namespace DotVVM.Framework.Hosting
             return result;
         }
 
+        static CommandArgumentInfo[]? GetCommandArguments(Type commandType)
+        {
+            if (commandType.IsDelegate(out var invoke) && invoke.GetParameters().Length > 0)
+                return invoke.GetParameters().Select(p => new CommandArgumentInfo(p.Name, p.ParameterType)).ToArray();
+            else
+                return null;
+        }
+
         public record DotvvmPropertyInfo(
             Type type,
             DataContextChangeAttribute[]? dataContextChange,
@@ -140,6 +150,10 @@ namespace DotVVM.Framework.Hosting
             DataContextStackManipulationAttribute? dataContextManipulation,
             [property: DefaultValue(MappingMode.Attribute)]
             MappingMode mappingMode = MappingMode.Attribute,
+            bool onlyBindings = false,
+            bool onlyHardcoded = false,
+            bool isCommand = false,
+            CommandArgumentInfo[]? commandArguments = null,
             string? fromCapability = null,
             bool isAttached = false
         ) { }

--- a/src/Framework/Framework/Hosting/ErrorPages/ErrorPageTemplate.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/ErrorPageTemplate.cs
@@ -160,6 +160,7 @@ $@"
                 Converters = {
                 new ReflectionTypeJsonConverter(),
                 new ReflectionAssemblyJsonConverter(),
+                new DotvvmTypeDescriptorJsonConverter(),
                 new Controls.DotvvmControlDebugJsonConverter(),
                 new IgnoreStuffJsonConverter(),
                 new BindingDebugJsonConverter()

--- a/src/Framework/Framework/Hosting/VisualStudioHelper.cs
+++ b/src/Framework/Framework/Hosting/VisualStudioHelper.cs
@@ -28,6 +28,7 @@ namespace DotVVM.Framework.Hosting
                 capabilities = includeProperties ? DotvvmPropertySerializableList.Capabilities : null,
                 propertyGroups = includeProperties ? DotvvmPropertySerializableList.PropertyGroups : null,
                 controls = includeProperties ? DotvvmPropertySerializableList.GetControls(config.ServiceProvider.GetRequiredService<CompiledAssemblyCache>()) : null,
+                assemblies = includeProperties ? AssemblySerializableList.CreateFromCache(config.ServiceProvider.GetRequiredService<CompiledAssemblyCache>()) : null,
             };
             return JsonConvert.SerializeObject(obj, Formatting.Indented, new JsonSerializerSettings {
                 TypeNameHandling = TypeNameHandling.Auto,

--- a/src/Framework/Framework/Hosting/VisualStudioHelper.cs
+++ b/src/Framework/Framework/Hosting/VisualStudioHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.IO;
+using DotVVM.Framework.Compilation;
 using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Configuration;
 using DotVVM.Framework.ResourceManagement;
@@ -26,6 +27,7 @@ namespace DotVVM.Framework.Hosting
                 properties = includeProperties ? DotvvmPropertySerializableList.Properties : null,
                 capabilities = includeProperties ? DotvvmPropertySerializableList.Capabilities : null,
                 propertyGroups = includeProperties ? DotvvmPropertySerializableList.PropertyGroups : null,
+                controls = includeProperties ? DotvvmPropertySerializableList.GetControls(config.ServiceProvider.GetRequiredService<CompiledAssemblyCache>()) : null,
             };
             return JsonConvert.SerializeObject(obj, Formatting.Indented, new JsonSerializerSettings {
                 TypeNameHandling = TypeNameHandling.Auto,

--- a/src/Framework/Framework/Hosting/VisualStudioHelper.cs
+++ b/src/Framework/Framework/Hosting/VisualStudioHelper.cs
@@ -43,6 +43,7 @@ namespace DotVVM.Framework.Hosting
                 Converters = {
                     new StringEnumConverter(),
                     new ReflectionTypeJsonConverter(),
+                    new DotvvmTypeDescriptorJsonConverter(),
                     new ReflectionAssemblyJsonConverter()
                 },
                 ContractResolver = new DotvvmConfigurationSerializationResolver()

--- a/src/Framework/Framework/ResourceManagement/ReflectionAssemblyJsonConverter.cs
+++ b/src/Framework/Framework/ResourceManagement/ReflectionAssemblyJsonConverter.cs
@@ -67,7 +67,7 @@ namespace DotVVM.Framework.ResourceManagement
         {
             var t = ((ITypeDescriptor)value);
             var coreAssembly = typeof(string).Assembly.GetName().Name;
-            var assembly = t.Assembly?.Split(',', 2)[0];
+            var assembly = t.Assembly?.Split(new char[] { ',' }, 2)[0];
             if (assembly is null || assembly == coreAssembly)
                 writer.WriteValue(t.FullName);
             else

--- a/src/Framework/Framework/ResourceManagement/ReflectionAssemblyJsonConverter.cs
+++ b/src/Framework/Framework/ResourceManagement/ReflectionAssemblyJsonConverter.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using DotVVM.Framework.Compilation.ControlTree;
+using DotVVM.Framework.Compilation.ControlTree.Resolved;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -46,6 +48,30 @@ namespace DotVVM.Framework.ResourceManagement
                 writer.WriteValue(t.FullName);
             else
                 writer.WriteValue($"{t.FullName}, {t.Assembly.GetName().Name}");
+        }
+    }
+    public class DotvvmTypeDescriptorJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType) => typeof(ITypeDescriptor).IsAssignableFrom(objectType);
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.Value is string name)
+            {
+                return new ResolvedTypeDescriptor(Type.GetType(name) ?? throw new Exception($"Cannot find type {name}."));
+            }
+            else throw new NotSupportedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var t = ((ITypeDescriptor)value);
+            var coreAssembly = typeof(string).Assembly.GetName().Name;
+            var assembly = t.Assembly?.Split(',', 2)[0];
+            if (assembly is null || assembly == coreAssembly)
+                writer.WriteValue(t.FullName);
+            else
+                writer.WriteValue($"{t.FullName}, {assembly}");
         }
     }
 }

--- a/src/Tests/Runtime/ConfigurationSerializationTests.cs
+++ b/src/Tests/Runtime/ConfigurationSerializationTests.cs
@@ -49,6 +49,7 @@ namespace DotVVM.Framework.Tests.Runtime
             removeTestStuff(jobject["propertyGroups"]);
             removeTestStuff(jobject["capabilities"]);
             removeTestStuff(jobject["controls"]);
+            jobject["assemblies"]?.Parent.Remove(); // there are user specific paths
             check.CheckString(jobject.ToString(), checkName, fileExtension, memberName, sourceFilePath);
         }
 

--- a/src/Tests/Runtime/ConfigurationSerializationTests.cs
+++ b/src/Tests/Runtime/ConfigurationSerializationTests.cs
@@ -39,17 +39,16 @@ namespace DotVVM.Framework.Tests.Runtime
             serialized = serialized.Replace("System.IServiceProvider, System.ComponentModel, Version=***, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.IServiceProvider, ComponentLibrary");
 
             var jobject = JObject.Parse(serialized);
-            bool shouldBeRemoved(JProperty p) =>
-                p.Name.Contains(".Tests.") || p.Name.Contains(".DynamicData.");
-            if (jobject["properties"] is object)
-                foreach (var testControl in ((JObject)jobject["properties"]).Properties().Where(shouldBeRemoved).ToArray())
-                    testControl.Remove();
-            if (jobject["propertyGroups"] is object)
-                foreach (var testControl in ((JObject)jobject["propertyGroups"]).Properties().Where(shouldBeRemoved).ToArray())
-                    testControl.Remove();
-            if (jobject["capabilities"] is object)
-                foreach (var testControl in ((JObject)jobject["capabilities"]).Properties().Where(shouldBeRemoved).ToArray())
-                    testControl.Remove();
+            void removeTestStuff(JToken token)
+            {
+                if (token is object)
+                    foreach (var testControl in ((JObject)token).Properties().Where(p => p.Name.Contains(".Tests.")).ToArray())
+                        testControl.Remove();
+            }
+            removeTestStuff(jobject["properties"]);
+            removeTestStuff(jobject["propertyGroups"]);
+            removeTestStuff(jobject["capabilities"]);
+            removeTestStuff(jobject["controls"]);
             check.CheckString(jobject.ToString(), checkName, fileExtension, memberName, sourceFilePath);
         }
 

--- a/src/Tests/Runtime/ConfigurationSerializationTests.cs
+++ b/src/Tests/Runtime/ConfigurationSerializationTests.cs
@@ -12,6 +12,7 @@ using DotVVM.Framework.ResourceManagement;
 using DotVVM.Framework.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DotVVM.Framework.Tests.Runtime
 {
@@ -58,7 +59,12 @@ namespace DotVVM.Framework.Tests.Runtime
         [TestMethod]
         public void SerializeDefaultConfig()
         {
-            var c = DotvvmConfiguration.CreateDefault();
+            var c = DotvvmConfiguration.CreateDefault(s => {
+                // explicitly register AutoUI, we want to check signatures of these controls too
+                DotVVM.AutoUI.AutoUIExtensions.AddAutoUI(new DotvvmServiceCollection(s));
+            });
+            // otherwise it behaves differently on .NET framework
+            c.ExperimentalFeatures.ExplicitAssemblyLoading.Enable();
             c.DefaultCulture = "en-US";
             checkConfig(c, includeProperties: true);
         }

--- a/src/Tests/Runtime/ConfigurationSerializationTests.cs
+++ b/src/Tests/Runtime/ConfigurationSerializationTests.cs
@@ -34,6 +34,8 @@ namespace DotVVM.Framework.Tests.Runtime
             // Unify all occurrences of mscorlib and system.private.corelib
             serialized = serialized.Replace("mscorlib, Version=***, Culture=neutral, PublicKeyToken=b77a5c561934e089", "CoreLibrary");
             serialized = serialized.Replace("System.Private.CoreLib, Version=***, Culture=neutral, PublicKeyToken=7cec85d7bea7798e", "CoreLibrary");
+            serialized = serialized.Replace("mscorlib", "CoreLibrary");
+            serialized = serialized.Replace("System.Private.CoreLib", "CoreLibrary");
             // Special case - unify IServiceProvider
             serialized = serialized.Replace("System.IServiceProvider, CoreLibrary", "System.IServiceProvider, ComponentLibrary");
             serialized = serialized.Replace("System.IServiceProvider, System.ComponentModel, Version=***, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.IServiceProvider, ComponentLibrary");

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.Markup.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.Markup.json
@@ -42,31 +42,13 @@
         {
           "$type": "DotVVM.Framework.Compilation.ControlTree.InjectedServiceExtensionParameter, DotVVM.Framework",
           "Identifier": "myService",
-          "ParameterType": {
-            "$type": "DotVVM.Framework.Compilation.ControlTree.Resolved.ResolvedTypeDescriptor, DotVVM.Framework",
-            "Type": "DotVVM.Framework.Tests.Runtime.ConfigurationSerializationTests, DotVVM.Framework.Tests",
-            "Name": "ConfigurationSerializationTests",
-            "Namespace": "DotVVM.Framework.Tests.Runtime",
-            "Assembly": "DotVVM.Framework.Tests, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da",
-            "FullName": "DotVVM.Framework.Tests.Runtime.ConfigurationSerializationTests",
-            "CSharpName": "ConfigurationSerializationTests",
-            "CSharpFullName": "DotVVM.Framework.Tests.Runtime.ConfigurationSerializationTests"
-          },
+          "ParameterType": "DotVVM.Framework.Tests.Runtime.ConfigurationSerializationTests, DotVVM.Framework.Tests",
           "Inherit": true
         },
         {
           "$type": "DotVVM.Framework.Compilation.ControlTree.InjectedServiceExtensionParameter, DotVVM.Framework",
           "Identifier": "secondService",
-          "ParameterType": {
-            "$type": "DotVVM.Framework.Compilation.ControlTree.Resolved.ResolvedTypeDescriptor, DotVVM.Framework",
-            "Type": "System.Func`1[[System.Collections.Generic.IEnumerable`1[[System.Lazy`1[[System.IServiceProvider, ComponentLibrary]], CoreLibrary]], CoreLibrary]]",
-            "Name": "Func`1",
-            "Namespace": "System",
-            "Assembly": "CoreLibrary",
-            "FullName": "System.Func`1[[System.Collections.Generic.IEnumerable`1[[System.Lazy`1[[System.IServiceProvider, ComponentLibrary]], CoreLibrary]], CoreLibrary]]",
-            "CSharpName": "Func<IEnumerable<Lazy<IServiceProvider>>>",
-            "CSharpFullName": "System.Func<System.Collections.Generic.IEnumerable<System.Lazy<System.IServiceProvider>>>"
-          },
+          "ParameterType": "System.Func`1[[System.Collections.Generic.IEnumerable`1[[System.Lazy`1[[System.IServiceProvider, ComponentLibrary]], CoreLibrary]], CoreLibrary]]",
           "Inherit": true
         }
       ],

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.RestAPI.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.RestAPI.json
@@ -14,16 +14,7 @@
         {
           "$type": "DotVVM.Framework.Configuration.RestApiRegistrationHelpers+ApiExtensionParameter, DotVVM.Framework",
           "Identifier": "_testApi",
-          "ParameterType": {
-            "$type": "DotVVM.Framework.Compilation.ControlTree.Resolved.ResolvedTypeDescriptor, DotVVM.Framework",
-            "Type": "DotVVM.Framework.Tests.Binding.TestApiClient, DotVVM.Framework.Tests",
-            "Name": "TestApiClient",
-            "Namespace": "DotVVM.Framework.Tests.Binding",
-            "Assembly": "DotVVM.Framework.Tests, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da",
-            "FullName": "DotVVM.Framework.Tests.Binding.TestApiClient",
-            "CSharpName": "TestApiClient",
-            "CSharpFullName": "DotVVM.Framework.Tests.Binding.TestApiClient"
-          },
+          "ParameterType": "DotVVM.Framework.Tests.Binding.TestApiClient, DotVVM.Framework.Tests",
           "Inherit": true
         }
       ],

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -253,30 +253,38 @@
         "type": "System.String"
       },
       "RequiresFormCheckCssClass": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "isAttached": true
       },
       "RequiresFormControlCssClass": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "isAttached": true
       },
       "RequiresFormSelectCssClass": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "isAttached": true
       }
     },
     "DotVVM.AutoUI.Controls.BulmaForm": {
       "WrapWithCheckboxClass": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "isAttached": true
       },
       "WrapWithInputClass": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "isAttached": true
       },
       "WrapWithRadioClass": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "isAttached": true
       },
       "WrapWithSelectClass": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "isAttached": true
       },
       "WrapWithTextareaClass": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "isAttached": true
       }
     },
     "DotVVM.Framework.Compilation.ControlTree.LifecycleRequirementsAssigningVisitor": {
@@ -483,11 +491,13 @@
     "DotVVM.Framework.Controls.Events": {
       "Click": {
         "type": "DotVVM.Framework.Binding.Expressions.ICommandBinding, DotVVM.Framework",
-        "isActive": true
+        "isActive": true,
+        "isAttached": true
       },
       "DoubleClick": {
         "type": "DotVVM.Framework.Binding.Expressions.ICommandBinding, DotVVM.Framework",
-        "isActive": true
+        "isActive": true,
+        "isAttached": true
       }
     },
     "DotVVM.Framework.Controls.FileUpload": {
@@ -527,7 +537,8 @@
     "DotVVM.Framework.Controls.FormControls": {
       "Enabled": {
         "type": "System.Boolean",
-        "isValueInherited": true
+        "isValueInherited": true,
+        "isAttached": true
       }
     },
     "DotVVM.Framework.Controls.GridView": {
@@ -957,22 +968,27 @@
     "DotVVM.Framework.Controls.PostBack": {
       "Concurrency": {
         "type": "DotVVM.Framework.Controls.PostbackConcurrencyMode, DotVVM.Framework",
-        "isValueInherited": true
+        "isValueInherited": true,
+        "isAttached": true
       },
       "ConcurrencyQueue": {
         "type": "System.String",
-        "isValueInherited": true
+        "isValueInherited": true,
+        "isAttached": true
       },
       "ConcurrencyQueueSettings": {
         "type": "DotVVM.Framework.Controls.ConcurrencyQueueSettingsCollection, DotVVM.Framework",
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "isAttached": true
       },
       "Handlers": {
         "type": "DotVVM.Framework.Controls.PostBackHandlerCollection, DotVVM.Framework",
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "isAttached": true
       },
       "Update": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "isAttached": true
       }
     },
     "DotVVM.Framework.Controls.PostBackHandler": {
@@ -997,7 +1013,8 @@
     "DotVVM.Framework.Controls.RenderSettings": {
       "Mode": {
         "type": "DotVVM.Framework.Controls.RenderMode, DotVVM.Framework",
-        "isValueInherited": true
+        "isValueInherited": true,
+        "isAttached": true
       }
     },
     "DotVVM.Framework.Controls.Repeater": {
@@ -1168,39 +1185,47 @@
       "Append": {
         "type": "System.Collections.Generic.IEnumerable`1[[DotVVM.Framework.Controls.DotvvmBindableObject, DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da]]",
         "mappingMode": "InnerElement",
-        "isCompileTimeOnly": true
+        "isCompileTimeOnly": true,
+        "isAttached": true
       },
       "Exclude": {
         "type": "System.Boolean",
-        "isCompileTimeOnly": true
+        "isCompileTimeOnly": true,
+        "isAttached": true
       },
       "Prepend": {
         "type": "System.Collections.Generic.IEnumerable`1[[DotVVM.Framework.Controls.DotvvmBindableObject, DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da]]",
         "mappingMode": "InnerElement",
-        "isCompileTimeOnly": true
+        "isCompileTimeOnly": true,
+        "isAttached": true
       },
       "Remove": {
         "type": "System.Boolean",
-        "isCompileTimeOnly": true
+        "isCompileTimeOnly": true,
+        "isAttached": true
       },
       "ReplaceWith": {
         "type": "DotVVM.Framework.Controls.DotvvmBindableObject, DotVVM.Framework",
         "mappingMode": "InnerElement",
-        "isCompileTimeOnly": true
+        "isCompileTimeOnly": true,
+        "isAttached": true
       },
       "RequiredResources": {
         "type": "System.String[]",
         "mappingMode": "Exclude",
-        "isCompileTimeOnly": true
+        "isCompileTimeOnly": true,
+        "isAttached": true
       },
       "Tag": {
         "type": "System.String[]",
-        "isCompileTimeOnly": true
+        "isCompileTimeOnly": true,
+        "isAttached": true
       },
       "Wrappers": {
         "type": "System.Collections.Generic.IEnumerable`1[[DotVVM.Framework.Controls.DotvvmBindableObject, DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da]]",
         "mappingMode": "InnerElement",
-        "isCompileTimeOnly": true
+        "isCompileTimeOnly": true,
+        "isAttached": true
       }
     },
     "DotVVM.Framework.Controls.SuppressPostBackHandler": {
@@ -1251,11 +1276,13 @@
     "DotVVM.Framework.Controls.UITests": {
       "GenerateStub": {
         "type": "System.Boolean",
-        "isValueInherited": true
+        "isValueInherited": true,
+        "isAttached": true
       },
       "Name": {
         "type": "System.String",
-        "isActive": true
+        "isActive": true,
+        "isAttached": true
       }
     },
     "DotVVM.Framework.Controls.UpdateProgress": {
@@ -1272,11 +1299,13 @@
     "DotVVM.Framework.Controls.Validation": {
       "Enabled": {
         "type": "System.Boolean",
-        "isValueInherited": true
+        "isValueInherited": true,
+        "isAttached": true
       },
       "Target": {
         "type": "System.Object",
-        "isValueInherited": true
+        "isValueInherited": true,
+        "isAttached": true
       }
     },
     "DotVVM.Framework.Controls.ValidationSummary": {
@@ -1293,23 +1322,28 @@
     "DotVVM.Framework.Controls.Validator": {
       "HideWhenValid": {
         "type": "System.Boolean",
-        "isValueInherited": true
+        "isValueInherited": true,
+        "isAttached": true
       },
       "InvalidCssClass": {
         "type": "System.String",
-        "isValueInherited": true
+        "isValueInherited": true,
+        "isAttached": true
       },
       "SetToolTipText": {
         "type": "System.Boolean",
-        "isValueInherited": true
+        "isValueInherited": true,
+        "isAttached": true
       },
       "ShowErrorMessageText": {
         "type": "System.Boolean",
-        "isValueInherited": true
+        "isValueInherited": true,
+        "isAttached": true
       },
       "Value": {
         "type": "System.Object",
-        "isActive": true
+        "isActive": true,
+        "isAttached": true
       }
     }
   },
@@ -1562,6 +1596,374 @@
         "prefix": "Query-",
         "type": "System.Object"
       }
+    }
+  },
+  "controls": {
+    "DotVVM.AutoUI.Controls.AutoEditor": {
+      "assembly": "DotVVM.AutoUI",
+      "baseType": "DotVVM.Framework.Controls.CompositeControl, DotVVM.Framework",
+      "withoutContent": true
+    },
+    "DotVVM.AutoUI.Controls.AutoForm": {
+      "assembly": "DotVVM.AutoUI",
+      "baseType": "DotVVM.AutoUI.Controls.AutoFormBase, DotVVM.AutoUI"
+    },
+    "DotVVM.AutoUI.Controls.AutoFormBase": {
+      "assembly": "DotVVM.AutoUI",
+      "baseType": "DotVVM.Framework.Controls.CompositeControl, DotVVM.Framework",
+      "isAbstract": true
+    },
+    "DotVVM.AutoUI.Controls.AutoGridViewColumn": {
+      "assembly": "DotVVM.AutoUI",
+      "baseType": "DotVVM.Framework.Controls.GridViewColumn, DotVVM.Framework"
+    },
+    "DotVVM.AutoUI.Controls.AutoGridViewColumns": {
+      "assembly": "DotVVM.AutoUI",
+      "baseType": "DotVVM.Framework.Controls.GridViewColumn, DotVVM.Framework"
+    },
+    "DotVVM.AutoUI.Controls.BootstrapForm": {
+      "assembly": "DotVVM.AutoUI",
+      "baseType": "DotVVM.AutoUI.Controls.AutoFormBase, DotVVM.AutoUI"
+    },
+    "DotVVM.AutoUI.Controls.BulmaForm": {
+      "assembly": "DotVVM.AutoUI",
+      "baseType": "DotVVM.AutoUI.Controls.AutoFormBase, DotVVM.AutoUI"
+    },
+    "DotVVM.Framework.Compilation.Styles.ResolvedControlHelper+LazyRuntimeControl": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.AuthenticatedView": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.ConfigurableHtmlControl, DotVVM.Framework",
+      "defaultContentProperty": "AuthenticatedTemplate"
+    },
+    "DotVVM.Framework.Controls.BodyResourceLinks": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.Button": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.ButtonBase, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.ButtonBase": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.HtmlGenericControl, DotVVM.Framework",
+      "isAbstract": true
+    },
+    "DotVVM.Framework.Controls.CheckableControlBase": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.HtmlGenericControl, DotVVM.Framework",
+      "isAbstract": true
+    },
+    "DotVVM.Framework.Controls.CheckBox": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.CheckableControlBase, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.ClaimView": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.ConfigurableHtmlControl, DotVVM.Framework",
+      "defaultContentProperty": "HasClaimTemplate",
+      "withoutContent": true
+    },
+    "DotVVM.Framework.Controls.ComboBox": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.SelectHtmlControlBase, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.CompositeControl": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework",
+      "isAbstract": true,
+      "withoutContent": true
+    },
+    "DotVVM.Framework.Controls.ConcurrencyQueueSetting": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmBindableObject, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.ConfigurableHtmlControl": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.HtmlGenericControl, DotVVM.Framework",
+      "isAbstract": true
+    },
+    "DotVVM.Framework.Controls.ConfirmPostBackHandler": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.PostBackHandler, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.Content": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.ContentPlaceHolder": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.ConfigurableHtmlControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.DataItemContainer": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.DataPager": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.HtmlGenericControl, DotVVM.Framework",
+      "withoutContent": true
+    },
+    "DotVVM.Framework.Controls.Decorator": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.HtmlGenericControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.DotvvmBindableObject": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "System.Object",
+      "isAbstract": true
+    },
+    "DotVVM.Framework.Controls.DotvvmControl": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmBindableObject, DotVVM.Framework",
+      "isAbstract": true
+    },
+    "DotVVM.Framework.Controls.DotvvmMarkupControl": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.HtmlGenericControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.EmptyData": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.ItemsControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.EnvironmentView": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.ConfigurableHtmlControl, DotVVM.Framework",
+      "defaultContentProperty": "IsEnvironmentTemplate",
+      "withoutContent": true
+    },
+    "DotVVM.Framework.Controls.FileUpload": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.HtmlGenericControl, DotVVM.Framework",
+      "withoutContent": true
+    },
+    "DotVVM.Framework.Controls.GridView": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.ItemsControl, DotVVM.Framework",
+      "defaultContentProperty": "Columns",
+      "withoutContent": true
+    },
+    "DotVVM.Framework.Controls.GridViewCheckBoxColumn": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.GridViewColumn, DotVVM.Framework",
+      "withoutContent": true
+    },
+    "DotVVM.Framework.Controls.GridViewColumn": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmBindableObject, DotVVM.Framework",
+      "isAbstract": true
+    },
+    "DotVVM.Framework.Controls.GridViewTemplateColumn": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.GridViewColumn, DotVVM.Framework",
+      "defaultContentProperty": "ContentTemplate",
+      "withoutContent": true
+    },
+    "DotVVM.Framework.Controls.GridViewTextColumn": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.GridViewColumn, DotVVM.Framework",
+      "withoutContent": true
+    },
+    "DotVVM.Framework.Controls.HeadResourceLinks": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.HierarchyRepeater": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.ItemsControl, DotVVM.Framework",
+      "defaultContentProperty": "ItemTemplate",
+      "withoutContent": true
+    },
+    "DotVVM.Framework.Controls.HierarchyRepeater+HierarchyRepeaterItem": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.HierarchyRepeater+HierarchyRepeaterLevel": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.HtmlGenericControl": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.HtmlLiteral": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.ConfigurableHtmlControl, DotVVM.Framework",
+      "defaultContentProperty": "Html"
+    },
+    "DotVVM.Framework.Controls.Infrastructure.DotvvmView": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.Infrastructure.GlobalizeResource": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.Infrastructure.MarkupControlContainer": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.Infrastructure.MarkupControlContainer`1": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.Infrastructure.MarkupControlContainer, DotVVM.Framework",
+      "isAbstract": true
+    },
+    "DotVVM.Framework.Controls.Infrastructure.RawLiteral": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.InlineScript": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework",
+      "defaultContentProperty": "Script"
+    },
+    "DotVVM.Framework.Controls.ItemsControl": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.HtmlGenericControl, DotVVM.Framework",
+      "isAbstract": true
+    },
+    "DotVVM.Framework.Controls.JsComponent": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.Label": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.HtmlGenericControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.LinkButton": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.ButtonBase, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.ListBox": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.SelectHtmlControlBase, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.Literal": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.HtmlGenericControl, DotVVM.Framework",
+      "withoutContent": true
+    },
+    "DotVVM.Framework.Controls.MultiSelect": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.MultiSelectHtmlControlBase, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.MultiSelectHtmlControlBase": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.MultiSelector, DotVVM.Framework",
+      "isAbstract": true
+    },
+    "DotVVM.Framework.Controls.MultiSelector": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.SelectorBase, DotVVM.Framework",
+      "isAbstract": true
+    },
+    "DotVVM.Framework.Controls.NamedCommand": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework",
+      "withoutContent": true
+    },
+    "DotVVM.Framework.Controls.Panel": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.HtmlGenericControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.PlaceHolder": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.PostBackHandler": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmBindableObject, DotVVM.Framework",
+      "isAbstract": true
+    },
+    "DotVVM.Framework.Controls.PrecompiledControlPlaceholder": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.RadioButton": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.CheckableControlBase, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.Repeater": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.ItemsControl, DotVVM.Framework",
+      "defaultContentProperty": "ItemTemplate",
+      "withoutContent": true
+    },
+    "DotVVM.Framework.Controls.RequiredResource": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework",
+      "withoutContent": true
+    },
+    "DotVVM.Framework.Controls.RoleView": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.ConfigurableHtmlControl, DotVVM.Framework",
+      "defaultContentProperty": "IsMemberTemplate",
+      "withoutContent": true
+    },
+    "DotVVM.Framework.Controls.RouteLink": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.HtmlGenericControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.SelectHtmlControlBase": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.Selector, DotVVM.Framework",
+      "isAbstract": true
+    },
+    "DotVVM.Framework.Controls.Selector": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.SelectorBase, DotVVM.Framework",
+      "isAbstract": true
+    },
+    "DotVVM.Framework.Controls.SelectorBase": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.ItemsControl, DotVVM.Framework",
+      "isAbstract": true
+    },
+    "DotVVM.Framework.Controls.SelectorItem": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.HtmlGenericControl, DotVVM.Framework",
+      "withoutContent": true
+    },
+    "DotVVM.Framework.Controls.SpaContentPlaceHolder": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.ContentPlaceHolder, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.SuppressPostBackHandler": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.PostBackHandler, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.TemplateHost": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework",
+      "withoutContent": true
+    },
+    "DotVVM.Framework.Controls.TextBox": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.HtmlGenericControl, DotVVM.Framework",
+      "withoutContent": true
+    },
+    "DotVVM.Framework.Controls.UpdateProgress": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.HtmlGenericControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Controls.ValidationSummary": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.HtmlGenericControl, DotVVM.Framework",
+      "withoutContent": true
+    },
+    "DotVVM.Framework.Controls.Validator": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.HtmlGenericControl, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Testing.FakeBodyResourceLink": {
+      "assembly": "DotVVM.Framework.Testing",
+      "baseType": "DotVVM.Framework.Controls.BodyResourceLinks, DotVVM.Framework"
+    },
+    "DotVVM.Framework.Testing.FakeHeadResourceLink": {
+      "assembly": "DotVVM.Framework.Testing",
+      "baseType": "DotVVM.Framework.Controls.HeadResourceLinks, DotVVM.Framework"
     }
   }
 }

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -302,6 +302,7 @@
     "DotVVM.Framework.Compilation.ControlTree.LifecycleRequirementsAssigningVisitor": {
       "CompileTimeLifecycleRequirements": {
         "type": "DotVVM.Framework.Controls.ControlLifecycleRequirements, DotVVM.Framework",
+        "defaultValue": "None",
         "isCompileTimeOnly": true
       }
     },
@@ -318,10 +319,12 @@
     "DotVVM.Framework.Controls.Button": {
       "ButtonTagName": {
         "type": "DotVVM.Framework.Controls.ButtonTagName, DotVVM.Framework",
+        "defaultValue": "input",
         "onlyHardcoded": true
       },
       "IsSubmitButton": {
         "type": "System.Boolean",
+        "defaultValue": false,
         "onlyHardcoded": true
       }
     },
@@ -331,10 +334,12 @@
         "isCommand": true
       },
       "Enabled": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "defaultValue": true
       },
       "Text": {
-        "type": "System.String"
+        "type": "System.String",
+        "defaultValue": ""
       }
     },
     "DotVVM.Framework.Controls.CheckableControlBase": {
@@ -346,7 +351,8 @@
         "type": "System.Object"
       },
       "Enabled": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "defaultValue": true
       },
       "InputCssClass": {
         "type": "System.String",
@@ -371,12 +377,14 @@
         "onlyHardcoded": true
       },
       "Text": {
-        "type": "System.String"
+        "type": "System.String",
+        "defaultValue": ""
       }
     },
     "DotVVM.Framework.Controls.CheckBox": {
       "Checked": {
         "type": "System.Nullable`1[[System.Boolean, CoreLibrary]]",
+        "defaultValue": false,
         "onlyBindings": true
       },
       "CheckedItems": {
@@ -400,6 +408,7 @@
       },
       "HideForAnonymousUsers": {
         "type": "System.Boolean",
+        "defaultValue": true,
         "onlyHardcoded": true
       },
       "Values": {
@@ -409,12 +418,14 @@
     },
     "DotVVM.Framework.Controls.ComboBox": {
       "EmptyItemText": {
-        "type": "System.String"
+        "type": "System.String",
+        "defaultValue": ""
       }
     },
     "DotVVM.Framework.Controls.ConcurrencyQueueSetting": {
       "ConcurrencyQueue": {
         "type": "System.String",
+        "defaultValue": "default",
         "onlyHardcoded": true
       },
       "EventName": {
@@ -425,10 +436,12 @@
     "DotVVM.Framework.Controls.ConfigurableHtmlControl": {
       "RenderWrapperTag": {
         "type": "System.Boolean",
+        "defaultValue": false,
         "onlyHardcoded": true
       },
       "WrapperTagName": {
         "type": "System.String",
+        "defaultValue": "div",
         "onlyHardcoded": true
       }
     },
@@ -448,7 +461,8 @@
         "onlyBindings": true
       },
       "Enabled": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "defaultValue": true
       },
       "FirstPageTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
@@ -457,6 +471,7 @@
       },
       "HideWhenOnlyOnePage": {
         "type": "System.Boolean",
+        "defaultValue": true,
         "onlyHardcoded": true
       },
       "LastPageTemplate": {
@@ -476,6 +491,7 @@
       },
       "RenderLinkForCurrentPage": {
         "type": "System.Boolean",
+        "defaultValue": false,
         "onlyHardcoded": true
       }
     },
@@ -494,6 +510,7 @@
       "ClientIDMode": {
         "type": "DotVVM.Framework.Controls.ClientIDMode, DotVVM.Framework",
         "isValueInherited": true,
+        "defaultValue": "Static",
         "onlyHardcoded": true
       },
       "ID": {
@@ -501,16 +518,19 @@
       },
       "IncludeInPage": {
         "type": "System.Boolean",
+        "defaultValue": true,
         "onlyBindings": true
       }
     },
     "DotVVM.Framework.Controls.EmptyData": {
       "RenderWrapperTag": {
         "type": "System.Boolean",
+        "defaultValue": true,
         "onlyHardcoded": true
       },
       "WrapperTagName": {
         "type": "System.String",
+        "defaultValue": "div",
         "onlyHardcoded": true
       }
     },
@@ -552,6 +572,7 @@
       },
       "AllowMultipleFiles": {
         "type": "System.Boolean",
+        "defaultValue": true,
         "onlyHardcoded": true
       },
       "MaxFileSize": {
@@ -560,15 +581,18 @@
       },
       "NumberOfFilesIndicatorText": {
         "type": "System.String",
-        "isValueInherited": true
+        "isValueInherited": true,
+        "defaultValue": "{0} files"
       },
       "SuccessMessageText": {
         "type": "System.String",
-        "isValueInherited": true
+        "isValueInherited": true,
+        "defaultValue": "The files were uploaded successfully."
       },
       "UploadButtonText": {
         "type": "System.String",
-        "isValueInherited": true
+        "isValueInherited": true,
+        "defaultValue": "Upload"
       },
       "UploadCompleted": {
         "type": "DotVVM.Framework.Binding.Expressions.Command, DotVVM.Framework",
@@ -582,13 +606,15 @@
       },
       "UploadErrorMessageText": {
         "type": "System.String",
-        "isValueInherited": true
+        "isValueInherited": true,
+        "defaultValue": "Error occurred."
       }
     },
     "DotVVM.Framework.Controls.FormControls": {
       "Enabled": {
         "type": "System.Boolean",
         "isValueInherited": true,
+        "defaultValue": true,
         "isAttached": true
       }
     },
@@ -638,7 +664,8 @@
         "mappingMode": "InnerElement"
       },
       "FilterPlacement": {
-        "type": "DotVVM.Framework.Controls.GridViewFilterPlacement, DotVVM.Framework"
+        "type": "DotVVM.Framework.Controls.GridViewFilterPlacement, DotVVM.Framework",
+        "defaultValue": "HeaderRow"
       },
       "HeaderRowDecorators": {
         "type": "System.Collections.Generic.List`1[[DotVVM.Framework.Controls.Decorator, DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da]]",
@@ -647,6 +674,7 @@
       },
       "InlineEditing": {
         "type": "System.Boolean",
+        "defaultValue": false,
         "onlyHardcoded": true
       },
       "RowDecorators": {
@@ -671,6 +699,7 @@
       },
       "ShowHeaderWhenNoData": {
         "type": "System.Boolean",
+        "defaultValue": false,
         "onlyHardcoded": true
       },
       "SortChanged": {
@@ -687,10 +716,12 @@
     },
     "DotVVM.Framework.Controls.GridViewCheckBoxColumn": {
       "ValidatorPlacement": {
-        "type": "DotVVM.Framework.Controls.ValidatorPlacement, DotVVM.Framework"
+        "type": "DotVVM.Framework.Controls.ValidatorPlacement, DotVVM.Framework",
+        "defaultValue": "None"
       },
       "ValueBinding": {
         "type": "System.Boolean",
+        "defaultValue": false,
         "required": true,
         "onlyBindings": true
       }
@@ -702,6 +733,7 @@
           "$type": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework",
           "TypeId": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework"
         },
+        "defaultValue": false,
         "onlyHardcoded": true
       },
       "CellDecorators": {
@@ -767,6 +799,7 @@
           "$type": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework",
           "TypeId": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework"
         },
+        "defaultValue": true,
         "onlyHardcoded": true
       },
       "SortAscendingHeaderCssClass": {
@@ -775,6 +808,7 @@
           "$type": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework",
           "TypeId": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework"
         },
+        "defaultValue": "sort-asc",
         "onlyHardcoded": true
       },
       "SortDescendingHeaderCssClass": {
@@ -783,6 +817,7 @@
           "$type": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework",
           "TypeId": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework"
         },
+        "defaultValue": "sort-desc",
         "onlyHardcoded": true
       },
       "SortExpression": {
@@ -799,6 +834,7 @@
           "$type": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework",
           "TypeId": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework"
         },
+        "defaultValue": true,
         "onlyBindings": true
       },
       "Width": {
@@ -829,6 +865,7 @@
       },
       "ValidatorPlacement": {
         "type": "DotVVM.Framework.Controls.ValidatorPlacement, DotVVM.Framework",
+        "defaultValue": "None",
         "onlyHardcoded": true
       },
       "ValueBinding": {
@@ -890,6 +927,7 @@
       },
       "ItemVisible": {
         "type": "System.Boolean",
+        "defaultValue": true,
         "fromCapability": "ItemHtmlCapability"
       },
       "ItemWrapperTagName": {
@@ -903,6 +941,7 @@
       },
       "LevelVisible": {
         "type": "System.Boolean",
+        "defaultValue": true,
         "fromCapability": "LevelHtmlCapability"
       },
       "LevelWrapperTagName": {
@@ -912,10 +951,12 @@
       },
       "RenderWrapperTag": {
         "type": "System.Boolean",
+        "defaultValue": true,
         "onlyHardcoded": true
       },
       "WrapperTagName": {
         "type": "System.String",
+        "defaultValue": "div",
         "onlyHardcoded": true
       }
     },
@@ -925,12 +966,14 @@
       },
       "Visible": {
         "type": "System.Boolean",
+        "defaultValue": true,
         "onlyBindings": true
       }
     },
     "DotVVM.Framework.Controls.HtmlLiteral": {
       "Html": {
-        "type": "System.String"
+        "type": "System.String",
+        "defaultValue": ""
       }
     },
     "DotVVM.Framework.Controls.Infrastructure.DotvvmView": {
@@ -942,6 +985,12 @@
     "DotVVM.Framework.Controls.InlineScript": {
       "Dependencies": {
         "type": "System.String[]",
+        "defaultValue": {
+          "$type": "System.String[], System.Private.CoreLib",
+          "$values": [
+            "dotvvm"
+          ]
+        },
         "onlyHardcoded": true
       },
       "Script": {
@@ -963,24 +1012,29 @@
         "isValueInherited": true
       },
       "IsControlBindingTarget": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "defaultValue": false
       },
       "IsMasterPageCompositionFinished": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "defaultValue": false
       },
       "IsNamingContainer": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "defaultValue": false
       },
       "IsSpaPage": {
         "type": "System.Boolean",
-        "isValueInherited": true
+        "isValueInherited": true,
+        "defaultValue": false
       },
       "MarkupFileName": {
         "type": "System.String",
         "isValueInherited": true
       },
       "MarkupLineNumber": {
-        "type": "System.Int32"
+        "type": "System.Int32",
+        "defaultValue": -1
       },
       "PathFragment": {
         "type": "System.String"
@@ -1000,7 +1054,8 @@
       },
       "UseHistoryApiSpaNavigation": {
         "type": "System.Boolean",
-        "isValueInherited": true
+        "isValueInherited": true,
+        "defaultValue": true
       }
     },
     "DotVVM.Framework.Controls.ItemsControl": {
@@ -1011,14 +1066,16 @@
     },
     "DotVVM.Framework.Controls.JsComponent": {
       "Global": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "defaultValue": false
       },
       "Name": {
         "type": "System.String",
         "required": true
       },
       "WrapperTagName": {
-        "type": "System.String"
+        "type": "System.String",
+        "defaultValue": "div"
       }
     },
     "DotVVM.Framework.Controls.Label": {
@@ -1029,20 +1086,24 @@
     },
     "DotVVM.Framework.Controls.ListBox": {
       "Size": {
-        "type": "System.Int32"
+        "type": "System.Int32",
+        "defaultValue": 10
       }
     },
     "DotVVM.Framework.Controls.Literal": {
       "FormatString": {
         "type": "System.String",
+        "defaultValue": "",
         "onlyHardcoded": true
       },
       "RenderSpanElement": {
         "type": "System.Boolean",
+        "defaultValue": true,
         "onlyHardcoded": true
       },
       "Text": {
-        "type": "System.Object"
+        "type": "System.Object",
+        "defaultValue": ""
       }
     },
     "DotVVM.Framework.Controls.MultiSelector": {
@@ -1068,12 +1129,14 @@
       "Concurrency": {
         "type": "DotVVM.Framework.Controls.PostbackConcurrencyMode, DotVVM.Framework",
         "isValueInherited": true,
+        "defaultValue": "Default",
         "onlyHardcoded": true,
         "isAttached": true
       },
       "ConcurrencyQueue": {
         "type": "System.String",
         "isValueInherited": true,
+        "defaultValue": "default",
         "onlyHardcoded": true,
         "isAttached": true
       },
@@ -1091,12 +1154,14 @@
       },
       "Update": {
         "type": "System.Boolean",
+        "defaultValue": false,
         "isAttached": true
       }
     },
     "DotVVM.Framework.Controls.PostBackHandler": {
       "Enabled": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "defaultValue": true
       },
       "EventName": {
         "type": "System.String",
@@ -1106,6 +1171,7 @@
     "DotVVM.Framework.Controls.RadioButton": {
       "Checked": {
         "type": "System.Boolean",
+        "defaultValue": false,
         "onlyBindings": true
       },
       "CheckedItem": {
@@ -1114,6 +1180,7 @@
       },
       "GroupName": {
         "type": "System.String",
+        "defaultValue": "",
         "onlyHardcoded": true
       }
     },
@@ -1121,6 +1188,7 @@
       "Mode": {
         "type": "DotVVM.Framework.Controls.RenderMode, DotVVM.Framework",
         "isValueInherited": true,
+        "defaultValue": "Client",
         "isAttached": true
       }
     },
@@ -1153,10 +1221,12 @@
       },
       "RenderAsNamedTemplate": {
         "type": "System.Boolean",
+        "defaultValue": true,
         "onlyHardcoded": true
       },
       "RenderWrapperTag": {
         "type": "System.Boolean",
+        "defaultValue": true,
         "onlyHardcoded": true
       },
       "SeparatorTemplate": {
@@ -1166,6 +1236,7 @@
       },
       "WrapperTagName": {
         "type": "System.String",
+        "defaultValue": "div",
         "onlyHardcoded": true
       }
     },
@@ -1179,6 +1250,7 @@
     "DotVVM.Framework.Controls.RoleView": {
       "HideForAnonymousUsers": {
         "type": "System.Boolean",
+        "defaultValue": true,
         "onlyHardcoded": true
       },
       "IsMemberTemplate": {
@@ -1199,7 +1271,8 @@
     },
     "DotVVM.Framework.Controls.RouteLink": {
       "Enabled": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "defaultValue": true
       },
       "RouteName": {
         "type": "System.String",
@@ -1207,7 +1280,8 @@
         "onlyHardcoded": true
       },
       "Text": {
-        "type": "System.String"
+        "type": "System.String",
+        "defaultValue": ""
       },
       "UrlSuffix": {
         "type": "System.String"
@@ -1222,7 +1296,8 @@
     },
     "DotVVM.Framework.Controls.SelectorBase": {
       "Enabled": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "defaultValue": true
       },
       "ItemTextBinding": {
         "type": "DotVVM.Framework.Binding.Expressions.IValueBinding, DotVVM.Framework",
@@ -1317,6 +1392,7 @@
       },
       "Exclude": {
         "type": "System.Boolean",
+        "defaultValue": false,
         "isCompileTimeOnly": true,
         "isAttached": true
       },
@@ -1328,6 +1404,7 @@
       },
       "Remove": {
         "type": "System.Boolean",
+        "defaultValue": false,
         "isCompileTimeOnly": true,
         "isAttached": true
       },
@@ -1357,12 +1434,14 @@
     },
     "DotVVM.Framework.Controls.SuppressPostBackHandler": {
       "Suppress": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "defaultValue": true
       }
     },
     "DotVVM.Framework.Controls.TableUtils": {
       "ColumnVisible": {
         "type": "System.Boolean",
+        "defaultValue": true,
         "onlyBindings": true,
         "isActive": true
       }
@@ -1380,17 +1459,20 @@
         "isCommand": true
       },
       "Enabled": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "defaultValue": true
       },
       "FormatString": {
         "type": "System.String",
         "onlyHardcoded": true
       },
       "SelectAllOnFocus": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "defaultValue": false
       },
       "Text": {
         "type": "System.Object",
+        "defaultValue": "",
         "required": true
       },
       "TextInput": {
@@ -1399,11 +1481,13 @@
       },
       "Type": {
         "type": "DotVVM.Framework.Controls.TextBoxType, DotVVM.Framework",
+        "defaultValue": "Normal",
         "onlyHardcoded": true
       },
       "UpdateTextOnInput": {
         "type": "System.Boolean",
         "isValueInherited": true,
+        "defaultValue": false,
         "onlyHardcoded": true
       }
     },
@@ -1411,6 +1495,7 @@
       "GenerateStub": {
         "type": "System.Boolean",
         "isValueInherited": true,
+        "defaultValue": true,
         "isAttached": true
       },
       "Name": {
@@ -1423,6 +1508,7 @@
     "DotVVM.Framework.Controls.UpdateProgress": {
       "Delay": {
         "type": "System.Int32",
+        "defaultValue": 0,
         "onlyHardcoded": true
       },
       "ExcludedQueues": {
@@ -1438,6 +1524,7 @@
       "Enabled": {
         "type": "System.Boolean",
         "isValueInherited": true,
+        "defaultValue": true,
         "onlyHardcoded": true,
         "isAttached": true
       },
@@ -1450,14 +1537,17 @@
     },
     "DotVVM.Framework.Controls.ValidationSummary": {
       "HideWhenValid": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "defaultValue": false
       },
       "IncludeErrorsFromChildren": {
         "type": "System.Boolean",
+        "defaultValue": false,
         "onlyHardcoded": true
       },
       "IncludeErrorsFromTarget": {
         "type": "System.Boolean",
+        "defaultValue": true,
         "onlyHardcoded": true
       }
     },
@@ -1465,6 +1555,7 @@
       "HideWhenValid": {
         "type": "System.Boolean",
         "isValueInherited": true,
+        "defaultValue": false,
         "isAttached": true
       },
       "InvalidCssClass": {
@@ -1476,12 +1567,14 @@
       "SetToolTipText": {
         "type": "System.Boolean",
         "isValueInherited": true,
+        "defaultValue": false,
         "onlyHardcoded": true,
         "isAttached": true
       },
       "ShowErrorMessageText": {
         "type": "System.Boolean",
         "isValueInherited": true,
+        "defaultValue": false,
         "onlyHardcoded": true,
         "isAttached": true
       },

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -7,7 +7,15 @@
           "tagPrefix": "dot",
           "namespace": "DotVVM.Framework.Controls",
           "assembly": "DotVVM.Framework"
+        },
+        {
+          "tagPrefix": "auto",
+          "namespace": "DotVVM.AutoUI.Controls",
+          "assembly": "DotVVM.AutoUI, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da"
         }
+      ],
+      "assemblies": [
+        "DotVVM.AutoUI, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da"
       ],
       "importedNamespaces": [
         {
@@ -140,7 +148,11 @@
     },
     "runtime": {},
     "defaultCulture": "en-US",
-    "experimentalFeatures": {},
+    "experimentalFeatures": {
+      "explicitAssemblyLoading": {
+        "enabled": true
+      }
+    },
     "debug": false,
     "diagnostics": {
       "compilationPage": {},
@@ -2248,14 +2260,6 @@
     "DotVVM.Framework.Controls.Validator": {
       "assembly": "DotVVM.Framework",
       "baseType": "DotVVM.Framework.Controls.HtmlGenericControl, DotVVM.Framework"
-    },
-    "DotVVM.Framework.Testing.FakeBodyResourceLink": {
-      "assembly": "DotVVM.Framework.Testing",
-      "baseType": "DotVVM.Framework.Controls.BodyResourceLinks, DotVVM.Framework"
-    },
-    "DotVVM.Framework.Testing.FakeHeadResourceLink": {
-      "assembly": "DotVVM.Framework.Testing",
-      "baseType": "DotVVM.Framework.Controls.HeadResourceLinks, DotVVM.Framework"
     }
   }
 }

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -1795,6 +1795,9 @@
     "DotVVM.Framework.Controls.ButtonBase": {
       "assembly": "DotVVM.Framework",
       "baseType": "DotVVM.Framework.Controls.HtmlGenericControl, DotVVM.Framework",
+      "interfaces": [
+        "DotVVM.Framework.Controls.IEventValidationHandler, DotVVM.Framework"
+      ],
       "isAbstract": true
     },
     "DotVVM.Framework.Controls.CheckableControlBase": {
@@ -1859,11 +1862,18 @@
     "DotVVM.Framework.Controls.DotvvmBindableObject": {
       "assembly": "DotVVM.Framework",
       "baseType": "System.Object",
+      "interfaces": [
+        "DotVVM.Framework.Controls.IDotvvmObjectLike, DotVVM.Framework"
+      ],
       "isAbstract": true
     },
     "DotVVM.Framework.Controls.DotvvmControl": {
       "assembly": "DotVVM.Framework",
       "baseType": "DotVVM.Framework.Controls.DotvvmBindableObject, DotVVM.Framework",
+      "interfaces": [
+        "DotVVM.Framework.Controls.IDotvvmControl, DotVVM.Framework",
+        "DotVVM.Framework.Controls.IRenderable, DotVVM.Framework"
+      ],
       "isAbstract": true
     },
     "DotVVM.Framework.Controls.DotvvmMarkupControl": {
@@ -1932,7 +1942,10 @@
     },
     "DotVVM.Framework.Controls.HtmlGenericControl": {
       "assembly": "DotVVM.Framework",
-      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework"
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework",
+      "interfaces": [
+        "DotVVM.Framework.Controls.IControlWithHtmlAttributes, DotVVM.Framework"
+      ]
     },
     "DotVVM.Framework.Controls.HtmlLiteral": {
       "assembly": "DotVVM.Framework",

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -153,6 +153,7 @@
     "DotVVM.AutoUI.Controls.AutoEditor": {
       "Changed": {
         "type": "DotVVM.Framework.Binding.Expressions.ICommandBinding, DotVVM.Framework",
+        "onlyBindings": true,
         "fromCapability": "Props"
       },
       "Enabled": {
@@ -162,10 +163,12 @@
       "OverrideTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
         "mappingMode": "InnerElement",
+        "onlyHardcoded": true,
         "fromCapability": "Props"
       },
       "Property": {
         "type": "DotVVM.Framework.Binding.Expressions.IValueBinding, DotVVM.Framework",
+        "onlyBindings": true,
         "fromCapability": "Props"
       },
       "Visible": {
@@ -184,6 +187,7 @@
     "DotVVM.AutoUI.Controls.AutoFormBase": {
       "ExcludeProperties": {
         "type": "System.String[]",
+        "onlyHardcoded": true,
         "fromCapability": "FieldSelectorProps"
       },
       "GroupName": {
@@ -191,6 +195,7 @@
       },
       "IncludeProperties": {
         "type": "System.String[]",
+        "onlyHardcoded": true,
         "fromCapability": "FieldSelectorProps"
       },
       "ViewName": {
@@ -200,33 +205,40 @@
     "DotVVM.AutoUI.Controls.AutoGridViewColumn": {
       "Changed": {
         "type": "DotVVM.Framework.Binding.Expressions.ICommandBinding, DotVVM.Framework",
+        "onlyBindings": true,
         "fromCapability": "Props"
       },
       "ContentTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
         "mappingMode": "InnerElement",
+        "onlyHardcoded": true,
         "fromCapability": "Props"
       },
       "Property": {
         "type": "DotVVM.Framework.Binding.Expressions.IValueBinding, DotVVM.Framework",
-        "required": true
+        "required": true,
+        "onlyBindings": true
       }
     },
     "DotVVM.AutoUI.Controls.AutoGridViewColumns": {
       "ExcludeProperties": {
         "type": "System.String[]",
+        "onlyHardcoded": true,
         "fromCapability": "FieldSelectorProps"
       },
       "GroupName": {
         "type": "System.String",
+        "onlyHardcoded": true,
         "fromCapability": "FieldSelectorProps"
       },
       "IncludeProperties": {
         "type": "System.String[]",
+        "onlyHardcoded": true,
         "fromCapability": "FieldSelectorProps"
       },
       "ViewName": {
         "type": "System.String",
+        "onlyHardcoded": true,
         "fromCapability": "FieldSelectorProps"
       }
     },
@@ -305,15 +317,18 @@
     },
     "DotVVM.Framework.Controls.Button": {
       "ButtonTagName": {
-        "type": "DotVVM.Framework.Controls.ButtonTagName, DotVVM.Framework"
+        "type": "DotVVM.Framework.Controls.ButtonTagName, DotVVM.Framework",
+        "onlyHardcoded": true
       },
       "IsSubmitButton": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.ButtonBase": {
       "Click": {
-        "type": "DotVVM.Framework.Binding.Expressions.Command, DotVVM.Framework"
+        "type": "DotVVM.Framework.Binding.Expressions.Command, DotVVM.Framework",
+        "isCommand": true
       },
       "Enabled": {
         "type": "System.Boolean"
@@ -324,7 +339,8 @@
     },
     "DotVVM.Framework.Controls.CheckableControlBase": {
       "Changed": {
-        "type": "DotVVM.Framework.Binding.Expressions.Command, DotVVM.Framework"
+        "type": "DotVVM.Framework.Binding.Expressions.Command, DotVVM.Framework",
+        "isCommand": true
       },
       "CheckedValue": {
         "type": "System.Object"
@@ -333,7 +349,8 @@
         "type": "System.Boolean"
       },
       "InputCssClass": {
-        "type": "System.String"
+        "type": "System.String",
+        "onlyHardcoded": true
       },
       "ItemKeyBinding": {
         "type": "DotVVM.Framework.Binding.Expressions.IValueBinding, DotVVM.Framework",
@@ -346,10 +363,12 @@
             ],
             "TypeId": "DotVVM.Framework.Binding.ControlPropertyBindingDataContextChangeAttribute, DotVVM.Framework"
           }
-        ]
+        ],
+        "onlyBindings": true
       },
       "LabelCssClass": {
-        "type": "System.String"
+        "type": "System.String",
+        "onlyHardcoded": true
       },
       "Text": {
         "type": "System.String"
@@ -357,7 +376,8 @@
     },
     "DotVVM.Framework.Controls.CheckBox": {
       "Checked": {
-        "type": "System.Nullable`1[[System.Boolean, CoreLibrary]]"
+        "type": "System.Nullable`1[[System.Boolean, CoreLibrary]]",
+        "onlyBindings": true
       },
       "CheckedItems": {
         "type": "System.Collections.IEnumerable"
@@ -370,17 +390,21 @@
       },
       "HasClaimTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       },
       "HasNotClaimTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       },
       "HideForAnonymousUsers": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "onlyHardcoded": true
       },
       "Values": {
-        "type": "System.String[]"
+        "type": "System.String[]",
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.ComboBox": {
@@ -390,18 +414,22 @@
     },
     "DotVVM.Framework.Controls.ConcurrencyQueueSetting": {
       "ConcurrencyQueue": {
-        "type": "System.String"
+        "type": "System.String",
+        "onlyHardcoded": true
       },
       "EventName": {
-        "type": "System.String"
+        "type": "System.String",
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.ConfigurableHtmlControl": {
       "RenderWrapperTag": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "onlyHardcoded": true
       },
       "WrapperTagName": {
-        "type": "System.String"
+        "type": "System.String",
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.ConfirmPostBackHandler": {
@@ -416,38 +444,46 @@
     },
     "DotVVM.Framework.Controls.DataPager": {
       "DataSet": {
-        "type": "DotVVM.Framework.Controls.IPageableGridViewDataSet, DotVVM.Core"
+        "type": "DotVVM.Framework.Controls.IPageableGridViewDataSet, DotVVM.Core",
+        "onlyBindings": true
       },
       "Enabled": {
         "type": "System.Boolean"
       },
       "FirstPageTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       },
       "HideWhenOnlyOnePage": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "onlyHardcoded": true
       },
       "LastPageTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       },
       "NextPageTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       },
       "PreviousPageTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       },
       "RenderLinkForCurrentPage": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.DotvvmBindableObject": {
       "DataContext": {
         "type": "System.Object",
-        "isValueInherited": true
+        "isValueInherited": true,
+        "onlyBindings": true
       }
     },
     "DotVVM.Framework.Controls.DotvvmControl": {
@@ -457,58 +493,70 @@
       },
       "ClientIDMode": {
         "type": "DotVVM.Framework.Controls.ClientIDMode, DotVVM.Framework",
-        "isValueInherited": true
+        "isValueInherited": true,
+        "onlyHardcoded": true
       },
       "ID": {
         "type": "System.String"
       },
       "IncludeInPage": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "onlyBindings": true
       }
     },
     "DotVVM.Framework.Controls.EmptyData": {
       "RenderWrapperTag": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "onlyHardcoded": true
       },
       "WrapperTagName": {
-        "type": "System.String"
+        "type": "System.String",
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.EnvironmentView": {
       "Environments": {
         "type": "System.String[]",
-        "required": true
+        "required": true,
+        "onlyHardcoded": true
       },
       "IsEnvironmentTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       },
       "IsNotEnvironmentTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.Events": {
       "Click": {
         "type": "DotVVM.Framework.Binding.Expressions.ICommandBinding, DotVVM.Framework",
+        "onlyBindings": true,
         "isActive": true,
         "isAttached": true
       },
       "DoubleClick": {
         "type": "DotVVM.Framework.Binding.Expressions.ICommandBinding, DotVVM.Framework",
+        "onlyBindings": true,
         "isActive": true,
         "isAttached": true
       }
     },
     "DotVVM.Framework.Controls.FileUpload": {
       "AllowedFileTypes": {
-        "type": "System.String"
+        "type": "System.String",
+        "onlyHardcoded": true
       },
       "AllowMultipleFiles": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "onlyHardcoded": true
       },
       "MaxFileSize": {
-        "type": "System.Nullable`1[[System.Int32, CoreLibrary]]"
+        "type": "System.Nullable`1[[System.Int32, CoreLibrary]]",
+        "onlyHardcoded": true
       },
       "NumberOfFilesIndicatorText": {
         "type": "System.String",
@@ -523,11 +571,14 @@
         "isValueInherited": true
       },
       "UploadCompleted": {
-        "type": "DotVVM.Framework.Binding.Expressions.Command, DotVVM.Framework"
+        "type": "DotVVM.Framework.Binding.Expressions.Command, DotVVM.Framework",
+        "onlyBindings": true,
+        "isCommand": true
       },
       "UploadedFiles": {
         "type": "DotVVM.Framework.Controls.UploadedFilesCollection, DotVVM.Framework",
-        "required": true
+        "required": true,
+        "onlyBindings": true
       },
       "UploadErrorMessageText": {
         "type": "System.String",
@@ -559,7 +610,8 @@
             "TypeId": "DotVVM.Framework.Binding.CollectionElementDataContextChangeAttribute, DotVVM.Framework"
           }
         ],
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       },
       "EditRowDecorators": {
         "type": "System.Collections.Generic.List`1[[DotVVM.Framework.Controls.Decorator, DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da]]",
@@ -578,7 +630,8 @@
             "TypeId": "DotVVM.Framework.Binding.CollectionElementDataContextChangeAttribute, DotVVM.Framework"
           }
         ],
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       },
       "EmptyDataTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
@@ -589,10 +642,12 @@
       },
       "HeaderRowDecorators": {
         "type": "System.Collections.Generic.List`1[[DotVVM.Framework.Controls.Decorator, DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da]]",
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       },
       "InlineEditing": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "onlyHardcoded": true
       },
       "RowDecorators": {
         "type": "System.Collections.Generic.List`1[[DotVVM.Framework.Controls.Decorator, DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da]]",
@@ -611,13 +666,23 @@
             "TypeId": "DotVVM.Framework.Binding.CollectionElementDataContextChangeAttribute, DotVVM.Framework"
           }
         ],
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       },
       "ShowHeaderWhenNoData": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "onlyHardcoded": true
       },
       "SortChanged": {
-        "type": "System.Action`1[[System.String, CoreLibrary]]"
+        "type": "System.Action`1[[System.String, CoreLibrary]]",
+        "onlyBindings": true,
+        "isCommand": true,
+        "commandArguments": [
+          {
+            "name": "obj",
+            "type": "System.String"
+          }
+        ]
       }
     },
     "DotVVM.Framework.Controls.GridViewCheckBoxColumn": {
@@ -626,7 +691,8 @@
       },
       "ValueBinding": {
         "type": "System.Boolean",
-        "required": true
+        "required": true,
+        "onlyBindings": true
       }
     },
     "DotVVM.Framework.Controls.GridViewColumn": {
@@ -635,22 +701,26 @@
         "dataContextManipulation": {
           "$type": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework",
           "TypeId": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework"
-        }
+        },
+        "onlyHardcoded": true
       },
       "CellDecorators": {
         "type": "System.Collections.Generic.List`1[[DotVVM.Framework.Controls.Decorator, DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da]]",
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       },
       "CssClass": {
         "type": "System.String"
       },
       "EditCellDecorators": {
         "type": "System.Collections.Generic.List`1[[DotVVM.Framework.Controls.Decorator, DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da]]",
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       },
       "EditTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       },
       "FilterTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
@@ -666,7 +736,8 @@
           "$type": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework",
           "TypeId": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework"
         },
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       },
       "HeaderCssClass": {
         "type": "System.String",
@@ -695,70 +766,82 @@
         "dataContextManipulation": {
           "$type": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework",
           "TypeId": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework"
-        }
+        },
+        "onlyHardcoded": true
       },
       "SortAscendingHeaderCssClass": {
         "type": "System.String",
         "dataContextManipulation": {
           "$type": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework",
           "TypeId": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework"
-        }
+        },
+        "onlyHardcoded": true
       },
       "SortDescendingHeaderCssClass": {
         "type": "System.String",
         "dataContextManipulation": {
           "$type": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework",
           "TypeId": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework"
-        }
+        },
+        "onlyHardcoded": true
       },
       "SortExpression": {
         "type": "System.String",
         "dataContextManipulation": {
           "$type": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework",
           "TypeId": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework"
-        }
+        },
+        "onlyHardcoded": true
       },
       "Visible": {
         "type": "System.Boolean",
         "dataContextManipulation": {
           "$type": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework",
           "TypeId": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework"
-        }
+        },
+        "onlyBindings": true
       },
       "Width": {
         "type": "System.String",
         "dataContextManipulation": {
           "$type": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework",
           "TypeId": "DotVVM.Framework.Compilation.ControlTree.PopDataContextManipulationAttribute, DotVVM.Framework"
-        }
+        },
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.GridViewTemplateColumn": {
       "ContentTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
         "mappingMode": "InnerElement",
-        "required": true
+        "required": true,
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.GridViewTextColumn": {
       "ChangedBinding": {
-        "type": "DotVVM.Framework.Binding.Expressions.ICommandBinding, DotVVM.Framework"
+        "type": "DotVVM.Framework.Binding.Expressions.ICommandBinding, DotVVM.Framework",
+        "onlyBindings": true
       },
       "FormatString": {
-        "type": "System.String"
+        "type": "System.String",
+        "onlyHardcoded": true
       },
       "ValidatorPlacement": {
-        "type": "DotVVM.Framework.Controls.ValidatorPlacement, DotVVM.Framework"
+        "type": "DotVVM.Framework.Controls.ValidatorPlacement, DotVVM.Framework",
+        "onlyHardcoded": true
       },
       "ValueBinding": {
         "type": "DotVVM.Framework.Binding.Expressions.IValueBinding, DotVVM.Framework",
-        "required": true
+        "required": true,
+        "onlyBindings": true
       }
     },
     "DotVVM.Framework.Controls.HierarchyRepeater": {
       "EmptyDataTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       },
       "ItemChildrenBinding": {
         "type": "DotVVM.Framework.Binding.Expressions.IValueBinding`1[[System.Collections.Generic.IEnumerable`1[[System.Object, CoreLibrary]], CoreLibrary]], DotVVM.Framework",
@@ -777,7 +860,8 @@
             "TypeId": "DotVVM.Framework.Binding.ControlPropertyBindingDataContextChangeAttribute, DotVVM.Framework"
           }
         ],
-        "required": true
+        "required": true,
+        "onlyBindings": true
       },
       "ItemID": {
         "type": "System.String",
@@ -801,7 +885,8 @@
           }
         ],
         "mappingMode": "InnerElement",
-        "required": true
+        "required": true,
+        "onlyHardcoded": true
       },
       "ItemVisible": {
         "type": "System.Boolean",
@@ -809,6 +894,7 @@
       },
       "ItemWrapperTagName": {
         "type": "System.String",
+        "onlyHardcoded": true,
         "fromCapability": "ItemWrapperCapability"
       },
       "LevelID": {
@@ -821,13 +907,16 @@
       },
       "LevelWrapperTagName": {
         "type": "System.String",
+        "onlyHardcoded": true,
         "fromCapability": "LevelWrapperCapability"
       },
       "RenderWrapperTag": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "onlyHardcoded": true
       },
       "WrapperTagName": {
-        "type": "System.String"
+        "type": "System.String",
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.HtmlGenericControl": {
@@ -835,7 +924,8 @@
         "type": "System.String"
       },
       "Visible": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "onlyBindings": true
       }
     },
     "DotVVM.Framework.Controls.HtmlLiteral": {
@@ -851,11 +941,13 @@
     },
     "DotVVM.Framework.Controls.InlineScript": {
       "Dependencies": {
-        "type": "System.String[]"
+        "type": "System.String[]",
+        "onlyHardcoded": true
       },
       "Script": {
         "type": "System.String",
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.Internal": {
@@ -863,7 +955,8 @@
         "type": "System.String"
       },
       "CurrentIndexBinding": {
-        "type": "DotVVM.Framework.Binding.Expressions.IValueBinding, DotVVM.Framework"
+        "type": "DotVVM.Framework.Binding.Expressions.IValueBinding, DotVVM.Framework",
+        "onlyBindings": true
       },
       "DataContextType": {
         "type": "DotVVM.Framework.Compilation.ControlTree.DataContextStack, DotVVM.Framework",
@@ -912,7 +1005,8 @@
     },
     "DotVVM.Framework.Controls.ItemsControl": {
       "DataSource": {
-        "type": "System.Object"
+        "type": "System.Object",
+        "onlyBindings": true
       }
     },
     "DotVVM.Framework.Controls.JsComponent": {
@@ -940,10 +1034,12 @@
     },
     "DotVVM.Framework.Controls.Literal": {
       "FormatString": {
-        "type": "System.String"
+        "type": "System.String",
+        "onlyHardcoded": true
       },
       "RenderSpanElement": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "onlyHardcoded": true
       },
       "Text": {
         "type": "System.Object"
@@ -952,38 +1048,45 @@
     "DotVVM.Framework.Controls.MultiSelector": {
       "SelectedValues": {
         "type": "System.Object",
-        "required": true
+        "required": true,
+        "onlyBindings": true
       }
     },
     "DotVVM.Framework.Controls.NamedCommand": {
       "Command": {
         "type": "DotVVM.Framework.Binding.Expressions.ICommandBinding, DotVVM.Framework",
-        "required": true
+        "required": true,
+        "onlyBindings": true
       },
       "Name": {
         "type": "System.String",
-        "required": true
+        "required": true,
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.PostBack": {
       "Concurrency": {
         "type": "DotVVM.Framework.Controls.PostbackConcurrencyMode, DotVVM.Framework",
         "isValueInherited": true,
+        "onlyHardcoded": true,
         "isAttached": true
       },
       "ConcurrencyQueue": {
         "type": "System.String",
         "isValueInherited": true,
+        "onlyHardcoded": true,
         "isAttached": true
       },
       "ConcurrencyQueueSettings": {
         "type": "DotVVM.Framework.Controls.ConcurrencyQueueSettingsCollection, DotVVM.Framework",
         "mappingMode": "InnerElement",
+        "onlyHardcoded": true,
         "isAttached": true
       },
       "Handlers": {
         "type": "DotVVM.Framework.Controls.PostBackHandlerCollection, DotVVM.Framework",
         "mappingMode": "InnerElement",
+        "onlyHardcoded": true,
         "isAttached": true
       },
       "Update": {
@@ -996,18 +1099,22 @@
         "type": "System.Boolean"
       },
       "EventName": {
-        "type": "System.String"
+        "type": "System.String",
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.RadioButton": {
       "Checked": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "onlyBindings": true
       },
       "CheckedItem": {
-        "type": "System.Object"
+        "type": "System.Object",
+        "onlyBindings": true
       },
       "GroupName": {
-        "type": "System.String"
+        "type": "System.String",
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.RenderSettings": {
@@ -1020,7 +1127,8 @@
     "DotVVM.Framework.Controls.Repeater": {
       "EmptyDataTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       },
       "ItemTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
@@ -1040,43 +1148,53 @@
           }
         ],
         "mappingMode": "InnerElement",
-        "required": true
+        "required": true,
+        "onlyHardcoded": true
       },
       "RenderAsNamedTemplate": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "onlyHardcoded": true
       },
       "RenderWrapperTag": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "onlyHardcoded": true
       },
       "SeparatorTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       },
       "WrapperTagName": {
-        "type": "System.String"
+        "type": "System.String",
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.RequiredResource": {
       "Name": {
         "type": "System.String",
-        "required": true
+        "required": true,
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.RoleView": {
       "HideForAnonymousUsers": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "onlyHardcoded": true
       },
       "IsMemberTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       },
       "IsNotMemberTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
-        "mappingMode": "InnerElement"
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
       },
       "Roles": {
         "type": "System.String[]",
-        "required": true
+        "required": true,
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.RouteLink": {
@@ -1085,7 +1203,8 @@
       },
       "RouteName": {
         "type": "System.String",
-        "required": true
+        "required": true,
+        "onlyHardcoded": true
       },
       "Text": {
         "type": "System.String"
@@ -1097,7 +1216,8 @@
     "DotVVM.Framework.Controls.Selector": {
       "SelectedValue": {
         "type": "System.Object",
-        "required": true
+        "required": true,
+        "onlyBindings": true
       }
     },
     "DotVVM.Framework.Controls.SelectorBase": {
@@ -1120,7 +1240,8 @@
             "Order": 1,
             "TypeId": "DotVVM.Framework.Binding.CollectionElementDataContextChangeAttribute, DotVVM.Framework"
           }
-        ]
+        ],
+        "onlyBindings": true
       },
       "ItemTitleBinding": {
         "type": "DotVVM.Framework.Binding.Expressions.IValueBinding, DotVVM.Framework",
@@ -1138,7 +1259,8 @@
             "Order": 1,
             "TypeId": "DotVVM.Framework.Binding.CollectionElementDataContextChangeAttribute, DotVVM.Framework"
           }
-        ]
+        ],
+        "onlyBindings": true
       },
       "ItemValueBinding": {
         "type": "DotVVM.Framework.Binding.Expressions.IValueBinding, DotVVM.Framework",
@@ -1156,10 +1278,12 @@
             "Order": 1,
             "TypeId": "DotVVM.Framework.Binding.CollectionElementDataContextChangeAttribute, DotVVM.Framework"
           }
-        ]
+        ],
+        "onlyBindings": true
       },
       "SelectionChanged": {
-        "type": "DotVVM.Framework.Binding.Expressions.Command, DotVVM.Framework"
+        "type": "DotVVM.Framework.Binding.Expressions.Command, DotVVM.Framework",
+        "isCommand": true
       }
     },
     "DotVVM.Framework.Controls.SelectorItem": {
@@ -1172,13 +1296,16 @@
     },
     "DotVVM.Framework.Controls.SpaContentPlaceHolder": {
       "DefaultRouteName": {
-        "type": "System.String"
+        "type": "System.String",
+        "onlyHardcoded": true
       },
       "PrefixRouteName": {
-        "type": "System.String"
+        "type": "System.String",
+        "onlyHardcoded": true
       },
       "UseHistoryApi": {
-        "type": "System.Nullable`1[[System.Boolean, CoreLibrary]]"
+        "type": "System.Nullable`1[[System.Boolean, CoreLibrary]]",
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.Styles": {
@@ -1236,24 +1363,28 @@
     "DotVVM.Framework.Controls.TableUtils": {
       "ColumnVisible": {
         "type": "System.Boolean",
+        "onlyBindings": true,
         "isActive": true
       }
     },
     "DotVVM.Framework.Controls.TemplateHost": {
       "Template": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
-        "required": true
+        "required": true,
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.TextBox": {
       "Changed": {
-        "type": "DotVVM.Framework.Binding.Expressions.Command, DotVVM.Framework"
+        "type": "DotVVM.Framework.Binding.Expressions.Command, DotVVM.Framework",
+        "isCommand": true
       },
       "Enabled": {
         "type": "System.Boolean"
       },
       "FormatString": {
-        "type": "System.String"
+        "type": "System.String",
+        "onlyHardcoded": true
       },
       "SelectAllOnFocus": {
         "type": "System.Boolean"
@@ -1263,14 +1394,17 @@
         "required": true
       },
       "TextInput": {
-        "type": "DotVVM.Framework.Binding.Expressions.Command, DotVVM.Framework"
+        "type": "DotVVM.Framework.Binding.Expressions.Command, DotVVM.Framework",
+        "isCommand": true
       },
       "Type": {
-        "type": "DotVVM.Framework.Controls.TextBoxType, DotVVM.Framework"
+        "type": "DotVVM.Framework.Controls.TextBoxType, DotVVM.Framework",
+        "onlyHardcoded": true
       },
       "UpdateTextOnInput": {
         "type": "System.Boolean",
-        "isValueInherited": true
+        "isValueInherited": true,
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.UITests": {
@@ -1281,30 +1415,36 @@
       },
       "Name": {
         "type": "System.String",
+        "onlyHardcoded": true,
         "isActive": true,
         "isAttached": true
       }
     },
     "DotVVM.Framework.Controls.UpdateProgress": {
       "Delay": {
-        "type": "System.Int32"
+        "type": "System.Int32",
+        "onlyHardcoded": true
       },
       "ExcludedQueues": {
-        "type": "System.String[]"
+        "type": "System.String[]",
+        "onlyHardcoded": true
       },
       "IncludedQueues": {
-        "type": "System.String[]"
+        "type": "System.String[]",
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.Validation": {
       "Enabled": {
         "type": "System.Boolean",
         "isValueInherited": true,
+        "onlyHardcoded": true,
         "isAttached": true
       },
       "Target": {
         "type": "System.Object",
         "isValueInherited": true,
+        "onlyBindings": true,
         "isAttached": true
       }
     },
@@ -1313,10 +1453,12 @@
         "type": "System.Boolean"
       },
       "IncludeErrorsFromChildren": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "onlyHardcoded": true
       },
       "IncludeErrorsFromTarget": {
-        "type": "System.Boolean"
+        "type": "System.Boolean",
+        "onlyHardcoded": true
       }
     },
     "DotVVM.Framework.Controls.Validator": {
@@ -1328,20 +1470,24 @@
       "InvalidCssClass": {
         "type": "System.String",
         "isValueInherited": true,
+        "onlyHardcoded": true,
         "isAttached": true
       },
       "SetToolTipText": {
         "type": "System.Boolean",
         "isValueInherited": true,
+        "onlyHardcoded": true,
         "isAttached": true
       },
       "ShowErrorMessageText": {
         "type": "System.Boolean",
         "isValueInherited": true,
+        "onlyHardcoded": true,
         "isAttached": true
       },
       "Value": {
         "type": "System.Object",
+        "onlyBindings": true,
         "isActive": true,
         "isAttached": true
       }

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -2217,5 +2217,29 @@
       "assembly": "DotVVM.Framework.Testing",
       "baseType": "DotVVM.Framework.Controls.HeadResourceLinks, DotVVM.Framework"
     }
+  },
+  "assemblies": {
+    "assemblyDirs": [
+      "/home/exyi/code/dotvvm/src/Tests/bin/Debug/net6.0",
+      "/usr/share/dotnet/shared/Microsoft.AspNetCore.App/6.0.9",
+      "/usr/share/dotnet/shared/Microsoft.NETCore.App/6.0.9"
+    ],
+    "assemblyNames": [
+      "DotVVM.Framework, Version=***",
+      "Microsoft.CSharp, Version=***",
+      "Microsoft.Extensions.DependencyInjection.Abstractions, Version=***",
+      "mscorlib, Version=***",
+      "netstandard, Version=***",
+      "System.Collections, Version=***",
+      "System.Collections.Concurrent, Version=***",
+      "System.ComponentModel, Version=***",
+      "System.Linq, Version=***",
+      "System.Linq.Expressions, Version=***",
+      "System.Private.CoreLib, Version=***",
+      "System.Runtime, Version=***",
+      "System.Runtime.InteropServices, Version=***",
+      "System.ValueTuple, Version=***"
+    ],
+    "mainAssembly": "testhost, Version=***"
   }
 }

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -190,7 +190,7 @@
       "ExcludeProperties": {
         "type": "System.String[]",
         "defaultValue": {
-          "$type": "System.String[], System.Private.CoreLib",
+          "$type": "System.String[], CoreLibrary",
           "$values": []
         },
         "onlyHardcoded": true,
@@ -230,7 +230,7 @@
       "ExcludeProperties": {
         "type": "System.String[]",
         "defaultValue": {
-          "$type": "System.String[], System.Private.CoreLib",
+          "$type": "System.String[], CoreLibrary",
           "$values": []
         },
         "onlyHardcoded": true,
@@ -1011,7 +1011,7 @@
       "Dependencies": {
         "type": "System.String[]",
         "defaultValue": {
-          "$type": "System.String[], System.Private.CoreLib",
+          "$type": "System.String[], CoreLibrary",
           "$values": [
             "dotvvm"
           ]

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -1866,32 +1866,46 @@
     "DotVVM.AutoUI.Controls.AutoEditor": {
       "assembly": "DotVVM.AutoUI",
       "baseType": "DotVVM.Framework.Controls.CompositeControl, DotVVM.Framework",
-      "withoutContent": true
+      "withoutContent": true,
+      "markupPrimaryName": "Editor",
+      "isComposite": true,
+      "precompilationMode": "InServerSideStyles"
     },
     "DotVVM.AutoUI.Controls.AutoForm": {
       "assembly": "DotVVM.AutoUI",
-      "baseType": "DotVVM.AutoUI.Controls.AutoFormBase, DotVVM.AutoUI"
+      "baseType": "DotVVM.AutoUI.Controls.AutoFormBase, DotVVM.AutoUI",
+      "markupPrimaryName": "Form",
+      "isComposite": true,
+      "precompilationMode": "InServerSideStyles"
     },
     "DotVVM.AutoUI.Controls.AutoFormBase": {
       "assembly": "DotVVM.AutoUI",
       "baseType": "DotVVM.Framework.Controls.CompositeControl, DotVVM.Framework",
-      "isAbstract": true
+      "isAbstract": true,
+      "isComposite": true,
+      "precompilationMode": "InServerSideStyles"
     },
     "DotVVM.AutoUI.Controls.AutoGridViewColumn": {
       "assembly": "DotVVM.AutoUI",
-      "baseType": "DotVVM.Framework.Controls.GridViewColumn, DotVVM.Framework"
+      "baseType": "DotVVM.Framework.Controls.GridViewColumn, DotVVM.Framework",
+      "markupPrimaryName": "GridViewColumn"
     },
     "DotVVM.AutoUI.Controls.AutoGridViewColumns": {
       "assembly": "DotVVM.AutoUI",
-      "baseType": "DotVVM.Framework.Controls.GridViewColumn, DotVVM.Framework"
+      "baseType": "DotVVM.Framework.Controls.GridViewColumn, DotVVM.Framework",
+      "markupPrimaryName": "GridViewColumns"
     },
     "DotVVM.AutoUI.Controls.BootstrapForm": {
       "assembly": "DotVVM.AutoUI",
-      "baseType": "DotVVM.AutoUI.Controls.AutoFormBase, DotVVM.AutoUI"
+      "baseType": "DotVVM.AutoUI.Controls.AutoFormBase, DotVVM.AutoUI",
+      "isComposite": true,
+      "precompilationMode": "InServerSideStyles"
     },
     "DotVVM.AutoUI.Controls.BulmaForm": {
       "assembly": "DotVVM.AutoUI",
-      "baseType": "DotVVM.AutoUI.Controls.AutoFormBase, DotVVM.AutoUI"
+      "baseType": "DotVVM.AutoUI.Controls.AutoFormBase, DotVVM.AutoUI",
+      "isComposite": true,
+      "precompilationMode": "InServerSideStyles"
     },
     "DotVVM.Framework.Compilation.Styles.ResolvedControlHelper+LazyRuntimeControl": {
       "assembly": "DotVVM.Framework",

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -2243,29 +2243,5 @@
       "assembly": "DotVVM.Framework.Testing",
       "baseType": "DotVVM.Framework.Controls.HeadResourceLinks, DotVVM.Framework"
     }
-  },
-  "assemblies": {
-    "assemblyDirs": [
-      "/home/exyi/code/dotvvm/src/Tests/bin/Debug/net6.0",
-      "/usr/share/dotnet/shared/Microsoft.AspNetCore.App/6.0.9",
-      "/usr/share/dotnet/shared/Microsoft.NETCore.App/6.0.9"
-    ],
-    "assemblyNames": [
-      "DotVVM.Framework, Version=***",
-      "Microsoft.CSharp, Version=***",
-      "Microsoft.Extensions.DependencyInjection.Abstractions, Version=***",
-      "mscorlib, Version=***",
-      "netstandard, Version=***",
-      "System.Collections, Version=***",
-      "System.Collections.Concurrent, Version=***",
-      "System.ComponentModel, Version=***",
-      "System.Linq, Version=***",
-      "System.Linq.Expressions, Version=***",
-      "System.Private.CoreLib, Version=***",
-      "System.Runtime, Version=***",
-      "System.Runtime.InteropServices, Version=***",
-      "System.ValueTuple, Version=***"
-    ],
-    "mainAssembly": "testhost, Version=***"
   }
 }

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -158,6 +158,7 @@
       },
       "Enabled": {
         "type": "System.Boolean",
+        "defaultValue": true,
         "fromCapability": "Props"
       },
       "OverrideTemplate": {
@@ -173,6 +174,7 @@
       },
       "Visible": {
         "type": "System.Boolean",
+        "defaultValue": true,
         "fromCapability": "HtmlCapability"
       }
     },
@@ -187,6 +189,10 @@
     "DotVVM.AutoUI.Controls.AutoFormBase": {
       "ExcludeProperties": {
         "type": "System.String[]",
+        "defaultValue": {
+          "$type": "System.String[], System.Private.CoreLib",
+          "$values": []
+        },
         "onlyHardcoded": true,
         "fromCapability": "FieldSelectorProps"
       },
@@ -223,6 +229,10 @@
     "DotVVM.AutoUI.Controls.AutoGridViewColumns": {
       "ExcludeProperties": {
         "type": "System.String[]",
+        "defaultValue": {
+          "$type": "System.String[], System.Private.CoreLib",
+          "$values": []
+        },
         "onlyHardcoded": true,
         "fromCapability": "FieldSelectorProps"
       },
@@ -244,58 +254,73 @@
     },
     "DotVVM.AutoUI.Controls.BootstrapForm": {
       "FormCheckCssClass": {
-        "type": "System.String"
+        "type": "System.String",
+        "defaultValue": "form-check"
       },
       "FormCheckInputCssClass": {
-        "type": "System.String"
+        "type": "System.String",
+        "defaultValue": "form-check-input"
       },
       "FormCheckLabelCssClass": {
-        "type": "System.String"
+        "type": "System.String",
+        "defaultValue": "form-check-label"
       },
       "FormControlCssClass": {
-        "type": "System.String"
+        "type": "System.String",
+        "defaultValue": "form-control"
       },
       "FormGroupCssClass": {
-        "type": "System.String"
+        "type": "System.String",
+        "defaultValue": "mb-4"
       },
       "FormSelectCssClass": {
-        "type": "System.String"
+        "type": "System.String",
+        "defaultValue": "form-select"
       },
       "LabelCssClass": {
-        "type": "System.String"
+        "type": "System.String",
+        "defaultValue": "control-label"
       },
       "RequiresFormCheckCssClass": {
         "type": "System.Boolean",
+        "defaultValue": false,
         "isAttached": true
       },
       "RequiresFormControlCssClass": {
         "type": "System.Boolean",
+        "defaultValue": false,
         "isAttached": true
       },
       "RequiresFormSelectCssClass": {
         "type": "System.Boolean",
+        "defaultValue": false,
         "isAttached": true
       }
     },
     "DotVVM.AutoUI.Controls.BulmaForm": {
       "WrapWithCheckboxClass": {
         "type": "System.Boolean",
+        "defaultValue": false,
         "isAttached": true
       },
       "WrapWithInputClass": {
         "type": "System.Boolean",
+        "defaultValue": false,
         "isAttached": true
       },
       "WrapWithRadioClass": {
         "type": "System.Boolean",
+        "defaultValue": false,
         "isAttached": true
       },
       "WrapWithSelectClass": {
         "type": "System.Boolean",
+        "defaultValue": false,
         "isAttached": true
       },
       "WrapWithTextareaClass": {
         "type": "System.Boolean",
+        "defaultValue": false,
         "isAttached": true
       }
     },
@@ -2037,7 +2062,8 @@
       "assembly": "DotVVM.Framework",
       "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework",
       "interfaces": [
-        "DotVVM.Framework.Controls.IControlWithHtmlAttributes, DotVVM.Framework"
+        "DotVVM.Framework.Controls.IControlWithHtmlAttributes, DotVVM.Framework",
+        "DotVVM.Framework.Controls.IObjectWithCapability`1[[DotVVM.Framework.Controls.HtmlCapability, DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da]], DotVVM.Framework"
       ]
     },
     "DotVVM.Framework.Controls.HtmlLiteral": {


### PR DESCRIPTION
I was considering moving the list of properties into each control,
but that would exclude attached properties from the list

resolves #1431