### PR TITLE
Fixed bug in RenderSettings.Mode=Server when a collection is set to null value

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/binding-handlers/SSR-foreach.ts
+++ b/src/Framework/Framework/Resources/Scripts/binding-handlers/SSR-foreach.ts
@@ -18,14 +18,14 @@ export default {
             let isInitial = true;
             ko.computed(() => {
                 const rawValue = valueAccessor().data;
-                ko.unwrap(rawValue); // we have to touch the observable in the binding so that the `getDependenciesCount` call knows about this dependency. If would be unwrapped only later (in the makeContextCallback) we would not have the savedNodes.
+                const unwrappedValue = ko.unwrap(rawValue); // we have to touch the observable in the binding so that the `getDependenciesCount` call knows about this dependency. If would be unwrapped only later (in the makeContextCallback) we would not have the savedNodes.
 
                 // save a copy of the inner nodes on the initial update, but only if we have dependencies.
                 if (isInitial && ko.computedContext.getDependenciesCount()) {
                     savedNodes = ko.utils.cloneNodes(ko.virtualElements.childNodes(element), true /* shouldCleanNodes */);
                 }
 
-                if (rawValue != null) {
+                if (rawValue != null && unwrappedValue != null) {
                     if (!isInitial) {
                         ko.virtualElements.setDomNodeChildren(element, ko.utils.cloneNodes(savedNodes!));
                     }

--- a/src/Framework/Framework/Resources/Scripts/binding-handlers/SSR-foreach.ts
+++ b/src/Framework/Framework/Resources/Scripts/binding-handlers/SSR-foreach.ts
@@ -25,7 +25,7 @@ export default {
                     savedNodes = ko.utils.cloneNodes(ko.virtualElements.childNodes(element), true /* shouldCleanNodes */);
                 }
 
-                if (rawValue != null && unwrappedValue != null) {
+                if (unwrappedValue != null) {
                     if (!isInitial) {
                         ko.virtualElements.setDomNodeChildren(element, ko.utils.cloneNodes(savedNodes!));
                     }

--- a/src/Samples/Common/DotVVM.Samples.Common.csproj
+++ b/src/Samples/Common/DotVVM.Samples.Common.csproj
@@ -96,6 +96,7 @@
     <None Remove="Views\FeatureSamples\MarkupControl\MarkupDefinedPropertiesControl.dotcontrol" />
     <None Remove="Views\FeatureSamples\MarkupControl\ServiceDependency\ServiceDependencyControl.dotcontrol" />
     <None Remove="Views\FeatureSamples\PostbackAbortSignal\LoadAbortViewModel.dothtml" />
+    <None Remove="Views\FeatureSamples\RenderSettingsModeServer\RepeaterCollectionSetToNull.dothtml" />
     <None Remove="Views\FeatureSamples\Serialization\ByteArray.dothtml" />
     <None Remove="Views\FeatureSamples\Serialization\TimeSpan.dothtml" />
     <None Remove="Views\FeatureSamples\Serialization\EnumSerializationCoercion.dothtml" />

--- a/src/Samples/Common/ViewModels/FeatureSamples/RenderSettingsModeServer/RepeaterCollectionSetToNullViewModel.cs
+++ b/src/Samples/Common/ViewModels/FeatureSamples/RenderSettingsModeServer/RepeaterCollectionSetToNullViewModel.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.RenderSettingsModeServer
+{
+    public class RepeaterCollectionSetToNullViewModel : DotvvmViewModelBase
+    {
+        public List<SomeObject> Objects { get; protected set; }
+
+        public string Value { get; set; }
+        
+
+        public void Test()
+        {
+            Objects = null;
+            Value = "Null assigned to the collection";
+        }
+
+        public void Test2()
+        {
+            Objects = new()
+            {
+                new SomeObject() { Id = 1 },
+                new SomeObject() { Id = 2 } 
+            };
+            Value = "Non-null assigned to the collection";
+        }
+
+        public override Task PreRender()
+        {
+            if (!Context.IsPostBack)
+            {
+                Objects = new()
+                {
+                    new SomeObject() { Id = 1 },
+                    new SomeObject() { Id = 2 }
+                };
+            }
+            return base.PreRender();
+        }
+    }
+
+    public class SomeObject
+    {
+        public int Id { get; set; }
+    }
+}
+

--- a/src/Samples/Common/Views/FeatureSamples/RenderSettingsModeServer/RepeaterCollectionExchange.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/RenderSettingsModeServer/RepeaterCollectionExchange.dothtml
@@ -15,7 +15,7 @@
 
     <div>
         <h3> Repeater </h3>
-        <dot:Repeater DataSource="{value: UseNull ? null : UseAlternativeCollection ? Collection2 : Collection1}" WrapperTagName=ul>
+        <dot:Repeater DataSource="{value: UseNull ? null : UseAlternativeCollection ? Collection2 : Collection1}" WrapperTagName=ul class="repeater">
             <li RenderSettings.Mode=Client>
                 {{value: _this}}
             </li>
@@ -24,7 +24,7 @@
 
     <div>
         <h3> GridView </h3>
-        <dot:GridView DataSource="{value: UseNull ? null : UseAlternativeCollection ? Collection2 : Collection1}">
+        <dot:GridView DataSource="{value: UseNull ? null : UseAlternativeCollection ? Collection2 : Collection1}" class="gridview">
             <dot:GridViewTemplateColumn HeaderText="some column">
                 <span RenderSettings.Mode=Client>{{value: _this}}</span>
             </dot:GridViewTemplateColumn>
@@ -33,7 +33,7 @@
 
     <div>
         <h3> ComboBox </h3>
-        <dot:ComboBox DataSource="{value: UseNull ? null : UseAlternativeCollection ? Collection2 : Collection1}" ItemTextBinding="{value: _this}" SelectedValue="{value: SelectedValue}" />
+        <dot:ComboBox DataSource="{value: UseNull ? null : UseAlternativeCollection ? Collection2 : Collection1}" ItemTextBinding="{value: _this}" SelectedValue="{value: SelectedValue}" class="combobox" />
     </div>
 
 </body>

--- a/src/Samples/Common/Views/FeatureSamples/RenderSettingsModeServer/RepeaterCollectionSetToNull.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/RenderSettingsModeServer/RepeaterCollectionSetToNull.dothtml
@@ -1,0 +1,26 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.RenderSettingsModeServer.RepeaterCollectionSetToNullViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+
+    <p>Sample for a bug fix - when a collection in the viewmodel was set to null and it was bound using dotvvm-SSR-foreach, an error occurred and the viewmodel wasn't applied. </p>
+
+    <dot:Button Text="Set null" Click="{command: Test()}" />
+    <dot:Button Text="Set non-null" Click="{command: Test2()}" />
+
+    <p>Value: <span class="value">{{value: Value}}</span></p>
+
+    <dot:Repeater DataSource="{value: Objects}" WrapperTagName="ul" RenderSettings.Mode="Server">
+        <li>{{value: Id}}</li>
+    </dot:Repeater>
+
+</body>
+</html>
+
+

--- a/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
@@ -297,6 +297,7 @@ namespace DotVVM.Testing.Abstractions
     public const string FeatureSamples_Redirect_Redirect_StaticCommand = "FeatureSamples/Redirect/Redirect_StaticCommand";
     public const string FeatureSamples_RenderSettingsModeServer_RenderSettingModeServerProperty = "FeatureSamples/RenderSettingsModeServer/RenderSettingModeServerProperty";
     public const string FeatureSamples_RenderSettingsModeServer_RepeaterCollectionExchange = "FeatureSamples/RenderSettingsModeServer/RepeaterCollectionExchange";
+    public const string FeatureSamples_RenderSettingsModeServer_RepeaterCollectionSetToNull = "FeatureSamples/RenderSettingsModeServer/RepeaterCollectionSetToNull";
     public const string FeatureSamples_Resources_CdnScriptPriority = "FeatureSamples/Resources/CdnScriptPriority";
     public const string FeatureSamples_Resources_CdnUnavailableResourceLoad = "FeatureSamples/Resources/CdnUnavailableResourceLoad";
     public const string FeatureSamples_Resources_OnlineNonameResourceLoad = "FeatureSamples/Resources/OnlineNonameResourceLoad";

--- a/src/Samples/Tests/Tests/Feature/RenderSettingsModeServerTest.cs
+++ b/src/Samples/Tests/Tests/Feature/RenderSettingsModeServerTest.cs
@@ -27,6 +27,67 @@ namespace DotVVM.Samples.Tests.Feature
             });
         }
 
+        [Fact]
+        public void Feature_RenderSettingsModeServer_RepeaterCollectionExchange()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_RenderSettingsModeServer_RepeaterCollectionExchange);
+
+                var repeater = browser.Single(".repeater");
+                var gridView = browser.Single(".gridview");
+                var comboBox = browser.Single(".combobox");
+
+                repeater.FindElements("li").ThrowIfDifferentCountThan(2);
+                gridView.FindElements("tbody tr").ThrowIfDifferentCountThan(2);
+                comboBox.FindElements("option").ThrowIfDifferentCountThan(2);
+
+                // use null
+                browser.ElementAt("input[type=checkbox]", 0).Click();
+                repeater.FindElements("li").ThrowIfDifferentCountThan(0);
+                browser.FindElements(".gridview").ThrowIfDifferentCountThan(0);
+                comboBox.FindElements("option").ThrowIfDifferentCountThan(0);
+
+                // don't use null
+                browser.ElementAt("input[type=checkbox]", 0).Click();
+                gridView = browser.Single(".gridview");
+                repeater.FindElements("li").ThrowIfDifferentCountThan(2);
+                gridView.FindElements("tbody tr").ThrowIfDifferentCountThan(2);
+                comboBox.FindElements("option").ThrowIfDifferentCountThan(2);
+
+                // use alternative collection
+                browser.ElementAt("input[type=checkbox]", 1).Click();
+                repeater.FindElements("li").ThrowIfDifferentCountThan(2);
+                gridView.FindElements("tbody tr").ThrowIfDifferentCountThan(2);
+                comboBox.FindElements("option").ThrowIfDifferentCountThan(2);
+                AssertUI.InnerTextEquals(repeater.First("li"), "alternative item 1");
+                AssertUI.InnerTextEquals(gridView.First("tbody tr"), "alternative item 1");
+                AssertUI.InnerTextEquals(comboBox.First("option"), "alternative item 1");
+            });
+        }
+
+        [Fact]
+        public void Feature_RenderSettingsModeServer_RepeaterCollectionSetToNull()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_RenderSettingsModeServer_RepeaterCollectionSetToNull);
+
+                var value = browser.Single(".value");
+                AssertUI.InnerTextEquals(value, "");
+                browser.FindElements("ul li").ThrowIfDifferentCountThan(2);
+
+                for (var i = 0; i < 2; i++)
+                {
+                    browser.ElementAt("input[type=button]", 0).Click();
+                    AssertUI.InnerTextEquals(value, "Null assigned to the collection");
+                    browser.FindElements("ul li").ThrowIfDifferentCountThan(0);
+
+                    browser.ElementAt("input[type=button]", 1).Click();
+                    AssertUI.InnerTextEquals(value, "Non-null assigned to the collection");
+                    browser.FindElements("ul li").ThrowIfDifferentCountThan(2);
+                }
+            });
+        }
+
         public RenderSettingsModeServerTest(ITestOutputHelper output) : base(output)
         {
         }


### PR DESCRIPTION
When a collection in the viewmodel was set to null, and there was a server-side rendered control bound to it, it was throwing an error in the `dotvvm-SSR-foreach` binding handler.
I've added a check for this situation and also added UI tests.