### PR TITLE
Improved error message on DataContext mismatch

### DIFF
--- a/src/Framework/Framework/Binding/ControlPropertyBindingDataContextChangeAttribute.cs
+++ b/src/Framework/Framework/Binding/ControlPropertyBindingDataContextChangeAttribute.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using DotVVM.Framework.Binding.Expressions;
 using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Controls;
@@ -29,11 +31,26 @@ namespace DotVVM.Framework.Binding
                 throw new Exception($"The property '{PropertyName}' was not found on control '{control.Metadata.Type}'!");
             }
 
+            [DoesNotReturn]
+            void ThrowDataContextMismatch(IAbstractBinding binding)
+            {
+                var sb = new StringBuilder();
+                sb.Append($"The '{controlProperty.Name}' property contains invalid data-binding. ");
+                sb.Append($"Binding '{binding}' could not be constructed on current context ({dataContext})");
+                throw new Exception(sb.ToString());
+            }
+
             if (control.TryGetProperty(controlProperty, out var setter))
             {
-                return setter is IAbstractPropertyBinding binding
-                    ? binding.Binding.ResultType ?? throw new Exception($"The '{controlProperty.Name}' property contains invalid data-binding")
-                    : dataContext;
+                if (setter is IAbstractPropertyBinding binding)
+                {
+                    if (binding.Binding.ResultType == null)
+                        ThrowDataContextMismatch(binding.Binding);
+
+                    return binding.Binding.ResultType;
+                }
+
+                return dataContext;
             }
 
             if (AllowMissingProperty)


### PR DESCRIPTION
This PR improves error message when user does something weird with data contexts. Example:

## ViewModel
```csharp
    public class CollectionIndexViewModel : DotvvmViewModelBase
    {
        public List<int> Collection { get; set; } = Enumerable.Range(0, 4).ToList();
        public SomeOtherType Property { get; set; }
    }
```

## View
```html
<div class="container" DataContext="{value: Property}">
   <dot:Repeater DataSource="{value: Collection}" RenderSettings.Mode="Client">
      ...
   </dot:Repeater>
</div>
```

## Original error message
>Could not compute the type of DataContext: System.Exception: The 'DataSource' property contains invalid data-binding

## New errror message
>Could not compute the type of DataContext: System.Exception: The 'DataSource' property contains invalid data-binding. Binding '{value: Collection}' could not be constructed on DataContext 'TestNamespace.SomeOtherType'