### PR TITLE
Remove colors handed to console.log as arguments

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/utils/logging.ts
+++ b/src/Framework/Framework/Resources/Scripts/utils/logging.ts
@@ -6,20 +6,20 @@ export const level = getLogLevel();
 
 export function logInfoVerbose(area: string, ...args: any[]) {
     if (compileConstants.debug && level === "verbose") {
-        console.log(`%c${area}`, "background-color: #7fdbff", ...args);
+        console.log(`%c${area}`, ...args);
     }
 }
 
 export function logInfo(area: string, ...args: any[]) {
-    console.log(`%c${area}`, "background-color: #f0f0f0", ...args);
+    console.log(`%c${area}`, ...args);
 }
 
 export function logWarning(area: string, ...args: any[]) {
-    console.warn(`%c${area}`, "background-color: #ff851b", ...args);
+    console.warn(`%c${area}`, ...args);
 }
 
 export function logError(area: string, ...args: any[]) {
-    console.error(`%c${area}`, "background-color: #ff4136; color: white", ...args);
+    console.error(`%c${area}`, ...args);
 }
 
 export function logPostBackScriptError(err: any) {


### PR DESCRIPTION
The methods console.log/warn/error already have appropriate coloring in browser's console and doesn't need overriding. Current implementation creates log entries such as this:
![image](https://user-images.githubusercontent.com/17752819/199283264-6457ef66-5e30-410a-ac41-0bcda86ad24c.png)
