### PR TITLE
MemberExpressionFactory filters out private members

### DIFF
--- a/src/Framework/Framework/Compilation/Binding/MemberExpressionFactory.cs
+++ b/src/Framework/Framework/Compilation/Binding/MemberExpressionFactory.cs
@@ -57,7 +57,7 @@ namespace DotVVM.Framework.Compilation.Binding
             catch { }
 
             var members = new List<MemberInfo>();
-            foreach (var m in type.GetAllMembers())
+            foreach (var m in type.GetAllMembers(bindingFlags))
                 if (((isGeneric && m is TypeInfo) ? genericName : name) == m.Name)
                     members.Add(m);
 
@@ -72,7 +72,11 @@ namespace DotVVM.Framework.Compilation.Binding
                 }
 
                 if (members.Count == 0 && throwExceptions)
-                    throw new Exception($"Could not find { (isStatic ? "static" : "instance") } member { name } on type { type.FullName }.");
+                {
+                    var privateMember = type.GetAllMembers(bindingFlags | BindingFlags.NonPublic).Where(m => m.Name == name).FirstOrDefault();
+                    var privateMemberHelp = privateMember is null ? "" : $" Note that private member '{privateMember}' exists, please make it public to use in the binding.";
+                    throw new Exception($"Could not find { (isStatic ? "static" : "instance") } member { name } on type { type.FullName }." + privateMemberHelp);
+                }
                 else if (members.Count == 0 && !throwExceptions)
                     return null;
             }

--- a/src/Framework/Framework/Compilation/Binding/MemberExpressionFactory.cs
+++ b/src/Framework/Framework/Compilation/Binding/MemberExpressionFactory.cs
@@ -74,8 +74,12 @@ namespace DotVVM.Framework.Compilation.Binding
                 if (members.Count == 0 && throwExceptions)
                 {
                     var privateMember = type.GetAllMembers(bindingFlags | BindingFlags.NonPublic).Where(m => m.Name == name).FirstOrDefault();
-                    var privateMemberHelp = privateMember is null ? "" : $" Note that private member '{privateMember}' exists, please make it public to use in the binding.";
-                    throw new Exception($"Could not find { (isStatic ? "static" : "instance") } member { name } on type { type.FullName }." + privateMemberHelp);
+                    if (privateMember is {})
+                        throw new Exception($"{ (isStatic ? "Static" : "Instance") } member '{privateMember}' is private, please make it public to use it in the binding.");
+                    var staticMember = type.GetAllMembers(bindingFlags | BindingFlags.Static | BindingFlags.Instance).Where(m => m.Name == name).FirstOrDefault();
+                    if (staticMember is {})
+                        throw new Exception($"Member '{staticMember}' is {(isStatic ? "not static" : "static")}.");
+                    throw new Exception($"Could not find { (isStatic ? "static" : "instance") } member { name } on type { type.FullName }.");
                 }
                 else if (members.Count == 0 && !throwExceptions)
                     return null;

--- a/src/Tests/Binding/ExpressionHelperTests.cs
+++ b/src/Tests/Binding/ExpressionHelperTests.cs
@@ -12,12 +12,15 @@ using DotVVM.Framework.Testing;
 using Microsoft.CSharp.RuntimeBinder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using CheckTestOutput;
+using DotVVM.Framework.Tests.Runtime;
 
 namespace DotVVM.Framework.Tests.Binding
 {
     [TestClass]
     public class ExpressionHelperTests
     {
+        OutputChecker check = new CheckTestOutput.OutputChecker("testoutputs");
         public TestContext TestContext { get; set; }
         private MemberExpressionFactory memberExpressionFactory;
 
@@ -278,6 +281,20 @@ namespace DotVVM.Framework.Tests.Binding
             Call_FindOverload_Generic(typeof(MethodsParamsArgumentsGenericResolvingSampleObject),
                 MethodsParamsArgumentsGenericResolvingSampleObject.MethodName, argTypes, resultIdentifierType, expectedArgsTypes);
         }
+
+        [TestMethod]
+        [DataRow("PrivateField", "Could not find instance member PrivateField on type DotVVM.Framework.Tests.Binding.ErrorSampleObject. Note that private member 'System.String PrivateField' exists, please make it public to use in the binding.")]
+        [DataRow("PrivateProperty", "Could not find instance member PrivateProperty on type DotVVM.Framework.Tests.Binding.ErrorSampleObject. Note that private member 'System.String PrivateProperty' exists, please make it public to use in the binding.")]
+        [DataRow("StaticProperty", "Could not find instance member StaticProperty on type DotVVM.Framework.Tests.Binding.ErrorSampleObject.")]
+        public void Error_MemberPrivate(string memberName, string error)
+        {
+            var ex = Assert.ThrowsException<Exception>(() =>
+                memberExpressionFactory.GetMember(
+                    Expression.Parameter(typeof(ErrorSampleObject), "vm"),
+                    memberName
+                ));
+            Assert.AreEqual(error, ex.Message);
+        }
     }
     public static class MethodsParamsArgumentsGenericResolvingSampleObject
     {
@@ -335,6 +352,13 @@ namespace DotVVM.Framework.Tests.Binding
     public class GenericModelSampleObject<T>
     {
         public T Prop { get; set; }
+    }
+
+    public class ErrorSampleObject
+    {
+        private string PrivateField;
+        private string PrivateProperty { get; }
+        public static string StaticProperty { get; }
     }
 
     public class GenericTestResult1 { }

--- a/src/Tests/Binding/ExpressionHelperTests.cs
+++ b/src/Tests/Binding/ExpressionHelperTests.cs
@@ -283,9 +283,9 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
-        [DataRow("PrivateField", "Could not find instance member PrivateField on type DotVVM.Framework.Tests.Binding.ErrorSampleObject. Note that private member 'System.String PrivateField' exists, please make it public to use in the binding.")]
-        [DataRow("PrivateProperty", "Could not find instance member PrivateProperty on type DotVVM.Framework.Tests.Binding.ErrorSampleObject. Note that private member 'System.String PrivateProperty' exists, please make it public to use in the binding.")]
-        [DataRow("StaticProperty", "Could not find instance member StaticProperty on type DotVVM.Framework.Tests.Binding.ErrorSampleObject.")]
+        [DataRow("PrivateField", "Instance member 'System.String PrivateField' is private, please make it public to use it in the binding.")]
+        [DataRow("PrivateProperty", "Instance member 'System.String PrivateProperty' is private, please make it public to use it in the binding.")]
+        [DataRow("StaticProperty", "Member 'System.String StaticProperty' is static.")]
         public void Error_MemberPrivate(string memberName, string error)
         {
             var ex = Assert.ThrowsException<Exception>(() =>

--- a/src/Tests/Binding/StaticCommandCompilationTests.cs
+++ b/src/Tests/Binding/StaticCommandCompilationTests.cs
@@ -414,7 +414,7 @@ namespace DotVVM.Framework.Tests.Binding
 
             var result = Assert.ThrowsException<BindingPropertyException>(() => CompileBinding("TestViewModel.GetCharCode", false, typeof(TestViewModel)));
 
-            Assert.AreEqual("Static method 'TestViewModel.GetCharCode' not found, but an instance method exists.", result.GetBaseException().Message);
+            Assert.AreEqual("Member 'Int32 GetCharCode(Char)' is not static.", result.GetBaseException().Message);
         }
 
         public void AreEqual(string expected, string actual)


### PR DESCRIPTION
We didn't pass bindingFlags to the GetAllMembers method :|

This bug was probably introduced in 4.0, but the fix will break any code depending on the behavior. However, I think it's quite unlikely many people would use private properties, since the serializer would ignore them.