### PR TITLE
Improvements of control property metadata for docs

### DIFF
--- a/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
+++ b/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
@@ -336,20 +336,22 @@ namespace DotVVM.Framework.Binding
                     dotvvmProperty = new DotvvmProperty(propertyName, type, declaringType, boxedDefaultValue, false, attributeProvider);
                     dotvvmProperty.OwningCapability = declaringCapability;
 
-                    var isNullable = propertyType.IsNullable() || propertyType.UnwrapValueOrBinding().IsNullable();
+                    if (!attributeProvider.IsDefined(typeof(MarkupOptionsAttribute), true))
+                    {
+                        var isNullable = propertyType.IsNullable() || propertyType.UnwrapValueOrBinding().IsNullable();
+                        if (!defaultValue.HasValue && !isNullable)
+                            dotvvmProperty.MarkupOptions.Required = true;
 
-                    if (!defaultValue.HasValue && !isNullable)
-                        dotvvmProperty.MarkupOptions.Required = true;
+                        if (typeof(IBinding).IsAssignableFrom(propertyType))
+                            dotvvmProperty.MarkupOptions.AllowHardCodedValue = false;
+                        else if (!typeof(ValueOrBinding).IsAssignableFrom(propertyType.UnwrapNullableType()))
+                            dotvvmProperty.MarkupOptions.AllowBinding = false;
 
-                    if (typeof(IBinding).IsAssignableFrom(propertyType))
-                        dotvvmProperty.MarkupOptions.AllowHardCodedValue = false;
-                    else if (!typeof(ValueOrBinding).IsAssignableFrom(propertyType.UnwrapNullableType()))
-                        dotvvmProperty.MarkupOptions.AllowBinding = false;
-
-                    if (typeof(IDotvvmObjectLike).IsAssignableFrom(type) ||
-                        typeof(ITemplate).IsAssignableFrom(type) ||
-                        typeof(IEnumerable<IDotvvmObjectLike>).IsAssignableFrom(type))
-                        dotvvmProperty.MarkupOptions.MappingMode = MappingMode.Both;
+                        if (typeof(IDotvvmObjectLike).IsAssignableFrom(type) ||
+                            typeof(ITemplate).IsAssignableFrom(type) ||
+                            typeof(IEnumerable<IDotvvmObjectLike>).IsAssignableFrom(type))
+                            dotvvmProperty.MarkupOptions.MappingMode = MappingMode.InnerElement;
+                    }
 
                     DotvvmProperty.Register(dotvvmProperty);
                 }

--- a/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
+++ b/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
@@ -335,18 +335,18 @@ namespace DotVVM.Framework.Binding
                 {
                     dotvvmProperty = new DotvvmProperty(propertyName, type, declaringType, boxedDefaultValue, false, attributeProvider);
                     dotvvmProperty.OwningCapability = declaringCapability;
+                    
+                    var isNullable = propertyType.IsNullable() || propertyType.UnwrapValueOrBinding().IsNullable();
+                    if (!defaultValue.HasValue && !isNullable)
+                        dotvvmProperty.MarkupOptions.Required = true;
+
+                    if (typeof(IBinding).IsAssignableFrom(propertyType))
+                        dotvvmProperty.MarkupOptions.AllowHardCodedValue = false;
+                    else if (!typeof(ValueOrBinding).IsAssignableFrom(propertyType.UnwrapNullableType()))
+                        dotvvmProperty.MarkupOptions.AllowBinding = false;
 
                     if (!attributeProvider.IsDefined(typeof(MarkupOptionsAttribute), true))
                     {
-                        var isNullable = propertyType.IsNullable() || propertyType.UnwrapValueOrBinding().IsNullable();
-                        if (!defaultValue.HasValue && !isNullable)
-                            dotvvmProperty.MarkupOptions.Required = true;
-
-                        if (typeof(IBinding).IsAssignableFrom(propertyType))
-                            dotvvmProperty.MarkupOptions.AllowHardCodedValue = false;
-                        else if (!typeof(ValueOrBinding).IsAssignableFrom(propertyType.UnwrapNullableType()))
-                            dotvvmProperty.MarkupOptions.AllowBinding = false;
-
                         if (typeof(IDotvvmObjectLike).IsAssignableFrom(type) ||
                             typeof(ITemplate).IsAssignableFrom(type) ||
                             typeof(IEnumerable<IDotvvmObjectLike>).IsAssignableFrom(type))

--- a/src/Framework/Framework/Controls/HtmlGenericControl.cs
+++ b/src/Framework/Framework/Controls/HtmlGenericControl.cs
@@ -578,15 +578,16 @@ namespace DotVVM.Framework.Controls
     [DotvvmControlCapability]
     public sealed record HtmlCapability
     {
-        /// <summary> A dictionary of html attributes that are rendered on this control's html tag. </summary>
+        /// <summary> Gets or sets a dictionary of HTML attributes that are rendered on this control HTML tag. </summary>
         [PropertyGroup("", "html:")]
         [MarkupOptions(MappingMode = MappingMode.Attribute, AllowBinding = true, AllowHardCodedValue = true, AllowValueMerging = true, AttributeValueMerger = typeof(HtmlAttributeValueMerger), AllowAttributeWithoutValue = true)]
         public IDictionary<string, ValueOrBinding<object?>> Attributes { get; init; } = new Dictionary<string, ValueOrBinding<object?>>();
 
-        /// <summary> A dictionary of css classes. All classes which value is `true` will be placed in the `class` attribute. </summary>
+        /// <summary> Gets or sets a dictionary of CSS classes. All classes which value is `true` will be placed in the `class` attribute. </summary>
         [PropertyGroup("Class-")]
         public IDictionary<string, ValueOrBinding<bool>> CssClasses { get; init; } = new Dictionary<string, ValueOrBinding<bool>>();
 
+        /// <summary> Gets or sets the ID of the control. Based on the `ClientIDMode` property, the value may be prefixed by DotVVM in order to be unique. </summary>
         public ValueOrBinding<string?> ID { get; init; }
 
         /// <summary> Returns true if all properties are set to default value </summary>
@@ -597,11 +598,11 @@ namespace DotVVM.Framework.Controls
             Visible.HasValue && Visible.ValueOrDefault == true &&
             ID.HasValue && ID.ValueOrDefault == null;
 
-        /// <summary> A dictionary of css styles which will be placed in the `style` attribute. </summary>
+        /// <summary> Gets or sets a dictionary of CSS styles which will be placed in the `style` attribute. </summary>
         [PropertyGroup("Style-")]
         public IDictionary<string, ValueOrBinding<object?>> CssStyles { get; init; } = new Dictionary<string, ValueOrBinding<object?>>();
 
-        /// <summary> When set to false, `style="display: none"` will be added to this control. </summary>
+        /// <summary> Gets or sets whether the control is visible. When set to false, `style="display: none"` will be added to this control. </summary>
         public ValueOrBinding<bool> Visible { get; init; } = new(true);
     }
 

--- a/src/Framework/Framework/Controls/TextOrContentCapability.cs
+++ b/src/Framework/Framework/Controls/TextOrContentCapability.cs
@@ -10,7 +10,14 @@ namespace DotVVM.Framework.Controls
     [DotvvmControlCapability]
     public sealed record TextOrContentCapability
     {
+        /// <summary>
+        /// Gets or sets the text inside the control.
+        /// </summary>
         public ValueOrBinding<string>? Text { get; init; }
+
+        /// <summary>
+        /// Gets or sets the content placed inside the control.
+        /// </summary>
         public List<DotvvmControl>? Content { get; init; }
 
         public TextOrContentCapability() { }

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -161,7 +161,7 @@
       },
       "OverrideTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
-        "mappingMode": "Both",
+        "mappingMode": "InnerElement",
         "fromCapability": "Props"
       },
       "Property": {
@@ -204,7 +204,7 @@
       },
       "ContentTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
-        "mappingMode": "Both",
+        "mappingMode": "InnerElement",
         "fromCapability": "Props"
       },
       "Property": {
@@ -1310,6 +1310,11 @@
       "Value": {
         "type": "System.Object",
         "isActive": true
+      }
+    },
+    "DotvvmMarkupControl-YYPITyOzVEL518wclEMJZw==": {
+      "SomeProperty": {
+        "type": "System.String"
       }
     }
   },

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -1311,11 +1311,6 @@
         "type": "System.Object",
         "isActive": true
       }
-    },
-    "DotvvmMarkupControl-YYPITyOzVEL518wclEMJZw==": {
-      "SomeProperty": {
-        "type": "System.String"
-      }
     }
   },
   "capabilities": {


### PR DESCRIPTION
I've added XML comments to builtin capabilities so they show up in the docs.
Also, I have updated the default mapping mode for properties of type control, collection of controls, or template. The user can override the default by placing his own `MarkupOptionsAttribute`.