### PR TITLE
Added `UnsupportedCallSiteAttribute` and an analyzer

### DIFF
--- a/src/Analyzers/Analyzers.Tests/ApiUsage/UnsupportedCallSiteAttributeTests.cs
+++ b/src/Analyzers/Analyzers.Tests/ApiUsage/UnsupportedCallSiteAttributeTests.cs
@@ -1,0 +1,66 @@
+﻿using System.Threading.Tasks;
+using DotVVM.Analyzers.ApiUsage;
+using Xunit;
+using VerifyCS = DotVVM.Analyzers.Tests.CSharpAnalyzerVerifier<
+    DotVVM.Analyzers.ApiUsage.UnsupportedCallSiteAttributeAnalyzer>;
+
+namespace DotVVM.Analyzers.Tests.ApiUsage
+{
+    public class UnsupportedCallSiteAttributeTests
+    {
+        [Fact]
+        public async Task Test_NoDiagnostics_InvokeMethod_WithoutUnsupportedCallSiteAttribute()
+        {
+            var test = @"
+    using System;
+    using System.IO;
+
+    namespace ConsoleApplication1
+    {
+        public class RegularClass
+        {
+            public void Target()
+            {
+
+            }
+
+            public void CallSite()
+            {
+                Target();
+            }
+        }
+    }";
+
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+
+        [Fact]
+        public async Task Test_Warning_InvokeMethod_WithUnsupportedCallSiteAttribute()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+    using System;
+    using System.IO;
+    using DotVVM.Core.CodeAnalysis;
+
+    namespace ConsoleApplication1
+    {
+        public class RegularClass
+        {
+            [UnsupportedCallSite(CallSiteType.ServerSide)]
+            public void Target()
+            {
+
+            }
+
+            public void CallSite()
+            {
+                {|#0:Target()|};
+            }
+        }
+    }",
+
+            VerifyCS.Diagnostic(UnsupportedCallSiteAttributeAnalyzer.DoNotInvokeMethodFromUnsupportedCallSite)
+                .WithLocation(0).WithArguments("Target"));
+        }
+    }
+}

--- a/src/Analyzers/Analyzers.Tests/ApiUsage/UnsupportedCallSiteAttributeTests.cs
+++ b/src/Analyzers/Analyzers.Tests/ApiUsage/UnsupportedCallSiteAttributeTests.cs
@@ -40,7 +40,7 @@ namespace DotVVM.Analyzers.Tests.ApiUsage
             await VerifyCS.VerifyAnalyzerAsync(@"
     using System;
     using System.IO;
-    using DotVVM.Core.CodeAnalysis;
+    using DotVVM.Framework.CodeAnalysis;
 
     namespace ConsoleApplication1
     {

--- a/src/Analyzers/Analyzers.Tests/ApiUsage/UnsupportedCallSiteAttributeTests.cs
+++ b/src/Analyzers/Analyzers.Tests/ApiUsage/UnsupportedCallSiteAttributeTests.cs
@@ -60,7 +60,36 @@ namespace DotVVM.Analyzers.Tests.ApiUsage
     }",
 
             VerifyCS.Diagnostic(UnsupportedCallSiteAttributeAnalyzer.DoNotInvokeMethodFromUnsupportedCallSite)
-                .WithLocation(0).WithArguments("Target"));
+                .WithLocation(0).WithArguments("Target", string.Empty));
+        }
+
+        [Fact]
+        public async Task Test_Warning_InvokeMethod_WithUnsupportedCallSiteAttribute_WithReason()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+    using System;
+    using System.IO;
+    using DotVVM.Framework.CodeAnalysis;
+
+    namespace ConsoleApplication1
+    {
+        public class RegularClass
+        {
+            [UnsupportedCallSite(CallSiteType.ServerSide, ""REASON"")]
+            public void Target()
+            {
+
+            }
+
+            public void CallSite()
+            {
+                {|#0:Target()|};
+            }
+        }
+    }",
+
+            VerifyCS.Diagnostic(UnsupportedCallSiteAttributeAnalyzer.DoNotInvokeMethodFromUnsupportedCallSite)
+                .WithLocation(0).WithArguments("Target", "due to: \"REASON\""));
         }
     }
 }

--- a/src/Analyzers/Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/Analyzers/AnalyzerReleases.Unshipped.md
@@ -6,3 +6,4 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 DotVVM02 | Serializability | Warning | ViewModelSerializabilityAnalyzer
 DotVVM03 | Serializability | Warning | ViewModelSerializabilityAnalyzer
+DotVVM04 | ApiUsage | Warning | UnsupportedCallSiteAttributeAnalyzer

--- a/src/Analyzers/Analyzers/ApiUsage/UnsupportedCallSiteAttributeAnalyzer.cs
+++ b/src/Analyzers/Analyzers/ApiUsage/UnsupportedCallSiteAttributeAnalyzer.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace DotVVM.Analyzers.ApiUsage
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class UnsupportedCallSiteAttributeAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly LocalizableResourceString unsupportedCallSiteTitle = new(nameof(Resources.ApiUsage_UnsupportedCallSite_Title), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableResourceString unsupportedCallSiteMessage = new(nameof(Resources.ApiUsage_UnsupportedCallSite_Message), Resources.ResourceManager, typeof(Resources));
+        private static readonly LocalizableResourceString unsupportedCallSiteDescription = new(nameof(Resources.ApiUsage_UnsupportedCallSite_Description), Resources.ResourceManager, typeof(Resources));
+        private const string unsupportedCallSiteAttributeMetadataName = "DotVVM.Core.CodeAnalysis.UnsupportedCallSiteAttribute";
+        private const int callSiteTypeServerUnderlyingValue = 0;
+
+        public static DiagnosticDescriptor DoNotInvokeMethodFromUnsupportedCallSite = new(
+            DotvvmDiagnosticIds.DoNotInvokeMethodFromUnsupportedCallSiteRuleId,
+            unsupportedCallSiteTitle,
+            unsupportedCallSiteMessage,
+            DiagnosticCategory.ApiUsage,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            unsupportedCallSiteDescription);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+            => ImmutableArray.Create(DoNotInvokeMethodFromUnsupportedCallSite);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.EnableConcurrentExecution();
+
+            context.RegisterOperationAction(context =>
+            {
+                var unsupportedCallSiteAttribute = context.Compilation.GetTypeByMetadataName(unsupportedCallSiteAttributeMetadataName);
+                if (unsupportedCallSiteAttribute is null)
+                    return;
+
+                if (context.Operation is IInvocationOperation invocation)
+                {
+                    var method = invocation.TargetMethod;
+                    var attribute = method.GetAttributes().FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, unsupportedCallSiteAttribute));
+                    if (attribute is null || !attribute.ConstructorArguments.Any())
+                        return;
+
+                    if (attribute.ConstructorArguments.First().Value is not int callSiteType || callSiteTypeServerUnderlyingValue != callSiteType)
+                        return;
+
+                    context.ReportDiagnostic(
+                        Diagnostic.Create(
+                            DoNotInvokeMethodFromUnsupportedCallSite,
+                            invocation.Syntax.GetLocation(),
+                            invocation.TargetMethod.Name));
+                }
+            }, OperationKind.Invocation);
+        }
+    }
+}

--- a/src/Analyzers/Analyzers/ApiUsage/UnsupportedCallSiteAttributeAnalyzer.cs
+++ b/src/Analyzers/Analyzers/ApiUsage/UnsupportedCallSiteAttributeAnalyzer.cs
@@ -48,11 +48,13 @@ namespace DotVVM.Analyzers.ApiUsage
                     if (attribute.ConstructorArguments.First().Value is not int callSiteType || callSiteTypeServerUnderlyingValue != callSiteType)
                         return;
 
+                    var reason = (string?)attribute.ConstructorArguments.Skip(1).First().Value;
                     context.ReportDiagnostic(
                         Diagnostic.Create(
                             DoNotInvokeMethodFromUnsupportedCallSite,
                             invocation.Syntax.GetLocation(),
-                            invocation.TargetMethod.Name));
+                            invocation.TargetMethod.Name,
+                            (reason != null) ? $"due to: \"{reason}\"" : string.Empty));
                 }
             }, OperationKind.Invocation);
         }

--- a/src/Analyzers/Analyzers/ApiUsage/UnsupportedCallSiteAttributeAnalyzer.cs
+++ b/src/Analyzers/Analyzers/ApiUsage/UnsupportedCallSiteAttributeAnalyzer.cs
@@ -12,7 +12,7 @@ namespace DotVVM.Analyzers.ApiUsage
         private static readonly LocalizableResourceString unsupportedCallSiteTitle = new(nameof(Resources.ApiUsage_UnsupportedCallSite_Title), Resources.ResourceManager, typeof(Resources));
         private static readonly LocalizableResourceString unsupportedCallSiteMessage = new(nameof(Resources.ApiUsage_UnsupportedCallSite_Message), Resources.ResourceManager, typeof(Resources));
         private static readonly LocalizableResourceString unsupportedCallSiteDescription = new(nameof(Resources.ApiUsage_UnsupportedCallSite_Description), Resources.ResourceManager, typeof(Resources));
-        private const string unsupportedCallSiteAttributeMetadataName = "DotVVM.Core.CodeAnalysis.UnsupportedCallSiteAttribute";
+        private const string unsupportedCallSiteAttributeMetadataName = "DotVVM.Framework.CodeAnalysis.UnsupportedCallSiteAttribute";
         private const int callSiteTypeServerUnderlyingValue = 0;
 
         public static DiagnosticDescriptor DoNotInvokeMethodFromUnsupportedCallSite = new(

--- a/src/Analyzers/Analyzers/DiagnosticCategory.cs
+++ b/src/Analyzers/Analyzers/DiagnosticCategory.cs
@@ -8,5 +8,6 @@ namespace DotVVM.Analyzers
     {
         public const string Serializability = nameof(Serializability);
         public const string StaticCommands = nameof(StaticCommands);
+        public const string ApiUsage = nameof(ApiUsage);
     }
 }

--- a/src/Analyzers/Analyzers/DotvvmDiagnosticIds.cs
+++ b/src/Analyzers/Analyzers/DotvvmDiagnosticIds.cs
@@ -11,5 +11,6 @@ namespace DotVVM.Analyzers
 
         public const string UseSerializablePropertiesInViewModelRuleId = "DotVVM02";
         public const string DoNotUseFieldsInViewModelRuleId = "DotVVM03";
+        public const string DoNotInvokeMethodFromUnsupportedCallSiteRuleId = "DotVVM04";
     }
 }

--- a/src/Analyzers/Analyzers/Resources.Designer.cs
+++ b/src/Analyzers/Analyzers/Resources.Designer.cs
@@ -61,7 +61,7 @@ namespace DotVVM.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Method that declares that it should not be called on server is only meant to be invoked on client.
+        ///   Looks up a localized string similar to Method that declares that it should not be called on server is only meant to be invoked on client..
         /// </summary>
         internal static string ApiUsage_UnsupportedCallSite_Description {
             get {

--- a/src/Analyzers/Analyzers/Resources.Designer.cs
+++ b/src/Analyzers/Analyzers/Resources.Designer.cs
@@ -70,7 +70,7 @@ namespace DotVVM.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Method &apos;{0}&apos; invocation is not supported on server.
+        ///   Looks up a localized string similar to Method &apos;{0}&apos; invocation is not supported on server {1}.
         /// </summary>
         internal static string ApiUsage_UnsupportedCallSite_Message {
             get {

--- a/src/Analyzers/Analyzers/Resources.Designer.cs
+++ b/src/Analyzers/Analyzers/Resources.Designer.cs
@@ -61,6 +61,33 @@ namespace DotVVM.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Method that declares that it should not be called on server is only meant to be invoked on client.
+        /// </summary>
+        internal static string ApiUsage_UnsupportedCallSite_Description {
+            get {
+                return ResourceManager.GetString("ApiUsage_UnsupportedCallSite_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Method &apos;{0}&apos; invocation is not supported on server.
+        /// </summary>
+        internal static string ApiUsage_UnsupportedCallSite_Message {
+            get {
+                return ResourceManager.GetString("ApiUsage_UnsupportedCallSite_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unsupported call site.
+        /// </summary>
+        internal static string ApiUsage_UnsupportedCallSite_Title {
+            get {
+                return ResourceManager.GetString("ApiUsage_UnsupportedCallSite_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fields are not supported in viewmodels. Use properties to save state of viewmodels instead..
         /// </summary>
         internal static string Serializability_DoNotUseFields_Description {

--- a/src/Analyzers/Analyzers/Resources.resx
+++ b/src/Analyzers/Analyzers/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ApiUsage_UnsupportedCallSite_Description" xml:space="preserve">
-    <value>Method that declares that it should not be called on server is only meant to be invoked on client</value>
+    <value>Method that declares that it should not be called on server is only meant to be invoked on client.</value>
   </data>
   <data name="ApiUsage_UnsupportedCallSite_Message" xml:space="preserve">
     <value>Method '{0}' invocation is not supported on server</value>

--- a/src/Analyzers/Analyzers/Resources.resx
+++ b/src/Analyzers/Analyzers/Resources.resx
@@ -117,6 +117,15 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ApiUsage_UnsupportedCallSite_Description" xml:space="preserve">
+    <value>Method that declares that it should not be called on server is only meant to be invoked on client</value>
+  </data>
+  <data name="ApiUsage_UnsupportedCallSite_Message" xml:space="preserve">
+    <value>Method '{0}' invocation is not supported on server</value>
+  </data>
+  <data name="ApiUsage_UnsupportedCallSite_Title" xml:space="preserve">
+    <value>Unsupported call site</value>
+  </data>
   <data name="Serializability_DoNotUseFields_Description" xml:space="preserve">
     <value>Fields are not supported in viewmodels. Use properties to save state of viewmodels instead.</value>
   </data>

--- a/src/Analyzers/Analyzers/Resources.resx
+++ b/src/Analyzers/Analyzers/Resources.resx
@@ -121,7 +121,7 @@
     <value>Method that declares that it should not be called on server is only meant to be invoked on client.</value>
   </data>
   <data name="ApiUsage_UnsupportedCallSite_Message" xml:space="preserve">
-    <value>Method '{0}' invocation is not supported on server</value>
+    <value>Method '{0}' invocation is not supported on server {1}</value>
   </data>
   <data name="ApiUsage_UnsupportedCallSite_Title" xml:space="preserve">
     <value>Unsupported call site</value>

--- a/src/Framework/Core/CodeAnalysis/CallSiteType.cs
+++ b/src/Framework/Core/CodeAnalysis/CallSiteType.cs
@@ -1,0 +1,8 @@
+﻿namespace DotVVM.Core.CodeAnalysis
+{
+    public enum CallSiteType
+    {
+        ServerSide,
+        ClientSide
+    }
+}

--- a/src/Framework/Core/CodeAnalysis/CallSiteType.cs
+++ b/src/Framework/Core/CodeAnalysis/CallSiteType.cs
@@ -1,4 +1,4 @@
-﻿namespace DotVVM.Core.CodeAnalysis
+﻿namespace DotVVM.Framework.CodeAnalysis
 {
     public enum CallSiteType
     {

--- a/src/Framework/Core/CodeAnalysis/UnsupportedCallSiteAttribute.cs
+++ b/src/Framework/Core/CodeAnalysis/UnsupportedCallSiteAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace DotVVM.Core.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = false)]
+    public class UnsupportedCallSiteAttribute : Attribute
+    {
+        public readonly CallSiteType Type;
+
+        public UnsupportedCallSiteAttribute(CallSiteType type)
+        {
+            Type = type;
+        }
+    }
+}

--- a/src/Framework/Core/CodeAnalysis/UnsupportedCallSiteAttribute.cs
+++ b/src/Framework/Core/CodeAnalysis/UnsupportedCallSiteAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace DotVVM.Core.CodeAnalysis
+namespace DotVVM.Framework.CodeAnalysis
 {
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = false)]
     public class UnsupportedCallSiteAttribute : Attribute

--- a/src/Framework/Core/CodeAnalysis/UnsupportedCallSiteAttribute.cs
+++ b/src/Framework/Core/CodeAnalysis/UnsupportedCallSiteAttribute.cs
@@ -6,10 +6,12 @@ namespace DotVVM.Framework.CodeAnalysis
     public class UnsupportedCallSiteAttribute : Attribute
     {
         public readonly CallSiteType Type;
+        public readonly string? Reason;
 
-        public UnsupportedCallSiteAttribute(CallSiteType type)
+        public UnsupportedCallSiteAttribute(CallSiteType type, string? reason = null)
         {
             Type = type;
+            Reason = reason;
         }
     }
 }

--- a/src/Framework/Core/DotVVM.Core.csproj
+++ b/src/Framework/Core/DotVVM.Core.csproj
@@ -10,6 +10,7 @@
     <Description>This package contains base classes and interfaces of DotVVM that might be useful in a business layer.
     DotVVM is an open source ASP.NET-based framework which allows to build modern web apps without writing any JavaScript code.</Description>
     <Nullable>enable</Nullable>
+    <RootNamespace>DotVVM.Framework</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="compiler\resources\**\*" />

--- a/src/Framework/Framework/Binding/HelperNamespace/DateTimeExtensions.cs
+++ b/src/Framework/Framework/Binding/HelperNamespace/DateTimeExtensions.cs
@@ -8,16 +8,14 @@ namespace DotVVM.Framework.Binding.HelperNamespace
 
         /// <summary>
         /// Converts the date (assuming it is in UTC) to browser's local time.
-        /// CAUTION: When evaluated on the server, no conversion is made as we don't know the browser timezone.
         /// </summary>
-        [UnsupportedCallSite(CallSiteType.ServerSide)]
+        [UnsupportedCallSite(CallSiteType.ServerSide, "When evaluated on the server, no conversion is made as we don't know the browser timezone.")]
         public static DateTime ToBrowserLocalTime(this DateTime value) => value;
 
         /// <summary>
         /// Converts the date (assuming it is in UTC) to browser's local time.
-        /// CAUTION: When evaluated on the server, no conversion is made as we don't know the browser timezone.
         /// </summary>
-        [UnsupportedCallSite(CallSiteType.ServerSide)]
+        [UnsupportedCallSite(CallSiteType.ServerSide, "When evaluated on the server, no conversion is made as we don't know the browser timezone.")]
         public static DateTime? ToBrowserLocalTime(this DateTime? value) => value;
 
     }

--- a/src/Framework/Framework/Binding/HelperNamespace/DateTimeExtensions.cs
+++ b/src/Framework/Framework/Binding/HelperNamespace/DateTimeExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using DotVVM.Core.CodeAnalysis;
+using DotVVM.Framework.CodeAnalysis;
 
 namespace DotVVM.Framework.Binding.HelperNamespace
 {

--- a/src/Framework/Framework/Binding/HelperNamespace/DateTimeExtensions.cs
+++ b/src/Framework/Framework/Binding/HelperNamespace/DateTimeExtensions.cs
@@ -9,14 +9,12 @@ namespace DotVVM.Framework.Binding.HelperNamespace
         /// Converts the date (assuming it is in UTC) to browser's local time.
         /// CAUTION: When evaluated on the server, no conversion is made as we don't know the browser timezone.
         /// </summary>
-        [Obsolete("When evaluated on the server, no conversion is made as we don't know the browser timezone.")]
         public static DateTime ToBrowserLocalTime(this DateTime value) => value;
 
         /// <summary>
         /// Converts the date (assuming it is in UTC) to browser's local time.
         /// CAUTION: When evaluated on the server, no conversion is made as we don't know the browser timezone.
         /// </summary>
-        [Obsolete("When evaluated on the server, no conversion is made as we don't know the browser timezone.")]
         public static DateTime? ToBrowserLocalTime(this DateTime? value) => value;
 
     }

--- a/src/Framework/Framework/Binding/HelperNamespace/DateTimeExtensions.cs
+++ b/src/Framework/Framework/Binding/HelperNamespace/DateTimeExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using DotVVM.Core.CodeAnalysis;
 
 namespace DotVVM.Framework.Binding.HelperNamespace
 {
@@ -9,12 +10,14 @@ namespace DotVVM.Framework.Binding.HelperNamespace
         /// Converts the date (assuming it is in UTC) to browser's local time.
         /// CAUTION: When evaluated on the server, no conversion is made as we don't know the browser timezone.
         /// </summary>
+        [UnsupportedCallSite(CallSiteType.ServerSide)]
         public static DateTime ToBrowserLocalTime(this DateTime value) => value;
 
         /// <summary>
         /// Converts the date (assuming it is in UTC) to browser's local time.
         /// CAUTION: When evaluated on the server, no conversion is made as we don't know the browser timezone.
         /// </summary>
+        [UnsupportedCallSite(CallSiteType.ServerSide)]
         public static DateTime? ToBrowserLocalTime(this DateTime? value) => value;
 
     }

--- a/src/Framework/Framework/Compilation/ControlTree/UnsupportedCallSiteCheckingVisitor.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/UnsupportedCallSiteCheckingVisitor.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using DotVVM.Core.CodeAnalysis;
+using DotVVM.Framework.CodeAnalysis;
 using DotVVM.Framework.Binding.Expressions;
 using DotVVM.Framework.Compilation.ControlTree.Resolved;
 

--- a/src/Framework/Framework/Compilation/ControlTree/UnsupportedCallSiteCheckingVisitor.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/UnsupportedCallSiteCheckingVisitor.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using DotVVM.Core.CodeAnalysis;
+using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Compilation.ControlTree.Resolved;
+
+namespace DotVVM.Framework.Compilation.ControlTree
+{
+    public class UnsupportedCallSiteCheckingVisitor : ResolvedControlTreeVisitor
+    {
+        class ExpressionInspectingVisitor : ExpressionVisitor
+        {
+            public event Action<MethodInfo>? InvalidCallSiteDetected;
+
+            protected override Expression VisitMethodCall(MethodCallExpression node)
+            {
+                var callSiteAttr = node.Method.CustomAttributes.FirstOrDefault(a => a.AttributeType == typeof(UnsupportedCallSiteAttribute));
+                if (callSiteAttr is not null && callSiteAttr.ConstructorArguments.Any())
+                {
+                    if (callSiteAttr.ConstructorArguments.First().Value is int type && type == (int)CallSiteType.ServerSide)
+                        InvalidCallSiteDetected?.Invoke(node.Method);
+                }
+
+                return base.VisitMethodCall(node);
+            }
+        }
+
+        public override void VisitBinding(ResolvedBinding binding)
+        {
+            base.VisitBinding(binding);
+            if (binding.Binding is not ResourceBindingExpression)
+                return;
+
+            var expressionVisitor = new ExpressionInspectingVisitor();
+            expressionVisitor.InvalidCallSiteDetected += method =>
+                binding.DothtmlNode?.AddWarning($"Evaluation of method \"{method.Name}\" on server-side may yield unexpected results.");
+
+            expressionVisitor.Visit(binding.Expression);
+        }
+    }
+}

--- a/src/Framework/Framework/Compilation/ControlTree/UnsupportedCallSiteCheckingVisitor.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/UnsupportedCallSiteCheckingVisitor.cs
@@ -16,10 +16,10 @@ namespace DotVVM.Framework.Compilation.ControlTree
 
             protected override Expression VisitMethodCall(MethodCallExpression node)
             {
-                var callSiteAttr = node.Method.CustomAttributes.FirstOrDefault(a => a.AttributeType == typeof(UnsupportedCallSiteAttribute));
-                if (callSiteAttr is not null && callSiteAttr.ConstructorArguments.Any())
+                if (node.Method.IsDefined(typeof(UnsupportedCallSiteAttribute)))
                 {
-                    if (callSiteAttr.ConstructorArguments.First().Value is int type && type == (int)CallSiteType.ServerSide)
+                    var callSiteAttr = node.Method.CustomAttributes.FirstOrDefault(a => a.AttributeType == typeof(UnsupportedCallSiteAttribute))!;
+                    if (callSiteAttr.ConstructorArguments.Any() && callSiteAttr.ConstructorArguments.First().Value is int type && type == (int)CallSiteType.ServerSide)
                         InvalidCallSiteDetected?.Invoke(node.Method);
                 }
 

--- a/src/Framework/Framework/Compilation/ControlTree/UnsupportedCallSiteCheckingVisitor.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/UnsupportedCallSiteCheckingVisitor.cs
@@ -30,7 +30,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
         public override void VisitBinding(ResolvedBinding binding)
         {
             base.VisitBinding(binding);
-            if (binding.Binding is not ResourceBindingExpression)
+            if (binding.Binding is not ResourceBindingExpression and not CommandBindingExpression)
                 return;
 
             var expressionVisitor = new ExpressionInspectingVisitor();

--- a/src/Framework/Framework/DependencyInjection/DotVVMServiceCollectionExtensions.cs
+++ b/src/Framework/Framework/DependencyInjection/DotVVMServiceCollectionExtensions.cs
@@ -120,6 +120,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 o.TreeVisitors.Add(() => ActivatorUtilities.CreateInstance<DataContextPropertyAssigningVisitor>(s));
                 o.TreeVisitors.Add(() => new UsedPropertiesFindingVisitor());
                 o.TreeVisitors.Add(() => new LifecycleRequirementsAssigningVisitor());
+                o.TreeVisitors.Add(() => new UnsupportedCallSiteCheckingVisitor());
             });
 
             services.TryAddSingleton<IDotvvmCacheAdapter, DefaultDotvvmCacheAdapter>();

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/DefaultControlTreeResolverTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/DefaultControlTreeResolverTests.cs
@@ -724,6 +724,21 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
         }
 
         [TestMethod]
+        public void DefaultViewCompiler_UnsupportedCallSite_ResourceBinding_Warning()
+        {
+            var markup = @"
+@viewModel System.DateTime
+{{resource: _this.ToBrowserLocalTime()}}
+";
+            var literal = ParseSource(markup)
+                .Content.SelectRecursively(c => c.Content)
+                .Single(c => c.Metadata.Type == typeof(Literal));
+
+            Assert.AreEqual(1, literal.DothtmlNode.NodeWarnings.Count());
+            Assert.AreEqual("Evaluation of method \"ToBrowserLocalTime\" on server-side may yield unexpected results.", literal.DothtmlNode.NodeWarnings.First());
+        }
+
+        [TestMethod]
         public void DefaultViewCompiler_DifferentControlPrimaryName()
         {
             var root = ParseSource(@"@viewModel System.String


### PR DESCRIPTION
This PR adds `UnsupportedCallSiteAttribute` that can be placed on a method to signalize that a specific invocation (either from server-side or client-side) is not supported. Moreover, there is also a Roslyn Analyzer that reports violation whenever someone tries to invoke a method marked as only client-side.

Our previous solution was to annotate the method with the `ObsoleteAttribute`. IMO there are the following advantages to the proposed solution for this problem:
* The API no longer looks like it is obsoleted
* VSExtension can not easily filter compiler warnings. Right now it issues false-positives whenever someone uses these methods (for example, `ToBrowserLocalTime`). It is easier to ignore analyzer.
* Users can also use the `UnsupportedCallSiteAttribute` if they wish to make for example a client-side-only method



