### PR TITLE
Fixed issue with not attaching errors when propertyPaths could not be resolved

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/tests/validation.test.ts
+++ b/src/Framework/Framework/Resources/Scripts/tests/validation.test.ts
@@ -120,33 +120,45 @@ describe("DotVVM.Validation - public API", () => {
     test("addErrors - second level nonexistent property", () => {
         //Setup
         const vm = createComplexObservableViewmodel();
+        var warnMock = jest.spyOn(console, 'warn').mockImplementation(() => { });
+        try {
+            //Act
+            validation.addErrors(
+                [
+                    { errorMessage: "Does not matter", propertyPath: "/Prop1/NonExistent" },
+                ],
+                { root: ko.observable(vm) }
+            );
 
-        //Act
-        const act = () => validation.addErrors(
-            [
-                { errorMessage: "Does not matter", propertyPath: "/Prop1/NonExistent" },
-            ],
-            { root: ko.observable(vm) }
-        )
-
-        //Check
-        expect(act).toThrowError("Validation error could not been applied to property specified by propertyPath /Prop1/NonExistent. Property with name NonExistent does not exist on /Prop1.");
+            //Check
+            expect(warnMock).toHaveBeenCalled();
+            expect(warnMock.mock.calls[0][2]).toContain("Unable to find viewmodel property /Prop1/NonExistent");
+        }
+        finally {
+            warnMock.mockRestore();
+        }
     })
 
     test("addErrors - root level nonexistent property", () => {
         //Setup
         const vm = createComplexObservableViewmodel();
+        var warnMock = jest.spyOn(console, 'warn').mockImplementation(() => { });
+        try {
+            //Act
+            validation.addErrors(
+                [
+                    { errorMessage: "Does not matter", propertyPath: "/NonExistent" },
+                ],
+                { root: ko.observable(vm) }
+            );
 
-        //Act
-        const act = () => validation.addErrors(
-            [
-                { errorMessage: "Does not matter", propertyPath: "/NonExistent" },
-            ],
-            { root: ko.observable(vm) }
-        )
-
-        //Check
-        expect(act).toThrowError("Validation error could not been applied to property specified by propertyPath /NonExistent. Property with name NonExistent does not exist on root.");
+            //Check
+            expect(warnMock).toHaveBeenCalled();
+            expect(warnMock.mock.calls[0][2]).toContain("Unable to find viewmodel property /NonExistent");
+        }
+        finally {
+            warnMock.mockRestore();
+        }
     })
 
     test("removeErrors - remove everything from root up", () => {

--- a/src/Framework/Framework/Resources/Scripts/tests/validation.test.ts
+++ b/src/Framework/Framework/Resources/Scripts/tests/validation.test.ts
@@ -132,7 +132,7 @@ describe("DotVVM.Validation - public API", () => {
 
             //Check
             expect(warnMock).toHaveBeenCalled();
-            expect(warnMock.mock.calls[0][2]).toContain("Unable to find viewmodel property /Prop1/NonExistent");
+            expect(warnMock.mock.calls[0][2]).toContain("Validation error could not been applied to property specified by propertyPath /Prop1/NonExistent. Property with name NonExistent does not exist on /Prop1.");
         }
         finally {
             warnMock.mockRestore();
@@ -154,7 +154,7 @@ describe("DotVVM.Validation - public API", () => {
 
             //Check
             expect(warnMock).toHaveBeenCalled();
-            expect(warnMock.mock.calls[0][2]).toContain("Unable to find viewmodel property /NonExistent");
+            expect(warnMock.mock.calls[0][2]).toContain("Validation error could not been applied to property specified by propertyPath /NonExistent. Property with name NonExistent does not exist on root.");
         }
         finally {
             warnMock.mockRestore();

--- a/src/Framework/Framework/Resources/Scripts/validation/validation.ts
+++ b/src/Framework/Framework/Resources/Scripts/validation/validation.ts
@@ -12,7 +12,7 @@ import { getObjectTypeInfo } from "../metadata/typeMap"
 import { tryCoerce } from "../metadata/coercer"
 import { primitiveTypes } from "../metadata/primitiveTypes"
 import { currentStateSymbol, lastSetErrorSymbol } from "../state-manager"
-import { logError } from "../utils/logging"
+import { logError, logWarning } from "../utils/logging"
 
 type ValidationSummaryBinding = {
     target: KnockoutObservable<any>,
@@ -332,11 +332,14 @@ export function removeErrors(...paths: string[]) {
 export function addErrors(errors: ValidationErrorDescriptor[], options: AddErrorsOptions = {}): void {
     const root = options.root ?? dotvvm.viewModelObservables.root
     for (const prop of errors) {
-        // find the property
         const propertyPath = prop.propertyPath;
-        const property = evaluator.traverseContext(root, propertyPath);
-
-        ValidationError.attach(prop.errorMessage, propertyPath, property);
+        try {
+            // find the property
+            const property = evaluator.traverseContext(root, propertyPath);
+            ValidationError.attach(prop.errorMessage, propertyPath, property);
+        } catch (err) {
+            logWarning("validation", err);
+        }
     }
 
     if (options.triggerErrorsChanged !== false && errors.length > 0) {


### PR DESCRIPTION
This PR is cherry-picking important bugfix from #1498. Right now, when attaching errors on an non-existing object, the function throws. Therefore, we never trigger the `validationErrorsChanged` event. At the end even valid errors are not displayed.

Users can encounter this issue in the following ways:
* Manually specifying incorrect property paths using our string notation
* Providing correct expression or correct property path but the viewmodel changes (i.e. the property where we need to attach errors is no longer reachable from root viewmodel)