### PR TITLE
Use JS standard library for date parsing and formatting

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/DotVVM.Globalize.ts
+++ b/src/Framework/Framework/Resources/Scripts/DotVVM.Globalize.ts
@@ -69,7 +69,7 @@ export function parseNumber(value: string): number {
     return getGlobalize().parseFloat(value, 10, getCulture());
 }
 
-export function parseDate(value: string, format: string, previousValue?: Date) {
+export function parseDate(value: string, format: string, previousValue?: Date | null) {
     return getGlobalize().parseDate(value, format, getCulture(), previousValue);
 }
 

--- a/src/Framework/Framework/Resources/Scripts/binding-handlers/textbox-text.ts
+++ b/src/Framework/Framework/Resources/Scripts/binding-handlers/textbox-text.ts
@@ -48,41 +48,26 @@ export default {
                 }
 
                 // parse the value
-                let result;
-                let isEmpty;
                 let newValue;
                 if (elmMetadata.dataType === "datetime") {
                     // parse date
-                    let currentValue = obs();
-                    if (currentValue != null) {
-                        currentValue = parseDate(currentValue);
-                    }
-                    result = globalize.parseDate(element.value, elmMetadata.format, currentValue) || globalize.parseDate(element.value, "", currentValue);
-                    isEmpty = result == null;
-                    newValue = isEmpty ? null : serializeDate(result, false);
+                    let currentValue = parseDate(obs());
+                    const result = globalize.parseDate(element.value, elmMetadata.format, currentValue) || globalize.parseDate(element.value, "", currentValue);
+                    newValue = result ? null : serializeDate(result, false);
                 } else if (elmMetadata.dataType === "number") {
                     // parse number
-                    result = globalize.parseNumber(element.value);
-                    isEmpty = result === null || isNaN(result);
-                    newValue = isEmpty ? null : result;
+                    const result = globalize.parseNumber(element.value);
+                    newValue = result == null || isNaN(result) ? null : result;
                 } else if (elmMetadata.dataType === "dateonly") {
                     // parse dateonly
-                    let currentValue = obs();
-                    if (currentValue != null) {
-                        currentValue = parseDateOnly(currentValue);
-                    }
-                    result = globalize.parseDate(element.value, elmMetadata.format, currentValue) || globalize.parseDate(element.value, "", currentValue);
-                    isEmpty = result == null;
-                    newValue = isEmpty ? null : serializeDateOnly(result);
+                    let currentValue = parseDateOnly(obs());
+                    const result = globalize.parseDate(element.value, elmMetadata.format, currentValue) || globalize.parseDate(element.value, "", currentValue);
+                    newValue = !result ? null : serializeDateOnly(result);
                 } else if (elmMetadata.dataType === "timeonly") {
                     // parse timeonly
-                    let currentValue = obs();
-                    if (currentValue != null) {
-                        currentValue = parseTimeOnly(currentValue);
-                    }
-                    result = globalize.parseDate(element.value, elmMetadata.format, currentValue) || globalize.parseDate(element.value, "", currentValue);
-                    isEmpty = result == null;
-                    newValue = isEmpty ? null : serializeTimeOnly(result);
+                    let currentValue = parseTimeOnly(obs());
+                    const result = globalize.parseDate(element.value, elmMetadata.format, currentValue) || globalize.parseDate(element.value, "", currentValue);
+                    newValue = !result ? null : serializeTimeOnly(result);
                 } else {
                     // string
                     newValue = element.value;

--- a/src/Framework/Framework/Resources/Scripts/binding-handlers/textbox-text.ts
+++ b/src/Framework/Framework/Resources/Scripts/binding-handlers/textbox-text.ts
@@ -53,7 +53,7 @@ export default {
                     // parse date
                     let currentValue = parseDate(obs());
                     const result = globalize.parseDate(element.value, elmMetadata.format, currentValue) || globalize.parseDate(element.value, "", currentValue);
-                    newValue = result ? null : serializeDate(result, false);
+                    newValue = !result ? null : serializeDate(result, false);
                 } else if (elmMetadata.dataType === "number") {
                     // parse number
                     const result = globalize.parseNumber(element.value);

--- a/src/Framework/Framework/Resources/Scripts/metadata/primitiveTypes.ts
+++ b/src/Framework/Framework/Resources/Scripts/metadata/primitiveTypes.ts
@@ -222,7 +222,7 @@ function validateTimeSpan(value: any) {
     if (typeof value === "string") {
         // strict DotVVM format parse
         const parsedValue = serializationParseTimeSpan(value);
-        if (parsedValue !== null) {
+        if (parsedValue != null) {
             return { value: serializeTimeSpan(parsedValue) };
         }
     }

--- a/src/Framework/Framework/Resources/Scripts/serialization/date.ts
+++ b/src/Framework/Framework/Resources/Scripts/serialization/date.ts
@@ -2,35 +2,17 @@ import { logWarning } from "../utils/logging";
 
 export function parseDate(value: string | null, convertFromUtc: boolean = false): Date | null {
     if (value == null) return null;
-    const match = value.match("^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})(\\.[0-9]{1,7})$");
-    if (match) {
-        const date = new Date(0);
-        let month = parseInt(match[2], 10) - 1;
-        let day = parseInt(match[3], 10);
+    if (/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d{1,7})?$/.test(value)) {
 
-        //Javascript date object does not support month 00 and rolls to december.
-        //In case of user input of 00 we correct it to january.
-        //This is more user friendly than suddendly having december.
-        month = month < 0 ? 0 : month;
-
-        //Javascript date object does not support day 0 and rolls to 30 or 31 and rolls the month value to previous month.
-        //This results in unpredictable behaviour if user inputs 00 into date input field for instance
-        //We sanitize it to 1st of the same month to avoid this unpredictability
-        day = day < 1 ? 1 : day;
-
-        //We set components of the date by hand, this prevents JS from 'correcting' years 00XX to 19XX
-        date.setMilliseconds(match.length > 7 ? parseInt(match[7].substring(1, 4), 10) : 0);
-        date.setSeconds(parseInt(match[6], 10));
-        date.setMinutes(parseInt(match[5], 10));
-        date.setHours(parseInt(match[4], 10));
-        date.setDate(day);
-        date.setMonth(month);
-        date.setFullYear(parseInt(match[1], 10));
-
-        if (convertFromUtc) {
-            date.setMinutes(date.getMinutes() - date.getTimezoneOffset());
+        // for some reason, we want to support date with 00 everywhere,
+        // so this hack sanitizes the date by setting day and month fields to 1
+        const sanitizedValue = value.replace(/00T/, "01T").replace(/00-(\d\d)T/, "01-$1T")
+        const d = Date.parse(sanitizedValue + (convertFromUtc ? "Z" : ""));
+        if (isNaN(d)) {
+            return null
+        } else {
+            return new Date(d)
         }
-        return date;
     }
     return null;
 }
@@ -45,7 +27,7 @@ export function parseTimeOnly(value: string | null): Date | null {
 
 export function parseTimeSpan(value: string | null): number | null {
     if (value == null) return null;
-    const match = value.match("^(-?)([0-9]+\\.)?([0-9]+):([0-9]{2}):([0-9]{2})(\\.[0-9]{3,7})?$");
+    const match = /^(-?)(\d+\.)?(\d+):(\d\d):(\d\d)(\.\d{3,7})?$/.exec(value);
     if (match) {
         const sign = match[1] ? -1 : 1;
         const days = match[2] ? parseInt(match[2], 10) : 0;
@@ -60,21 +42,15 @@ export function parseTimeSpan(value: string | null): number | null {
 
 export function parseDateTimeOffset(value: string | null): Date | null {
     if (value == null) return null;
-    const match = value.match("^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})(\\.[0-9]{1,7})?(Z|[+-]([0-9]{1,2}):([0-9]{2}))$");
-    if (match) {
-        const offset = match[8] === "Z" ? 0 : ((match[8] === "-" ? -1 : 1) * (parseInt(match[9], 10) * 60 + parseInt(match[10], 10)));
-        return new Date(parseInt(match[1], 10), parseInt(match[2], 10) - 1, parseInt(match[3], 10),
-            parseInt(match[4], 10), parseInt(match[5], 10) + offset, parseInt(match[6], 10), match[7] ? parseInt(match[7].substring(1, 4), 10) : 0);
+    const d = Date.parse(value)
+    if (d) {
+        return new Date(d)
     }
     return null;
 }
 
 function padNumber(value: string | number, digits: number): string {
-    value = value + ""
-    while (value.length < digits) {
-        value = "0" + value;
-    }
-    return value;
+    return (value + "").padStart(digits, "0");
 }
 
 export function serializeDate(date: string | Date | null, convertToUtc: boolean = true): string | null {
@@ -87,32 +63,19 @@ export function serializeDate(date: string | Date | null, convertToUtc: boolean 
         }
         return date;
     }
-    let date2 = new Date(date.getTime());
-    if (convertToUtc) {
-        date2.setMinutes(date.getMinutes() + date.getTimezoneOffset());
-    } else {
-        date2 = date;
-    }
-
-    const y = padNumber(date2.getFullYear(), 4);
-    const m = padNumber((date2.getMonth() + 1), 2);
-    const d = padNumber(date2.getDate(), 2);
-    const h = padNumber(date2.getHours(), 2);
-    const mi = padNumber(date2.getMinutes(), 2);
-    const s = padNumber(date2.getSeconds(), 2);
-    const ms = padNumber(date2.getMilliseconds(), 3);
-    return `${y}-${m}-${d}T${h}:${mi}:${s}.${ms}0000`;
+    return date
+        .toLocaleString( 'sv', { timeZone: convertToUtc ? 'UTC' : undefined } )
+        .replace(' ', 'T')
+        + '.' + padNumber(date.getMilliseconds(), 3) + '0000';
 }
 
 export function serializeDateOnly(date: Date | null): string | null {
     if (date == null) {
         return null;
     }
-
-    const y = padNumber(date.getFullYear(), 4);
-    const m = padNumber((date.getMonth() + 1), 2);
-    const d = padNumber(date.getDate(), 2);
-    return `${y}-${m}-${d}`;
+    // https://stackoverflow.com/a/58633651/3577667
+    // Note that I'm using Sweden as locale because it is one of the countries that uses ISO 8601 format.
+    return date.toLocaleDateString('sv');
 }
 
 export function serializeTimeOnly(date: Date | null): string | null {
@@ -120,11 +83,7 @@ export function serializeTimeOnly(date: Date | null): string | null {
         return null;
     }
 
-    const h = padNumber(date.getHours(), 2);
-    const mi = padNumber(date.getMinutes(), 2);
-    const s = padNumber(date.getSeconds(), 2);
-    const ms = padNumber(date.getMilliseconds(), 3);
-    return `${h}:${mi}:${s}.${ms}0000`;
+    return date.toLocaleTimeString('sv') + '.' + padNumber(date.getMilliseconds(), 3) + '0000';
 }
 
 export function serializeTimeSpan(time: string | number | null): string | null {

--- a/src/Framework/Framework/Resources/Scripts/serialization/date.ts
+++ b/src/Framework/Framework/Resources/Scripts/serialization/date.ts
@@ -1,6 +1,6 @@
 import { logWarning } from "../utils/logging";
 
-export function parseDate(value: string | null, convertFromUtc: boolean = false): Date | null {
+export function parseDate(value: string | null | undefined, convertFromUtc: boolean = false): Date | null {
     if (value == null) return null;
     if (/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d{1,7})?$/.test(value)) {
 
@@ -17,15 +17,15 @@ export function parseDate(value: string | null, convertFromUtc: boolean = false)
     return null;
 }
 
-export function parseDateOnly(value: string | null): Date | null {
+export function parseDateOnly(value: string | null | undefined): Date | null {
     return parseDate(`${value}T00:00:00.00`, false);
 }
 
-export function parseTimeOnly(value: string | null): Date | null {
+export function parseTimeOnly(value: string | null | undefined): Date | null {
     return parseDate(`1970-01-01T${value}`, false);
 }
 
-export function parseTimeSpan(value: string | null): number | null {
+export function parseTimeSpan(value: string | null | undefined): number | null {
     if (value == null) return null;
     const match = /^(-?)(\d+\.)?(\d+):(\d\d):(\d\d)(\.\d{3,7})?$/.exec(value);
     if (match) {
@@ -40,7 +40,7 @@ export function parseTimeSpan(value: string | null): number | null {
     return null;
 }
 
-export function parseDateTimeOffset(value: string | null): Date | null {
+export function parseDateTimeOffset(value: string | null | undefined): Date | null {
     if (value == null) return null;
     const d = Date.parse(value)
     if (d) {
@@ -68,42 +68,17 @@ export function serializeDate(date: string | Date | null, convertToUtc: boolean 
         .replace(' ', 'T')
         + '.' + padNumber(date.getMilliseconds(), 3) + '0000';
 }
-
-export function serializeDateOnly(date: Date | null): string | null {
-    if (date == null) {
-        return null;
-    }
+export function serializeDateOnly(date: Date): string {
     // https://stackoverflow.com/a/58633651/3577667
     // Note that I'm using Sweden as locale because it is one of the countries that uses ISO 8601 format.
     return date.toLocaleDateString('sv');
 }
 
-export function serializeTimeOnly(date: Date | null): string | null {
-    if (date == null) {
-        return null;
-    }
-
+export function serializeTimeOnly(date: Date): string {
     return date.toLocaleTimeString('sv') + '.' + padNumber(date.getMilliseconds(), 3) + '0000';
 }
 
-export function serializeTimeSpan(time: string | number | null): string | null {
-    let ticks: number;
-
-    if (time === null) {
-        return null;
-    } else if (typeof time == "string") {
-        // just print in the console if it's invalid
-        const parsedTime = parseTimeSpan(time);
-        if (parsedTime === null) {
-            logWarning("coercer", `TimeSpan ${time} is invalid.`);
-            return null;
-        }
-
-        ticks = parsedTime;
-    } else {
-        ticks = time;
-    }
-    
+export function serializeTimeSpan(ticks: number): string {
     const sign = ticks >= 0 ? "" : "-";
     ticks = Math.abs(ticks);
     const hours = (ticks / 1000 / 3600) | 0;

--- a/src/Framework/Framework/Resources/Scripts/serialization/date.ts
+++ b/src/Framework/Framework/Resources/Scripts/serialization/date.ts
@@ -67,13 +67,11 @@ export function serializeDate(date: string | Date | null, convertToUtc: boolean 
     return serializeDateOnly(date) + "T" + serializeTimeOnly(date);
 }
 export function serializeDateOnly(date: Date): string {
-    // https://stackoverflow.com/a/58633651/3577667
-    // Note that I'm using Sweden as locale because it is one of the countries that uses ISO 8601 format.
     return padNumber(date.getFullYear(), 4) + "-" + padNumber(date.getMonth() + 1, 2) + "-" + padNumber(date.getDate(), 2)
 }
 
 export function serializeTimeOnly(date: Date): string {
-    return date.toLocaleTimeString('sv') + '.' + padNumber(date.getMilliseconds(), 3) + '0000';
+    return padNumber(date.getHours(), 2) + ':' + padNumber(date.getMinutes(), 2) + ':' + padNumber(date.getSeconds(), 2) + '.' + padNumber(date.getMilliseconds(), 3) + '0000';
 }
 
 export function serializeTimeSpan(ticks: number): string {

--- a/src/Framework/Framework/Resources/Scripts/serialization/date.ts
+++ b/src/Framework/Framework/Resources/Scripts/serialization/date.ts
@@ -1,8 +1,7 @@
 import { logWarning } from "../utils/logging";
 
 export function parseDate(value: string | null | undefined, convertFromUtc: boolean = false): Date | null {
-    if (value == null) return null;
-    if (/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d{1,7})?$/.test(value)) {
+    if (value && /^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d{1,7})?$/.test(value)) {
 
         // for some reason, we want to support date with 00 everywhere,
         // so this hack sanitizes the date by setting day and month fields to 1
@@ -41,8 +40,7 @@ export function parseTimeSpan(value: string | null | undefined): number | null {
 }
 
 export function parseDateTimeOffset(value: string | null | undefined): Date | null {
-    if (value == null) return null;
-    const d = Date.parse(value)
+    const d = Date.parse(value!)
     if (d) {
         return new Date(d)
     }
@@ -63,15 +61,15 @@ export function serializeDate(date: string | Date | null, convertToUtc: boolean 
         }
         return date;
     }
-    return date
-        .toLocaleString( 'sv', { timeZone: convertToUtc ? 'UTC' : undefined } )
-        .replace(' ', 'T')
-        + '.' + padNumber(date.getMilliseconds(), 3) + '0000';
+    if (convertToUtc) {
+        return date.toISOString().replace(/Z$/, "") + '0000'
+    }
+    return serializeDateOnly(date) + "T" + serializeTimeOnly(date);
 }
 export function serializeDateOnly(date: Date): string {
     // https://stackoverflow.com/a/58633651/3577667
     // Note that I'm using Sweden as locale because it is one of the countries that uses ISO 8601 format.
-    return date.toLocaleDateString('sv');
+    return padNumber(date.getFullYear(), 4) + "-" + padNumber(date.getMonth() + 1, 2) + "-" + padNumber(date.getDate(), 2)
 }
 
 export function serializeTimeOnly(date: Date): string {

--- a/src/Framework/Framework/Resources/Scripts/serialization/deserialize.ts
+++ b/src/Framework/Framework/Resources/Scripts/serialization/deserialize.ts
@@ -40,12 +40,7 @@ export function deserializePrimitive(viewModel: any, target?: any): any {
 }
 
 export function deserializeDate(viewModel: any, target?: any): any {
-    serializeDate(viewModel);
-    if (ko.isObservable(target)) {
-        target(viewModel);
-        return target;
-    }
-    return viewModel;
+    return deserializePrimitive(target, serializeDate(viewModel));
 }
 
 export function deserializeArray(viewModel: any, target?: any, deserializeAll: boolean = false): any {

--- a/src/Framework/Framework/Resources/Scripts/serialization/deserialize.ts
+++ b/src/Framework/Framework/Resources/Scripts/serialization/deserialize.ts
@@ -40,7 +40,7 @@ export function deserializePrimitive(viewModel: any, target?: any): any {
 }
 
 export function deserializeDate(viewModel: any, target?: any): any {
-    viewModel = serializeDate(viewModel);
+    serializeDate(viewModel);
     if (ko.isObservable(target)) {
         target(viewModel);
         return target;

--- a/src/Framework/Framework/Resources/Scripts/serialization/deserialize.ts
+++ b/src/Framework/Framework/Resources/Scripts/serialization/deserialize.ts
@@ -40,7 +40,7 @@ export function deserializePrimitive(viewModel: any, target?: any): any {
 }
 
 export function deserializeDate(viewModel: any, target?: any): any {
-    return deserializePrimitive(target, serializeDate(viewModel));
+    return deserializePrimitive(serializeDate(viewModel), target);
 }
 
 export function deserializeArray(viewModel: any, target?: any, deserializeAll: boolean = false): any {

--- a/src/Framework/Framework/Resources/Scripts/tests/date.test.ts
+++ b/src/Framework/Framework/Resources/Scripts/tests/date.test.ts
@@ -1,4 +1,12 @@
-﻿import { parseDate } from "../serialization/date"
+﻿import { parseDate, parseDateOnly, parseDateTimeOffset, parseTimeOnly, parseTimeSpan, serializeDateOnly, serializeTimeOnly } from "../serialization/date"
+
+test("Date invalid", () => {
+    expect(parseDate("")).toBe(null);
+    expect(parseDate("2021-01-40T12:12:12")).toBe(null);
+    expect(parseDate("2020-01-01T12:12:12.")).toBe(null);
+    expect(parseDate("2020-01-01T12:12:12.grrrr")).toBe(null);
+    expect(parseDate("blablabla2020-01-01T12:12:12")).toBe(null);
+})
 
 test("Date 6:58:10.500001 PM 8/10/2022", () => {
     testDateIsSameAfterParse("2022-08-10T18:58:10.501000");
@@ -68,3 +76,52 @@ function testDateIsSameAfterParse(dateInputString: string, expectedOutputDateStr
 
     expect(outputDateString).toBe(expectedOutputDateString);
 }
+
+
+test("date parse null propagation", () => {
+    expect(parseDate(null)).toBe(null)
+    expect(parseDate(undefined)).toBe(null)
+    expect(parseDateOnly(null)).toBe(null)
+    expect(parseDateOnly(undefined)).toBe(null)
+    expect(parseTimeOnly(null)).toBe(null)
+    expect(parseTimeOnly(undefined)).toBe(null)
+    expect(parseTimeSpan(null)).toBe(null)
+    expect(parseTimeSpan(undefined)).toBe(null)
+    expect(parseDateTimeOffset(null)).toBe(null)
+    expect(parseDateTimeOffset(undefined)).toBe(null)
+})
+
+
+test("DateTimeOffset parse", () => {
+    const d = parseDateTimeOffset("2021-06-28T15:28:31.000000+02:00")
+    // we only know the UTC time of d, toLocalString() would be in local time of whoever is running the test
+    expect(d?.toISOString()).toBe("2021-06-28T13:28:31.000Z")
+})
+test("DateTimeOffset invalid", () => {
+    expect(parseDateTimeOffset("")).toBe(null)
+    expect(parseDateTimeOffset("2021-01-40T15:28:31.000000+02:00")).toBe(null)
+})
+
+test("DateOnly serialize", () => {
+    expect(serializeDateOnly(new Date(2020, 1, 29))).toBe("2020-02-29")
+})
+
+test("DateOnly parse", () => {
+    const d = parseDateOnly("2020-01-10")
+    expect(d?.toLocaleString('sv')).toBe("2020-01-10 00:00:00")
+
+    expect(serializeDateOnly(d!)).toBe("2020-01-10")
+})
+
+test("TimeOnly serialize", () => {
+    expect(serializeTimeOnly(new Date(0, 0, 1, 10, 10, 10, 123))).toBe("10:10:10.1230000")
+})
+
+test("TimeOnly parse", () => {
+    const d = parseTimeOnly("18:58:10.501")
+    expect(d?.toLocaleTimeString('sv')).toBe("18:58:10")
+    expect(d?.getHours()).toBe(18)
+    expect(d?.getMilliseconds()).toBe(501)
+
+    expect(serializeTimeOnly(d!)).toBe("18:58:10.5010000")
+})

--- a/src/Framework/Framework/Resources/Scripts/tests/date.test.ts
+++ b/src/Framework/Framework/Resources/Scripts/tests/date.test.ts
@@ -1,4 +1,4 @@
-﻿import { parseDate, parseDateOnly, parseDateTimeOffset, parseTimeOnly, parseTimeSpan, serializeDateOnly, serializeTimeOnly } from "../serialization/date"
+﻿import { parseDate, parseDateOnly, parseDateTimeOffset, parseTimeOnly, parseTimeSpan, serializeDate, serializeDateOnly, serializeTimeOnly } from "../serialization/date"
 
 test("Date invalid", () => {
     expect(parseDate("")).toBe(null);
@@ -75,6 +75,9 @@ function testDateIsSameAfterParse(dateInputString: string, expectedOutputDateStr
     expectedOutputDateString = expectedOutputDateString ?? dateInputString;
 
     expect(outputDateString).toBe(expectedOutputDateString);
+
+    const serializedDate = serializeDate(date, false)!;
+    expect(serializedDate.replace(/0+$/, "")).toBe(expectedOutputDateString.replace(/0+$/, ""));
 }
 
 

--- a/src/Framework/Framework/Resources/Scripts/tests/serialization.fastcheck.test.ts
+++ b/src/Framework/Framework/Resources/Scripts/tests/serialization.fastcheck.test.ts
@@ -15,7 +15,6 @@ test('Serialize and parse date', () => {
             const parsedDate = parseDate(serialized!)
             expect(date).toStrictEqual(parsedDate)
 
-            // hmm, actually, I don't know why this works 🤔
             const normalParsed = new Date(serialized!)
             expect(normalParsed).toStrictEqual(date)
 

--- a/src/Framework/Framework/Resources/Scripts/tests/serialization.test.ts
+++ b/src/Framework/Framework/Resources/Scripts/tests/serialization.test.ts
@@ -1,4 +1,4 @@
-﻿import dotvvm from '../dotvvm-root'
+import dotvvm from '../dotvvm-root'
 import { deserialize } from '../serialization/deserialize'
 import { serialize } from '../serialization/serialize'
 import { serializeDate } from '../serialization/date'

--- a/src/Framework/Framework/Resources/Scripts/typings/globalize/globalize.d.ts
+++ b/src/Framework/Framework/Resources/Scripts/typings/globalize/globalize.d.ts
@@ -1,6 +1,6 @@
 interface GlobalizeStatic {
     format(value: Date | number, format: string, cultureSelector?: string): string;
-    parseDate(value: string, formats: string, cultureSelector?: string, previousValue?: Date): Date | null;
+    parseDate(value: string, formats: string, cultureSelector?: string, previousValue?: Date | null): Date | null;
     parseFloat(value: string, radix?: number, cultureSelector?: string): number;
     parseInt(value: string, radix?: number, cultureSelector?: string): number;
 }

--- a/src/Framework/Framework/package.json
+++ b/src/Framework/Framework/package.json
@@ -21,6 +21,7 @@
     "build-development": "rollup -c && npm run tsc-types",
     "build-rollup": "npm run build-production && npm run build-development",
     "build-production": "rollup -c --environment BUILD:production",
+    "test": "jest --silent",
     "tsc-check": "tsc -p . --noEmit",
     "tsc-types": "tsc -d -p . --outFile ./obj/typescript-types/dotvvm.d.ts --emitDeclarationOnly --skipLibCheck"
   }

--- a/src/Samples/Common/Views/FeatureSamples/JavascriptTranslation/DateTimeTranslations.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/JavascriptTranslation/DateTimeTranslations.dothtml
@@ -7,7 +7,7 @@
     <meta charset="utf-8" />
     <title></title>
 
-    <script src="https://cdn.jsdelivr.net/npm/timeshift-js@1.1.1/timeshift.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/timeshift-js@1.2.0/timeshift.min.js"></script>
     <script>
         // force UTC+01:00 for the test (careful - TimeShift cannot emulate timezones with DST, it only forces the offset)
         Date = TimeShift.Date;

--- a/src/Samples/Common/Views/FeatureSamples/JavascriptTranslation/DateTimeTranslations.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/JavascriptTranslation/DateTimeTranslations.dothtml
@@ -9,9 +9,20 @@
 
     <script src="https://cdn.jsdelivr.net/npm/timeshift-js@1.2.0/timeshift.min.js"></script>
     <script>
-        // force UTC+01:00 for the test (careful - TimeShift cannot emulate timezones with DST, it only forces the offset)
-        Date = TimeShift.Date;
-        TimeShift.setTimezoneOffset(-120);
+        (function () {
+            // force UTC+01:00 for the test (careful - TimeShift cannot emulate timezones with DST, it only forces the offset)
+            const originalDate = Date
+
+            TimeShift.Date.parse = function (date) {
+                let x = originalDate.parse(date)
+                if (date.endsWith("Z")) {
+                    return x
+                }
+                return x + TimeShift.getTimezoneOffset() * 60 * 1000
+            }
+            window.Date = TimeShift.Date;
+            TimeShift.setTimezoneOffset(-120);
+        }())
     </script>
 </head>
 <body>


### PR DESCRIPTION
This avoids some known problems:

* setting year after setting setting day leads to problems on lap years
* datetimeoffset parsing didn't use setFullYear, so year<100 was parsed as year 19__

Using Date.parse shouldn't bring new issues,
we had an assert that it behaves same in the fastcheck test for some time.

Maybe the hack with Sweden is questionable  (: