### PR TITLE
Don't update properties with update: "no" 

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/global-declarations.ts
+++ b/src/Framework/Framework/Resources/Scripts/global-declarations.ts
@@ -254,7 +254,7 @@ type TypeMetadata = ObjectTypeMetadata | EnumTypeMetadata;
 type PropertyMetadata = {
     type: TypeDefinition;
     post?: "always" | "pathOnly" | "no";
-    update?: "always" | "firstRequest" | "no";
+    update?: "always" | "no";
     validationRules?: PropertyValidationRuleInfo[];
     clientExtenders?: ClientExtenderInfo[]
 }

--- a/src/Framework/Framework/Resources/Scripts/postback/postbackCore.ts
+++ b/src/Framework/Framework/Resources/Scripts/postback/postbackCore.ts
@@ -13,6 +13,7 @@ import { DotvvmPostbackError } from '../shared-classes';
 import { getKnownTypes, updateTypeInfo } from '../metadata/typeMap';
 import { isPrimitive } from '../utils/objects';
 import * as stateManager from '../state-manager'
+import { mapUpdatableProperties } from '../serialization/deserialize';
 
 let lastStartedPostbackId: number;
 
@@ -135,7 +136,7 @@ async function processPostbackResponse(options: PostbackOptions, context: any, p
     let isSuccess = false;
     if (result.action == "successfulCommand") {
         updateTypeInfo(result.typeMetadata)
-        result.viewModel = updater.patchViewModel(getState(), result.viewModel)
+        result.viewModel = updater.patchViewModel(getState(), mapUpdatableProperties(result.viewModel))
         updater.updateViewModelAndControls(result);
         events.postbackViewModelUpdated.trigger({
             ...options,

--- a/src/Framework/Framework/ViewModel/Serialization/ViewModelTypeMetadataSerializer.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/ViewModelTypeMetadataSerializer.cs
@@ -125,7 +125,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
 
                 if (!property.TransferAfterPostback)
                 {
-                    prop["update"] = property.TransferFirstRequest ? "firstRequest" : "no";
+                    prop["update"] = "no";
                 }
 
                 if (property.ValidationRules.Any() && property.ClientValidationRules.Any())

--- a/src/Samples/Common/ViewModels/FeatureSamples/PostbackConcurrency/PostbackConcurrencyViewModel.cs
+++ b/src/Samples/Common/ViewModels/FeatureSamples/PostbackConcurrency/PostbackConcurrencyViewModel.cs
@@ -14,6 +14,10 @@ namespace DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.PostbackConcurre
         [Bind(Direction.None)]
         public PostbackConcurrencyMode ConcurrencyMode { get; set; }
 
+
+        [Bind(Direction.ServerToClientFirstRequest | Direction.ClientToServer)]
+        public int ClientSideOnlyCounter { get; set; }
+
         public void LongAction()
         {
             Thread.Sleep(LongActionDurationInMs);

--- a/src/Samples/Common/ViewModels/FeatureSamples/Serialization/ViewModelTransferredOnlyInPath.cs
+++ b/src/Samples/Common/ViewModels/FeatureSamples/Serialization/ViewModelTransferredOnlyInPath.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.Serialization
+{
+    public class ViewModelTransferredOnlyInPath: DotvvmViewModelBase
+    {
+        [Bind(Direction.ServerToClientFirstRequest | Direction.ClientToServerInPostbackPath)]
+        public List<ViewModel2> Collection { get; set; }
+
+        public string Result { get; set; } = "";
+
+        public override Task PreRender()
+        {
+            Collection = new() {
+                new ViewModel2 { Name = "A" },
+                new ViewModel2 { Name = "B" },
+                new ViewModel2 { Name = "C" },
+                new ViewModel2 { Name = "D" }
+            };
+            return base.PreRender();
+        }
+
+        public void Method(ViewModel2 viewModel2)
+        {
+            Result = viewModel2.Name;
+        }
+
+        public class ViewModel2
+        {
+            public string Name { get; set; }
+            public string Value { get; set; } = "test";
+        }
+    }
+}
+

--- a/src/Samples/Common/Views/FeatureSamples/PostbackConcurrency/PostbackConcurrencyMode.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/PostbackConcurrency/PostbackConcurrencyMode.dothtml
@@ -43,6 +43,15 @@
         </div>
 
         <div>
+            <p>Client-side only counter - should be unaffected by running postbacks</p>
+            <dot:Button Text={value: ClientSideOnlyCounter}
+                        Click={staticCommand: ClientSideOnlyCounter = ClientSideOnlyCounter + 1}
+                        Postback.concurrency=Default
+                        style="width: 100px"
+                        data-ui="counter" />
+        </div>
+
+        <div>
             Concurrency Mode:
             <a href="?concurrency=None">None</a> /
             <a href="?concurrency=Queue">Queue</a> /

--- a/src/Samples/Common/Views/FeatureSamples/Serialization/TransferredOnlyInPath.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/Serialization/TransferredOnlyInPath.dothtml
@@ -1,0 +1,30 @@
+@viewModel DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.Serialization.ViewModelTransferredOnlyInPath
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+	<h1></h1>
+
+	<p> Click on Set Result, the name of the item should appear bellow.  </p>
+	<p> Only the row on which you clicked should be transferred to server, and only the Result property should be transferred back to the client. </p>
+
+	<div>Count = <dot:Literal Text={value: Collection.Count} data-ui=count /> </div>
+	<div>Result = <dot:Literal Text={value: Result} data-ui=result /> </div>
+
+	<hr />
+
+	<dot:Repeater DataSource={value: Collection}>
+		<ItemTemplate>
+			<div>
+				{{value: Name}}
+				<dot:Button Text="Set Result" data-ui={value: "set_result_" + Name} Click={command: _parent.Method(_this)} />
+			</div>
+		</ItemTemplate>
+	</dot:Repeater>
+</body>
+</html>

--- a/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
@@ -1,4 +1,4 @@
-﻿
+
 
 // DO NOT MODIFY THIS FILE - THIS FILE IS GENERATED !!!
 
@@ -322,6 +322,7 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_Serialization_Serialization = "FeatureSamples/Serialization/Serialization";
         public const string FeatureSamples_Serialization_SerializationDateTimeOffset = "FeatureSamples/Serialization/SerializationDateTimeOffset";
         public const string FeatureSamples_Serialization_TimeSpan = "FeatureSamples/Serialization/TimeSpan";
+        public const string FeatureSamples_Serialization_TransferredOnlyInPath = "FeatureSamples/Serialization/TransferredOnlyInPath";
         public const string FeatureSamples_ServerComments_ServerComments = "FeatureSamples/ServerComments/ServerComments";
         public const string FeatureSamples_ServerSideStyles_ServerSideStyles = "FeatureSamples/ServerSideStyles/ServerSideStyles";
         public const string FeatureSamples_ServerSideStyles_ServerSideStyles_ControlProperties = "FeatureSamples/ServerSideStyles/ServerSideStyles_ControlProperties";

--- a/src/Samples/Tests/Tests/Feature/PostbackConcurrencyTests.cs
+++ b/src/Samples/Tests/Tests/Feature/PostbackConcurrencyTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
 using Riganti.Selenium.Core;
@@ -119,6 +119,30 @@ namespace DotVVM.Samples.Tests.Feature
                     AssertUI.InnerTextEquals(postbackIndexSpan, "1");
                     AssertUI.InnerTextEquals(lastActionSpan, "long");
                 }, 6000);
+            });
+        }
+
+        [Theory]
+        [InlineData("input[data-ui=long-action-button]")]
+        [InlineData("input[data-ui=short-action-button]")]
+        [InlineData("input[data-ui=long-static-action-button]")]
+        public void Feature_PostbackConcurrency_UnrelatedProperty(string actionSelector)
+        {
+            // execute action, before it finishes update the counter, check that counter value didn't get reverted
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_PostbackConcurrency_DefaultMode);
+                browser.WaitUntilDotvvmInited();
+
+                browser.Single(actionSelector).Click();
+                browser.Wait(300);
+
+                browser.Single("counter", SelectByDataUi).Click();
+                browser.Single("counter", SelectByDataUi).Click();
+                AssertUI.InnerTextEquals(browser.Single("counter", SelectByDataUi), "2");
+
+                browser.Wait(6000);
+                AssertUI.InnerTextEquals(browser.Single("span[data-ui=postback-index]"), "1");
+                AssertUI.InnerTextEquals(browser.Single("counter", SelectByDataUi), "2");
             });
         }
 

--- a/src/Samples/Tests/Tests/Feature/SerializationTests.cs
+++ b/src/Samples/Tests/Tests/Feature/SerializationTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
 using OpenQA.Selenium;
@@ -300,6 +300,34 @@ namespace DotVVM.Samples.Tests.Feature
                 AssertUI.TextEquals(timeOnlyTextBox, newTimeOnlyValue);
                 AssertUI.TextEquals(timeOnlySpan, newTimeOnlyValue);
                 AssertUI.TextEquals(timeOnlyPlain, "TimeOnly: " + newTimeOnlyValue);
+            });
+        }
+
+        [Fact]
+        public void Feature_Serialization_TransferredOnlyInPath()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_Serialization_TransferredOnlyInPath);
+
+                browser.Single("set_result_B", SelectByDataUi).Click();
+                AssertUI.InnerTextEquals(browser.Single("result", SelectByDataUi), "B");
+
+                browser.Single("set_result_B", SelectByDataUi).Click();
+                AssertUI.InnerTextEquals(browser.Single("result", SelectByDataUi), "B");
+                AssertUI.InnerTextEquals(browser.Single("count", SelectByDataUi), "4");
+
+                browser.Single("set_result_D", SelectByDataUi).Click();
+                AssertUI.InnerTextEquals(browser.Single("result", SelectByDataUi), "D");
+
+                browser.Single("set_result_C", SelectByDataUi).Click();
+                AssertUI.InnerTextEquals(browser.Single("result", SelectByDataUi), "C");
+
+                browser.Single("set_result_A", SelectByDataUi).Click();
+                AssertUI.InnerTextEquals(browser.Single("result", SelectByDataUi), "A");
+
+                browser.Single("set_result_B", SelectByDataUi).Click();
+                AssertUI.InnerTextEquals(browser.Single("result", SelectByDataUi), "B");
+                AssertUI.InnerTextEquals(browser.Single("count", SelectByDataUi), "4");
             });
         }
 

--- a/src/Tests/ViewModel/testoutputs/ViewModelTypeMetadataSerializerTests.ViewModelTypeMetadata_TypeMetadata.json
+++ b/src/Tests/ViewModel/testoutputs/ViewModelTypeMetadataSerializerTests.ViewModelTypeMetadata_TypeMetadata.json
@@ -5,11 +5,11 @@
 			"ChildFirstRequest": {
 				"type": "5PrhilQGdc+tT1tU",
 				"post": "no",
-				"update": "firstRequest"
+				"update": "no"
 			},
 			"ClientToServer": {
 				"type": "String",
-				"update": "firstRequest"
+				"update": "no"
 			},
 			"NestedList": {
 				"type": [


### PR DESCRIPTION
Properties not tranferred server->client shouldn't be updated after a
postback. Doing this lead to unnecesary reverts of client-side
changed value and broke ClientToServerInPostbackPath bind direction.

Resolves https://github.com/riganti/dotvvm/issues/1534