### PR TITLE
Fix console.log in hot reaload

### DIFF
--- a/src/Tools/HotReload/AspNetCore/Scripts/dotvvm.hotreload.js
+++ b/src/Tools/HotReload/AspNetCore/Scripts/dotvvm.hotreload.js
@@ -16,8 +16,8 @@
             window.location.reload();
         });
         connection.start()
-            .then(function () { dotvvm.log.logInfo('DotVVM view hot reload active.'); })
-            .catch(function (e) { dotvvm.log.logWarning('DotVVM view hot reload error!', e); });
+            .then(function () { console.log('DotVVM view hot reload active.'); })
+            .catch(function (e) { console.warn('DotVVM view hot reload error!', e); });
     }
 
     if (typeof dotvvm !== "undefined") {

--- a/src/Tools/HotReload/Owin/Scripts/dotvvm.hotreload.js
+++ b/src/Tools/HotReload/Owin/Scripts/dotvvm.hotreload.js
@@ -13,8 +13,8 @@
             window.location.reload();
         };
         $.connection.hub.start()
-            .done(function() { dotvvm.log.logInfo('DotVVM view hot reload active.'); })
-            .fail(function(e) { dotvvm.log.logWarning('DotVVM view hot reload error!', e); });
+            .done(function() { console.log('DotVVM view hot reload active.'); })
+            .fail(function(e) { console.warn('DotVVM view hot reload error!', e); });
     }
 
     if (typeof dotvvm !== "undefined") {


### PR DESCRIPTION
We can't use dotvvm.log there, because dotvvm might not be loaded.