### PR TITLE
Added `CopyTo` implementation for HTTP headers collection to improve debugging

### DIFF
--- a/src/Framework/Hosting.AspNetCore/Hosting/DotvvmHeaderCollection.cs
+++ b/src/Framework/Hosting.AspNetCore/Hosting/DotvvmHeaderCollection.cs
@@ -55,7 +55,15 @@ namespace DotVVM.Framework.Hosting
 
         public void CopyTo(KeyValuePair<string, string[]>[] array, int arrayIndex)
         {
-            throw new NotImplementedException();
+            if (array.Length - arrayIndex < OriginalHeaders.Count)
+                throw new ArgumentException("Insufficient array size");
+
+            foreach (var (key, values) in OriginalHeaders)
+            {
+                var valuesCopy = (values.Count > 0) ? new string[values.Count] : Array.Empty<string>();
+                Array.Copy(values, valuesCopy, values.Count);
+                array[arrayIndex++] = new KeyValuePair<string, string[]>(key: key, value: valuesCopy);
+            }
         }
 
         public bool Remove(KeyValuePair<string, string[]> item)


### PR DESCRIPTION
This PR adds implementation for a method internally used by VS when debugging. Otherwise, inspecting the collection throws `NotImplementedException`.