### PR TITLE
CompositeControl: merge MarkupOption attribute with implicit metadata

### DIFF
--- a/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
+++ b/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
@@ -349,7 +349,7 @@ namespace DotVVM.Framework.Binding
                     if (typeof(IDotvvmObjectLike).IsAssignableFrom(type) ||
                         typeof(ITemplate).IsAssignableFrom(type) ||
                         typeof(IEnumerable<IDotvvmObjectLike>).IsAssignableFrom(type))
-                        dotvvmProperty.MarkupOptions._mappingMode = MappingMode.InnerElement;
+                        dotvvmProperty.MarkupOptions._mappingMode ??= MappingMode.InnerElement;
 
                     DotvvmProperty.Register(dotvvmProperty);
                 }

--- a/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
+++ b/src/Framework/Framework/Binding/DotvvmCapabilityProperty.cs
@@ -339,20 +339,17 @@ namespace DotVVM.Framework.Binding
                     
                     var isNullable = propertyType.IsNullable() || type.IsNullable();
                     if (!defaultValue.HasValue && !isNullable)
-                        dotvvmProperty.MarkupOptions.Required = true;
+                        dotvvmProperty.MarkupOptions._required ??= true;
 
                     if (typeof(IBinding).IsAssignableFrom(propertyType))
-                        dotvvmProperty.MarkupOptions.AllowHardCodedValue = false;
+                        dotvvmProperty.MarkupOptions._allowHardCodedValue ??= false;
                     else if (!typeof(ValueOrBinding).IsAssignableFrom(propertyType.UnwrapNullableType()))
-                        dotvvmProperty.MarkupOptions.AllowBinding = false;
+                        dotvvmProperty.MarkupOptions._allowBinding ??= false;
 
-                    if (!attributeProvider.IsDefined(typeof(MarkupOptionsAttribute), true))
-                    {
-                        if (typeof(IDotvvmObjectLike).IsAssignableFrom(type) ||
-                            typeof(ITemplate).IsAssignableFrom(type) ||
-                            typeof(IEnumerable<IDotvvmObjectLike>).IsAssignableFrom(type))
-                            dotvvmProperty.MarkupOptions.MappingMode = MappingMode.InnerElement;
-                    }
+                    if (typeof(IDotvvmObjectLike).IsAssignableFrom(type) ||
+                        typeof(ITemplate).IsAssignableFrom(type) ||
+                        typeof(IEnumerable<IDotvvmObjectLike>).IsAssignableFrom(type))
+                        dotvvmProperty.MarkupOptions._mappingMode = MappingMode.InnerElement;
 
                     DotvvmProperty.Register(dotvvmProperty);
                 }

--- a/src/Framework/Framework/Controls/MarkupOptionsAttribute.cs
+++ b/src/Framework/Framework/Controls/MarkupOptionsAttribute.cs
@@ -15,12 +15,23 @@ namespace DotVVM.Framework.Controls
         /// <summary>
         /// Gets or sets whether client-side data-bindings can be used on this property (`value` and `controlProperty`).
         /// </summary>
-        public bool AllowBinding { get; set; } = true;
+        public bool AllowBinding
+        {
+            get => _allowBinding ?? true;
+            set => _allowBinding = value;
+        }
+
+        internal bool? _allowBinding = null;
 
         /// <summary>
         /// Gets or sets whether the server-side value in markup can be used on this property. Allows both value hard-coded in markup and `resource` binding, which is always evaluated server-side.
         /// </summary>
-        public bool AllowHardCodedValue { get; set; } = true;
+        public bool AllowHardCodedValue
+        {
+            get => _allowHardCodedValue ?? true;
+            set => _allowHardCodedValue = value;
+        }
+        internal bool? _allowHardCodedValue = null;
 
         /// <summary>
         /// Gets or sets the name in markup. Null means that the name of the property should be used.
@@ -30,24 +41,49 @@ namespace DotVVM.Framework.Controls
         /// <summary>
         /// Determines if multiple property assignments can be merged into one value. For example `&lt;div class='x' class='y' ...` is equivalent to `&lt;div class='x y'` because of the merging.
         /// </summary>
-        public bool AllowValueMerging { get; set; }
+        public bool AllowValueMerging
+        {
+            get => _allowValueMerging ?? false;
+            set => _allowValueMerging = value;
+        }
+        internal bool? _allowValueMerging = null;
 
         /// <summary>
         /// Type with non parametric constructor which implements IAttributeValueMerger interface
         /// </summary>
-        public Type AttributeValueMerger { get; set; } = typeof(DefaultAttributeValueMerger);
+        public Type AttributeValueMerger
+        {
+            get => _attributeValueMerger ?? typeof(DefaultAttributeValueMerger);
+            set => _attributeValueMerger = value;
+        }
+        internal Type? _attributeValueMerger = null;
 
         /// <summary>
         /// Gets or sets the mapping mode - whether the property is used as an attribute or inner element (or both are allowed).
         /// </summary>
-        public MappingMode MappingMode { get; set; } = MappingMode.Attribute;
+        public MappingMode MappingMode
+        {
+            get => _mappingMode ?? MappingMode.Attribute;
+            set => _mappingMode = value;
+        }
+        internal MappingMode? _mappingMode = null;
 
         /// <summary>
         /// Determines whether attributes without value are allowed.
         /// </summary>
-        public bool AllowAttributeWithoutValue { get; set; }
+        public bool AllowAttributeWithoutValue
+        {
+            get => _allowAttributeWithoutValue ?? false;
+            set => _allowAttributeWithoutValue = value;
+        }
+        internal bool? _allowAttributeWithoutValue = null;
 
         /// <summary> Whether the property must always be specified on this control. It is also allowed to set the property using server-side styles. </summary>
-        public bool Required { get; set; }
+        public bool Required
+        {
+            get => _required ?? false;
+            set => _required = value;
+        }
+        internal bool? _required = null;
     }
 }

--- a/src/Tests/Runtime/CompositeControlPropertyRegistrationTests.cs
+++ b/src/Tests/Runtime/CompositeControlPropertyRegistrationTests.cs
@@ -47,14 +47,22 @@ namespace DotVVM.Framework.Tests.Runtime
             var template1 = DotvvmProperty.ResolveProperty(typeof(Control_BasicPropertyAttributes), "Template1").NotNull();
             Assert.AreEqual(typeof(ITemplate), template1.PropertyType);
             Assert.AreEqual(MappingMode.InnerElement, template1.MarkupOptions.MappingMode);
+            Assert.IsTrue(template1.MarkupOptions.Required);
 
             var template2 = DotvvmProperty.ResolveProperty(typeof(Control_BasicPropertyAttributes), "Template2").NotNull();
             Assert.AreEqual(typeof(HtmlGenericControl), template2.PropertyType);
             Assert.AreEqual(MappingMode.InnerElement, template2.MarkupOptions.MappingMode);
+            Assert.AreEqual("Template2-ChangedName", template2.MarkupOptions.Name);
+            Assert.IsTrue(template2.MarkupOptions.Required);
 
             var template3 = DotvvmProperty.ResolveProperty(typeof(Control_BasicPropertyAttributes), "Template3").NotNull();
             Assert.AreEqual(typeof(IEnumerable<GridView>), template3.PropertyType);
             Assert.AreEqual(MappingMode.InnerElement, template3.MarkupOptions.MappingMode);
+            Assert.IsFalse(template3.MarkupOptions.Required);
+
+            var requiredInnerElementProperty = DotvvmProperty.ResolveProperty(typeof(Control_BasicPropertyAttributes), "RequiredInnerElementProperty").NotNull();
+            Assert.AreEqual(MappingMode.Both, requiredInnerElementProperty.MarkupOptions.MappingMode);
+            Assert.IsTrue(requiredInnerElementProperty.MarkupOptions.Required);
         }
 
         [TestMethod]
@@ -80,11 +88,13 @@ namespace DotVVM.Framework.Tests.Runtime
                 DotvvmProperty.Register<string, Control_BasicPropertyAttributes>(nameof(AnotherHiddenProperty));
 
             public DotvvmControl GetContents(
+                [MarkupOptions(MappingMode = MappingMode.Both)]
+                string requiredInnerElementProperty,
                 int valueOnlyProperty,
                 IValueBinding<string> bindingOnlyProperty,
                 ValueOrBinding<string> property,
                 ITemplate template1,
-                // [MarkupOptions(Name = "Template2-ChangedName")]
+                [MarkupOptions(Name = "Template2-ChangedName", Required = true)]
                 HtmlGenericControl template2 = null,
                 IEnumerable<GridView> template3 = null,
                 ITemplate template = null,

--- a/src/Tests/Runtime/CompositeControlPropertyRegistrationTests.cs
+++ b/src/Tests/Runtime/CompositeControlPropertyRegistrationTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Compilation.ControlTree;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DotVVM.Framework.Utils;
+
+namespace DotVVM.Framework.Tests.Runtime
+{
+    [TestClass]
+    public class CompositeControlPropertyRegistrationTests
+    {
+        // initialize properties
+        IControlResolver controlResolver = DotvvmTestHelper.DefaultConfig.ServiceProvider.GetRequiredService<IControlResolver>();
+
+        [TestMethod]
+        public void PropertyBindableOrHardcoded()
+        {
+            var valueOnlyProperty = DotvvmProperty.ResolveProperty(typeof(Control_BasicPropertyAttributes), "ValueOnlyProperty").NotNull();
+            Assert.IsTrue(valueOnlyProperty.MarkupOptions.AllowHardCodedValue);
+            Assert.IsFalse(valueOnlyProperty.MarkupOptions.AllowBinding);
+            Assert.AreEqual(typeof(int), valueOnlyProperty.PropertyType);
+            var bindingOnlyProperty = DotvvmProperty.ResolveProperty(typeof(Control_BasicPropertyAttributes), "BindingOnlyProperty").NotNull();
+            Assert.IsFalse(bindingOnlyProperty.MarkupOptions.AllowHardCodedValue);
+            Assert.IsTrue(bindingOnlyProperty.MarkupOptions.AllowBinding);
+            Assert.AreEqual(typeof(IValueBinding<string>), bindingOnlyProperty.PropertyType);
+            Assert.IsTrue(bindingOnlyProperty.IsBindingProperty);
+            var property = DotvvmProperty.ResolveProperty(typeof(Control_BasicPropertyAttributes), "Property").NotNull();
+            Assert.IsTrue(property.MarkupOptions.AllowHardCodedValue);
+            Assert.IsTrue(property.MarkupOptions.AllowBinding);
+            Assert.AreEqual(typeof(string), property.PropertyType);
+            Assert.IsFalse(property.IsBindingProperty);
+
+            Assert.IsTrue(valueOnlyProperty.MarkupOptions.Required);
+            Assert.IsTrue(bindingOnlyProperty.MarkupOptions.Required);
+            Assert.IsTrue(property.MarkupOptions.Required);
+        }
+
+        [TestMethod]
+        public void TemplateProperties()
+        {
+            var template1 = DotvvmProperty.ResolveProperty(typeof(Control_BasicPropertyAttributes), "Template1").NotNull();
+            Assert.AreEqual(typeof(ITemplate), template1.PropertyType);
+            Assert.AreEqual(MappingMode.InnerElement, template1.MarkupOptions.MappingMode);
+
+            var template2 = DotvvmProperty.ResolveProperty(typeof(Control_BasicPropertyAttributes), "Template2").NotNull();
+            Assert.AreEqual(typeof(HtmlGenericControl), template2.PropertyType);
+            Assert.AreEqual(MappingMode.InnerElement, template2.MarkupOptions.MappingMode);
+
+            var template3 = DotvvmProperty.ResolveProperty(typeof(Control_BasicPropertyAttributes), "Template3").NotNull();
+            Assert.AreEqual(typeof(IEnumerable<GridView>), template3.PropertyType);
+            Assert.AreEqual(MappingMode.InnerElement, template3.MarkupOptions.MappingMode);
+        }
+
+        [TestMethod]
+        public void ExplicitMappingMode()
+        {
+            var hiddenProperty = DotvvmProperty.ResolveProperty(typeof(Control_BasicPropertyAttributes), "HiddenProperty").NotNull();
+            Assert.AreEqual(MappingMode.Exclude, hiddenProperty.MarkupOptions.MappingMode);
+            Assert.IsFalse(hiddenProperty.MarkupOptions.Required);
+
+            var anotherHiddenProperty = DotvvmProperty.ResolveProperty(typeof(Control_BasicPropertyAttributes), "AnotherHiddenProperty").NotNull();
+            Assert.AreEqual(MappingMode.Exclude, anotherHiddenProperty.MarkupOptions.MappingMode);
+        }
+
+        public class Control_BasicPropertyAttributes: CompositeControl
+        {
+            [MarkupOptions(MappingMode = MappingMode.Exclude)]
+            public string AnotherHiddenProperty
+            {
+                get { return (string)GetValue(AnotherHiddenPropertyProperty); }
+                set { SetValue(AnotherHiddenPropertyProperty, value); }
+            }
+            public static readonly DotvvmProperty AnotherHiddenPropertyProperty =
+                DotvvmProperty.Register<string, Control_BasicPropertyAttributes>(nameof(AnotherHiddenProperty));
+
+            public DotvvmControl GetContents(
+                int valueOnlyProperty,
+                IValueBinding<string> bindingOnlyProperty,
+                ValueOrBinding<string> property,
+                ITemplate template1,
+                // [MarkupOptions(Name = "Template2-ChangedName")]
+                HtmlGenericControl template2 = null,
+                IEnumerable<GridView> template3 = null,
+                ITemplate template = null,
+                [MarkupOptions(MappingMode = MappingMode.Exclude)]
+                int hiddenProperty = 0
+            )
+            {
+                return new PlaceHolder();
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Added internal nullable field to each MarkupOptions property, so
we can distinguish if the user used the property explicitly or
it only contains the default value.