### PR TITLE
Fixed CommandLine publishing on CI

### DIFF
--- a/src/Tools/CommandLine/DotVVM.CommandLine.csproj
+++ b/src/Tools/CommandLine/DotVVM.CommandLine.csproj
@@ -102,7 +102,7 @@
       <NuspecProperty Include="Version=$(PackageVersion)" />
       <NuspecProperty Include="ProjectDirectory=$(MSBuildProjectDirectory)" />
       <NuspecProperty Include="SettingsFile=$(_ToolsSettingsFilePath)" />
-      <NuspecProperty Include="Output=$(PublishDir)**\*" />
+      <NuspecProperty Include="Output=$(PublishDir)" />
     </ItemGroup>
     <PropertyGroup Condition="'$(NuspecFile)' != '' and '$(NuspecProperties)' == ''">
       <NuspecProperties>@(NuspecProperty, ';')</NuspecProperties>

--- a/src/Tools/CommandLine/DotVVM.CommandLine.nuspec
+++ b/src/Tools/CommandLine/DotVVM.CommandLine.nuspec
@@ -9,6 +9,6 @@
 
   <files>
     <file src="$SettingsFile$" target="tools\$TargetFramework$\any" />
-    <file src="$Output$" target="tools\$TargetFramework$\any" />
+    <file src="$Output$**\*" target="tools\$TargetFramework$\any" />
   </files>
 </package>


### PR DESCRIPTION
This PR fixes releasing of CommandLine. The fix is already present in recent builds of `release/4.0` but was missing in `main` and `release/4.1`.