### PR TITLE
Added missing GetDotvvmContext method for ASP.NET Core

### DIFF
--- a/src/Framework/Framework/Hosting/DotvvmRequestContext.cs
+++ b/src/Framework/Framework/Hosting/DotvvmRequestContext.cs
@@ -138,7 +138,7 @@ namespace DotVVM.Framework.Hosting
         /// </summary>
         public static DotvvmRequestContext? TryGetCurrent(IHttpContext httpContext)
         {
-            return httpContext.GetItem<DotvvmRequestContext>(HostingConstants.DotvvmRequestContextOwinKey);
+            return httpContext.GetItem<DotvvmRequestContext>(HostingConstants.DotvvmRequestContextKey);
         }
 
         public CustomResponsePropertiesManager CustomResponseProperties { get; } = new CustomResponsePropertiesManager();

--- a/src/Framework/Framework/Hosting/HostingConstants.cs
+++ b/src/Framework/Framework/Hosting/HostingConstants.cs
@@ -2,7 +2,7 @@
 {
     public class HostingConstants
     {
-        public const string DotvvmRequestContextOwinKey = "dotvvm.requestContext";
+        public const string DotvvmRequestContextKey = "dotvvm.requestContext";
 
         public const string GlobalizeCultureUrlPath = "dotvvmGlobalizeCulture";
         public const string GlobalizeCultureUrlIdParameter = "id";

--- a/src/Framework/Hosting.AspNetCore/Hosting/AspNetCoreDotvvmRequestContextExtensions.cs
+++ b/src/Framework/Hosting.AspNetCore/Hosting/AspNetCoreDotvvmRequestContextExtensions.cs
@@ -35,5 +35,14 @@ namespace DotVVM.Framework.Hosting
             }
             return new AuthenticationManager(concreteContext.OriginalContext);
         }
+
+
+        /// <summary>
+        /// Gets the <see cref="IDotvvmRequestContext"/> bound to the specified <see cref="HttpContext"/>.
+        /// </summary>
+        public static IDotvvmRequestContext? GetDotvvmContext(this HttpContext httpContext)
+        {
+            return httpContext.Items.TryGetValue(HostingConstants.DotvvmRequestContextKey, out var value) ? value as IDotvvmRequestContext : null;
+        }
     }
 }

--- a/src/Framework/Hosting.AspNetCore/Hosting/AspNetCoreDotvvmRequestContextExtensions.cs
+++ b/src/Framework/Hosting.AspNetCore/Hosting/AspNetCoreDotvvmRequestContextExtensions.cs
@@ -40,7 +40,7 @@ namespace DotVVM.Framework.Hosting
         /// <summary>
         /// Gets the <see cref="IDotvvmRequestContext"/> bound to the specified <see cref="HttpContext"/>.
         /// </summary>
-        public static IDotvvmRequestContext? GetDotvvmContext(this HttpContext httpContext)
+        public static IDotvvmRequestContext GetDotvvmContext(this HttpContext httpContext)
         {
             return httpContext.Items.TryGetValue(HostingConstants.DotvvmRequestContextKey, out var value) ? value as IDotvvmRequestContext : null;
         }

--- a/src/Framework/Hosting.AspNetCore/Hosting/Middlewares/DotvvmMiddleware.cs
+++ b/src/Framework/Hosting.AspNetCore/Hosting/Middlewares/DotvvmMiddleware.cs
@@ -43,7 +43,7 @@ namespace DotVVM.Framework.Hosting
             // create the context
             var dotvvmContext = CreateDotvvmContext(context);
             context.RequestServices.GetRequiredService<DotvvmRequestContextStorage>().Context = dotvvmContext;
-            context.Items[HostingConstants.DotvvmRequestContextOwinKey] = dotvvmContext;
+            context.Items[HostingConstants.DotvvmRequestContextKey] = dotvvmContext;
 
             var requestCultureFeature = context.Features.Get<IRequestCultureFeature>();
 

--- a/src/Framework/Hosting.Owin/Hosting/Middlewares/DotvvmMiddleware.cs
+++ b/src/Framework/Hosting.Owin/Hosting/Middlewares/DotvvmMiddleware.cs
@@ -48,7 +48,7 @@ namespace DotVVM.Framework.Hosting
                 // create the context
                 var dotvvmContext = CreateDotvvmContext(context, scope);
                 dotvvmContext.Services.GetRequiredService<DotvvmRequestContextStorage>().Context = dotvvmContext;
-                context.Set(HostingConstants.DotvvmRequestContextOwinKey, dotvvmContext);
+                context.Set(HostingConstants.DotvvmRequestContextKey, dotvvmContext);
                 dotvvmContext.ChangeCurrentCulture(Configuration.DefaultCulture);
 
                 try

--- a/src/Framework/Hosting.Owin/Hosting/OwinDotvvmRequestContextExtensions.cs
+++ b/src/Framework/Hosting.Owin/Hosting/OwinDotvvmRequestContextExtensions.cs
@@ -34,7 +34,7 @@ namespace DotVVM.Framework.Hosting
         /// </summary>
         public static IDotvvmRequestContext GetDotvvmContext(this IOwinContext owinContext)
         {
-            return owinContext.Get<IDotvvmRequestContext>(HostingConstants.DotvvmRequestContextOwinKey);
+            return owinContext.Get<IDotvvmRequestContext>(HostingConstants.DotvvmRequestContextKey);
         }
     }
 }


### PR DESCRIPTION
We already had this method implemented for OWIN but not for ASP.NET Core.
Also, I have removed the word `Owin` from the `DotvvmRequestContextOwinKey` as it was used in ASP.NET Core version too.