### PR TITLE
Fixed UI tests in Firefox

### DIFF
--- a/src/Samples/Common/Views/ControlSamples/ListBox/ListBox.dothtml
+++ b/src/Samples/Common/Views/ControlSamples/ListBox/ListBox.dothtml
@@ -14,7 +14,7 @@
                  ItemTextBinding="{value: Text}"
                  ItemValueBinding="{value: Value}"
                  ItemTitleBinding="{value: Title}"
-                 Size="3" />
+                 Size="4" />
 
     Selected: <span data-ui="result" InnerText="{value: SelectedValue}"></span>
 
@@ -23,7 +23,7 @@
                  ItemTextBinding="{value: Text}"
                  ItemValueBinding="{value: Value}"
                  ItemTitleBinding="{value: Title}"
-                 Size="3" />
+                 Size="4" />
 
     Selected:
     <dot:Repeater WrapperTagName="ul" DataSource={value: SelectedValues}>

--- a/src/Samples/Common/Views/FeatureSamples/Api/ApiRefresh.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/Api/ApiRefresh.dothtml
@@ -32,6 +32,8 @@
         Number of requests: <span data-ui="number">{{value: NumberOfRequests}}</span>
     </p>
 
+    <button>button because of firefox</button>
+
     <script type="text/javascript">
         var fetchBackup = window.fetch;
         window.fetch = function (url, init) {

--- a/src/Samples/Tests/Tests/Control/ListBoxTests.cs
+++ b/src/Samples/Tests/Tests/Control/ListBoxTests.cs
@@ -24,7 +24,7 @@ namespace DotVVM.Samples.Tests.Control
                 var result = browser.Single("[data-ui=result]");
                 AssertUI.InnerTextEquals(result, "0");
 
-                AssertUI.Attribute(browser.Single("select[data-ui=single]"), "size", "3");
+                AssertUI.Attribute(browser.Single("select[data-ui=single]"), "size", "4");
 
                 var firstOption = browser.ElementAt("select[data-ui=single] option", 0);
 


### PR DESCRIPTION
Firefox cannot scroll in the ListBox, so I increased its size.
It doesn't set focus to input when it tabs out from the page.