### PR TITLE
Added UI test for REST API bindings with _collection variable

### DIFF
--- a/src/Samples/Common/DotVVM.Samples.Common.csproj
+++ b/src/Samples/Common/DotVVM.Samples.Common.csproj
@@ -78,6 +78,7 @@
     <None Remove="Views\FeatureSamples\Api\ApiInSpa_PageA.dothtml" />
     <None Remove="Views\FeatureSamples\Api\ApiInSpa_PageB.dothtml" />
     <None Remove="Views\FeatureSamples\Api\ApiRefresh.dothtml" />
+    <None Remove="Views\FeatureSamples\Api\CollectionOddEvenWithRestApi.dothtml" />
     <None Remove="Views\FeatureSamples\Attribute\ToStringConversion.dothtml" />
     <None Remove="Views\FeatureSamples\AutoUI\AutoEditor.dothtml" />
     <None Remove="Views\FeatureSamples\AutoUI\AutoForm.dothtml" />

--- a/src/Samples/Common/ViewModels/FeatureSamples/Api/CollectionOddEvenWithRestApiViewModel.cs
+++ b/src/Samples/Common/ViewModels/FeatureSamples/Api/CollectionOddEvenWithRestApiViewModel.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+using DotVVM.Samples.BasicSamples.Api.Common.Model;
+using DotVVM.Samples.Common.Api.Owin;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.Api
+{
+    public class CollectionOddEvenWithRestApiViewModel : DotvvmViewModelBase
+    {
+        private readonly ResetClient owinResetApi;
+
+        public ICollection<Company<string>> Companies { get; set; }
+        public int Value { get; set; }
+
+        public CollectionOddEvenWithRestApiViewModel(ResetClient owinResetApi)
+        {
+            this.owinResetApi = owinResetApi;
+        }
+
+        public override Task Init()
+        {
+            owinResetApi.ResetData();
+            return base.Init();
+        }
+    }
+}
+

--- a/src/Samples/Common/Views/FeatureSamples/Api/CollectionOddEvenWithRestApi.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/Api/CollectionOddEvenWithRestApi.dothtml
@@ -1,0 +1,34 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.Api.CollectionOddEvenWithRestApiViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+    <style>
+        .even {
+            background-color: yellow;
+        }
+        .odd {
+            background-color: lime;
+        }
+    </style>
+</head>
+<body>
+
+    <dot:Button Text="Refresh" Click="{staticCommand: Value = Value + 1}" />
+
+    <dot:Repeater DataSource="{value: Companies = _api.RefreshOnChange(_apiOwin.Companies.Get(), Value)}"
+                  data-ui="repeater">
+        <div class-even="{value: _collection.IsEven}"
+             class-odd="{value: _collection.IsOdd}">
+            {{value: Id}}: {{value: Name}}
+        </div>
+    </dot:Repeater>
+
+
+</body>
+</html>
+
+

--- a/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
@@ -1,4 +1,4 @@
-
+﻿
 
 // DO NOT MODIFY THIS FILE - THIS FILE IS GENERATED !!!
 
@@ -199,6 +199,7 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_Api_AzureFunctionsApi = "FeatureSamples/Api/AzureFunctionsApi";
         public const string FeatureSamples_Api_AzureFunctionsApiTable = "FeatureSamples/Api/AzureFunctionsApiTable";
         public const string FeatureSamples_Api_BindingSharing = "FeatureSamples/Api/BindingSharing";
+        public const string FeatureSamples_Api_CollectionOddEvenWithRestApi = "FeatureSamples/Api/CollectionOddEvenWithRestApi";
         public const string FeatureSamples_Api_GetCollection = "FeatureSamples/Api/GetCollection";
         public const string FeatureSamples_Api_GridViewDataSetAspNetCore = "FeatureSamples/Api/GridViewDataSetAspNetCore";
         public const string FeatureSamples_Api_GridViewDataSetOwin = "FeatureSamples/Api/GridViewDataSetOwin";

--- a/src/Samples/Tests/Tests/Feature/ApiTests.cs
+++ b/src/Samples/Tests/Tests/Feature/ApiTests.cs
@@ -383,6 +383,25 @@ namespace DotVVM.Samples.Tests.Feature
             });
         }
 
+        [Fact]
+        [Trait("Category", "owin-only")]
+        public void Feature_Api_CollectionOddEvenWithRestApi()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_Api_CollectionOddEvenWithRestApi);
+
+                // make sure that the collection is 
+                var rows = browser
+                    .Single("repeater", SelectByDataUi)
+                    .FindElements("div")
+                    .ThrowIfDifferentCountThan(35);
+                for (var i = 0; i < rows.Count; i++)
+                {
+                    AssertUI.HasClass(rows[i], i % 2 == 0 ? "even" : "odd");
+                }
+            });
+        }
+
         public ApiTests(ITestOutputHelper output) : base(output)
         {
         }


### PR DESCRIPTION
I've added a test for a scenario where REST API binding is on a `Repeater` and it uses the `_collection` binding inside. 
A customer reported that it didn't work in `4.1-preview14-final` but it works in the current `main`.
I've added the test to ensure that we don't break the functionality in the future.