### PR TITLE
Removed warning when a plain object is pushed in the observable array

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/state-manager.ts
+++ b/src/Framework/Framework/Resources/Scripts/state-manager.ts
@@ -327,7 +327,7 @@ function createWrappedObservable<T>(initialValue: DeepReadonly<T>, typeHint: Typ
                     if (newContents[index] && newContents[index][notifySymbol as any]) {
                         continue
                     }
-                    if (compileConstants.debug && newContents[index]) {
+                    if (compileConstants.debug && ko.isObservable(newContents[index])) {
                         logWarning("state-manager", `Replacing old knockout observable with a new one, just because it is not created by DotVVM. Please do not assign objects into the knockout tree directly. The object is `, unmapKnockoutObservables(newContents[index]))
                     }
                     const indexForClosure = index

--- a/src/Framework/Framework/Resources/Scripts/tests/stateManagement.test.ts
+++ b/src/Framework/Framework/Resources/Scripts/tests/stateManagement.test.ts
@@ -468,3 +468,41 @@ test("remove on observable array - state is updated immediately", () => {
     expect(vm.Array.state.length).toEqual(2)
 
 })
+
+test("push on observable array - no warning when the new item is not observable", () => {
+    vm.Array([
+        { Id: 1 },
+        { Id: 3 },
+        { Id: 4 },
+    ])
+    s.doUpdateNow();
+    expect(vm.Array().length).toEqual(3)
+    
+    const warn = jest.spyOn(console, 'warn');
+    try {
+        vm.Array.push({ Id: 5 });
+        expect(warn).toHaveBeenCalledTimes(0);
+    }
+    finally {
+        warn.mockRestore();
+    }
+})
+
+test("push on observable array - keep warning when the new item is observable", () => {
+    vm.Array([
+        { Id: 1 },
+        { Id: 3 },
+        { Id: 4 },
+    ])
+    s.doUpdateNow();
+    expect(vm.Array().length).toEqual(3)
+    
+    const warn = jest.spyOn(console, 'warn');
+    try {
+        vm.Array.push(ko.observable({ Id: ko.observable(5) }));
+        expect(warn).toHaveBeenCalled();
+    }
+    finally {
+        warn.mockRestore();
+    }
+})


### PR DESCRIPTION
When the user calls `observableArray.push(someItem)`, DotVVM was always producing a warning "Replacing old knockout observable with a new one, just because it is not created by DotVVM. Please do not assign objects into the knockout tree directly."

I believe the problem can occur only when the user pushes observable objects in the array but not when it is just a plain object.

I've also added tests for this warning.