### PR TITLE
Add support for $rawData to ViewModelSymbolicParameter

### DIFF
--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslator.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslator.cs
@@ -20,21 +20,29 @@ namespace DotVVM.Framework.Compilation.Javascript
 {
     public class JavascriptTranslator
     {
-        public static readonly CodeSymbolicParameter KnockoutContextParameter = new ContextSymbolicParameter(0, "");
-        public static readonly CodeSymbolicParameter ParentKnockoutContextParameter = new ContextSymbolicParameter(1, "Parent");
-        public static readonly CodeSymbolicParameter KnockoutViewModelParameter = new ViewModelSymbolicParameter(0, "", "$data");
-        public static readonly CodeSymbolicParameter ParentKnockoutViewModelParameter = new ViewModelSymbolicParameter(1, "Parent", "$parent");
+        /// <summary> Parameter representing the current knockout context (`$context`) </summary>
+        public static readonly ContextSymbolicParameter KnockoutContextParameter = new ContextSymbolicParameter(0, "");
+        /// <summary> Parameter representing the parent knockout context (`$parentContext`) </summary>
+        public static readonly ContextSymbolicParameter ParentKnockoutContextParameter = new ContextSymbolicParameter(1, "Parent");
+        /// <summary> Parameter representing the current view model (`$data`). The view model itself is not an ko.observable, but all it's properties are. </summary>
+        public static readonly ViewModelSymbolicParameter KnockoutViewModelParameter = new ViewModelSymbolicParameter(0, "", false);
+        /// <summary> Parameter representing the current view model in ko.observable (`$rawData`). </summary>
+        public static readonly ViewModelSymbolicParameter KnockoutViewModelObservableParameter = new ViewModelSymbolicParameter(0, "", true);
+        /// <summary> Parameter representing the parent view model (`$parent`). The view model itself is not an ko.observable, but all it's properties are. </summary>
+        public static readonly ViewModelSymbolicParameter ParentKnockoutViewModelParameter = new ViewModelSymbolicParameter(1, "Parent", false);
+        /// <summary> Gets the HTML element where this binding is being evaluated. In knockout bindings, this translates to `$element`, in command bindings (i.e. JS event handlers), it translates to `this` </summary>
         public static readonly CodeSymbolicParameter CurrentElementParameter = new CodeSymbolicParameter("CurrentElement",
             new CodeParameterAssignment("$element", OperatorPrecedence.Max)
         );
 
-        public static CodeSymbolicParameter GetKnockoutViewModelParameter(int parentIndex) => parentIndex switch {
-            < 0 => throw new ArgumentOutOfRangeException("parentIndex"),
-            0 => KnockoutViewModelParameter,
-            1 => ParentKnockoutViewModelParameter,
-            _ => new ViewModelSymbolicParameter(parentIndex, $"Parent{parentIndex}", null)
+        public static ViewModelSymbolicParameter GetKnockoutViewModelParameter(int parentIndex, bool returnsObservable = false) => (parentIndex, returnsObservable) switch {
+            (< 0, _) => throw new ArgumentOutOfRangeException("parentIndex"),
+            (0, false) => KnockoutViewModelParameter,
+            (0, true) => KnockoutViewModelObservableParameter,
+            (1, false) => ParentKnockoutViewModelParameter,
+            _ => new ViewModelSymbolicParameter(parentIndex, $"Parent{parentIndex}", returnsObservable)
         };
-        public static CodeSymbolicParameter GetKnockoutContextParameter(int parentIndex) => parentIndex switch {
+        public static ContextSymbolicParameter GetKnockoutContextParameter(int parentIndex) => parentIndex switch {
             < 0 => throw new ArgumentOutOfRangeException("parentIndex"),
             0 => KnockoutContextParameter,
             1 => ParentKnockoutContextParameter,
@@ -43,18 +51,36 @@ namespace DotVVM.Framework.Compilation.Javascript
 
         public sealed class ViewModelSymbolicParameter: CodeSymbolicParameter
         {
-            internal ViewModelSymbolicParameter(int parentIndex, string description, string? member): base(
+            internal ViewModelSymbolicParameter(int parentIndex, string description, bool returnObservable): base(
                 $"JavascriptTranslator.{description}KnockoutViewModelParameter",
                 new CodeParameterAssignment(
-                    (member is null ? KnockoutContextParameter.ToExpression().Member("$parents").Indexer(new JsLiteral(parentIndex - 1))
-                                    : KnockoutContextParameter.ToExpression().Member(member)).FormatParametrizedScript(),
+                    GetDefaultAssignment(parentIndex, returnObservable),
                     isGlobalContext: parentIndex == 0
                 )
             )
             {
                 this.ParentIndex = parentIndex;
+                this.ReturnObservable = returnObservable;
             }
+            /// <summary> Index in the knockout data context hierarchy. `ParentIndex == 0` means $data, ... </summary>
             public int ParentIndex { get; }
+            /// <summary> If the expression should return knockout observable. For `ReturnObservable == true` and `ParentIndex == 0`, it outputs `$rawData`, for false it outputs `$data`. </summary>
+            public bool ReturnObservable { get; }
+
+            internal static ParametrizedCode GetDefaultAssignment(int parentIndex, bool returnObservable)
+            {
+                return (parentIndex, returnObservable) switch {
+                    (0, _) => KnockoutContextParameter.ToExpression().Member(returnObservable ? "$rawData" : "$data").FormatParametrizedScript(),
+                    (1, false) => KnockoutContextParameter.ToExpression().Member("$parent").FormatParametrizedScript(),
+                    (_, false) => KnockoutContextParameter.ToExpression().Member("$parents").Indexer(new JsLiteral(parentIndex - 1)).FormatParametrizedScript(),
+                    (_, true) => GetKnockoutContextParameter(parentIndex).ToExpression().Member("$rawData").FormatParametrizedScript(),
+                };
+            }
+
+            public ViewModelSymbolicParameter WithIndex(int index) =>
+                index == ParentIndex ? this : JavascriptTranslator.GetKnockoutViewModelParameter(index, ReturnObservable);
+            public ViewModelSymbolicParameter WithReturnsObservable(bool returnsObservable) =>
+                returnsObservable == ReturnObservable ? this : JavascriptTranslator.GetKnockoutViewModelParameter(ParentIndex, returnsObservable);
         }
         public sealed class ContextSymbolicParameter: CodeSymbolicParameter
         {

--- a/src/Framework/Framework/Compilation/Javascript/JsViewModelPropertyAdjuster.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JsViewModelPropertyAdjuster.cs
@@ -143,8 +143,7 @@ namespace DotVVM.Framework.Compilation.Javascript
                 {
                     vmType.ContainsObservables = false;
                     newExpr = (JsExpression)expr.ReplaceWith(_ =>
-                        JavascriptTranslator.GetKnockoutContextParameter(vmSymbol.ParentIndex).ToExpression()
-                            .Member("$rawData")
+                        JavascriptTranslator.GetKnockoutViewModelParameter(vmSymbol.ParentIndex, returnsObservable: true).ToExpression()
                             .Member("state").WithAnnotation(vmType));
                 }
                 else

--- a/src/Framework/Framework/Compilation/Javascript/KnockoutObservableHandlingVisitor.cs
+++ b/src/Framework/Framework/Compilation/Javascript/KnockoutObservableHandlingVisitor.cs
@@ -46,9 +46,9 @@ namespace DotVVM.Framework.Compilation.Javascript
                     node.RemoveAnnotation(MayBeNullAnnotation.Instance);
                 }
             }
-            else if (node is JsSymbolicParameter sp && sp.Symbol == JavascriptTranslator.KnockoutViewModelParameter && !ShouldUnwrap(node))
+            else if (node is JsSymbolicParameter sp && sp.Symbol is JavascriptTranslator.ViewModelSymbolicParameter vm && !ShouldUnwrap(node))
             {
-                node.ReplaceWith(new JsSymbolicParameter(JavascriptTranslator.KnockoutContextParameter).Member("$rawData"));
+                node.ReplaceWith(new JsSymbolicParameter(vm.WithReturnsObservable(true)));
             }
         }
 

--- a/src/Framework/Framework/Controls/HierarchyRepeater.cs
+++ b/src/Framework/Framework/Controls/HierarchyRepeater.cs
@@ -269,8 +269,9 @@ namespace DotVVM.Framework.Controls
                     .GetParametrizedKnockoutExpression(dataItem)
                     .ToString(p =>
                         p == JavascriptTranslator.KnockoutViewModelParameter ? CodeParameterAssignment.FromIdentifier($"ko.unwrap($foreachCollectionSymbol)[{index}]()") :
+                        p == JavascriptTranslator.KnockoutViewModelObservableParameter ? CodeParameterAssignment.FromIdentifier($"ko.unwrap($foreachCollectionSymbol)[{index}]") :
                         p is JavascriptTranslator.ViewModelSymbolicParameter vm ?
-                            JavascriptTranslator.GetKnockoutViewModelParameter(vm.ParentIndex - 1).DefaultAssignment :
+                            vm.WithIndex(vm.ParentIndex - 1).DefaultAssignment :
                         default
                     );
 
@@ -310,8 +311,10 @@ namespace DotVVM.Framework.Controls
                 .ToString(p =>
                     p == JavascriptTranslator.KnockoutViewModelParameter ?
                         CodeParameterAssignment.FromIdentifier("$item()") :
+                    p == JavascriptTranslator.KnockoutViewModelObservableParameter ?
+                        CodeParameterAssignment.FromIdentifier("$item") :
                     p is JavascriptTranslator.ViewModelSymbolicParameter vm ?
-                        JavascriptTranslator.GetKnockoutViewModelParameter(vm.ParentIndex - 1).DefaultAssignment :
+                        vm.WithIndex(vm.ParentIndex - 1).DefaultAssignment :
                     default
                 );
 

--- a/src/Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/Tests/Binding/JavascriptCompilationTests.cs
@@ -266,6 +266,23 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        public void JavascriptCompilation_ParentReference()
+        {
+            var result = bindingHelper.ValueBinding<object>("_parent", new [] {typeof(TestViewModel), typeof(string) });
+            Assert.AreEqual("$parent", FormatKnockoutScript(result.UnwrappedKnockoutExpression));
+            Assert.AreEqual("$parentContext.$rawData", FormatKnockoutScript(result.KnockoutExpression));
+            Assert.AreEqual("$parentContext.$rawData", FormatKnockoutScript(result.WrappedKnockoutExpression));
+        }
+        [TestMethod]
+        public void JavascriptCompilation_ParentPropertyReference()
+        {
+            var result = bindingHelper.ValueBinding<object>("_parent.StringProp", new [] {typeof(TestViewModel), typeof(string) });
+            Assert.AreEqual("$parent.StringProp()", FormatKnockoutScript(result.UnwrappedKnockoutExpression));
+            Assert.AreEqual("$parent.StringProp", FormatKnockoutScript(result.KnockoutExpression));
+            Assert.AreEqual("$parent.StringProp", FormatKnockoutScript(result.WrappedKnockoutExpression));
+        }
+
+        [TestMethod]
         public void JavascriptCompilation_WrappedPropertyAccessExpression()
         {
             var result = bindingHelper.ValueBinding<object>("StringProp", new [] {typeof(TestViewModel) });

--- a/src/Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/Tests/Binding/JavascriptCompilationTests.cs
@@ -257,6 +257,15 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        public void JavascriptCompilation_BindingDateToString()
+        {
+            var result = bindingHelper.ValueBinding<object>("_this.ToString()", new [] { typeof(DateTime) });
+            Assert.AreEqual("dotvvm.globalize.bindingDateToString($rawData)()", FormatKnockoutScript(result.UnwrappedKnockoutExpression));
+            Assert.AreEqual("dotvvm.globalize.bindingDateToString($rawData)", FormatKnockoutScript(result.KnockoutExpression));
+            Assert.AreEqual("dotvvm.globalize.bindingDateToString($rawData)", FormatKnockoutScript(result.WrappedKnockoutExpression));
+        }
+
+        [TestMethod]
         public void JavascriptCompilation_WrappedPropertyAccessExpression()
         {
             var result = bindingHelper.ValueBinding<object>("StringProp", new [] {typeof(TestViewModel) });

--- a/src/Tests/ControlTests/HierarchyRepeaterTests.cs
+++ b/src/Tests/ControlTests/HierarchyRepeaterTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Threading.Tasks;
+using CheckTestOutput;
+using DotVVM.Framework.Compilation;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Tests.Binding;
+using DotVVM.Framework.ViewModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DotVVM.Framework.Testing;
+using System.Security.Claims;
+using System.Collections;
+
+namespace DotVVM.Framework.Tests.ControlTests
+{
+    [TestClass]
+    public class HierarchyRepeaterTests
+    {
+        static readonly ControlTestHelper cth = new ControlTestHelper(config: config => {
+            config.RouteTable.Add("Simple", "Simple", "Simple.dothtml");
+        });
+        OutputChecker check = new OutputChecker("testoutputs");
+
+        [TestMethod]
+        public async Task UsageWithThisInBindings()
+        {
+            var r = await cth.RunPage(typeof(BasicTestViewModel), @"
+                    <dot:HierarchyRepeater DataSource={value: HItems}
+                                           ItemChildrenBinding={value: Children}
+                                           RenderSettings.Mode=Server>
+                        <ItemTemplate>
+                            {{resource: Label}}
+                        </ItemTemplate>
+                    </dot:HierarchyRepeater>
+                "
+            );
+
+            check.CheckString(r.FormattedHtml, fileExtension: "html");
+        }
+
+        public class BasicTestViewModel: DotvvmViewModelBase
+        {
+            public List<SaneHierarchicalItem> HItems { get; set; } = new () {
+                new() {
+                    Label = "A",
+                    Children = {
+                        new() {
+                            Label = "A_1",
+                            Children = {
+                                new() { Label = "A_1_1" },
+                                new() { Label = "A_1_2" }
+                            }
+                        }
+                    }
+                },
+                new() { Label = "B" },
+            };
+
+            public class SaneHierarchicalItem
+            {
+                public string Label { get; set; }
+                public List<SaneHierarchicalItem> Children { get; set; } = new List<SaneHierarchicalItem>();
+            }
+        }
+    }
+}

--- a/src/Tests/ControlTests/testoutputs/HierarchyRepeaterTests.UsageWithThisInBindings.html
+++ b/src/Tests/ControlTests/testoutputs/HierarchyRepeaterTests.UsageWithThisInBindings.html
@@ -1,0 +1,25 @@
+<html>
+	<head></head>
+	<body>
+		
+		<!-- insane hierarchical list, the binding should contain `$item()`, not `$rawData` -->
+		<div>
+			<!-- ko dotvvm-SSR-foreach: { data: HItems } -->
+			<!-- ko dotvvm-SSR-item: 0 -->A
+			<!-- /ko -->
+			<!-- ko dotvvm-SSR-foreach: { data: ko.unwrap($foreachCollectionSymbol)[0]().Children } -->
+			<!-- ko dotvvm-SSR-item: 0 -->A_1
+			<!-- /ko -->
+			<!-- ko dotvvm-SSR-foreach: { data: ko.unwrap($foreachCollectionSymbol)[0]().Children } -->
+			<!-- ko dotvvm-SSR-item: 0 -->A_1_1
+			<!-- /ko -->
+			<!-- ko dotvvm-SSR-item: 1 -->A_1_2
+			<!-- /ko -->
+			<!-- /ko -->
+			<!-- /ko -->
+			<!-- ko dotvvm-SSR-item: 1 -->B
+			<!-- /ko -->
+			<!-- /ko -->
+		</div>
+	</body>
+</html>

--- a/src/Tests/ControlTests/testoutputs/HierarchyRepeaterTests.UsageWithThisInBindings.html
+++ b/src/Tests/ControlTests/testoutputs/HierarchyRepeaterTests.UsageWithThisInBindings.html
@@ -1,8 +1,6 @@
 <html>
 	<head></head>
 	<body>
-		
-		<!-- insane hierarchical list, the binding should contain `$item()`, not `$rawData` -->
 		<div>
 			<!-- ko dotvvm-SSR-foreach: { data: HItems } -->
 			<!-- ko dotvvm-SSR-item: 0 -->A

--- a/src/Tests/ControlTests/testoutputs/MarkupControlTests.MarkupControl_PassingStaticCommand.html
+++ b/src/Tests/ControlTests/testoutputs/MarkupControlTests.MarkupControl_PassingStaticCommand.html
@@ -14,7 +14,7 @@
 		<!-- /ko -->
 		<div data-bind="foreach: { data: Collection }">
 			<div data-bind="dotvvm-with-control-properties: { Click: (...args)=>(dotvvm.applyPostbackHandlers(async (options) => {
-	await dotvvm.staticCommandPostback(&quot;WARNING/NOT/ENCRYPTED+++WyJEb3RWVk0uRnJhbWV3b3JrLlRlc3RzLkJpbmRpbmcuVGVzdFNlcnZpY2UsIERvdFZWTS5GcmFtZXdvcmsuVGVzdHMiLCJTYXZlIixbXSwxLG51bGwsIkFRQT0iXQ==&quot;, [$rawData.state], options);
+	await dotvvm.staticCommandPostback(&quot;WARNING/NOT/ENCRYPTED+++WyJEb3RWVk0uRnJhbWV3b3JrLlRlc3RzLkJpbmRpbmcuVGVzdFNlcnZpY2UsIERvdFZWTS5GcmFtZXdvcmsuVGVzdHMiLCJTYXZlIixbXSwxLG51bGwsIkFRQT0iXQ==&quot;, [$context.$rawData.state], options);
 },$element,[],args,$context)) }">
 				<input onclick="dotvvm.applyPostbackHandlers(async (options) => {
 	let a;


### PR DESCRIPTION
Lack of this feature caused problems in BP, where {value: _this} translated to something using $context, instead
of using the ViewModelSymbolicParameter,
which is easier to process