### PR TITLE
Fixed issue with rejecting requests when restoring closed tabs on chrome

### DIFF
--- a/src/Framework/Framework/Hosting/DotvvmPresenter.cs
+++ b/src/Framework/Framework/Hosting/DotvvmPresenter.cs
@@ -498,14 +498,17 @@ namespace DotVVM.Framework.Hosting
                 { // fine, this is allowed even cross-site
                 }
                 // if SPA is used, dest will be empty, since it's initiated from JS
-                // we only allow this with the X-DotVVM-SpaContentPlaceHolder header
+                // every SPA request has the X-DotVVM-SpaContentPlaceHolder header
                 // we "trust" the client - as if he lies about it being a SPA request,
                 // he'll will just get a redirect response, not anything useful
+                //
+                // however, it is possible that destination is empty also when
+                // restoring closed tabs (tested on chrome)
+                // therefore, we can not discard non-SPA requests either
+
                 else if (dest is "empty")
                 {
-                    if (!DetermineSpaRequest(context.HttpContext))
-                        await context.RejectRequest($"Pages can not be loaded using Javascript for security reasons. If you are the developer, you can disable this check by setting DotvvmConfiguration.Security.VerifySecFetchForPages.DisableForRoute(\"{route}\")");
-                    if (site != "same-origin")
+                    if (DetermineSpaRequest(context.HttpContext) && site != "same-origin")
                         await context.RejectRequest($"Cross site SPA requests are disabled.");
                 }
                 else

--- a/src/Framework/Hosting.AspNetCore/Hosting/DotvvmHeaderCollection.cs
+++ b/src/Framework/Hosting.AspNetCore/Hosting/DotvvmHeaderCollection.cs
@@ -55,7 +55,15 @@ namespace DotVVM.Framework.Hosting
 
         public void CopyTo(KeyValuePair<string, string[]>[] array, int arrayIndex)
         {
-            throw new NotImplementedException();
+            if (array.Length - arrayIndex < OriginalHeaders.Count)
+                throw new ArgumentException("Insufficient array size");
+
+            foreach (var (key, values) in OriginalHeaders)
+            {
+                var valuesCopy = (values.Count > 0) ? new string[values.Count] : Array.Empty<string>();
+                Array.Copy(values, valuesCopy, values.Count);
+                array[arrayIndex++] = new KeyValuePair<string, string[]>(key: key, value: valuesCopy);
+            }
         }
 
         public bool Remove(KeyValuePair<string, string[]> item)


### PR DESCRIPTION
This PR suggests relaxing our security checks, as right now one of them is too strict. Some customers started noticing this issue since 4.0 and I was able to replicate it as well on our samples using chrome.

1. Run samples and open any page (does not need to contain `SpaContentPlaceHolder`)
2. Close the tab
3. Restore the tab
4. Open developer tools

At this point a request is issued with `sec-fetch-destination`=`empty` and `sec-fetch-mode`=`no-cors`