### PR TITLE
Fix deserialization when a viewmodel is also a service

### DIFF
--- a/src/Framework/Framework/ViewModel/Serialization/ViewModelSerializationMap.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/ViewModelSerializationMap.cs
@@ -91,7 +91,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
                 var prop = Properties.FirstOrDefault(pp => pp.ConstructorParameter == p);
                 if (prop is null)
                 {
-                    var mayBeService = !ReflectionUtils.IsPrimitiveType(p.ParameterType) && !typeof(IDotvvmViewModel).IsAssignableFrom(p.ParameterType);
+                    var mayBeService = !ReflectionUtils.IsPrimitiveType(p.ParameterType);
                     if (!mayBeService)
                         throw new Exception($"Can not deserialize {Type.ToCode()}, constructor parameter {p.Name} is not mapped to any property.");
 


### PR DESCRIPTION
Turns out people register viewmodels as services into DI, so our heuristic for "better" error handling breaks code.