### PR TITLE
Option to disable checkbox indeterminate mode

### DIFF
--- a/src/Samples/Common/Views/ControlSamples/CheckBox/Indeterminate.dothtml
+++ b/src/Samples/Common/Views/ControlSamples/CheckBox/Indeterminate.dothtml
@@ -15,11 +15,20 @@
                 <fieldset>
                     <legend>Indeterminate CheckBox</legend>
                     <p>
-                        <dot:CheckBox Text="Indeterminate Test" Checked="{value: Indeterminate}" />
+                        <label>
+                            <dot:CheckBox ID="checkbox-indeterminate" Checked="{value: Indeterminate}" />
+                            Indeterminate Test
+                        </label>
                         &nbsp; &nbsp;
                         <dot:Button Text="Reset" Click="{staticCommand: Indeterminate = null}" />
                         &nbsp; &nbsp;
                         <span class="value">{{value: Indeterminate == null ? "Indeterminate": "Other"}}</span>                        
+                    </p>
+                    <p>
+                        <label>
+                            <dot:CheckBox ID="checkbox-no-indeterminate" Checked={value: Indeterminate} DisableIndeterminate />
+                            This checkbox should treat null as unchecked
+                        </label>
                     </p>
                 </fieldset>
             </div>

--- a/src/Samples/Tests/Tests/Control/CheckBoxTests.cs
+++ b/src/Samples/Tests/Tests/Control/CheckBoxTests.cs
@@ -1,5 +1,6 @@
 ﻿using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
+using Newtonsoft.Json;
 using Riganti.Selenium.Core;
 using Riganti.Selenium.DotVVM;
 using Xunit;
@@ -116,15 +117,27 @@ namespace DotVVM.Samples.Tests.Control
             RunInAllBrowsers(browser => {
                 browser.NavigateToUrl(SamplesRouteUrls.ControlSamples_CheckBox_Indeterminate);
 
-                var checkBox = browser.First("input[type=checkbox]");
+                bool isIndeterminate(string id) =>
+                    (bool)browser.GetJavaScriptExecutor().ExecuteScript($"return document.getElementById({JsonConvert.ToString(id)}).indeterminate");
+
+                var checkBox = browser.First("#checkbox-indeterminate");
                 var reset = browser.First("input[type=button]");
                 var value = browser.First("span.value");
 
                 AssertUI.InnerTextEquals(value, "Indeterminate");
+                Assert.True(isIndeterminate("checkbox-indeterminate"), "The checkbox should be in indeterminate state.");
+                Assert.False(isIndeterminate("checkbox-no-indeterminate"), "The checkbox should be unchecked, not in indetermined state.");
+
                 checkBox.Click();
                 AssertUI.InnerTextEquals(value, "Other");
+                Assert.False(isIndeterminate("checkbox-indeterminate"), "The checkbox should not be in indeterminate state anymore.");
+                AssertUI.IsChecked(checkBox);
+                AssertUI.IsChecked(browser.First("#checkbox-no-indeterminate"));
+
                 reset.Click();
                 AssertUI.InnerTextEquals(value, "Indeterminate");
+                Assert.True(isIndeterminate("checkbox-indeterminate"), "The checkbox should be in indeterminate state.");
+                AssertUI.IsNotChecked(browser.First("#checkbox-no-indeterminate"));
             });
         }
 

--- a/src/Samples/Tests/Tests/Control/CheckBoxTests.cs
+++ b/src/Samples/Tests/Tests/Control/CheckBoxTests.cs
@@ -200,7 +200,7 @@ namespace DotVVM.Samples.Tests.Control
                 AssertUI.TextEquals(ul.ElementAt("li", 1), "3: Blue");
 
                 // click button
-                browser.Single("input[type=button]").Click().Wait();
+                browser.Single("input[type=button]").Click();
                 AssertUI.IsNotChecked(checkboxes[0]);
                 AssertUI.IsChecked(checkboxes[1]);
                 AssertUI.IsNotChecked(checkboxes[2]);

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -353,6 +353,9 @@
       },
       "CheckedItems": {
         "type": "System.Collections.IEnumerable"
+      },
+      "DisableIndeterminate": {
+        "type": "System.Boolean"
       }
     },
     "DotVVM.Framework.Controls.ClaimView": {


### PR DESCRIPTION
resolves #862

The syntax is `<dot;CheckBox DisableIndeterminate`, the property is only valid when the checkbox is used in boolean mode, not collection mode. It's not AllowIndeterminate, because then you'd
have to type the `=false`, since we don't want to
make it a default option.