### PR TITLE
Fix handling of known type metadata in static commands

### DIFF
--- a/src/Framework/Framework/Hosting/DotvvmPresenter.cs
+++ b/src/Framework/Framework/Hosting/DotvvmPresenter.cs
@@ -361,6 +361,7 @@ namespace DotVVM.Framework.Hosting
                 context.CsrfToken = postData["$csrfToken"].Value<string>();
                 CsrfProtector.VerifyToken(context, context.CsrfToken);
 
+                var knownTypes = postData["knownTypeMetadata"].Values<string>().ToArray();
                 var command = postData["command"].Value<string>();
                 var arguments = postData["args"] as JArray;
                 var executionPlan =
@@ -380,7 +381,7 @@ namespace DotVVM.Framework.Hosting
 
                 await OutputRenderer.WriteStaticCommandResponse(
                     context,
-                    ViewModelSerializer.BuildStaticCommandResponse(context, result));
+                    ViewModelSerializer.BuildStaticCommandResponse(context, result, knownTypes));
             }
             finally
             {

--- a/src/Framework/Framework/ViewModel/Serialization/IViewModelSerializer.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/IViewModelSerializer.cs
@@ -9,7 +9,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
     {
         void BuildViewModel(IDotvvmRequestContext context, object? commandResult);
 
-        string BuildStaticCommandResponse(IDotvvmRequestContext context, object? commandResult);
+        string BuildStaticCommandResponse(IDotvvmRequestContext context, object? commandResult, string[]? knownTypeMetadata = null);
 
         string SerializeViewModel(IDotvvmRequestContext context);
 

--- a/src/Framework/Framework/ViewModel/Serialization/IViewModelTypeMetadataSerializer.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/IViewModelTypeMetadataSerializer.cs
@@ -5,7 +5,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
 {
     public interface IViewModelTypeMetadataSerializer
     {
-        JToken SerializeTypeMetadata(IEnumerable<ViewModelSerializationMap> usedSerializationMaps, ISet<string>? knownTypeIds = null);
+        JObject SerializeTypeMetadata(IEnumerable<ViewModelSerializationMap> usedSerializationMaps, ISet<string>? knownTypeIds = null);
     }
 
 }

--- a/src/Framework/Framework/ViewModel/Serialization/ViewModelTypeMetadataSerializer.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/ViewModelTypeMetadataSerializer.cs
@@ -27,7 +27,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
             this.debug = config != null && config.Debug;
         }
 
-        public JToken SerializeTypeMetadata(IEnumerable<ViewModelSerializationMap> usedSerializationMaps, ISet<string>? ignoredTypes = null)
+        public JObject SerializeTypeMetadata(IEnumerable<ViewModelSerializationMap> usedSerializationMaps, ISet<string>? ignoredTypes = null)
         {
             var dependentEnumTypes = new HashSet<Type>();
             var resultJson = new JObject();


### PR DESCRIPTION
We ignored the knownTypeMetadata field sent
by the client and always sent back all the types.