### PR TITLE
MarkupFileLoader will not reload in Release and not leak in Debug

### DIFF
--- a/src/Framework/Framework/Compilation/DefaultControlBuilderFactory.cs
+++ b/src/Framework/Framework/Compilation/DefaultControlBuilderFactory.cs
@@ -31,7 +31,7 @@ namespace DotVVM.Framework.Compilation
         public DefaultControlBuilderFactory(DotvvmConfiguration configuration, IMarkupFileLoader markupFileLoader, CompiledAssemblyCache compiledAssemblyCache)
         {
             this.configuration = configuration;
-            this.allowReload = configuration.Debug; // TODO: do we want another option for this?
+            this.allowReload = configuration.Debug;
 
             // WORKAROUND: there is a circular dependency
             // TODO: get rid of that
@@ -57,7 +57,8 @@ namespace DotVVM.Framework.Compilation
                 {
                     return builder.Value;
                 }
-                // because race conditions, this can happen, so just let if fallback onto creating the builder again
+                // because of race conditions, the builder doesn't need to be created
+                // we let it fallback onto creating the builder again
             }
 
             var lazy = new Lazy<(ControlBuilderDescriptor, Lazy<IControlBuilder>)>(() =>
@@ -65,7 +66,8 @@ namespace DotVVM.Framework.Compilation
 
             if (allowReload)
             {
-                return (controlBuilders[virtualPath] = lazy).Value;
+                controlBuilders[virtualPath] = lazy;
+                return lazy.Value;
             }
             else
             {

--- a/src/Framework/Framework/Compilation/DefaultControlBuilderFactory.cs
+++ b/src/Framework/Framework/Compilation/DefaultControlBuilderFactory.cs
@@ -20,16 +20,18 @@ namespace DotVVM.Framework.Compilation
     public class DefaultControlBuilderFactory : IControlBuilderFactory
     {
         private readonly DotvvmConfiguration configuration;
+        private readonly bool allowReload;
         private readonly IMarkupFileLoader markupFileLoader;
         private readonly CompiledAssemblyCache compiledAssemblyCache;
 
         public Func<IViewCompiler> ViewCompilerFactory { get; private set; }
 
-        private ConcurrentDictionary<MarkupFile, Lazy<(ControlBuilderDescriptor, Lazy<IControlBuilder>)>> controlBuilders = new ConcurrentDictionary<MarkupFile, Lazy<(ControlBuilderDescriptor, Lazy<IControlBuilder>)>>();
+        private ConcurrentDictionary<string, Lazy<(ControlBuilderDescriptor, Lazy<IControlBuilder>)>> controlBuilders = new();
 
         public DefaultControlBuilderFactory(DotvvmConfiguration configuration, IMarkupFileLoader markupFileLoader, CompiledAssemblyCache compiledAssemblyCache)
         {
             this.configuration = configuration;
+            this.allowReload = configuration.Debug; // TODO: do we want another option for this?
 
             // WORKAROUND: there is a circular dependency
             // TODO: get rid of that
@@ -48,12 +50,50 @@ namespace DotVVM.Framework.Compilation
         /// </summary>
         public (ControlBuilderDescriptor descriptor, Lazy<IControlBuilder> builder) GetControlBuilder(string virtualPath)
         {
+            var (markupFile, markupChanged) = GetMarkupFile(virtualPath);
+            if (!markupChanged)
+            {
+                if (controlBuilders.TryGetValue(virtualPath, out var builder))
+                {
+                    return builder.Value;
+                }
+                // because race conditions, this can happen, so just let if fallback onto creating the builder again
+            }
+
+            var lazy = new Lazy<(ControlBuilderDescriptor, Lazy<IControlBuilder>)>(() =>
+                CreateControlBuilder(markupFile));
+
+            if (allowReload)
+            {
+                return (controlBuilders[virtualPath] = lazy).Value;
+            }
+            else
+            {
+                return controlBuilders.GetOrAdd(virtualPath, lazy).Value;
+            }
+        }
+
+
+        readonly ConcurrentDictionary<string, MarkupFile> markupFiles = new();
+        private (MarkupFile file, bool changed) GetMarkupFile(string virtualPath)
+        {
+            if (markupFiles.TryGetValue(virtualPath, out var cachedFile))
+            {
+                if (!allowReload)
+                    return (cachedFile, false);
+                
+                var newFile = markupFileLoader.GetMarkup(configuration, virtualPath);
+                if (newFile is null || cachedFile.Equals(newFile))
+                    return (cachedFile, false);
+                else
+                {
+                    markupFiles[virtualPath] = newFile;
+                    return (newFile, true);
+                }
+            }
             var markupFile = markupFileLoader.GetMarkup(configuration, virtualPath) ?? throw new DotvvmCompilationException($"File '{virtualPath}' was not found. This exception is possibly caused because of incorrect route registration.");
-            return controlBuilders.GetOrAdd(
-                markupFile,
-                // use lazy - do not compile the same view multiple times
-                file => new Lazy<(ControlBuilderDescriptor, Lazy<IControlBuilder>)>(() => CreateControlBuilder(file))
-            ).Value;
+            markupFiles.TryAdd(virtualPath, markupFile);
+            return (markupFile, true);
         }
 
         /// <summary>
@@ -201,9 +241,7 @@ namespace DotVVM.Framework.Compilation
 
         public void RegisterControlBuilder(string file, IControlBuilder builder)
         {
-            var markup = markupFileLoader.GetMarkup(configuration, file) ??
-                         throw new Exception($"Could not load markup file {file}.");
-            controlBuilders.TryAdd(markup, new Lazy<(ControlBuilderDescriptor, Lazy<IControlBuilder>)>(() => (builder.Descriptor, new Lazy<IControlBuilder>(() => builder))));
+            controlBuilders.TryAdd(file, new Lazy<(ControlBuilderDescriptor, Lazy<IControlBuilder>)>(() => (builder.Descriptor, new Lazy<IControlBuilder>(() => builder))));
         }
 
         private static readonly HashSet<string> csharpKeywords = new HashSet<string>(new[]

--- a/src/Framework/Framework/Hosting/MarkupFile.cs
+++ b/src/Framework/Framework/Hosting/MarkupFile.cs
@@ -16,17 +16,8 @@ namespace DotVVM.Framework.Hosting
             return other != null && string.Equals(FullPath, other.FullPath, StringComparison.OrdinalIgnoreCase) && LastWriteDateTimeUtc.Equals(other.LastWriteDateTimeUtc);
         }
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return ((FullPath != null ? FullPath.ToLowerInvariant().GetHashCode() : 0) * 397) ^ LastWriteDateTimeUtc.GetHashCode();
-            }
-        }
-
-        public const string ViewFileExtension = ".dothtml";
-
-
+        public override int GetHashCode() =>
+            HashCode.Combine(StringComparer.OrdinalIgnoreCase.GetHashCode(FullPath), LastWriteDateTimeUtc);
 
         public Func<string> ReadContent { get; private set; }
 

--- a/src/Framework/Framework/Hosting/MarkupFile.cs
+++ b/src/Framework/Framework/Hosting/MarkupFile.cs
@@ -17,7 +17,7 @@ namespace DotVVM.Framework.Hosting
         }
 
         public override int GetHashCode() =>
-            HashCode.Combine(StringComparer.OrdinalIgnoreCase.GetHashCode(FullPath), LastWriteDateTimeUtc);
+            (StringComparer.OrdinalIgnoreCase.GetHashCode(FullPath), LastWriteDateTimeUtc).GetHashCode();
 
         public Func<string> ReadContent { get; private set; }
 


### PR DESCRIPTION
MarkupFileLoader did check the LastWriteTimeUtc on each request and would recompile the page if the page changed. While we have worse performance issues, this is quite unnecesary. IMHO it's more likely to break production server when new source code is copied there.

Moreover, the loader would allocate new IControlBuilder, but didn't unreference the old one, leaking some memory. I didn't test that this commit fixes it, though.