### PR TITLE
Allow Sec-Fetch-Dest: empty in returned files

### DIFF
--- a/src/Framework/Framework/Hosting/DotvvmPresenter.cs
+++ b/src/Framework/Framework/Hosting/DotvvmPresenter.cs
@@ -477,9 +477,15 @@ namespace DotVVM.Framework.Hosting
                 else
                 {
                     if (site == "same-origin")
-                        await context.RejectRequest($"Same site iframe are disabled in this application. If you are the developer, you can enable iframes by setting DotvvmConfiguration.Security.FrameOptionsSameOrigin.EnableForRoute(\"{route}\")");
+                        await context.RejectRequest($"""
+                            Same site iframe are disabled in this application.
+                            If you are the developer, you can enable iframes by setting DotvvmConfiguration.Security.FrameOptionsSameOrigin.EnableForRoute("{route}")
+                            """);
                     else
-                        await context.RejectRequest($"Cross site iframe are disabled in this application. If you are the developer, you can enable cross-site iframes by setting DotvvmConfiguration.Security.FrameOptionsCrossOrigin.EnableForRoute(\"{route}\"). Note that it's not recommended to enable cross-site iframes for sites / pages where security is important (due to Clickjacking)");
+                        await context.RejectRequest($"""
+                        Cross site iframe are disabled in this application.
+                        If you are the developer, you can enable cross-site iframes by setting DotvvmConfiguration.Security.FrameOptionsCrossOrigin.EnableForRoute("{route}"). Note that it's not recommended to enable cross-site iframes for sites / pages where security is important (due to Clickjacking)
+                        """);
                 }
             }
 
@@ -491,7 +497,7 @@ namespace DotVVM.Framework.Hosting
                 if (site != "same-origin")
                     await context.RejectRequest($"Cross site postbacks are disabled.");
                 if (dest != "empty")
-                    await context.RejectRequest($"postbacks must have Sec-Fetch-Dest: empty");
+                    await context.RejectRequest($"Postbacks must have Sec-Fetch-Dest: empty");
             }
             else
             {
@@ -505,12 +511,16 @@ namespace DotVVM.Framework.Hosting
                 else if (dest is "empty")
                 {
                     if (!DetermineSpaRequest(context.HttpContext))
-                        await context.RejectRequest($"Pages can not be loaded using Javascript for security reasons. If you are the developer, you can disable this check by setting DotvvmConfiguration.Security.VerifySecFetchForPages.DisableForRoute(\"{route}\"). [dest: {dest}, site: {site}]");
+                        await context.RejectRequest($"""
+                            Pages can not be loaded using Javascript for security reasons.
+                            Try refreshing the page to get rid of the error.
+                            If you are the developer, you can disable this check by setting DotvvmConfiguration.Security.VerifySecFetchForPages.DisableForRoute("{route}"). [dest: {dest}, site: {site}]
+                            """);
                     if (site != "same-origin")
                         await context.RejectRequest($"Cross site SPA requests are disabled.");
                 }
                 else
-                    await context.RejectRequest("Can not load a DotVVM page with this Sec-Fetch-Dest.");
+                    await context.RejectRequest($"Cannot load a DotVVM page with Sec-Fetch-Dest: {dest}.");
             }
         }
 

--- a/src/Framework/Framework/Hosting/Middlewares/DotvvmReturnedFileMiddleware.cs
+++ b/src/Framework/Framework/Hosting/Middlewares/DotvvmReturnedFileMiddleware.cs
@@ -39,7 +39,10 @@ namespace DotVVM.Framework.Hosting.Middlewares
                 // the user may have control over contents of the file and it may served from a trusted domain.
                 // if you don't like this behavior, you can return the file from your own middleware,
                 // we'll not add an option to disable this check.
-                if (site == "cross-site" || dest != "document")
+
+                // in addition to navigation, we also allow usage from JS, since it simplifies service worker implementation
+                // and there probably isn't a way to do harm (we need to prevent the files getting into script tags, styles, ...)
+                if (!(site != "cross-site" && dest is "document" or "empty"))
                     await c.RejectRequest("Returned file can only be used from same-site navigation.");
             }
         }


### PR DESCRIPTION
This should simplify using service workers with dotvvm, since the worker often replaces all requests with
Sec-Fetch-Dest: empty. I don't think there is any
problem with allowing the JS requests if people
want them - this rule is mostly to prevent returned files being used for XSS (for example, by being a script)