### PR TITLE
Move data context resolving into the compiled BindingDelegate

### DIFF
--- a/src/AutoUI/Core/Metadata/LocalizableString.cs
+++ b/src/AutoUI/Core/Metadata/LocalizableString.cs
@@ -47,7 +47,7 @@ namespace DotVVM.AutoUI.Metadata
                         new ParsedExpressionBindingProperty(
                             ExpressionUtils.Replace(() => this.Localize())
                         ),
-                        (BindingDelegate)((_, _) => this.Localize()) // skip the expression compilation
+                        (BindingDelegate)(_ => this.Localize()) // skip the expression compilation
                     }
                 );
                 return new ValueOrBinding<string>(binding);

--- a/src/Framework/Framework/Binding/BindingHelper.cs
+++ b/src/Framework/Framework/Binding/BindingHelper.cs
@@ -112,9 +112,8 @@ namespace DotVVM.Framework.Binding
         /// </summary>
         public static void ExecUpdateDelegate(this BindingUpdateDelegate func, DotvvmBindableObject contextControl, object? value)
         {
-            var dataContexts = GetDataContexts(contextControl);
             //var control = contextControl.GetClosestControlBindingTarget();
-            func(dataContexts.ToArray(), contextControl, value);
+            func(contextControl, value);
         }
 
         /// <summary>
@@ -122,9 +121,8 @@ namespace DotVVM.Framework.Binding
         /// </summary>
         public static void ExecUpdateDelegate<T>(this BindingUpdateDelegate<T> func, DotvvmBindableObject contextControl, T value)
         {
-            var dataContexts = GetDataContexts(contextControl);
             //var control = contextControl.GetClosestControlBindingTarget();
-            func(dataContexts.ToArray(), contextControl, value);
+            func(contextControl, value);
         }
 
         /// <summary>
@@ -132,8 +130,7 @@ namespace DotVVM.Framework.Binding
         /// </summary>
         public static object? ExecDelegate(this BindingDelegate func, DotvvmBindableObject contextControl)
         {
-            var dataContexts = GetDataContexts(contextControl);
-            return func(dataContexts.ToArray(), contextControl);
+            return func(contextControl);
         }
 
         /// <summary>
@@ -141,8 +138,7 @@ namespace DotVVM.Framework.Binding
         /// </summary>
         public static T ExecDelegate<T>(this BindingDelegate<T> func, DotvvmBindableObject contextControl)
         {
-            var dataContexts = GetDataContexts(contextControl);
-            return func(dataContexts.ToArray(), contextControl);
+            return func(contextControl);
         }
 
         /// <summary>
@@ -459,8 +455,8 @@ namespace DotVVM.Framework.Binding
             }
         }
 
-        public static BindingDelegate<T> ToGeneric<T>(this BindingDelegate d) => (a, b) => (T)d(a, b)!;
-        public static BindingUpdateDelegate<T> ToGeneric<T>(this BindingUpdateDelegate d) => (a, b, c) => d(a, b, c);
+        public static BindingDelegate<T> ToGeneric<T>(this BindingDelegate d) => control => (T)d(control)!;
+        public static BindingUpdateDelegate<T> ToGeneric<T>(this BindingUpdateDelegate d) => (control, val) => d(control, val);
 
         public static string GetBindingName(this IBinding binding) =>
             binding switch {

--- a/src/Framework/Framework/Binding/BindingHelper.cs
+++ b/src/Framework/Framework/Binding/BindingHelper.cs
@@ -19,6 +19,7 @@ using DotVVM.Framework.Compilation.Binding;
 using DotVVM.Framework.Compilation;
 using DotVVM.Framework.Runtime;
 using FastExpressionCompiler;
+using System.Diagnostics;
 
 namespace DotVVM.Framework.Binding
 {
@@ -149,9 +150,12 @@ namespace DotVVM.Framework.Binding
             DotvvmBindableObject? c = contextControl;
             while (c != null)
             {
-                // PERF: O(h^2) because GetValue calls another GetDataContexts
+                // this has O(h^2) complexity because GetValue calls another GetDataContexts,
+                // but this function is used rarely - for exceptions, manually created bindings, ...
+                // Normal bindings have specialized code generated in BindingCompiler
                 if (c.IsPropertySet(DotvvmBindableObject.DataContextProperty, inherit: false))
                 {
+                    Debug.Assert(c.properties.Contains(DotvvmBindableObject.DataContextProperty), "Control claims that DataContextProperty is set, but it's not present in the properties dictionary.");
                     yield return c.GetValue(DotvvmBindableObject.DataContextProperty);
                     count--;
                 }

--- a/src/Framework/Framework/Binding/BindingHelper.cs
+++ b/src/Framework/Framework/Binding/BindingHelper.cs
@@ -230,6 +230,9 @@ namespace DotVVM.Framework.Binding
         public static object? Evaluate(this ICommandBinding binding, DotvvmBindableObject control, params Func<Type, object>[] args)
         {
             var action = binding.GetCommandDelegate(control);
+            if (action is null)
+                // only if data context is null will our compiler return null instead of command delegate
+                throw new DotvvmControlException(control, $"Cannot invoke {binding}, a referenced data context is null") { RelatedBinding = binding }; 
             if (action is Command command) return command();
             if (action is Action actionDelegate) { actionDelegate(); return null; }
             if (action is Func<Task> command2) return command2();

--- a/src/Framework/Framework/Binding/BindingPropertyException.cs
+++ b/src/Framework/Framework/Binding/BindingPropertyException.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using DotVVM.Framework.Binding.Expressions;
 using DotVVM.Framework.Compilation;
 using DotVVM.Framework.Runtime;
+using FastExpressionCompiler;
 using Newtonsoft.Json;
 
 namespace DotVVM.Framework.Binding
@@ -43,7 +44,7 @@ namespace DotVVM.Framework.Binding
             var pathMsg = "";
             if (properties.Length > 1)
             {
-                pathMsg = $" Property path: {string.Join(", ", properties.Select(p => p.Name))}";
+                pathMsg = $" Property path: {string.Join(", ", properties.Select(p => p.ToCode(stripNamespace: true)))}";
                 if (innerException is null)
                     pathMsg += " - adding any of those properties to the binding would fix the issue";
                 pathMsg += ".";

--- a/src/Framework/Framework/Binding/Expressions/BindingDelegates.cs
+++ b/src/Framework/Framework/Binding/Expressions/BindingDelegates.cs
@@ -5,8 +5,8 @@ using DotVVM.Framework.Runtime.Filters;
 
 namespace DotVVM.Framework.Binding.Expressions
 {
-    public delegate object? BindingDelegate(object?[] dataContextHierarchy, DotvvmBindableObject rootControl);
-    public delegate T BindingDelegate<out T>(object?[] dataContextHierarchy, DotvvmBindableObject rootControl);
-    public delegate void BindingUpdateDelegate(object?[] dataContextHierarchy, DotvvmBindableObject rootControl, object? value);
-    public delegate void BindingUpdateDelegate<in T>(object?[] dataContextHierarchy, DotvvmBindableObject rootControl, T value);
+    public delegate object? BindingDelegate(DotvvmBindableObject rootControl);
+    public delegate T BindingDelegate<out T>(DotvvmBindableObject rootControl);
+    public delegate void BindingUpdateDelegate(DotvvmBindableObject rootControl, object? value);
+    public delegate void BindingUpdateDelegate<in T>(DotvvmBindableObject rootControl, T value);
 }

--- a/src/Framework/Framework/Binding/Expressions/CommandBindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/CommandBindingExpression.cs
@@ -153,15 +153,15 @@ namespace DotVVM.Framework.Binding.Expressions
                 default);
 
         public CommandBindingExpression(BindingCompilationService service, Action<object[]> command, string id)
-            : this(service, (h, o) => (Action)(() => command(h!)), id)
+            : this(service, c => (Action)(() => command(BindingHelper.GetDataContexts(c).ToArray()!)), id)
         { }
 
         public CommandBindingExpression(BindingCompilationService service, Func<object[], Task> command, string id)
-            : this(service, (h, o) => (Command)(() => command(h!)), id)
+            : this(service, c => (Command)(() => command(BindingHelper.GetDataContexts(c).ToArray()!)), id)
         { }
 
         public CommandBindingExpression(BindingCompilationService service, Delegate command, string id)
-            : this(service, (h, o) => command, id)
+            : this(service, c => command, id)
         { }
 
         public CommandBindingExpression(BindingCompilationService service, BindingDelegate command, string id)

--- a/src/Framework/Framework/Binding/Expressions/ValueBindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/ValueBindingExpression.cs
@@ -113,7 +113,7 @@ namespace DotVVM.Framework.Binding.Expressions
         /// Crates a new value binding expression from the specified .NET delegate and Javascript expression. Note that this operation is not very cheap and the result is not cached.
         public static ValueBindingExpression<T> CreateBinding<T>(BindingCompilationService service, Func<object?[], T> func, JsExpression expression, DataContextStack? dataContext = null) =>
             new ValueBindingExpression<T>(service, new object?[] {
-                new BindingDelegate((o, c) => func(o)),
+                new BindingDelegate(c => func(BindingHelper.GetDataContexts(c).ToArray())),
                 new ResultTypeBindingProperty(typeof(T)),
                 new KnockoutJsExpressionBindingProperty(expression),
                 dataContext
@@ -122,7 +122,7 @@ namespace DotVVM.Framework.Binding.Expressions
         /// Crates a new value binding expression from the specified .NET delegate and Javascript expression. Note that this operation is not very cheap and the result is not cached.
         public static ValueBindingExpression<T> CreateBinding<T>(BindingCompilationService service, Func<object?[], T> func, ParametrizedCode expression, DataContextStack? dataContext = null, object?[]? additionalProperties = null) =>
             new ValueBindingExpression<T>(service, new object?[] {
-                new BindingDelegate((o, c) => func(o)),
+                new BindingDelegate(c => func(BindingHelper.GetDataContexts(c).ToArray())),
                 new ResultTypeBindingProperty(typeof(T)),
                 new KnockoutExpressionBindingProperty(expression, expression, expression),
                 dataContext

--- a/src/Framework/Framework/Binding/ValueOrBindingExtensions.cs
+++ b/src/Framework/Framework/Binding/ValueOrBindingExtensions.cs
@@ -192,7 +192,7 @@ public static class ValueOrBindingExtensions
                     new ParsedExpressionBindingProperty(expr),
                     new CastedExpressionBindingProperty(expr),
                     new KnockoutJsExpressionBindingProperty(JavascriptTranslationVisitor.TranslateConstant(expr)),
-                    new BindingDelegate((_, _) => constant)
+                    new BindingDelegate(_ => constant)
                 });
             });
 

--- a/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
+++ b/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
@@ -61,7 +61,7 @@ namespace DotVVM.Framework.Compilation.Binding
             expr = new ExpressionNullPropagationVisitor(e => true).Visit(expr);
             expr = ExpressionUtils.ConvertToObject(expr);
             expr = replacementVisitor.WrapExpression(expr, contextObject: binding);
-            var l = Expression.Lambda<BindingDelegate>(expr, BindingCompiler.ViewModelsParameter, BindingCompiler.CurrentControlParameter);
+            var l = Expression.Lambda<BindingDelegate>(expr, BindingCompiler.CurrentControlParameter);
             // Console.WriteLine(l.ToCSharpString());
             return l;
         }
@@ -92,7 +92,6 @@ namespace DotVVM.Framework.Compilation.Binding
 
             return Expression.Lambda<BindingUpdateDelegate>(
                 body,
-                BindingCompiler.ViewModelsParameter,
                 BindingCompiler.CurrentControlParameter,
                 valueParameter);
         }

--- a/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
+++ b/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
@@ -62,6 +62,8 @@ namespace DotVVM.Framework.Compilation.Binding
             expr = ExpressionUtils.ConvertToObject(expr);
             expr = replacementVisitor.WrapExpression(expr, contextObject: binding);
             var l = Expression.Lambda<BindingDelegate>(expr, BindingCompiler.CurrentControlParameter);
+            // Console.WriteLine(new string('-', 80));
+            // Console.WriteLine(binding.ToString());
             // Console.WriteLine(l.ToCSharpString());
             return l;
         }
@@ -88,6 +90,8 @@ namespace DotVVM.Framework.Compilation.Binding
             {
                 return null;
             }
+            // return void
+            body = Expression.Block(body, Expression.Default(typeof(void)));
             body = replacementVisitor.WrapExpression(body, contextObject: binding);
 
             return Expression.Lambda<BindingUpdateDelegate>(

--- a/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
+++ b/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
@@ -61,11 +61,11 @@ namespace DotVVM.Framework.Compilation.Binding
             expr = new ExpressionNullPropagationVisitor(e => true).Visit(expr);
             expr = ExpressionUtils.ConvertToObject(expr);
             expr = replacementVisitor.WrapExpression(expr, contextObject: binding);
-            var l = Expression.Lambda<BindingDelegate>(expr, BindingCompiler.CurrentControlParameter);
+            var resultLambda = Expression.Lambda<BindingDelegate>(expr, BindingCompiler.CurrentControlParameter);
             // Console.WriteLine(new string('-', 80));
             // Console.WriteLine(binding.ToString());
-            // Console.WriteLine(l.ToCSharpString());
-            return l;
+            // Console.WriteLine(resultLambda.ToCSharpString());
+            return resultLambda;
         }
 
         public CastedExpressionBindingProperty ConvertExpressionToType(ParsedExpressionBindingProperty expr, ExpectedTypeBindingProperty? expectedType = null)

--- a/src/Framework/Framework/Compilation/BindingCompiler.cs
+++ b/src/Framework/Framework/Compilation/BindingCompiler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -21,6 +21,8 @@ using System.Diagnostics;
 using DotVVM.Framework.Compilation.ViewCompiler;
 using DotVVM.Framework.Utils;
 using System.Diagnostics.CodeAnalysis;
+using FastExpressionCompiler;
+using DotVVM.Framework.Runtime;
 
 namespace DotVVM.Framework.Compilation
 {
@@ -38,15 +40,22 @@ namespace DotVVM.Framework.Compilation
             this.bindingService = bindingService;
         }
 
-        public static Expression ReplaceParameters(Expression expression, DataContextStack? dataContext, bool assertAllReplaced = true) =>
-            new ParameterReplacementVisitor(dataContext, assertAllReplaced).Visit(expression);
+        public static Expression ReplaceParameters(Expression expression, DataContextStack? dataContext, IBinding contextObject, bool assertAllReplaced = true)
+        {
+            var visitor = new ParameterReplacementVisitor(dataContext, assertAllReplaced);
+            var expression2 = visitor.Visit(expression);
+            return visitor.WrapExpression(expression2, contextObject);
+        }
 
-        class ParameterReplacementVisitor: ExpressionVisitor
+        internal class ParameterReplacementVisitor: ExpressionVisitor
         {
             private readonly Dictionary<DataContextStack, int> ContextMap;
             private readonly DataContextStack? DataContext;
             private readonly bool AssertAllReplaced;
             private readonly HashSet<ParameterExpression> contextParameters = new HashSet<ParameterExpression>();
+
+            private readonly Dictionary<DataContextStack, ParameterExpression> viewModelParameters = new();
+            private readonly Dictionary<DataContextStack, ParameterExpression> controlParameters = new();
 
             public ParameterReplacementVisitor(DataContextStack? dataContext, bool assertAllReplaced = true)
             {
@@ -58,12 +67,38 @@ namespace DotVVM.Framework.Compilation
                 this.AssertAllReplaced = assertAllReplaced;
             }
 
-            private int FindContext(DataContextStack context)
+            private int? FindIndex(DataContextStack context)
             {
                 if (this.ContextMap.TryGetValue(context, out var result))
                     return result;
+                return null;
+            }
 
-                throw new InvalidOperationException($"Cannot find data context of a binding parameter: {context}. Binding data context is {this.DataContext?.ToString() ?? "null"}");
+            private ParameterExpression GetControlParameter(DataContextStack? context)
+            {
+                if (context is null || context == this.DataContext)
+                    return CurrentControlParameter;
+
+                if (controlParameters.TryGetValue(context, out var result))
+                    return result;
+
+                var name = this.ContextMap.TryGetValue(context, out var index) ? index.ToString() : context.DataContextType.Name;
+                return controlParameters[context] = Expression.Parameter(typeof(DotvvmBindableObject), $"control{name}");
+            }
+
+            private ParameterExpression GetViewModelParameter(DataContextStack context)
+            {
+                if (viewModelParameters.TryGetValue(context, out var result))
+                    return result;
+
+                var name = FindIndex(context) switch {
+                    
+                    0 => "_this",
+                    1 => "_parent",
+                    int n => "_parent" + n,
+                    null => "viewModel_" + context.DataContextType.Name
+                };
+                return viewModelParameters[context] = Expression.Parameter(context.DataContextType, name);
             }
 
             [return: NotNullIfNotNull("node")]
@@ -73,22 +108,13 @@ namespace DotVVM.Framework.Compilation
                 {
                     if (ann.ExtensionParameter != null)
                     {
-                        // handle data context hierarchy
-                        var friendlyIdentifier = $"extension parameter {ann.ExtensionParameter.Identifier}";
-                        var targetControl =
-                            ann.DataContext is null || FindContext(ann.DataContext) == 0
-                                ? CurrentControlParameter
-                                : ExpressionUtils.Replace(
-                                    (DotvvmBindableObject control) => BindingHelper.FindDataContextTarget(control, ann.DataContext, friendlyIdentifier).target,
-                                    CurrentControlParameter
-                                ).OptimizeConstants();
-
+                        var targetControl = GetControlParameter(ann.DataContext);
                         return ann.ExtensionParameter.GetServerEquivalent(targetControl);
                     }
                     else
                     {
                         var dc = ann.DataContext.NotNull("Invalid BindingParameterAnnotation");
-                        return Expression.Convert(Expression.ArrayIndex(ViewModelsParameter, Expression.Constant(FindContext(dc))), dc.DataContextType);
+                        return GetViewModelParameter(dc);
                     }
                 }
                 return base.Visit(node);
@@ -122,11 +148,208 @@ namespace DotVVM.Framework.Compilation
                     throw new Exception($"Parameter {node.Name}:{node.Type.Name} could not be translated.");
                 return base.VisitParameter(node);
             }
-        }
 
-        private static KeyValuePair<string, Expression> GetParameter(int index, string name, Expression vmArray, Type[] parents)
-        {
-            return new KeyValuePair<string, Expression>(name, Expression.Convert(Expression.ArrayIndex(vmArray, Expression.Constant(index)), parents[index]));
+            /// <summary> Data context variables introduced by the visitor. The variables are all the `_parentX` and parent controls referenced in the binding. </summary>
+            public IEnumerable<ParameterExpression> IntroducedVariables => viewModelParameters.Values.Concat(controlParameters.Values);
+
+
+            /// <summary> Wraps the expression in a block which declared and initializes all the <see cref="IntroducedVariables" /> </summary>
+            public Expression WrapExpression(Expression expression, IBinding contextObject)
+            {
+                var variables = IntroducedVariables.ToArray();
+                if (variables.Length == 0)
+                    return expression;
+                
+                var initializer = GenerateInitializer(contextObject);
+                return Expression.Block(variables, initializer, expression);
+            }
+
+            /// <summary> Generates block which initializes the needed data context parameters (<see cref="IntroducedVariables" />) </summary>
+            public BlockExpression GenerateInitializer(IBinding contextObject)
+            {
+                var result = new List<Expression>();
+                var tempVariables = new List<ParameterExpression>();
+                var contexts =
+                    viewModelParameters.Keys.Concat(controlParameters.Keys).Distinct().OrderBy(cx => FindIndex(cx) ?? -1).ToList();
+
+                var lastContextIndex = -1;
+                Expression? lastContextControl = null;
+                foreach (var cx in contexts)
+                {
+                    var cxIndex = FindIndex(cx);
+                    Debug.Assert(cxIndex != lastContextIndex);
+                    var controlVariable = controlParameters.GetValueOrDefault(cx);
+                    var viewModelVariable = viewModelParameters.GetValueOrDefault(cx);
+
+                    if (cxIndex == null)
+                    {
+                        // bindings without DataContext set
+                        // this should be rare, so we can just use BindingHelper.FindDataContextTarget for each data context
+                        var controlExpression = ExpressionUtils.Replace(
+                                (DotvvmBindableObject control) => BindingHelper.FindDataContextTarget(control, cx, contextObject).target,
+                                CurrentControlParameter
+                            ).OptimizeConstants();
+
+                        if (controlVariable is {})
+                            result.Add(Expression.Assign(controlVariable, controlExpression));
+
+                        if (viewModelVariable is {})
+                        {
+                            var control = controlVariable ?? controlExpression;
+                            var tuple = getContextAndControl(0, control, cx);
+                            result.Add(Expression.Assign(viewModelVariable, Expression.Field(tuple, "Item2")));
+                        }
+                    }
+                    else
+                    {
+                        // We aim to build a chain of GetContextControl / GetContextAndControl invocations.
+                        // This should traverse the DataContext hierarchy only once, and only to the required depth.
+                        // The binding in DataContext property evaluated only if the data context is used in the current binding.
+                        var (baseControl, skip) = lastContextControl switch {
+                            null => (CurrentControlParameter, cxIndex.Value),
+                            _ => (
+                                (Expression)Expression.Property(lastContextControl, "Parent"),
+                                cxIndex.Value - lastContextIndex - 1
+                            )
+                        };
+                        lastContextIndex = cxIndex.Value;
+                        if (viewModelVariable is null)
+                        {
+                            var control = getContextControl(skip, baseControl, cx);
+                            result.Add(Expression.Assign(controlVariable.NotNull(), control));
+                            lastContextControl = controlVariable;
+                        }
+                        else
+                        {
+                            var tuple = getContextAndControl(skip, baseControl, cx);
+                            var tupleVariable = Expression.Variable(tuple.Type, "tuple" + cxIndex);
+                            tempVariables.Add(tupleVariable);
+                            result.Add(Expression.Assign(tupleVariable, tuple));
+                            result.Add(Expression.Assign(viewModelVariable, Expression.Field(tupleVariable, "Item2")));
+                            if (controlVariable is {})
+                            {
+                                result.Add(Expression.Assign(controlVariable, Expression.Field(tupleVariable, "Item1")));
+                                lastContextControl = controlVariable;
+                            }
+                            else
+                            {
+                                lastContextControl = Expression.Field(tupleVariable, "Item1");
+                            }
+                        }
+                    }
+                }
+                return Expression.Block(tempVariables, result);
+
+                Expression getContextAndControl(int skip, Expression control, DataContextStack x) =>
+                    Expression.Call(
+                        typeof(CodegenHelpers),
+                        nameof(CodegenHelpers.GetContextAndControl),
+                        new Type[] { x.DataContextType },
+                        Expression.Constant(skip),
+                        control,
+                        Expression.Constant(new ErrorInfo(contextObject, x, FindIndex(x))),
+                        CurrentControlParameter
+                    );
+                Expression getContextControl(int skip, Expression control, DataContextStack x) =>
+                    Expression.Call(
+                        typeof(CodegenHelpers),
+                        nameof(CodegenHelpers.GetContextControl),
+                        Type.EmptyTypes,
+                        Expression.Constant(skip),
+                        control,
+                        Expression.Constant(new ErrorInfo(contextObject, x, FindIndex(x))),
+                        CurrentControlParameter
+                    );
+            }
+
+            static class CodegenHelpers
+            {
+                // public static DotvvmBindableObject GetContextControl(DotvvmBindableObject? control, ErrorInfo errorInfo, DotvvmBindableObject evaluatingControl)
+                // {
+                //     while (control != null)
+                //     {
+                //         if (control.properties.Contains(DotvvmBindableObject.DataContextProperty))
+                //             return control;
+                //         control = control.Parent;
+                //     }
+                //     ThrowNotEnoughDataContexts(errorInfo, evaluatingControl);
+                //     return null!;
+                // }
+
+                /// <summary> Returns the nearest ancestor control with DataContext property set, after skipping `skip` such ancestors. </summary>
+                public static DotvvmBindableObject GetContextControl(int skip, DotvvmBindableObject? control, ErrorInfo errorInfo, DotvvmBindableObject evaluatingControl)
+                {
+                    while (control != null)
+                    {
+                        if (control.properties.Contains(DotvvmBindableObject.DataContextProperty))
+                        {
+                            if (skip == 0)
+                                return control;
+                            skip--;
+                        }
+                        control = control.Parent;
+                    }
+                    ThrowNotEnoughDataContexts(errorInfo, evaluatingControl);
+                    return null!;
+                }
+
+
+                /// <summary> Returns the nearest ancestor control with DataContext property set, after skipping `skip` such ancestors. Includes the DataContext value </summary>
+                public static (DotvvmBindableObject, T) GetContextAndControl<T>(int skip, DotvvmBindableObject? control, ErrorInfo errorInfo, DotvvmBindableObject evaluatingControl)
+                {
+                    while (control != null)
+                    {
+                        if (control.properties.TryGet(DotvvmBindableObject.DataContextProperty, out var contextRaw))
+                        {
+                            if (skip == 0)
+                            {
+                                var context = control.EvalPropertyValue(DotvvmBindableObject.DataContextProperty, contextRaw);
+                                if (context is T result)
+                                    return (control, result);
+                                ThrowWrongContextType(errorInfo, context, evaluatingControl);
+                            }
+                            skip--;
+                        }
+                        control = control.Parent;
+                    }
+                    ThrowNotEnoughDataContexts(errorInfo, evaluatingControl);
+                    return default;
+                }
+
+                [MethodImpl(MethodImplOptions.NoInlining), DoesNotReturn]
+                static void ThrowNotEnoughDataContexts(ErrorInfo errorInfo, DotvvmBindableObject evaluatingControl)
+                {
+                    throw new NotEnoughDataContextsException(errorInfo.DataContext, errorInfo.Index!.Value, errorInfo.Binding, evaluatingControl);
+                }
+
+                [MethodImpl(MethodImplOptions.NoInlining), DoesNotReturn]
+                static void ThrowWrongContextType(ErrorInfo errorInfo, object? receivedObject, DotvvmBindableObject evaluatingControl)
+                {
+                    throw new WrongDataContextTypeException(errorInfo.DataContext, receivedObject?.GetType(), errorInfo.Index, errorInfo.Binding, evaluatingControl);
+                }
+            }
+
+            sealed record ErrorInfo(
+                IBinding Binding,
+                DataContextStack DataContext,
+                int? Index
+            )
+            { }
+
+            sealed record NotEnoughDataContextsException(DataContextStack MissingDataContext, int DataContextIndex, IBinding RelatedBinding, DotvvmBindableObject RelatedControl): DotvvmExceptionBase(RelatedBinding: RelatedBinding, RelatedControl: RelatedControl)
+            {
+                public override string Message => $"Could not evaluate binding {RelatedBinding!.ToString()}, " + 
+                    $"data context {DataContextIndex switch { 0 => "_this", 1 => "_parent", var n => "_parent"+n }}: {MissingDataContext.DataContextType.ToCode(stripNamespace: true)} does not exist. " +
+                    $"Control has the following contexts: {string.Join(", ", RelatedControl!.GetDataContexts().Select(c => c?.GetType().ToCode(stripNamespace: true) ?? "?"))}";
+            }
+
+            sealed record WrongDataContextTypeException(DataContextStack ExpectedDataContext, Type? ReceivedType, int? DataContextIndex, IBinding RelatedBinding, DotvvmBindableObject RelatedControl): DotvvmExceptionBase(RelatedBinding: RelatedBinding, RelatedControl: RelatedControl)
+            {
+                public override string Message => $"Could not evaluate binding {RelatedBinding!.ToString()}, " + 
+                    $"data context {DataContextIndex switch { null => "?", 0 => "_this", 1 => "_parent", var n => "_parent"+n }}: {ExpectedDataContext.DataContextType.ToCode()} was expected, but got {ReceivedType?.ToCode() ?? "null"}. " +
+                    $"Control has the following contexts: {string.Join(", ", RelatedControl!.GetDataContexts().Select(c => c?.GetType().ToCode(stripNamespace: true) ?? "?"))}";
+            }
+
         }
 
         public virtual IBinding CreateMinimalClone(IBinding binding)

--- a/src/Framework/Framework/Compilation/BindingCompiler.cs
+++ b/src/Framework/Framework/Compilation/BindingCompiler.cs
@@ -29,7 +29,6 @@ namespace DotVVM.Framework.Compilation
     public class BindingCompiler : IBindingCompiler
     {
         public static readonly ParameterExpression CurrentControlParameter = Expression.Parameter(typeof(DotvvmBindableObject), "currentControl");
-        public static readonly ParameterExpression ViewModelsParameter = Expression.Parameter(typeof(object[]), "vm");
 
         protected readonly DotvvmConfiguration configuration;
         protected readonly BindingCompilationService bindingService;
@@ -144,7 +143,7 @@ namespace DotVVM.Framework.Compilation
 
             protected override Expression VisitParameter(ParameterExpression node)
             {
-                if (AssertAllReplaced && node != CurrentControlParameter && node != ViewModelsParameter && !contextParameters.Contains(node))
+                if (AssertAllReplaced && node != CurrentControlParameter && !contextParameters.Contains(node))
                     throw new Exception($"Parameter {node.Name}:{node.Type.Name} could not be translated.");
                 return base.VisitParameter(node);
             }

--- a/src/Framework/Framework/Controls/DotvvmBindableObject.cs
+++ b/src/Framework/Framework/Controls/DotvvmBindableObject.cs
@@ -72,8 +72,17 @@ namespace DotVVM.Framework.Controls
         [MarkupOptions(AllowHardCodedValue = false)]
         public object? DataContext
         {
-            get { return GetValue(DataContextProperty); }
-            set { SetValue(DataContextProperty, value); }
+            get {
+                for (var c = this; c != null; c = c.Parent)
+                {
+                    if (c.properties.TryGet(DotvvmBindableObject.DataContextProperty, out var value))
+                    {
+                        return c.EvalPropertyValue(DotvvmBindableObject.DataContextProperty, value);
+                    }
+                }
+                return null;
+            }
+            set { this.properties.Set(DataContextProperty, value); }
         }
 
         DotvvmBindableObject IDotvvmObjectLike.Self => this;

--- a/src/Framework/Framework/Controls/PropertyImmutableHashtable.cs
+++ b/src/Framework/Framework/Controls/PropertyImmutableHashtable.cs
@@ -13,13 +13,13 @@ namespace DotVVM.Framework.Controls
 
         public static bool ContainsKey(DotvvmProperty?[] keys, int hashSeed, DotvvmProperty p)
         {
-            var l = keys.Length;
-            if (l == 4)
+            var len = keys.Length;
+            if (len == 4)
             {
                 return keys[0] == p | keys[1] == p | keys[2] == p | keys[3] == p;
             }
 
-            var lengthMap = l - 1; // trims the hash to be in bounds of the array
+            var lengthMap = len - 1; // trims the hash to be in bounds of the array
             var hash = HashCombine(p.GetHashCode(), hashSeed) & lengthMap;
 
             var i1 = hash & -2; // hash with last bit == 0 (-2 is something like ff...fe because two's complement)
@@ -30,8 +30,8 @@ namespace DotVVM.Framework.Controls
 
         public static int FindSlot(DotvvmProperty?[] keys, int hashSeed, DotvvmProperty p)
         {
-            var l = keys.Length;
-            if (l == 4)
+            var len = keys.Length;
+            if (len == 4)
             {
                 for (int i = 0; i < 4; i++)
                 {
@@ -40,7 +40,7 @@ namespace DotVVM.Framework.Controls
                 return -1;
             }
 
-            var lengthMap = l - 1; // trims the hash to be in bounds of the array
+            var lengthMap = len - 1; // trims the hash to be in bounds of the array
             var hash = HashCombine(p.GetHashCode(), hashSeed) & lengthMap;
 
             var i1 = hash & -2; // hash with last bit == 0 (-2 is something like ff...fe because two's complement)

--- a/src/Framework/Framework/ResourceManagement/LinkResourceBase.cs
+++ b/src/Framework/Framework/ResourceManagement/LinkResourceBase.cs
@@ -41,9 +41,9 @@ namespace DotVVM.Framework.ResourceManagement
             yield return Location;
             if (LocationFallback != null)
             {
-                foreach (var l in LocationFallback.AlternativeLocations)
+                foreach (var loc in LocationFallback.AlternativeLocations)
                 {
-                    yield return l;
+                    yield return loc;
                 }
             }
         }

--- a/src/Framework/Framework/Utils/ExpressionUtils.cs
+++ b/src/Framework/Framework/Utils/ExpressionUtils.cs
@@ -266,14 +266,10 @@ namespace DotVVM.Framework.Utils
             }
             protected override Expression VisitBinary(BinaryExpression node)
             {
-                var l = Visit(node.Left);
-                var lc = l as ConstantExpression;
-                var r = Visit(node.Right);
-                var rc = r as ConstantExpression;
-                if (lc != null && rc != null)
+                if (Visit(node.Left) is ConstantExpression lConst && Visit(node.Right) is ConstantExpression rConst)
                 {
                     if (node.Method != null)
-                        return Expression.Constant(node.Method.Invoke(null, new [] { lc.Value, rc.Value }), node.Type);
+                        return Expression.Constant(node.Method.Invoke(null, new [] { lConst.Value, rConst.Value }), node.Type);
                     else return node;
                 }
                 else return base.VisitBinary(node);

--- a/src/Framework/Framework/Utils/ExpressionUtils.cs
+++ b/src/Framework/Framework/Utils/ExpressionUtils.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using System.Diagnostics;
 using DotVVM.Framework.Compilation.ControlTree;
 using System.Diagnostics.CodeAnalysis;
+using DotVVM.Framework.Compilation.Binding;
 
 namespace DotVVM.Framework.Utils
 {
@@ -25,7 +26,7 @@ namespace DotVVM.Framework.Utils
         {
             if (expr.Type == typeof(object)) return expr;
             else if (expr.Type == typeof(void)) return WrapInReturnNull(expr);
-            else return Expression.Convert(expr, typeof(object));
+            else return TypeConversion.BoxToObject(expr);
         }
 
         public static Expression WrapInReturnNull(Expression expr)

--- a/src/Samples/Common/Views/ControlSamples/TemplateHost/CompositeListControlWithTemplate.cs
+++ b/src/Samples/Common/Views/ControlSamples/TemplateHost/CompositeListControlWithTemplate.cs
@@ -52,7 +52,7 @@ namespace DotVVM.Samples.Common.Views.ControlSamples.TemplateHost
                 .AppendChildren(new Button(
                     "Add item",
                     new CommandBindingExpression(bindingCompilationService, contexts => {
-                                var item = onCreateItem.BindingDelegate(this.GetDataContexts().ToArray(), this);
+                                var item = onCreateItem.BindingDelegate(this);
                                 ((dynamic)dataSource.GetBindingValue(this)).Add(((dynamic)item)());
                             }, "38921DE7-936D-4862-921A-5051DA0CAEB1")));
         }

--- a/src/Samples/Common/Views/ControlSamples/TemplateHost/TemplatedListControl.cs
+++ b/src/Samples/Common/Views/ControlSamples/TemplateHost/TemplatedListControl.cs
@@ -44,7 +44,7 @@ namespace DotVVM.Samples.Common.Views.ControlSamples.TemplateHost
 
         public void AddItem()
         {
-            var item = OnCreateItem.BindingDelegate(this.GetDataContexts().ToArray(), this);
+            var item = OnCreateItem.BindingDelegate(this);
             ((dynamic)DataSource).Add(((dynamic)item)());
         }
 

--- a/src/Tests/Binding/BindingCompilationTests.cs
+++ b/src/Tests/Binding/BindingCompilationTests.cs
@@ -66,7 +66,7 @@ namespace DotVVM.Framework.Tests.Binding
                 BindingParserOptions.Resource.AddImports(imports),
                 new ExpectedTypeBindingProperty(expectedType ?? typeof(object))
             });
-            return binding.BindingDelegate.Invoke(control.GetDataContexts().ToArray(), control);
+            return binding.BindingDelegate.Invoke(control);
         }
 
         DotvvmControl BuildFakeControlHierarchy(DataContextStack contextType, object[] contexts, DotvvmControl rootControl)

--- a/src/Tests/Binding/BindingCompilationTests.cs
+++ b/src/Tests/Binding/BindingCompilationTests.cs
@@ -36,37 +36,58 @@ namespace DotVVM.Framework.Tests.Binding
             this.bindingService = configuration.ServiceProvider.GetRequiredService<BindingCompilationService>();
         }
 
-        public object ExecuteBinding(string expression, object[] contexts, DotvvmControl control, NamespaceImport[] imports = null, Type expectedType = null)
+        public object ExecuteBinding(string expression, NamespaceImport[] imports = null, Type expectedType = null)
         {
-            var context = DataContextStack.Create(contexts.FirstOrDefault()?.GetType() ?? typeof(object), extensionParameters: new[] {
-                new CurrentMarkupControlExtensionParameter(new ResolvedTypeDescriptor(control?.GetType() ?? typeof(DotvvmControl)))
-            });
+            return ExecuteBinding(expression, DataContextStack.Create(typeof(object)), new [] { new object() }, imports, expectedType);
+        }
+        internal object ExecuteBinding(string expression, object context)
+        {
+            return ExecuteBinding(expression, new [] { context });
+        }
+        public object ExecuteBinding(string expression, object[] contexts, NamespaceImport[] imports = null, Type expectedType = null)
+        {
+            var context = DataContextStack.Create(contexts.First().GetType());
             for (int i = 1; i < contexts.Length; i++)
             {
                 context = DataContextStack.Create(contexts[i].GetType(), context);
             }
-            return ExecuteBinding(expression, context, contexts, control, imports, expectedType);
+            return ExecuteBinding(expression, context, contexts, imports, expectedType);
         }
-        public object ExecuteBinding(string expression, DataContextStack contextType, object[] contexts, DotvvmControl control, NamespaceImport[] imports = null, Type expectedType = null)
+        public object ExecuteBinding(string expression, DataContextStack contextType, object[] contexts, NamespaceImport[] imports = null, Type expectedType = null)
         {
-            Array.Reverse(contexts);
+            var control = BuildFakeControlHierarchy(contextType, contexts, null);
+            return ExecuteBinding(expression, contextType, control, imports, expectedType);
+        }
+        public object ExecuteBinding(string expression, DataContextStack contextType, DotvvmControl control, NamespaceImport[] imports = null, Type expectedType = null)
+        {
             var binding = new ResourceBindingExpression(bindingService, new object[] {
                 contextType,
                 new OriginalStringBindingProperty(expression),
                 BindingParserOptions.Resource.AddImports(imports),
                 new ExpectedTypeBindingProperty(expectedType ?? typeof(object))
             });
-            return binding.BindingDelegate.Invoke(contexts, control);
+            return binding.BindingDelegate.Invoke(control.GetDataContexts().ToArray(), control);
         }
 
-        public object ExecuteBinding(string expression, params object[] contexts)
+        DotvvmControl BuildFakeControlHierarchy(DataContextStack contextType, object[] contexts, DotvvmControl rootControl)
         {
-            return ExecuteBinding(expression, contexts, null);
+            var types = contextType.EnumerableItems().Reverse().ToArray();
+            DotvvmControl parent = rootControl;
+            Assert.AreEqual(types.Length, contexts.Length, $"{contextType} does not match real types: {string.Join(", ", contexts.Select(t => t?.GetType().Name))}");
+            for (int i = 0; i < types.Length; i++)
+            {
+                var c = new PlaceHolder();
+                parent?.Children.Add(c);
+                c.DataContext = contexts[i];
+                c.SetDataContextType(types[i]);
+                parent = c;
+            }
+            return parent;
         }
 
         public object ExecuteBinding(string expression, NamespaceImport[] imports, params object[] contexts)
         {
-            return ExecuteBinding(expression, contexts, null, imports);
+            return ExecuteBinding(expression, contexts, imports);
         }
 
         [TestMethod]
@@ -78,7 +99,7 @@ namespace DotVVM.Framework.Tests.Binding
         [TestMethod]
         public void BindingCompiler_NamespaceResourceBinding()
         {
-            Assert.AreEqual(Resource1.ResourceKey123, ExecuteBinding("Resource1.ResourceKey123", new object[0], null, new NamespaceImport[]
+            Assert.AreEqual(Resource1.ResourceKey123, ExecuteBinding("Resource1.ResourceKey123", new NamespaceImport[]
             {
                 new NamespaceImport("DotVVM.Framework.Tests")
             }));
@@ -87,7 +108,7 @@ namespace DotVVM.Framework.Tests.Binding
         [TestMethod]
         public void BindingCompiler_MoreNamespacesResourceBinding()
         {
-            Assert.AreEqual(Resource1.ResourceKey123, ExecuteBinding("Resource1.ResourceKey123", new object[0], null, new NamespaceImport[]
+            Assert.AreEqual(Resource1.ResourceKey123, ExecuteBinding("Resource1.ResourceKey123", new NamespaceImport[]
             {
                 new NamespaceImport("DotVVM.Framework.Tests0"),
                 new NamespaceImport("DotVVM.Framework.Tests"),
@@ -98,7 +119,7 @@ namespace DotVVM.Framework.Tests.Binding
         [TestMethod]
         public void BindingCompiler_NamespaceAliasResourceBinding()
         {
-            Assert.AreEqual(Resource1.ResourceKey123, ExecuteBinding("ghg.Resource1.ResourceKey123", new object[0], null, new NamespaceImport[]
+            Assert.AreEqual(Resource1.ResourceKey123, ExecuteBinding("ghg.Resource1.ResourceKey123", new NamespaceImport[]
             {
                 new NamespaceImport("DotVVM.Framework.Tests","ghg")
             }));
@@ -109,7 +130,7 @@ namespace DotVVM.Framework.Tests.Binding
         {
             try
             {
-                Assert.AreEqual(Resource1.ResourceKey123, ExecuteBinding("Resource1.NotExist", new object[0], null, new NamespaceImport[]
+                Assert.AreEqual(Resource1.ResourceKey123, ExecuteBinding("Resource1.NotExist", new NamespaceImport[]
                     {
                         new NamespaceImport("DotVVM.Framework.Tests")
                     }));
@@ -311,7 +332,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void BindingCompiler_RegularGenericMethodsInference(string expr, params Type[] instantiations)
         {
             var viewModel = new TestViewModel() { StringProp = "abc" };
-            var binding = ExecuteBinding(expr, new[] { viewModel }, null, new[] { new NamespaceImport("System.Linq") });
+            var binding = ExecuteBinding(expr, new[] { viewModel }, new[] { new NamespaceImport("System.Linq") });
             var genericArgs = binding.GetType().GetGenericArguments();
 
             for (var argIndex = 0; argIndex < genericArgs.Length; argIndex++)
@@ -325,7 +346,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void BindingCompiler_ExtensionGenericMethodsInference(string expr, params Type[] instantiations)
         {
             var viewModel = new TestViewModel() { StringProp = "abc" };
-            var binding = ExecuteBinding(expr, new[] { viewModel }, null, new[] { new NamespaceImport("System.Linq") });
+            var binding = ExecuteBinding(expr, new[] { viewModel }, new[] { new NamespaceImport("System.Linq") });
             var genericArgs = binding.GetType().GetGenericArguments();
 
             for (var argIndex = 0; argIndex < genericArgs.Length; argIndex++)
@@ -347,7 +368,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void BindingCompiler_LinqMethodsInference(string expr, Type resultType)
         {
             var viewModel = new TestViewModel() { StringProp = "abc" };
-            var result = ExecuteBinding(expr, new[] { viewModel }, null, new[] { new NamespaceImport("System.Linq") });
+            var result = ExecuteBinding(expr, new[] { viewModel }, new[] { new NamespaceImport("System.Linq") });
             Assert.AreEqual(resultType, result.GetType());
         }
 
@@ -359,7 +380,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void BindingCompiler_MoreComplexInference(string expr, int[] result)
         {
             var viewModel = new TestViewModel() { StringProp = "abc", List = new List<int>() { 1, 2, 3 } };
-            ExecuteBinding(expr, new[] { viewModel }, null, new[] { new NamespaceImport("DotVVM.Framework.Binding.HelperNamespace") }, expectedType: typeof(void));
+            ExecuteBinding(expr, new[] { viewModel }, new[] { new NamespaceImport("DotVVM.Framework.Binding.HelperNamespace") }, expectedType: typeof(void));
             CollectionAssert.AreEqual(result, viewModel.List);
         }
 
@@ -542,13 +563,13 @@ namespace DotVVM.Framework.Tests.Binding
         [TestMethod]
         public void BindingCompiler_EnumToStringConversion()
         {
-            var result1 = ExecuteBinding("DotVVM.Framework.Tests.Binding.TestEnum.Underscore_hhh", new object[0], null, expectedType: typeof(string));
+            var result1 = ExecuteBinding("DotVVM.Framework.Tests.Binding.TestEnum.Underscore_hhh", expectedType: typeof(string));
             Assert.AreEqual("Underscore_hhh", result1);
-            var result2 = ExecuteBinding("DotVVM.Framework.Tests.Binding.TestEnum.SpecialField", new object[0], null, expectedType: typeof(string));
+            var result2 = ExecuteBinding("DotVVM.Framework.Tests.Binding.TestEnum.SpecialField", expectedType: typeof(string));
             Assert.AreEqual("xxx", result2);
-            var result3 = ExecuteBinding("EnumProperty", new object[] { new TestViewModel { EnumProperty = TestEnum.A } }, null, expectedType: typeof(string));
+            var result3 = ExecuteBinding("EnumProperty", new object[] { new TestViewModel { EnumProperty = TestEnum.A } }, expectedType: typeof(string));
             Assert.AreEqual("A", result3);
-            var result4 = ExecuteBinding("EnumProperty", new object[] { new TestViewModel { EnumProperty = TestEnum.SpecialField } }, null, expectedType: typeof(string));
+            var result4 = ExecuteBinding("EnumProperty", new object[] { new TestViewModel { EnumProperty = TestEnum.SpecialField } }, expectedType: typeof(string));
             Assert.AreEqual("xxx", result4);
         }
 
@@ -661,28 +682,28 @@ namespace DotVVM.Framework.Tests.Binding
         [TestMethod]
         public void BindingCompiler_Valid_NamespaceAlias()
         {
-            var result = ExecuteBinding("Alias.TestClass2.Property", new object[0], null, new NamespaceImport[] { new NamespaceImport("DotVVM.Framework.Tests.Binding.TestNamespace2", "Alias") });
+            var result = ExecuteBinding("Alias.TestClass2.Property", new NamespaceImport[] { new NamespaceImport("DotVVM.Framework.Tests.Binding.TestNamespace2", "Alias") });
             Assert.AreEqual(TestNamespace2.TestClass2.Property, result);
         }
 
         [TestMethod]
         public void BindingCompiler_Valid_MultipleNamespaceAliases()
         {
-            var result = ExecuteBinding("Alias.TestClass1.Property", new object[0], null, new NamespaceImport[] { new NamespaceImport("DotVVM.Framework.Tests.Binding.TestNamespace2", "Alias"), new NamespaceImport("DotVVM.Framework.Tests.Binding.TestNamespace1", "Alias") });
+            var result = ExecuteBinding("Alias.TestClass1.Property", new NamespaceImport[] { new NamespaceImport("DotVVM.Framework.Tests.Binding.TestNamespace2", "Alias"), new NamespaceImport("DotVVM.Framework.Tests.Binding.TestNamespace1", "Alias") });
             Assert.AreEqual(TestNamespace1.TestClass1.Property, result);
         }
 
         [TestMethod]
         public void BindingCompiler_Valid_NamespaceImportAndAlias()
         {
-            var result = ExecuteBinding("TestClass2.Property + Alias.TestClass1.Property", new object[0], null, new NamespaceImport[] { new NamespaceImport("DotVVM.Framework.Tests.Binding.TestNamespace2"), new NamespaceImport("DotVVM.Framework.Tests.Binding.TestNamespace1", "Alias") });
+            var result = ExecuteBinding("TestClass2.Property + Alias.TestClass1.Property", new NamespaceImport[] { new NamespaceImport("DotVVM.Framework.Tests.Binding.TestNamespace2"), new NamespaceImport("DotVVM.Framework.Tests.Binding.TestNamespace1", "Alias") });
             Assert.AreEqual(TestNamespace2.TestClass2.Property + TestNamespace1.TestClass1.Property, result);
         }
 
         [TestMethod]
         public void BindingCompiler_Valid_TypeAlias()
         {
-            var result = ExecuteBinding("Alias.Property", new object[0], null,
+            var result = ExecuteBinding("Alias.Property",
                 new NamespaceImport[] { new NamespaceImport("DotVVM.Framework.Tests.Binding.TestNamespace2.TestClass2", alias: "Alias") });
             Assert.AreEqual(TestNamespace2.TestClass2.Property, result);
         }
@@ -712,15 +733,17 @@ namespace DotVVM.Framework.Tests.Binding
 
             var control1 = new DataItemContainer() { DataItemIndex = 10 };
             control1.SetDataContextType(dc1);
+            control1.DataContext = "a";
             var control2 = new DataItemContainer() { DataItemIndex = 21 };
             control2.SetDataContextType(dc2);
+            control2.DataContext = "b";
             control1.Children.Add(control2);
             var html = new HtmlGenericControl("span");
             control2.Children.Add(html);
 
-            var result = ExecuteBinding(expr, dc2, new object[] { "a", "b" }, html);
+            var result = ExecuteBinding(expr, dc2, html);
             Assert.AreEqual(expectedResult, result);
-            var result2 = ExecuteBinding(expr, dc2, new object[] { "a", "b" }, control2);
+            var result2 = ExecuteBinding(expr, dc2, control2);
             Assert.AreEqual(expectedResult, result2);
         }
 
@@ -728,7 +751,7 @@ namespace DotVVM.Framework.Tests.Binding
         [TestMethod]
         public void BindingCompiler_Valid_ToStringConstantConversion()
         {
-            var result = ExecuteBinding("false", new object[0], null, expectedType: typeof(string));
+            var result = ExecuteBinding("false", expectedType: typeof(string));
             Assert.AreEqual("False", result);
         }
 
@@ -791,7 +814,7 @@ namespace DotVVM.Framework.Tests.Binding
         [TestMethod]
         public void BindingCompiler_ImplicitConstantConversionInsideConditional()
         {
-            var result = ExecuteBinding("true ? 'Utc' : 'Local'", new object[] { }, null, null, typeof(DateTimeKind));
+            var result = ExecuteBinding("true ? 'Utc' : 'Local'", expectedType: typeof(DateTimeKind));
             Assert.AreEqual(DateTimeKind.Utc, result);
         }
 

--- a/src/Tests/Binding/BindingCompilationTests.cs
+++ b/src/Tests/Binding/BindingCompilationTests.cs
@@ -1,4 +1,4 @@
-﻿using DotVVM.Framework.Binding;
+using DotVVM.Framework.Binding;
 using DotVVM.Framework.Controls;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
@@ -785,14 +785,18 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
-        public void BindingCompiler_Parents()
+        [DataRow("54554321", "_this.StringProp + _parent.StringProp + StringProp + _parent0.StringProp + _parent1.StringProp + _parent2.StringProp + _parent3.StringProp + _parent4.StringProp")]
+        [DataRow("315", "_parent2.StringProp + _root.StringProp + _this.StringProp")] // different order could break it
+        [DataRow("3", "_this.StringProp.Length + MethodWithOverloads(_parent2.StringProp.Length, _parent1.StringProp.Length)")] // different order could break it
+        public void BindingCompiler_Parents(string expected, string expression)
         {
-            var result = ExecuteBinding("_this.StringProp + _parent.StringProp + StringProp + _parent0.StringProp + _parent1.StringProp + _parent2.StringProp + _parent3.StringProp + _parent4.StringProp", new[] { new TestViewModel { StringProp = "1" },
+            var contexts = new[] { new TestViewModel { StringProp = "1" },
                 new TestViewModel { StringProp = "2" },
                 new TestViewModel { StringProp = "3" },
                 new TestViewModel { StringProp = "4" },
-                new TestViewModel { StringProp = "5" }});
-            Assert.AreEqual("54554321", result);
+                new TestViewModel { StringProp = "5" }};
+            var result = ExecuteBinding(expression, contexts, expectedType: typeof(string));
+            Assert.AreEqual(expected, result);
         }
 
         [TestMethod]

--- a/src/Tests/Binding/BindingCompilationTests.cs
+++ b/src/Tests/Binding/BindingCompilationTests.cs
@@ -20,12 +20,15 @@ using DotVVM.Framework.ViewModel;
 using DotVVM.Framework.Testing;
 using System.Collections.ObjectModel;
 using System.Runtime.Serialization;
+using CheckTestOutput;
+using DotVVM.Framework.Tests.Runtime;
 
 namespace DotVVM.Framework.Tests.Binding
 {
     [TestClass]
     public class BindingCompilationTests
     {
+        OutputChecker check = new OutputChecker("testoutputs");
         private DotvvmConfiguration configuration;
         private BindingCompilationService bindingService;
 
@@ -1058,6 +1061,31 @@ namespace DotVVM.Framework.Tests.Binding
         {
             Assert.AreEqual(-1025, ExecuteBinding("var intVariable = ~IntProp; intVariable", new TestViewModel { IntProp = 1024 }));
         }
+
+        [TestMethod]
+        public void Error_MissingDataContext()
+        {
+            var type = DataContextStack.Create(typeof(string), parent: DataContextStack.Create(typeof(TestViewModel)));
+            var control = new PlaceHolder();
+            control.SetDataContextType(type);
+            control.DataContext = "test";
+            check.CheckException(() =>
+                ExecuteBinding("_parent.StringProp", type, control)
+            );
+        }
+
+        [TestMethod]
+        public void Error_DifferentDataContext()
+        {
+            var type = DataContextStack.Create(typeof(string), parent: DataContextStack.Create(typeof(TestViewModel)));
+            var control = new PlaceHolder();
+            control.SetDataContextType(type);
+            control.DataContext = 1;
+            check.CheckException(() =>
+                ExecuteBinding("_this + 'aaa'", type, control)
+            );
+        }
+
     }
     class TestViewModel
     {

--- a/src/Tests/Binding/testoutputs/BindingCompilationTests.Error_DifferentDataContext.txt
+++ b/src/Tests/Binding/testoutputs/BindingCompilationTests.Error_DifferentDataContext.txt
@@ -1,0 +1,2 @@
+WrongDataContextTypeException occurred: Could not evaluate binding {resource: _this + 'aaa'}, data context _this: string was expected, but got int. Control has the following contexts: int
+    at void DotVVM.Framework.Compilation.BindingCompiler+ParameterReplacementVisitor+CodegenHelpers.ThrowWrongContextType(ErrorInfo errorInfo, object receivedObject, DotvvmBindableObject evaluatingControl)

--- a/src/Tests/Binding/testoutputs/BindingCompilationTests.Error_MissingDataContext.txt
+++ b/src/Tests/Binding/testoutputs/BindingCompilationTests.Error_MissingDataContext.txt
@@ -1,0 +1,2 @@
+NotEnoughDataContextsException occurred: Could not evaluate binding {resource: _parent.StringProp}, data context _parent: TestViewModel does not exist. Control has the following contexts: string
+    at void DotVVM.Framework.Compilation.BindingCompiler+ParameterReplacementVisitor+CodegenHelpers.ThrowNotEnoughDataContexts(ErrorInfo errorInfo, DotvvmBindableObject evaluatingControl)

--- a/src/Tests/ControlTests/MarkupControlTests.cs
+++ b/src/Tests/ControlTests/MarkupControlTests.cs
@@ -33,6 +33,7 @@ namespace DotVVM.Framework.Tests.ControlTests
             config.Markup.AddMarkupControl("cc", "CustomControlWithInternalProperty", "CustomControlWithInternalProperty.dotcontrol");
             config.Markup.AddMarkupControl("cc", "CustomControlWithResourceProperty", "CustomControlWithResourceProperty.dotcontrol");
             config.Markup.AddMarkupControl("cc", "CustomControlWithJsInvoke", "CustomControlWithJsInvoke.dotcontrol");
+            config.Markup.AddMarkupControl("cc", "DataContextChangeControl", "DataContextChangeControl.dotcontrol");
             config.Styles.Register<Repeater>().SetProperty(r => r.RenderAsNamedTemplate, false, StyleOverrideOptions.Ignore);
         }, services: s => {
             s.Services.AddSingleton<TestService>();
@@ -229,6 +230,32 @@ namespace DotVVM.Framework.Tests.ControlTests
             );
 
             check.CheckString(p.FormattedHtml, fileExtension: "html");
+        }
+
+        [TestMethod]
+        public async Task DataContextChange()
+        {
+            var r = await cth.RunPage(typeof(BasicTestViewModel), """
+                    <cc:DataContextChangeControl DataContext={value: _this} Something=321 RenderSettings.Mode=Server />
+                """,
+                directives: $"@service s = {typeof(TestService)}",
+                markupFiles: new Dictionary<string, string> {
+                    ["DataContextChangeControl.dotcontrol"] = """
+                        @viewModel DotVVM.Framework.Tests.ControlTests.MarkupControlTests.BasicTestViewModel
+                        @property int Something
+                        
+                        <div DataContext={value: Collection}>
+                            <dot:Repeater DataSource={value: _this}>
+                                {{value: _this}}
+
+                                <span data-x={value: _control.Something} />
+                            </dot:Repeater>
+                        </div>
+                        """
+                }
+            );
+
+            check.CheckString(r.OutputString, fileExtension: "html");
         }
 
 

--- a/src/Tests/ControlTests/RepeaterTests.cs
+++ b/src/Tests/ControlTests/RepeaterTests.cs
@@ -106,6 +106,25 @@ namespace DotVVM.Framework.Tests.ControlTests
             check.CheckString(r.FormattedHtml, fileExtension: "html");
         }
 
+        [TestMethod]
+        public async Task RepeatedTextBox()
+        {
+            var r = await cth.RunPage(typeof(BasicTestViewModel), @"
+                <!-- client-side -->
+                <dot:Repeater DataSource={value: Items} RenderSettings.Mode=Client>
+                    <dot:TextBox Text={value: Number} />
+                    <span Visible={value: ShowSomethingElse}>xx</span>
+                </dot:Repeater>
+                <dot:Repeater DataSource={value: Items} RenderSettings.Mode=Server>
+                    <dot:TextBox Text={value: Number} />
+                    <span Visible={value: ShowSomethingElse}>xx</span>
+                </dot:Repeater>
+                "
+            );
+
+            check.CheckString(r.FormattedHtml, fileExtension: "html");
+        }
+
     }
 
     public class BasicTestViewModel
@@ -113,8 +132,8 @@ namespace DotVVM.Framework.Tests.ControlTests
         public TestItem[] Items { get; set; } = new []
         {
             new TestItem() { Number = 1 },
-            new TestItem() { Number = 2 },
-            new TestItem() { Number = 3 },
+            new TestItem() { Number = 2, ShowSomethingElse = true },
+            new TestItem() { Number = 3, ShowSomethingElse = true },
             new TestItem() { Number = 4 }
         };
     }
@@ -122,6 +141,7 @@ namespace DotVVM.Framework.Tests.ControlTests
     public class TestItem
     {
         public int Number { get; set; }
+        public bool ShowSomethingElse { get; set; }
     }
 
     [ControlMarkupOptions(AllowContent = false, DefaultContentProperty = "ItemTemplate")]

--- a/src/Tests/ControlTests/testoutputs/MarkupControlTests.DataContextChange.html
+++ b/src/Tests/ControlTests/testoutputs/MarkupControlTests.DataContextChange.html
@@ -1,0 +1,18 @@
+
+<head></head>
+<body>
+    <!-- ko with: $rawData --><div data-bind="dotvvm-with-control-properties: { Something: 321 }">
+<!-- ko with: Collection --><div>
+    <div data-bind="dotvvm-SSR-foreach: { data: $rawData }"><!-- ko dotvvm-SSR-item: 0 -->
+        <!-- ko text: $rawData -->10<!-- /ko -->
+
+        <span data-x=321 data-bind='attr: { "data-x": $parentContext.$parentContext.$control.Something }'></span>
+    <!-- /ko --><!-- ko dotvvm-SSR-item: 1 -->
+        <!-- ko text: $rawData -->-20<!-- /ko -->
+
+        <span data-x=321 data-bind='attr: { "data-x": $parentContext.$parentContext.$control.Something }'></span>
+    <!-- /ko --></div>
+</div><!-- /ko --></div><!-- /ko -->
+
+
+</body>

--- a/src/Tests/ControlTests/testoutputs/RepeaterTests.RepeatedTextBox.html
+++ b/src/Tests/ControlTests/testoutputs/RepeaterTests.RepeatedTextBox.html
@@ -1,0 +1,33 @@
+<html>
+	<head></head>
+	<body>
+		
+		<!-- client-side -->
+		<div data-bind="foreach: { data: Items }">
+			<input data-bind="dotvvm-textbox-text: Number" data-dotvvm-format="G" data-dotvvm-value-type="number" type="text">
+			<span data-bind="visible: ShowSomethingElse">xx</span>
+		</div>
+		<div data-bind="dotvvm-SSR-foreach: { data: Items }">
+			<!-- ko dotvvm-SSR-item: 0 -->
+			<input data-bind="dotvvm-textbox-text: Number" data-dotvvm-format="G" data-dotvvm-value-type="number" type="text">
+			<span data-bind="visible: ShowSomethingElse" style="display:none">xx</span>
+			
+			<!-- /ko -->
+			<!-- ko dotvvm-SSR-item: 1 -->
+			<input data-bind="dotvvm-textbox-text: Number" data-dotvvm-format="G" data-dotvvm-value-type="number" type="text">
+			<span data-bind="visible: ShowSomethingElse">xx</span>
+			
+			<!-- /ko -->
+			<!-- ko dotvvm-SSR-item: 2 -->
+			<input data-bind="dotvvm-textbox-text: Number" data-dotvvm-format="G" data-dotvvm-value-type="number" type="text">
+			<span data-bind="visible: ShowSomethingElse">xx</span>
+			
+			<!-- /ko -->
+			<!-- ko dotvvm-SSR-item: 3 -->
+			<input data-bind="dotvvm-textbox-text: Number" data-dotvvm-format="G" data-dotvvm-value-type="number" type="text">
+			<span data-bind="visible: ShowSomethingElse" style="display:none">xx</span>
+			
+			<!-- /ko -->
+		</div>
+	</body>
+</html>


### PR DESCRIPTION
Resolving of binding data contexts is moved to the compiled binding delegate.
Instead creating a data context array, we emit a sequence of `GetContextControl` and `GetContextAndControl<T>` calls,
which efficiently walks the control hierarchy while evaluating the needed data context.

Note that it evaluates only data contexts referenced in the binding. DataContext is also evaluated, if the it's is only referenced, but not needed due to conditional evaluation (`_this.MyProperty == 0 ? _parent.X : "xx"` always evaluates `_parent`). It's not that common and would be significantly more complex to implement.

This should improve error reporting when binding is being evaluated in unexpected data context. In a way, this is overengineered version of #1286  

* Data context is missing, the hierarchy isn't deep enough.
    - previously this lead to IndexOutOfRangeException
    - now it will produce custom exception with the type of the missing context
* Data context has different type
   - previously InvalidCastException
   - now custom message including the affected binding, expected type,
      actual type

Moreover, it should now be faster to evaluate bindings, especially for deeply nested controls, and for resource binding not referencing view model at all. (I didn't measure the impact)

It should behave the same way as the original version, but removing the `BindingDelegate` argument is a breaking change.

resolves  #1301