### PR TITLE
Refactored DotVVM presenter

### DIFF
--- a/src/Framework/Framework/Hosting/Middlewares/DotvvmFileUploadMiddleware.cs
+++ b/src/Framework/Framework/Hosting/Middlewares/DotvvmFileUploadMiddleware.cs
@@ -107,12 +107,13 @@ namespace DotVVM.Framework.Hosting.Middlewares
                 if (string.IsNullOrEmpty(errorMessage))
                 {
                     var json = viewModelSerializer.BuildStaticCommandResponse(request, uploadedFiles);
-                    await outputRenderer.RenderPlainJsonResponse(context, json);
+                    context.Response.StatusCode = (int)HttpStatusCode.OK;
+                    await outputRenderer.WritePlainJsonResponse(context, json);
                 }
                 else
                 {
                     context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
-                    await outputRenderer.RenderPlainTextResponse(context, errorMessage);
+                    await outputRenderer.WritePlainTextResponse(context, errorMessage);
                 }
             }
             

--- a/src/Framework/Framework/Runtime/DefaultOutputRenderer.cs
+++ b/src/Framework/Framework/Runtime/DefaultOutputRenderer.cs
@@ -91,32 +91,22 @@ namespace DotVVM.Framework.Runtime
             await context.HttpContext.Response.WriteAsync(serializedViewModel);
         }
 
-        public virtual async Task WriteStaticCommandResponse(IDotvvmRequestContext context, string json)
+        public virtual async Task WritePlainJsonResponse(IHttpContext context, string json)
         {
-            context.HttpContext.Response.ContentType = "application/json; charset=utf-8";
-            SetCacheHeaders(context.HttpContext);
-            await context.HttpContext.Response.WriteAsync(json);
-        }
-
-        public virtual async Task RenderPlainJsonResponse(IHttpContext context, string json)
-        {
-            context.Response.StatusCode = (int)HttpStatusCode.OK;
             context.Response.ContentType = "application/json; charset=utf-8";
             SetCacheHeaders(context);
             await context.Response.WriteAsync(json);
         }
 
-        public virtual async Task RenderHtmlResponse(IHttpContext context, string html)
+        public virtual async Task WriteHtmlResponse(IHttpContext context, string html)
         {
-            context.Response.StatusCode = (int)HttpStatusCode.OK;
             context.Response.ContentType = "text/html; charset=utf-8";
             SetCacheHeaders(context);
             await context.Response.WriteAsync(html);
         }
 
-        public virtual async Task RenderPlainTextResponse(IHttpContext context, string text)
+        public virtual async Task WritePlainTextResponse(IHttpContext context, string text)
         {
-            context.Response.StatusCode = (int)HttpStatusCode.OK;
             context.Response.ContentType = "text/plain; charset=utf-8";
             SetCacheHeaders(context);
             await context.Response.WriteAsync(text);

--- a/src/Framework/Framework/Runtime/IOutputRenderer.cs
+++ b/src/Framework/Framework/Runtime/IOutputRenderer.cs
@@ -14,13 +14,9 @@ namespace DotVVM.Framework.Runtime
 
         Task WriteViewModelResponse(IDotvvmRequestContext context, DotvvmView view);
 
-        Task WriteStaticCommandResponse(IDotvvmRequestContext context, string json);
+        Task WritePlainJsonResponse(IHttpContext context, string json);
 
-        Task RenderPlainJsonResponse(IHttpContext context, string json);
-
-        Task RenderHtmlResponse(IHttpContext context, string html);
-
-        Task RenderPlainTextResponse(IHttpContext context, string text);
+        Task WritePlainTextResponse(IHttpContext context, string text);
 
         IEnumerable<(string name, string html)> RenderPostbackUpdatedControls(IDotvvmRequestContext context, DotvvmView page);
     }

--- a/src/Framework/Framework/ViewModel/Serialization/DefaultViewModelSerializer.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/DefaultViewModelSerializer.cs
@@ -17,6 +17,9 @@ using DotVVM.Framework.ResourceManagement;
 using DotVVM.Framework.Binding;
 using System.Collections.Immutable;
 using RecordExceptions;
+using DotVVM.Framework.Compilation.Binding;
+using Microsoft.Extensions.DependencyInjection;
+using System.Threading.Tasks;
 
 namespace DotVVM.Framework.ViewModel.Serialization
 {
@@ -304,6 +307,17 @@ namespace DotVVM.Framework.ViewModel.Serialization
             return result.ToString(JsonFormatting);
         }
 
+        /// <summary>
+        /// Serializes the HTTP request error object.
+        /// </summary>
+        public string SerializeErrorResponse(string action, string errorMessage)
+        {
+            // create result object
+            var result = new JObject();
+            result["action"] = action;
+            result["message"] = errorMessage;
+            return result.ToString(JsonFormatting);
+        }
 
         /// <summary>
         /// Populates the view model from the data received from the request.
@@ -364,6 +378,28 @@ namespace DotVVM.Framework.ViewModel.Serialization
             }
         }
 
+        public async Task<StaticCommandRequest> DeserializeStaticCommandRequest(IDotvvmRequestContext context)
+        {
+            JObject postData;
+            using (var jsonReader = new JsonTextReader(new StreamReader(context.HttpContext.Request.Body)))
+            {
+                postData = await JObject.LoadAsync(jsonReader);
+            }
+
+            // validate csrf token
+            context.CsrfToken = postData["$csrfToken"].Value<string>();
+
+            var command = postData["command"].Value<string>();
+            var arguments = postData["args"] as JArray;
+            var executionPlan =
+                StaticCommandExecutionPlanSerializer.DecryptJson(Convert.FromBase64String(command), context.Services.GetRequiredService<IViewModelProtector>())
+                    .Apply(StaticCommandExecutionPlanSerializer.DeserializePlan);
+
+            var serializer = CreateJsonSerializer();
+            var argumentAccessors = arguments.Select(a => (Func<Type, object>)(targetType => a.ToObject(targetType, serializer)));
+            return new StaticCommandRequest(executionPlan, argumentAccessors);
+        }
+
         /// <summary>
         /// Resolves the command for the specified post data.
         /// </summary>
@@ -415,5 +451,6 @@ namespace DotVVM.Framework.ViewModel.Serialization
 
             context.ViewModelJson["updatedControls"] = result;
         }
+
     }
 }

--- a/src/Framework/Framework/ViewModel/Serialization/IViewModelSerializer.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/IViewModelSerializer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using DotVVM.Framework.Controls.Infrastructure;
 using DotVVM.Framework.Hosting;
 using DotVVM.Framework.Runtime.Filters;
@@ -15,11 +16,16 @@ namespace DotVVM.Framework.ViewModel.Serialization
 
         string SerializeModelState(IDotvvmRequestContext context);
 
+        string SerializeErrorResponse(string action, string errorMessage);
+
         void PopulateViewModel(IDotvvmRequestContext context, string serializedPostData);
+
+        Task<StaticCommandRequest> DeserializeStaticCommandRequest(IDotvvmRequestContext context);
 
         ActionInfo? ResolveCommand(IDotvvmRequestContext context, DotvvmView view);
 
         void AddPostBackUpdatedControls(IDotvvmRequestContext context, IEnumerable<(string name, string html)> postbackUpdatedControls);
+
         void AddNewResources(IDotvvmRequestContext context);
     }
 }

--- a/src/Framework/Framework/ViewModel/Serialization/StaticCommandRequest.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/StaticCommandRequest.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using DotVVM.Framework.Compilation.Binding;
+
+namespace DotVVM.Framework.ViewModel.Serialization
+{
+    public class StaticCommandRequest
+    {
+
+        public StaticCommandInvocationPlan ExecutionPlan { get; }
+        public IEnumerable<Func<Type, object>> ArgumentAccessors { get; }
+
+        public StaticCommandRequest(StaticCommandInvocationPlan executionPlan, IEnumerable<Func<Type, object>> argumentAccessors)
+        {
+            ExecutionPlan = executionPlan;
+            ArgumentAccessors = argumentAccessors;
+        }
+    }
+}


### PR DESCRIPTION
I didn't like that the `DotvvmPresenter` relies on `Newtonsoft.Json` so I've moved all serialization code into the `IViewModelSerializer` implementation.

I also had to change the interface, and also I've merged several similar methods into one, so it is a breaking change.
However, it doesn't seem very probable to me that someone would actually implement these interfaces.

I want to wait until #1498 is merged as there will be conflicts.