### PR TITLE
Instrument DotVVM with System.Diagnostics.Metrics 

### DIFF
--- a/src/Framework/Framework/Binding/BindingCompilationService.cs
+++ b/src/Framework/Framework/Binding/BindingCompilationService.cs
@@ -14,6 +14,7 @@ using DotVVM.Framework.Compilation;
 using DotVVM.Framework.Compilation.Binding;
 using DotVVM.Framework.Compilation.ControlTree.Resolved;
 using DotVVM.Framework.Controls;
+using DotVVM.Framework.Hosting;
 using DotVVM.Framework.Runtime.Caching;
 using DotVVM.Framework.Utils;
 using Microsoft.CodeAnalysis;
@@ -85,7 +86,10 @@ namespace DotVVM.Framework.Binding
             {
                 var result = ComputeProperty(typeof(Expression<>).MakeGenericType(type), binding);
                 if (result is LambdaExpression lambda)
+                {
+                    DotvvmMetrics.BindingsCompiled.Add(1, new KeyValuePair<string, object?>("binding_type", binding.GetBindingName()));
                     return expressionCompiler.Compile(lambda);
+                }
                 else return result;
             }
             // instead of returning exception we return null since this is the most common exception
@@ -135,6 +139,8 @@ namespace DotVVM.Framework.Binding
 
         protected static void InitializeBindingCore(IBinding binding, BindingCompilationRequirementsAttribute bindingRequirements)
         {
+            DotvvmMetrics.BindingsInitialized.Add(1, new KeyValuePair<string, object?>("binding_type", binding.GetBindingName()), new KeyValuePair<string, object?>("is_lazy_init", false));
+
             var reporter = binding.GetProperty<BindingErrorReporterProperty>(ErrorHandlingMode.ReturnNull);
             var throwException = reporter == null;
             reporter = reporter ?? new BindingErrorReporterProperty();
@@ -168,6 +174,7 @@ namespace DotVVM.Framework.Binding
 
             public override void InitializeBinding(IBinding binding, IEnumerable<BindingCompilationRequirementsAttribute>? bindingRequirements = null)
             {
+                DotvvmMetrics.BindingsInitialized.Add(1, new KeyValuePair<string, object?>("binding_type", binding.GetBindingName()), new KeyValuePair<string, object?>("is_lazy_init", true));
                 // no-op
             }
         }

--- a/src/Framework/Framework/Binding/BindingHelper.cs
+++ b/src/Framework/Framework/Binding/BindingHelper.cs
@@ -462,6 +462,17 @@ namespace DotVVM.Framework.Binding
         public static BindingDelegate<T> ToGeneric<T>(this BindingDelegate d) => (a, b) => (T)d(a, b)!;
         public static BindingUpdateDelegate<T> ToGeneric<T>(this BindingUpdateDelegate d) => (a, b, c) => d(a, b, c);
 
+        public static string GetBindingName(this IBinding binding) =>
+            binding switch {
+                ControlPropertyBindingExpression => "controlProperty",
+                ValueBindingExpression => "value",
+                ResourceBindingExpression => "resource",
+                ControlCommandBindingExpression => "controlCommand",
+                StaticCommandBindingExpression => "staticCommand",
+                CommandBindingExpression => "command",
+                _ => binding.GetType().Name
+            };
+
         public record InvalidDataContextTypeException(
             DotvvmBindableObject Control,
             object? ContextObject,

--- a/src/Framework/Framework/Binding/DotvvmProperty.cs
+++ b/src/Framework/Framework/Binding/DotvvmProperty.cs
@@ -15,6 +15,7 @@ using Newtonsoft.Json;
 using System.Diagnostics.CodeAnalysis;
 using System.Collections.Immutable;
 using DotVVM.Framework.Runtime;
+using System.Threading;
 
 namespace DotVVM.Framework.Binding
 {
@@ -396,6 +397,7 @@ namespace DotVVM.Framework.Binding
             if (property.DeclaringType is null || property.PropertyType is null)
                 throw new Exception($"DotvvmProperty {property.DeclaringType?.Name}.{property.Name} must have PropertyType and DeclaringType.");
 
+            Interlocked.Increment(ref Hosting.DotvvmMetrics.BareCounters.DotvvmPropertyInitialized);
 
             property.PropertyInfo ??= property.DeclaringType.GetProperty(property.Name);
             property.AttributeProvider ??=

--- a/src/Framework/Framework/Binding/Expressions/BindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/BindingExpression.cs
@@ -295,15 +295,7 @@ namespace DotVVM.Framework.Binding.Expressions
                 // Binding.ToString is used in error handling, so it should not fail
                 value = $"Unable to get binding string due to {ex.GetType().Name}: {ex.Message}";
             }
-            var typeName = this switch {
-                ControlPropertyBindingExpression => "controlProperty",
-                ValueBindingExpression => "value",
-                ResourceBindingExpression => "resource",
-                ControlCommandBindingExpression => "controlCommand",
-                StaticCommandBindingExpression => "staticCommand",
-                CommandBindingExpression => "command",
-                _ => this.GetType().Name
-            };
+            var typeName = this.GetBindingName();
             return $"{{{typeName}: {value}}}";
         }
 

--- a/src/Framework/Framework/Compilation/Binding/StaticCommandBindingCompiler.cs
+++ b/src/Framework/Framework/Compilation/Binding/StaticCommandBindingCompiler.cs
@@ -147,7 +147,7 @@ namespace DotVVM.Framework.Compilation.Binding
                 StaticCommandParameterType.DefaultValue => "default",
                 StaticCommandParameterType.Argument => "?",
                 StaticCommandParameterType.Inject => $"service({((Type)Arg!).ToCode(stripNamespace: true)})",
-                StaticCommandParameterType.Invocation => Arg!.ToString(),
+                StaticCommandParameterType.Invocation => Arg!.ToString()!,
                 _ => "...invalid argument..."
             };
     }

--- a/src/Framework/Framework/Compilation/Binding/StaticCommandBindingCompiler.cs
+++ b/src/Framework/Framework/Compilation/Binding/StaticCommandBindingCompiler.cs
@@ -13,6 +13,7 @@ using DotVVM.Framework.Compilation.Javascript;
 using DotVVM.Framework.Compilation.Javascript.Ast;
 using DotVVM.Framework.Utils;
 using DotVVM.Framework.ViewModel.Serialization;
+using FastExpressionCompiler;
 using Microsoft.Extensions.Options;
 
 namespace DotVVM.Framework.Compilation.Binding
@@ -121,6 +122,12 @@ namespace DotVVM.Framework.Compilation.Binding
                     foreach (var r in arg.Arg!.CastTo<StaticCommandInvocationPlan>().GetAllMethods())
                         yield return r;
         }
+
+        public override string ToString()
+        {
+            var args = Arguments.Select(arg => arg.ToString()).StringJoin(", ");
+            return $"{Method.DeclaringType.ToCode(stripNamespace: true)}{Method.Name}({args})";
+        }
     }
 
     public class StaticCommandParameterPlan
@@ -133,6 +140,16 @@ namespace DotVVM.Framework.Compilation.Binding
             this.Type = type;
             this.Arg = arg;
         }
+
+        public override string ToString() =>
+            Type switch {
+                StaticCommandParameterType.Constant => Arg?.ToString() ?? "null",
+                StaticCommandParameterType.DefaultValue => "default",
+                StaticCommandParameterType.Argument => "?",
+                StaticCommandParameterType.Inject => $"service({((Type)Arg!).ToCode(stripNamespace: true)})",
+                StaticCommandParameterType.Invocation => Arg!.ToString(),
+                _ => "...invalid argument..."
+            };
     }
     public enum StaticCommandParameterType : byte
     {

--- a/src/Framework/Framework/Compilation/DefaultControlBuilderFactory.cs
+++ b/src/Framework/Framework/Compilation/DefaultControlBuilderFactory.cs
@@ -79,10 +79,12 @@ namespace DotVVM.Framework.Compilation
             {
                 var sw = ValueStopwatch.StartNew();
                 var (descriptor, factory) = ViewCompilerFactory().CompileView(file.ReadContent(), file.FileName);
+                var phase1Ticks = sw.ElapsedTicks;
 
                 var lazyBuilder = new Lazy<IControlBuilder>(() => {
                     try
                     {
+                        sw.Restart();
                         var result = factory();
 
                         // register the internal resource after the page is successfully compiled,
@@ -111,7 +113,7 @@ namespace DotVVM.Framework.Compilation
                     }
                     finally
                     {
-                        Interlocked.Add(ref DotvvmMetrics.BareCounters.ViewsCompilationTime, sw.ElapsedTicks);
+                        Interlocked.Add(ref DotvvmMetrics.BareCounters.ViewsCompilationTime, phase1Ticks + sw.ElapsedTicks);
                     }
                 });
 

--- a/src/Framework/Framework/Compilation/DefaultControlBuilderFactory.cs
+++ b/src/Framework/Framework/Compilation/DefaultControlBuilderFactory.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using DotVVM.Framework.Compilation.ViewCompiler;
 using DotVVM.Framework.Configuration;
@@ -91,14 +92,14 @@ namespace DotVVM.Framework.Compilation
                             var (import, init) = descriptor.ViewModuleReference.BuildResources(configuration.Resources);
                             configuration.Resources.RegisterViewModuleResources(import, init);
                         }
-                        DotvvmMetrics.ViewsCompiled.Add(1, new KeyValuePair<string, object?>("success", true));
+                        Interlocked.Increment(ref DotvvmMetrics.BareCounters.ViewsCompiledOk);
 
                         compilationService.RegisterCompiledView(file.FileName, descriptor, null);
                         return result;
                     }
                     catch (DotvvmCompilationException ex)
                     {
-                        DotvvmMetrics.ViewsCompiled.Add(1, new KeyValuePair<string, object?>("success", false));
+                        Interlocked.Increment(ref DotvvmMetrics.BareCounters.ViewsCompiledFailed);
                         editCompilationException(ex);
                         compilationService.RegisterCompiledView(file.FileName, descriptor, ex);
                         throw;
@@ -110,7 +111,7 @@ namespace DotVVM.Framework.Compilation
                     }
                     finally
                     {
-                        DotvvmMetrics.ViewsCompilationTime.Add(sw.ElapsedSeconds);
+                        Interlocked.Add(ref DotvvmMetrics.BareCounters.ViewsCompilationTime, sw.ElapsedTicks);
                     }
                 });
 

--- a/src/Framework/Framework/Controls/DotvvmControlCollection.cs
+++ b/src/Framework/Framework/Controls/DotvvmControlCollection.cs
@@ -413,7 +413,7 @@ namespace DotVVM.Framework.Controls
             }
             finally
             {
-                DotvvmMetrics.LifecycleInfocationDuration.Record(timer.ElapsedSeconds, context.RouteLabel(), new KeyValuePair<string, object?>("lifecycle_type", eventType.ToString()));
+                DotvvmMetrics.LifecycleInvocationDuration.Record(timer.ElapsedSeconds, context.RouteLabel(), new KeyValuePair<string, object?>("lifecycle_type", eventType.ToString()));
             }
         }
 

--- a/src/Framework/Framework/Controls/DotvvmControlCollection.cs
+++ b/src/Framework/Framework/Controls/DotvvmControlCollection.cs
@@ -315,12 +315,12 @@ namespace DotVVM.Framework.Controls
         /// <summary>
         /// Invokes missed page life cycle events on the control.
         /// </summary>
-        private void InvokeMissedPageLifeCycleEvents(LifeCycleEventType targetEventType, bool isMissingInvoke)
+        private void InvokeMissedPageLifeCycleEvents(LifeCycleEventType targetEventType, bool isMissingInvoke, IDotvvmRequestContext? context = null)
         {
             // just a quick check to save GetValue call
             if (lastLifeCycleEvent >= targetEventType || parent.LifecycleRequirements == ControlLifecycleRequirements.None) return;
 
-            var context = GetContext();
+            context ??= GetContext();
             if (context == null)
                 throw new DotvvmControlException(parent, "InvokeMissedPageLifeCycleEvents must be called on a control rooted in a view.");
 
@@ -404,9 +404,17 @@ namespace DotVVM.Framework.Controls
         /// <summary>
         /// Invokes the specified method on all controls in the page control tree.
         /// </summary>
-        public static void InvokePageLifeCycleEventRecursive(DotvvmControl rootControl, LifeCycleEventType eventType)
+        public static void InvokePageLifeCycleEventRecursive(DotvvmControl rootControl, LifeCycleEventType eventType, IDotvvmRequestContext context)
         {
-            rootControl.Children.InvokeMissedPageLifeCycleEvents(eventType, isMissingInvoke: false);
+            var timer = ValueStopwatch.StartNew();
+            try
+            {
+                rootControl.Children.InvokeMissedPageLifeCycleEvents(eventType, isMissingInvoke: false, context);
+            }
+            finally
+            {
+                DotvvmMetrics.LifecycleInfocationDuration.Record(timer.ElapsedSeconds, context.RouteLabel(), new KeyValuePair<string, object?>("lifecycle_type", eventType.ToString()));
+            }
         }
 
         private static DotvvmControl? GetClosestDotvvmControlAncestor(DotvvmControl control)

--- a/src/Framework/Framework/Controls/HierarchyRepeater.cs
+++ b/src/Framework/Framework/Controls/HierarchyRepeater.cs
@@ -121,7 +121,7 @@ namespace DotVVM.Framework.Controls
 
         protected internal override void OnLoad(IDotvvmRequestContext context)
         {
-            if (context.IsPostBack)
+            if (context.RequestType == DotvvmRequestType.Command)
             {
                 SetChildren(context, renderClientTemplate: false);
             }

--- a/src/Framework/Framework/Controls/Repeater.cs
+++ b/src/Framework/Framework/Controls/Repeater.cs
@@ -125,7 +125,7 @@ namespace DotVVM.Framework.Controls
         /// </summary>
         protected internal override void OnLoad(IDotvvmRequestContext context)
         {
-            if (context.IsPostBack)
+            if (context.RequestType == DotvvmRequestType.Command)
             {
                 SetChildren(context, renderClientTemplate: false, memoizeReferences: true);
             }
@@ -313,7 +313,7 @@ namespace DotVVM.Framework.Controls
                         AddSeparator(Children, context);
                     }
                     AddItem(Children, context, item, index,
-                        allowMemoizationRetrieve: context.IsPostBack && !memoizeReferences, // on GET request we are not initializing the Repeater twice
+                        allowMemoizationRetrieve: context.RequestType == DotvvmRequestType.Command && !memoizeReferences, // on GET request we are not initializing the Repeater twice
                         allowMemoizationStore: memoizeReferences
                     );
                     index++;

--- a/src/Framework/Framework/Controls/SpaContentPlaceHolder.cs
+++ b/src/Framework/Framework/Controls/SpaContentPlaceHolder.cs
@@ -98,7 +98,7 @@ namespace DotVVM.Framework.Controls
 
         protected internal override void OnPreRender(IDotvvmRequestContext context)
         {
-            if (context.RequestType == DotvvmRequestType.SpaGet)
+            if (context.RequestType == DotvvmRequestType.SpaNavigate)
             {
                 // we need to render the HTML on postback when SPA request arrives
                 SetValue(PostBack.UpdateProperty, true);
@@ -109,7 +109,7 @@ namespace DotVVM.Framework.Controls
 
         protected override void AddAttributesToRender(IHtmlWriter writer, IDotvvmRequestContext context)
         {
-            if (context.RequestType == DotvvmRequestType.Get)
+            if (context.RequestType == DotvvmRequestType.Navigate)
             {
                 writer.AddStyleAttribute("display", "none");
             }

--- a/src/Framework/Framework/Controls/SpaContentPlaceHolder.cs
+++ b/src/Framework/Framework/Controls/SpaContentPlaceHolder.cs
@@ -98,7 +98,7 @@ namespace DotVVM.Framework.Controls
 
         protected internal override void OnPreRender(IDotvvmRequestContext context)
         {
-            if (context.IsSpaRequest)
+            if (context.RequestType == DotvvmRequestType.SpaGet)
             {
                 // we need to render the HTML on postback when SPA request arrives
                 SetValue(PostBack.UpdateProperty, true);
@@ -109,7 +109,7 @@ namespace DotVVM.Framework.Controls
 
         protected override void AddAttributesToRender(IHtmlWriter writer, IDotvvmRequestContext context)
         {
-            if (!context.IsInPartialRenderingMode)
+            if (context.RequestType == DotvvmRequestType.Get)
             {
                 writer.AddStyleAttribute("display", "none");
             }

--- a/src/Framework/Framework/DotVVM.Framework.csproj
+++ b/src/Framework/Framework/DotVVM.Framework.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-    <PackageReference Include="FastExpressionCompiler" Version="3.2.1" />
+    <PackageReference Include="FastExpressionCompiler" Version="3.3.3" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.1" />
     <PackageReference Include="RecordException" Version="0.1.2" />
@@ -56,6 +56,7 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="Portable.System.DateTimeOnly" Version="6.0.2" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="System" />
@@ -68,6 +69,7 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="ResourceManagement\ClientGlobalize\JQueryGlobalizeRegisterTemplate.tt">

--- a/src/Framework/Framework/Hosting/DotvvmMetrics.cs
+++ b/src/Framework/Framework/Hosting/DotvvmMetrics.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Linq;
+
+namespace DotVVM.Framework.Hosting
+{
+    /// <summary> Class containing all metrics collected by DotVVM framework </summary>
+    public static class DotvvmMetrics
+    {
+        public static readonly Meter Meter = new Meter("dotvvm");
+
+        /// <summary> Labeled with success=true/false </summary>
+        public static readonly Counter<long> ViewsCompiled =
+            Meter.CreateCounter<long>("view_compiled_total", description: "Number of dothtml pages that were compiled. It should reach a steady state shortly after startup.");
+        public static readonly Counter<double> ViewsCompilationTime =
+            Meter.CreateCounter<double>("view_compilation_seconds_total", unit: "seconds", description: "CPU time spent in dothtml page compilation (in seconds).");
+
+        public static readonly Counter<long> DotvvmPropertyInitialized =
+            Meter.CreateCounter<long>("property_initialized_total", description: "Number of DotvvmProperties that were initialized.");
+
+        /// <summary> Labeled with binding_type=value/resource/... and is_lazy_init=true/false </summary>
+        public static readonly Counter<long> BindingsInitialized =
+            Meter.CreateCounter<long>("binding_initialized_total", description: "Number of bindings that were initialized.");
+
+        /// <summary> Labeled with binding_type=value/resource/... </summary>
+        public static readonly Counter<long> BindingsCompiled =
+            Meter.CreateCounter<long>("binding_compiled_total", description: "Number of bindings that were compiled. It should reach a steady state shortly after startup.");
+
+        /// <summary> Labeled by route=RouteName and request_type=GET/POST </summary>
+        public static readonly Histogram<long> ViewModelSize =
+            Meter.CreateHistogram<long>("viewmodel_size_bytes", unit: "bytes", description: "Size of the viewmodel JSON in bytes.");
+
+        /// <summary> Labeled by route=RouteName and request_type=GET/POST </summary>
+        public static readonly Histogram<double> ViewModelStringificationTime =
+            Meter.CreateHistogram<double>("viewmodel_stringification_seconds", unit: "seconds", description: "Time it took to stringify the resulting JSON view model.");
+
+        /// <summary> Labeled by route=RouteName and request_type=GET/POST </summary>
+        public static readonly Histogram<double> ViewModelSerializationTime =
+            Meter.CreateHistogram<double>("viewmodel_serialization_seconds", unit: "seconds", description: "Time it took to serialize view model to JSON objects.");
+
+        /// <summary> Labeled by route=RouteName and lifecycle_type=TODO </summary>
+        public static readonly Histogram<double> LifecycleInfocationDuration =
+            Meter.CreateHistogram<double>("control_lifecycle_seconds", unit: "seconds", description: "Time it took to process a request on the specific route.");
+
+        /// <summary> Labeled by route=RouteName, dothtml_file=filepath, request_type=GET/POST </summary>
+        public static readonly Histogram<double> RequestDuration =
+            Meter.CreateHistogram<double>("request_duration_seconds", unit: "seconds", description: "Time it took to process a request on the specific route.");
+
+        /// <summary> Labeled by route=RouteName, dothtml_file=filepath, request_type=GET/POST </summary>
+        public static readonly Counter<long> RequestsRejected =
+            Meter.CreateCounter<long>("request_rejected_total", description: "Number of requests rejected (for security reasons) on the specific route.");
+
+        /// <summary> Labeled by command="method invoked", result=Ok/Exception/UnhandledException </summary>
+        public static readonly Histogram<double> StaticCommandInvocationDuration =
+            Meter.CreateHistogram<double>("staticcommand_invocation_seconds", unit: "seconds", description: "Time it took to invoke the staticCommand method. Note that serialization overhead is not included, look at request_duration_seconds{request_type=\"staticCommand\"}.");
+
+        /// <summary> Labeled by command={command: TheBinding()}, result=Ok/Exception/UnhandledException </summary>
+        public static readonly Histogram<double> CommandInvocationDuration =
+            Meter.CreateHistogram<double>("command_invocation_seconds", unit: "seconds", description: "Time it took to invoke the command method. Note that this does not include any of the overhead which is quite heavy for commands. Look at request_duration_seconds{request_type=\"command\"}.");
+
+        public static readonly Histogram<long> ValidationErrorsReturned =
+            Meter.CreateHistogram<long>("viewmodel_validation_errors_total", description: "Number of validation errors returned to the client.");
+
+        public static readonly Histogram<double> ResourceServeDuration =
+            Meter.CreateHistogram<double>("resource_serve_seconds", unit: "seconds", description: "Time it took to lookup and serve a resource.");
+
+        public static readonly Counter<long> LazyCsrfTokenGenerated =
+            Meter.CreateCounter<long>("lazy_csrf_token_created_total", description: "Number of lazy CSRF tokens created.");
+
+        public static readonly Histogram<long> UploadedFileSize =
+            Meter.CreateHistogram<long>("uploaded_file_bytes", unit: "bytes", description: "Total size of user-uploaded files");
+
+        public static readonly Histogram<long> ReturnedFileSize =
+            Meter.CreateHistogram<long>("returned_file_bytes", unit: "bytes", description: "Total size of returned files. Measured when the file is downloaded by user - if it's downloaded twice, it's counted twice; if it's not downloaded, it's not counted.");
+
+        /// <summary> Labeled by route=RouteName </summary>
+        public static readonly Counter<long> ViewModelCacheHit =
+            Meter.CreateCounter<long>("viewmodel_cache_hit_total", description: "Number of requests with view model cache enabled which were successful");
+        /// <summary> Labeled by route=RouteName </summary>
+        public static readonly Counter<long> ViewModelCacheMiss =
+            Meter.CreateCounter<long>("viewmodel_cache_miss_total", description: "Number of requests with view model cache enabled which were not successful");
+
+        /// <summary> Labeled by route=RouteName </summary>
+        public static readonly Counter<long> ViewModelCacheBytesLoaded =
+            Meter.CreateCounter<long>("viewmodel_cache_loaded_bytes_total", "bytes", description: "Total number of bytes loaded from view model cache");
+
+
+        public static double[]? TryGetRecommendedBuckets(Instrument instrument)
+        {
+            if (instrument.Meter != Meter)
+                return null;
+
+            if (instrument == ValidationErrorsReturned)
+                return new double[] { 1, 2, 3, 5, 8, 13, 21 };
+
+            var secStart = 1.0 / 128.0; // about 10ms, so that 1second is a boundary
+            if (instrument == ResourceServeDuration)
+                return ExponentialBuckets(secStart, 2, 0.5);
+
+            if (instrument == ResourceServeDuration)
+                return ExponentialBuckets(secStart, 2, 0.5);
+
+            if (instrument == ResourceServeDuration)
+                return ExponentialBuckets(secStart, 2, 1);
+
+            if (instrument == RequestDuration || instrument == CommandInvocationDuration || instrument == StaticCommandInvocationDuration)
+                return ExponentialBuckets(secStart, 2, 65);
+
+            if (instrument.Unit == "seconds")
+                return ExponentialBuckets(secStart, 2, 2.0);
+
+            if (instrument.Unit == "bytes")
+                return ExponentialBuckets(1024, 2, 130 * 1024 * 1024); // 1KB ... 128MB
+
+            return ExponentialBuckets(secStart, 2, 10);
+        }
+
+        internal static double[] ExponentialBuckets(double start, double factor, double end)
+        {
+            return Enumerable.Range(0, 1000)
+                .Select(i => start * Math.Pow(factor, i))
+                .TakeWhile(b => b <= end)
+                .ToArray();
+        }
+
+        // internal static CounterMeasurer MeasureTime(this Counter<double> counter)
+        // {
+        // 	var ts = Stopwatch.GetTimestamp();
+        // 	return new CounterMeasurer(counter, ts);
+        // }
+
+        // internal struct CounterMeasurer
+        // {
+        //     private Counter<double> counter;
+        //     private readonly long timestamp;
+
+        //     public CounterMeasurer(Counter<double> counter, long timestamp)
+        //     {
+        //         this.counter = counter;
+        //         this.timestamp = timestamp;
+        //     }
+
+        // 	public void Dispose()
+        // 	{
+        // 		var duration = Stopwatch.GetTimestamp() - timestamp;
+        // 		var seconds = duration / (double)Stopwatch.Frequency;
+        // 		this.counter.Add(seconds);
+        // 	}
+        // }
+
+        internal static KeyValuePair<string, object?> RouteLabel(this IDotvvmRequestContext context) =>
+            new("route", context.Route?.RouteName);
+        internal static KeyValuePair<string, object?> RequestTypeLabel(this IDotvvmRequestContext context)
+        {
+            var type = context.RequestType;
+            return new("request_type", type.ToString());
+        }
+
+    }
+
+
+    // stolen from https://source.dot.net/#Microsoft.Extensions.Http/ValueStopwatch.cs,492ce3a1c6245cd8
+    internal struct ValueStopwatch
+    {
+        private static readonly double TimestampToSeconds = 1 / (double)Stopwatch.Frequency;
+
+        private long _startTimestamp;
+
+        public bool IsActive => _startTimestamp != 0;
+
+        private ValueStopwatch(long startTimestamp)
+        {
+            _startTimestamp = startTimestamp;
+        }
+
+        public static ValueStopwatch StartNew() => new ValueStopwatch(Stopwatch.GetTimestamp());
+        public static ValueStopwatch StartNew(bool isActive) =>
+            isActive ? new ValueStopwatch(Stopwatch.GetTimestamp()) : default;
+
+        public double ElapsedSeconds
+        {
+            get
+            {
+                // Start timestamp can't be zero in an initialized ValueStopwatch. It would have to be literally the first thing executed when the machine boots to be 0.
+                // So it being 0 is a clear indication of default(ValueStopwatch)
+                if (!IsActive)
+                {
+                    return 0;
+                }
+
+                long end = Stopwatch.GetTimestamp();
+                long timestampDelta = end - _startTimestamp;
+                return TimestampToSeconds * timestampDelta;
+            }
+        }
+    }
+}

--- a/src/Framework/Framework/Hosting/DotvvmMetrics.cs
+++ b/src/Framework/Framework/Hosting/DotvvmMetrics.cs
@@ -86,7 +86,7 @@ namespace DotVVM.Framework.Hosting
             Meter.CreateHistogram<long>("uploaded_file_bytes", unit: "bytes", description: "Total size of user-uploaded files");
 
         public static readonly Histogram<long> ReturnedFileSize =
-            Meter.CreateHistogram<long>("returned_file_bytes", unit: "bytes", description: "Total size of returned files. Measured when the file is downloaded by user - if it's downloaded twice, it's counted twice; if it's not downloaded, it's not counted.");
+            Meter.CreateHistogram<long>("returned_file_bytes", unit: "bytes", description: "Total size of returned files. Measured when the file is returned, not when downloaded by the client.");
 
         /// <summary> Labeled by route=RouteName </summary>
         public static readonly Counter<long> ViewModelCacheHit =

--- a/src/Framework/Framework/Hosting/DotvvmMetrics.cs
+++ b/src/Framework/Framework/Hosting/DotvvmMetrics.cs
@@ -54,7 +54,7 @@ namespace DotVVM.Framework.Hosting
             Meter.CreateHistogram<double>("viewmodel_serialization_seconds", unit: "seconds", description: "Time it took to serialize view model to JSON objects.");
 
         /// <summary> Labeled by route=RouteName and lifecycle_type=TODO </summary>
-        public static readonly Histogram<double> LifecycleInfocationDuration =
+        public static readonly Histogram<double> LifecycleInvocationDuration =
             Meter.CreateHistogram<double>("control_lifecycle_seconds", unit: "seconds", description: "Time it took to process a request on the specific route.");
 
         /// <summary> Labeled by route=RouteName, dothtml_file=filepath, request_type=GET/POST </summary>
@@ -177,6 +177,9 @@ namespace DotVVM.Framework.Hosting
         public static ValueStopwatch StartNew() => new ValueStopwatch(Stopwatch.GetTimestamp());
         public static ValueStopwatch StartNew(bool isActive) =>
             isActive ? new ValueStopwatch(Stopwatch.GetTimestamp()) : default;
+
+
+        public void Restart() => _startTimestamp = Stopwatch.GetTimestamp();
 
         public long ElapsedTicks
         {

--- a/src/Framework/Framework/Hosting/DotvvmPresenter.cs
+++ b/src/Framework/Framework/Hosting/DotvvmPresenter.cs
@@ -538,7 +538,7 @@ namespace DotVVM.Framework.Hosting
                 // he'll will just get a redirect response, not anything useful
                 else if (dest is "empty")
                 {
-                    if (context.RequestType is DotvvmRequestType.SpaGet)
+                    if (context.RequestType is not DotvvmRequestType.SpaGet)
                         await context.RejectRequest($"""
                             Pages can not be loaded using Javascript for security reasons.
                             Try refreshing the page to get rid of the error.

--- a/src/Framework/Framework/Hosting/DotvvmPresenter.cs
+++ b/src/Framework/Framework/Hosting/DotvvmPresenter.cs
@@ -256,7 +256,7 @@ namespace DotVVM.Framework.Hosting
                             commandTimer.ElapsedSeconds,
                             new KeyValuePair<string, object?>("command", actionInfo.Binding!.ToString()),
                             new KeyValuePair<string, object?>("result", context.CommandException is null ? "Ok" :
-                                                                        context.IsCommandExceptionHandled ? "Exception" :
+                                                                        context.IsCommandExceptionHandled ? "HandledException" :
                                                                         "UnhandledException"));
                     }
                     await requestTracer.TraceEvent(RequestTracingConstants.CommandExecuted, context);
@@ -289,13 +289,13 @@ namespace DotVVM.Framework.Hosting
 
                 ViewModelSerializer.BuildViewModel(context, commandResult);
 
-                if (context.RequestType == DotvvmRequestType.Get)
+                if (context.RequestType == DotvvmRequestType.Navigate)
                 {
                     await OutputRenderer.WriteHtmlResponse(context, page);
                 }
                 else
                 {
-                    Debug.Assert(context.RequestType is DotvvmRequestType.Command or DotvvmRequestType.SpaGet);
+                    Debug.Assert(context.RequestType is DotvvmRequestType.Command or DotvvmRequestType.SpaNavigate);
                     // postback or SPA content
                     var postBackUpdates = OutputRenderer.RenderPostbackUpdatedControls(context, page);
                     ViewModelSerializer.AddPostBackUpdatedControls(context, postBackUpdates);
@@ -403,7 +403,7 @@ namespace DotVVM.Framework.Hosting
                         commandTimer.ElapsedSeconds,
                         new KeyValuePair<string, object?>("command", executionPlan.ToString()),
                         new KeyValuePair<string, object?>("result", context.CommandException is null ? "Ok" :
-                                                                    context.IsCommandExceptionHandled ? "Exception" :
+                                                                    context.IsCommandExceptionHandled ? "HandledException" :
                                                                     "UnhandledException"));
                 }
 
@@ -538,7 +538,7 @@ namespace DotVVM.Framework.Hosting
                 // he'll will just get a redirect response, not anything useful
                 else if (dest is "empty")
                 {
-                    if (context.RequestType is not DotvvmRequestType.SpaGet)
+                    if (context.RequestType is not DotvvmRequestType.SpaNavigate)
                         await context.RejectRequest($"""
                             Pages can not be loaded using Javascript for security reasons.
                             Try refreshing the page to get rid of the error.
@@ -561,11 +561,11 @@ namespace DotVVM.Framework.Hosting
 
         [Obsolete("Use context.RequestType == DotvvmRequestType.SpaGet")]
         public static bool DetermineSpaRequest(IHttpContext context) =>
-            DotvvmRequestContext.DetermineRequestType(context) == DotvvmRequestType.SpaGet;
+            DotvvmRequestContext.DetermineRequestType(context) == DotvvmRequestType.SpaNavigate;
 
         [Obsolete("Use context.RequestType is DotvvmRequestType.Command or DotvvmRequestType.SpaGet")]
         public static bool DeterminePartialRendering(IHttpContext context) =>
-            DotvvmRequestContext.DetermineRequestType(context) is DotvvmRequestType.Command or DotvvmRequestType.SpaGet;
+            DotvvmRequestContext.DetermineRequestType(context) is DotvvmRequestType.Command or DotvvmRequestType.SpaNavigate;
 
         public static string? DetermineSpaContentPlaceHolderUniqueId(IHttpContext context)
         {

--- a/src/Framework/Framework/Hosting/DotvvmRequestContext.cs
+++ b/src/Framework/Framework/Hosting/DotvvmRequestContext.cs
@@ -27,7 +27,21 @@ namespace DotVVM.Framework.Hosting
         /// <summary>
         /// Determines whether this HTTP request is a postback or a classic GET request.
         /// </summary>
-        public bool IsPostBack { get; set; }
+        public bool IsPostBack
+        {
+            get => RequestType == DotvvmRequestType.Command;
+            set
+            {
+                // TODO: remove this setter
+                if (value) RequestType = DotvvmRequestType.Command;
+                else if (RequestType == DotvvmRequestType.Command) RequestType = DotvvmRequestType.Get;
+            }
+        }
+
+        /// <summary>
+        /// Determines type of the request - initial GET, command, staticCommand, ...
+        /// </summary>
+        public DotvvmRequestType RequestType { get; private set; }
 
         /// <summary>
         /// Gets the view model object for the current HTTP request.
@@ -98,7 +112,7 @@ namespace DotVVM.Framework.Hosting
         /// <summary>
         /// Gets a value indicating whether the HTTP request wants to render only content of a specific SpaContentPlaceHolder.
         /// </summary>
-        public bool IsSpaRequest => DotvvmPresenter.DetermineSpaRequest(HttpContext);
+        public bool IsSpaRequest => RequestType is DotvvmRequestType.SpaGet;
 
         /// <summary>
         /// Gets a value indicating whether this HTTP request is made from single page application and only the SpaContentPlaceHolder content will be rendered.
@@ -123,9 +137,41 @@ namespace DotVVM.Framework.Hosting
             DotvvmConfiguration configuration,
             IServiceProvider? services)
         {
+            if (httpContext is null) throw new ArgumentNullException(nameof(httpContext));
+            if (configuration is null) throw new ArgumentNullException(nameof(configuration));
+
             HttpContext = httpContext;
+            RequestType = DetermineRequestType(httpContext);
             Configuration = configuration;
             _services = services;
+        }
+
+        internal static DotvvmRequestType DetermineRequestType(IHttpContext context)
+        {
+            var method = context.Request.Method;
+            if (method == "GET")
+            {
+                if (context.Request.Headers.ContainsKey(HostingConstants.SpaContentPlaceHolderHeaderName))
+                {
+                    return DotvvmRequestType.SpaGet;
+                }
+                return DotvvmRequestType.Get;
+            }
+            if (method == "POST")
+            {
+                if (context.Request.Headers.TryGetValue("X-PostbackType", out var postbackType))
+                {
+                    if (postbackType[0] == "StaticCommand")
+                    {
+                        return DotvvmRequestType.StaticCommand;
+                    }
+                }
+                if (context.Request.Headers.ContainsKey(HostingConstants.PostBackHeaderName))
+                {
+                    return DotvvmRequestType.Command;
+                }
+            }
+            return DotvvmRequestType.Unknown;
         }
 
         /// <summary>

--- a/src/Framework/Framework/Hosting/DotvvmRequestContext.cs
+++ b/src/Framework/Framework/Hosting/DotvvmRequestContext.cs
@@ -117,7 +117,7 @@ namespace DotVVM.Framework.Hosting
         /// <summary>
         /// Gets a value indicating whether this HTTP request is made from single page application and only the SpaContentPlaceHolder content will be rendered.
         /// </summary>
-        public bool IsInPartialRenderingMode => DotvvmPresenter.DeterminePartialRendering(HttpContext);
+        public bool IsInPartialRenderingMode => RequestType is DotvvmRequestType.Command or DotvvmRequestType.SpaGet;
 
         [Obsolete("Get the IViewModelSerializer from IServiceProvider")]
         public IViewModelSerializer ViewModelSerializer => Services.GetRequiredService<IViewModelSerializer>();
@@ -135,18 +135,19 @@ namespace DotVVM.Framework.Hosting
         public DotvvmRequestContext(
             IHttpContext httpContext,
             DotvvmConfiguration configuration,
-            IServiceProvider? services)
+            IServiceProvider? services,
+            DotvvmRequestType? requestType = null)
         {
             if (httpContext is null) throw new ArgumentNullException(nameof(httpContext));
             if (configuration is null) throw new ArgumentNullException(nameof(configuration));
 
             HttpContext = httpContext;
-            RequestType = DetermineRequestType(httpContext);
+            RequestType = requestType ?? DetermineRequestType(httpContext);
             Configuration = configuration;
             _services = services;
         }
 
-        internal static DotvvmRequestType DetermineRequestType(IHttpContext context)
+        public static DotvvmRequestType DetermineRequestType(IHttpContext context)
         {
             var method = context.Request.Method;
             if (method == "GET")

--- a/src/Framework/Framework/Hosting/DotvvmRequestContext.cs
+++ b/src/Framework/Framework/Hosting/DotvvmRequestContext.cs
@@ -34,7 +34,7 @@ namespace DotVVM.Framework.Hosting
             {
                 // TODO: remove this setter
                 if (value) RequestType = DotvvmRequestType.Command;
-                else if (RequestType == DotvvmRequestType.Command) RequestType = DotvvmRequestType.Get;
+                else if (RequestType == DotvvmRequestType.Command) RequestType = DotvvmRequestType.Navigate;
             }
         }
 
@@ -112,12 +112,12 @@ namespace DotVVM.Framework.Hosting
         /// <summary>
         /// Gets a value indicating whether the HTTP request wants to render only content of a specific SpaContentPlaceHolder.
         /// </summary>
-        public bool IsSpaRequest => RequestType is DotvvmRequestType.SpaGet;
+        public bool IsSpaRequest => RequestType is DotvvmRequestType.SpaNavigate;
 
         /// <summary>
         /// Gets a value indicating whether this HTTP request is made from single page application and only the SpaContentPlaceHolder content will be rendered.
         /// </summary>
-        public bool IsInPartialRenderingMode => RequestType is DotvvmRequestType.Command or DotvvmRequestType.SpaGet;
+        public bool IsInPartialRenderingMode => RequestType is DotvvmRequestType.Command or DotvvmRequestType.SpaNavigate;
 
         [Obsolete("Get the IViewModelSerializer from IServiceProvider")]
         public IViewModelSerializer ViewModelSerializer => Services.GetRequiredService<IViewModelSerializer>();
@@ -154,9 +154,9 @@ namespace DotVVM.Framework.Hosting
             {
                 if (context.Request.Headers.ContainsKey(HostingConstants.SpaContentPlaceHolderHeaderName))
                 {
-                    return DotvvmRequestType.SpaGet;
+                    return DotvvmRequestType.SpaNavigate;
                 }
-                return DotvvmRequestType.Get;
+                return DotvvmRequestType.Navigate;
             }
             if (method == "POST")
             {

--- a/src/Framework/Framework/Hosting/DotvvmRequestContextExtensions.cs
+++ b/src/Framework/Framework/Hosting/DotvvmRequestContextExtensions.cs
@@ -160,6 +160,11 @@ public static class DotvvmRequestContextExtensions
         context.PreprocessModelState();
         if (!context.ModelState.IsValid)
         {
+            DotvvmMetrics.ValidationErrorsReturned.Record(
+                context.ModelState.ErrorsInternal.Count,
+                context.RouteLabel(),
+                context.RequestTypeLabel()
+            );
             context.HttpContext.Response.ContentType = "application/json";
             context.HttpContext.Response
                 .WriteAsync(context.Services.GetRequiredService<IViewModelSerializer>().SerializeModelState(context))
@@ -264,6 +269,10 @@ public static class DotvvmRequestContextExtensions
 
     internal static async Task RejectRequest(this IDotvvmRequestContext context, string message, int statusCode = 403)
     {
+        DotvvmMetrics.RequestsRejected.Add(1,
+            context.RouteLabel(),
+            context.RequestTypeLabel());
+
         // push it as a warning to ILogger
         var msg = "request rejected: " + message;
         context.Services

--- a/src/Framework/Framework/Hosting/HostingConstants.cs
+++ b/src/Framework/Framework/Hosting/HostingConstants.cs
@@ -1,4 +1,6 @@
-﻿namespace DotVVM.Framework.Hosting
+﻿using System;
+
+namespace DotVVM.Framework.Hosting
 {
     public class HostingConstants
     {
@@ -14,7 +16,9 @@
         public const string CsrfTokenMatchUrl = "___dotvvm-create-csrf-token___";
 
         public const string SpaContentPlaceHolderHeaderName = "X-DotVVM-SpaContentPlaceHolder";
-        public const string SpaPostBackHeaderName = "X-DotVVM-PostBack";
+        public const string PostBackHeaderName = "X-DotVVM-PostBack";
+        [Obsolete("Use PostBackHeaderName instead")]
+        public const string SpaPostBackHeaderName = PostBackHeaderName;
         public const string SpaContentPlaceHolderID = "__dot_SpaContentPlaceHolder";
         public const string SpaUrlIdentifier = "___dotvvm-spa___";
 

--- a/src/Framework/Framework/Hosting/HttpRedirectService.cs
+++ b/src/Framework/Framework/Hosting/HttpRedirectService.cs
@@ -32,7 +32,8 @@ namespace DotVVM.Framework.Hosting
     {
         public void WriteRedirectResponse(IHttpContext httpContext, string url, int statusCode = (int)HttpStatusCode.Redirect, bool replaceInHistory = false, bool allowSpaRedirect = false)
         {
-            if (!DotvvmPresenter.DeterminePartialRendering(httpContext))
+            
+            if (DotvvmRequestContext.DetermineRequestType(httpContext) is DotvvmRequestType.Get)
             {
                 httpContext.Response.Headers["Location"] = url;
                 httpContext.Response.StatusCode = statusCode;

--- a/src/Framework/Framework/Hosting/HttpRedirectService.cs
+++ b/src/Framework/Framework/Hosting/HttpRedirectService.cs
@@ -33,7 +33,7 @@ namespace DotVVM.Framework.Hosting
         public void WriteRedirectResponse(IHttpContext httpContext, string url, int statusCode = (int)HttpStatusCode.Redirect, bool replaceInHistory = false, bool allowSpaRedirect = false)
         {
             
-            if (DotvvmRequestContext.DetermineRequestType(httpContext) is DotvvmRequestType.Get)
+            if (DotvvmRequestContext.DetermineRequestType(httpContext) is DotvvmRequestType.Navigate)
             {
                 httpContext.Response.Headers["Location"] = url;
                 httpContext.Response.StatusCode = statusCode;

--- a/src/Framework/Framework/Hosting/IDotvvmRequestContext.cs
+++ b/src/Framework/Framework/Hosting/IDotvvmRequestContext.cs
@@ -55,7 +55,7 @@ namespace DotVVM.Framework.Hosting
         /// <summary>
         /// Determines whether this HTTP request is a postback or a classic GET request.
         /// </summary>
-        [Obsolete("Use RequestType == DotvvmRequestType.Command instead.")]
+        [Obsolete("Use RequestType == DotvvmRequestType.Command instead.")] // TODO: remove, used too often, only for our integrity
         bool IsPostBack { get; set; }
 
         /// <summary>

--- a/src/Framework/Framework/Hosting/IDotvvmRequestContext.cs
+++ b/src/Framework/Framework/Hosting/IDotvvmRequestContext.cs
@@ -55,7 +55,13 @@ namespace DotVVM.Framework.Hosting
         /// <summary>
         /// Determines whether this HTTP request is a postback or a classic GET request.
         /// </summary>
+        [Obsolete("Use RequestType == DotvvmRequestType.Command instead.")]
         bool IsPostBack { get; set; }
+
+        /// <summary>
+        /// Determines type of the request - initial GET, command, staticCommand, ...
+        /// </summary>
+        DotvvmRequestType RequestType { get; }
 
         /// <summary>
         /// Gets the values of parameters specified in the <see cref="P:Route" /> property.
@@ -97,11 +103,13 @@ namespace DotVVM.Framework.Hosting
         /// <summary>
         /// Gets a value indicating whether the HTTP request wants to render only content of a specific SpaContentPlaceHolder.
         /// </summary>
+        [Obsolete("Use RequestType == DotvvmRequestType.SpaGet instead.")]
         bool IsSpaRequest { get; }
 
         /// <summary>
         /// Gets a value indicating whether this HTTP request is made from single page application and only the SpaContentPlaceHolder content will be rendered.
         /// </summary>
+        [Obsolete("Use RequestType is DotvvmRequestType.SpaGet or DotvvmRequestType.Command instead.")]
         bool IsInPartialRenderingMode { get; }
 
         /// <summary>
@@ -110,7 +118,20 @@ namespace DotVVM.Framework.Hosting
         string? ResultIdFragment { get; set; }
 
         IServiceProvider Services { get; }
-        public CustomResponsePropertiesManager CustomResponseProperties { get; }
+        CustomResponsePropertiesManager CustomResponseProperties { get; }
+    }
 
+    public enum DotvvmRequestType
+    {
+        Unknown,
+        /// <summary> Initial GET request returning html output </summary>
+        Get, // TODO: naming? Navigate?
+
+        /// <summary> Initial GET request for already loaded SPA website. Expected to return JSON with html fragments </summary>
+        SpaGet,
+        /// <summary> POST request handling a command binding invocation. </summary>
+        Command,
+        /// <summary> POST request handling a static command binding invocation. </summary>
+        StaticCommand
     }
 }

--- a/src/Framework/Framework/Hosting/IDotvvmRequestContext.cs
+++ b/src/Framework/Framework/Hosting/IDotvvmRequestContext.cs
@@ -53,9 +53,8 @@ namespace DotVVM.Framework.Hosting
         RouteBase? Route { get; set; }
 
         /// <summary>
-        /// Determines whether this HTTP request is a postback or a classic GET request.
+        /// Determines whether this HTTP request is a command executing POST request.
         /// </summary>
-        [Obsolete("Use RequestType == DotvvmRequestType.Command instead.")] // TODO: remove, used too often, only for our integrity
         bool IsPostBack { get; set; }
 
         /// <summary>

--- a/src/Framework/Framework/Hosting/IDotvvmRequestContext.cs
+++ b/src/Framework/Framework/Hosting/IDotvvmRequestContext.cs
@@ -124,10 +124,9 @@ namespace DotVVM.Framework.Hosting
     {
         Unknown,
         /// <summary> Initial GET request returning html output </summary>
-        Get, // TODO: naming? Navigate?
-
-        /// <summary> Initial GET request for already loaded SPA website. Expected to return JSON with html fragments </summary>
-        SpaGet,
+        Navigate,
+        /// <summary> Initial GET request for an already loaded SPA website. Expected to return JSON with html fragments </summary>
+        SpaNavigate,
         /// <summary> POST request handling a command binding invocation. </summary>
         Command,
         /// <summary> POST request handling a static command binding invocation. </summary>

--- a/src/Framework/Framework/Hosting/Middlewares/DotvvmCsrfTokenMiddleware.cs
+++ b/src/Framework/Framework/Hosting/Middlewares/DotvvmCsrfTokenMiddleware.cs
@@ -17,6 +17,8 @@ namespace DotVVM.Framework.Hosting.Middlewares
         {
             if (DotvvmMiddlewareBase.GetCleanRequestUrl(cx.HttpContext) == HostingConstants.CsrfTokenMatchUrl)
             {
+                DotvvmMetrics.LazyCsrfTokenGenerated.Add(1);
+
                 var token = csrfProtector.GenerateToken(cx);
                 await cx.HttpContext.Response.WriteAsync(token);
                 return true;

--- a/src/Framework/Framework/Hosting/Middlewares/DotvvmFileUploadMiddleware.cs
+++ b/src/Framework/Framework/Hosting/Middlewares/DotvvmFileUploadMiddleware.cs
@@ -143,6 +143,7 @@ namespace DotVVM.Framework.Hosting.Middlewares
             var fileName = fileNameGroup.Success ? fileNameGroup.Value : string.Empty;
             var mimeType = section.ContentType ?? string.Empty;
             var fileSize = section.Body.Length;
+            DotvvmMetrics.UploadedFileSize.Record(section.Body.Length);
 
             return new UploadedFile {
                 FileId = fileId,

--- a/src/Framework/Framework/Hosting/Middlewares/DotvvmLocalResourceMiddleware.cs
+++ b/src/Framework/Framework/Hosting/Middlewares/DotvvmLocalResourceMiddleware.cs
@@ -23,7 +23,7 @@ namespace DotVVM.Framework.Hosting.Middlewares
 
         public async Task<bool> Handle(IDotvvmRequestContext request)
         {
-            var sw = ValueStopwatch.StartNew();
+            var sw = ValueStopwatch.StartNew(isActive: DotvvmMetrics.ResourceServeDuration.Enabled);
             var resource = urlManager.FindResource(request.HttpContext.Request.Url.ToString(), request, out var mimeType);
             if (resource != null)
             {

--- a/src/Framework/Framework/Hosting/Middlewares/DotvvmLocalResourceMiddleware.cs
+++ b/src/Framework/Framework/Hosting/Middlewares/DotvvmLocalResourceMiddleware.cs
@@ -23,6 +23,7 @@ namespace DotVVM.Framework.Hosting.Middlewares
 
         public async Task<bool> Handle(IDotvvmRequestContext request)
         {
+            var sw = ValueStopwatch.StartNew();
             var resource = urlManager.FindResource(request.HttpContext.Request.Url.ToString(), request, out var mimeType);
             if (resource != null)
             {
@@ -38,6 +39,8 @@ namespace DotVVM.Framework.Hosting.Middlewares
 
                     await body.CopyToAsync(request.HttpContext.Response.Body);
                 }
+
+                DotvvmMetrics.ResourceServeDuration.Record(sw.ElapsedSeconds);
                 return true;
             }
             else

--- a/src/Framework/Framework/Hosting/Middlewares/DotvvmReturnedFileMiddleware.cs
+++ b/src/Framework/Framework/Hosting/Middlewares/DotvvmReturnedFileMiddleware.cs
@@ -81,8 +81,6 @@ namespace DotVVM.Framework.Hosting.Middlewares
 
                 context.Response.StatusCode = (int)HttpStatusCode.OK;
                 await stream.CopyToAsync(context.Response.Body);
-
-                DotvvmMetrics.ReturnedFileSize.Record(context.Response.Body.Length);
             }
         }
     }

--- a/src/Framework/Framework/Hosting/Middlewares/DotvvmReturnedFileMiddleware.cs
+++ b/src/Framework/Framework/Hosting/Middlewares/DotvvmReturnedFileMiddleware.cs
@@ -81,6 +81,8 @@ namespace DotVVM.Framework.Hosting.Middlewares
 
                 context.Response.StatusCode = (int)HttpStatusCode.OK;
                 await stream.CopyToAsync(context.Response.Body);
+
+                DotvvmMetrics.ReturnedFileSize.Record(context.Response.Body.Length);
             }
         }
     }

--- a/src/Framework/Framework/Hosting/Middlewares/DotvvmRoutingMiddleware.cs
+++ b/src/Framework/Framework/Hosting/Middlewares/DotvvmRoutingMiddleware.cs
@@ -75,6 +75,8 @@ namespace DotVVM.Framework.Hosting.Middlewares
             //check if route exists
             if (route == null) return false;
 
+            var timer = ValueStopwatch.StartNew();
+
             context.Route = route;
             context.Parameters = parameters;
             var presenter = context.Presenter = route.GetPresenter(context.Services);
@@ -101,6 +103,14 @@ namespace DotVVM.Framework.Hosting.Middlewares
                 }
                 await requestTracer.EndRequest(context, exception);
                 throw;
+            }
+            finally
+            {
+                DotvvmMetrics.RequestDuration.Record(
+                    timer.ElapsedSeconds,
+                    context.RouteLabel(),
+                    new KeyValuePair<string, object?>("dothtml_file", route.VirtualPath),
+                    context.RequestTypeLabel());
             }
 
             await requestTracer.EndRequest(context);

--- a/src/Framework/Framework/Runtime/DefaultDotvvmViewBuilder.cs
+++ b/src/Framework/Framework/Runtime/DefaultDotvvmViewBuilder.cs
@@ -68,7 +68,7 @@ namespace DotVVM.Framework.Runtime
         /// </summary>
         protected void VerifySpaRequest(IDotvvmRequestContext context, DotvvmView page)
         {
-            if (context.IsSpaRequest)
+            if (context.RequestType == DotvvmRequestType.SpaGet)
             {
                 var spaContentPlaceHolders = page.GetAllDescendants().OfType<SpaContentPlaceHolder>().ToList();
                 var spaContentPlaceHolderIds = context.GetSpaContentPlaceHolderUniqueId()!.Split(';');

--- a/src/Framework/Framework/Runtime/DefaultDotvvmViewBuilder.cs
+++ b/src/Framework/Framework/Runtime/DefaultDotvvmViewBuilder.cs
@@ -68,7 +68,7 @@ namespace DotVVM.Framework.Runtime
         /// </summary>
         protected void VerifySpaRequest(IDotvvmRequestContext context, DotvvmView page)
         {
-            if (context.RequestType == DotvvmRequestType.SpaGet)
+            if (context.RequestType == DotvvmRequestType.SpaNavigate)
             {
                 var spaContentPlaceHolders = page.GetAllDescendants().OfType<SpaContentPlaceHolder>().ToList();
                 var spaContentPlaceHolderIds = context.GetSpaContentPlaceHolderUniqueId()!.Split(';');

--- a/src/Framework/Framework/Storage/FileSystemReturnedFileStorage.cs
+++ b/src/Framework/Framework/Storage/FileSystemReturnedFileStorage.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DotVVM.Core.Storage;
 using DotVVM.Framework.Configuration;
+using DotVVM.Framework.Hosting;
 using DotVVM.Framework.Utils;
 using Newtonsoft.Json;
 
@@ -77,6 +78,7 @@ namespace DotVVM.Framework.Storage
             using (var fs = new FileStream(dataFilePath, FileMode.Create))
             {
                 await stream.CopyToAsync(fs).ConfigureAwait(false);
+                DotvvmMetrics.ReturnedFileSize.Record(fs.Length);
             }
 
             await StoreMetadata(id, metadata);

--- a/src/Framework/Framework/Testing/TestDotvvmRequestContext.cs
+++ b/src/Framework/Framework/Testing/TestDotvvmRequestContext.cs
@@ -30,7 +30,7 @@ namespace DotVVM.Framework.Testing
             get => RequestType == DotvvmRequestType.Command;
             [Obsolete("Don't do this", true)] set { }
         }
-        public DotvvmRequestType RequestType { get; set; } = DotvvmRequestType.Get;
+        public DotvvmRequestType RequestType { get; set; } = DotvvmRequestType.Navigate;
         public IDictionary<string, object> Parameters { get; set; }
         public ResourceManager ResourceManager { get; set; }
         public ModelState ModelState { get; set; }
@@ -38,8 +38,8 @@ namespace DotVVM.Framework.Testing
         public bool IsCommandExceptionHandled { get; set; }
         public bool IsPageExceptionHandled { get; set; }
         public Exception CommandException { get; set; }
-        public bool IsSpaRequest => RequestType == DotvvmRequestType.SpaGet;
-        public bool IsInPartialRenderingMode => RequestType is DotvvmRequestType.SpaGet or DotvvmRequestType.Command;
+        public bool IsSpaRequest => RequestType == DotvvmRequestType.SpaNavigate;
+        public bool IsInPartialRenderingMode => RequestType is DotvvmRequestType.SpaNavigate or DotvvmRequestType.Command;
         public string ApplicationHostPath { get; set; }
         public string ResultIdFragment { get; set; }
         public DotvvmView View { get; set; }

--- a/src/Framework/Framework/Testing/TestDotvvmRequestContext.cs
+++ b/src/Framework/Framework/Testing/TestDotvvmRequestContext.cs
@@ -25,7 +25,12 @@ namespace DotVVM.Framework.Testing
         public DotvvmConfiguration Configuration { get; set; }
         public IDotvvmPresenter Presenter { get; set; }
         public RouteBase Route { get; set; }
-        public bool IsPostBack { get; set; }
+        public bool IsPostBack
+        {
+            get => RequestType == DotvvmRequestType.Command;
+            [Obsolete("Don't do this", true)] set { }
+        }
+        public DotvvmRequestType RequestType { get; set; } = DotvvmRequestType.Get;
         public IDictionary<string, object> Parameters { get; set; }
         public ResourceManager ResourceManager { get; set; }
         public ModelState ModelState { get; set; }
@@ -33,8 +38,8 @@ namespace DotVVM.Framework.Testing
         public bool IsCommandExceptionHandled { get; set; }
         public bool IsPageExceptionHandled { get; set; }
         public Exception CommandException { get; set; }
-        public bool IsSpaRequest { get; set; }
-        public bool IsInPartialRenderingMode { get; set; }
+        public bool IsSpaRequest => RequestType == DotvvmRequestType.SpaGet;
+        public bool IsInPartialRenderingMode => RequestType is DotvvmRequestType.SpaGet or DotvvmRequestType.Command;
         public string ApplicationHostPath { get; set; }
         public string ResultIdFragment { get; set; }
         public DotvvmView View { get; set; }

--- a/src/Framework/Framework/ViewModel/Serialization/DefaultViewModelSerializer.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/DefaultViewModelSerializer.cs
@@ -153,7 +153,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
                 result["resultIdFragment"] = context.ResultIdFragment;
             }
 
-            if (context.RequestType is DotvvmRequestType.Command or DotvvmRequestType.SpaGet)
+            if (context.RequestType is DotvvmRequestType.Command or DotvvmRequestType.SpaNavigate)
             {
                 result["action"] = "successfulCommand";
             }

--- a/src/Framework/Testing/ControlTestHelper.cs
+++ b/src/Framework/Testing/ControlTestHelper.cs
@@ -88,6 +88,7 @@ namespace DotVVM.Framework.Testing
 
             if (postback is object)
             {
+                context.RequestType = DotvvmRequestType.Command;
                 httpContext.Request.Method = "POST";
                 httpContext.Request.Headers["X-DotVVM-PostBack"] = new[] { "true" };
                 httpContext.Request.Body = new MemoryStream(

--- a/src/Samples/AspNetCoreLatest/DotVVM.Samples.BasicSamples.AspNetCoreLatest.csproj
+++ b/src/Samples/AspNetCoreLatest/DotVVM.Samples.BasicSamples.AspNetCoreLatest.csproj
@@ -14,6 +14,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="8.0.0-pre-230102092516-2351266" />
+    <PackageReference Include="prometheus-net.DotNetRuntime" Version="4.4.0" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>

--- a/src/Samples/AspNetCoreLatest/Startup.cs
+++ b/src/Samples/AspNetCoreLatest/Startup.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -14,6 +15,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Prometheus;
 
 namespace DotVVM.Samples.BasicSamples
 {
@@ -25,6 +27,12 @@ namespace DotVVM.Samples.BasicSamples
 
         public void ConfigureServices(IServiceCollection services)
         {
+            MeterAdapter.StartListening(new MeterAdapterOptions {
+                ResolveHistogramBuckets = instrument => {
+                    return DotvvmMetrics.TryGetRecommendedBuckets(instrument) ?? MeterAdapterOptions.DefaultHistogramBuckets;
+                }
+            });
+
             services.AddAuthentication("Scheme1")
                 .AddCookie("Scheme1", o => {
                     o.LoginPath = new PathString("/ComplexSamples/Auth/Login");
@@ -92,6 +100,7 @@ namespace DotVVM.Samples.BasicSamples
 
             app.UseEndpoints(endpoints => {
                 endpoints.MapDotvvmHotReload();
+                endpoints.MapMetrics(); // prometheus metrics on /metrics
             });
         }
 

--- a/src/Samples/Owin/Web.config
+++ b/src/Samples/Owin/Web.config
@@ -49,8 +49,8 @@
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Tests/AspCore/Middleware/MiddlewareTest.cs
+++ b/src/Tests/AspCore/Middleware/MiddlewareTest.cs
@@ -40,7 +40,7 @@ namespace DotVVM.Framework.Tests.AspCore.Middleware
             mockContext.Setup(m => m.Response).Returns(mockResponse.Object);
 
             var configuration = DotvvmConfiguration.CreateDefault();
-            _requestContext = new DotvvmRequestContext(mockContext.Object, configuration, configuration.ServiceProvider);
+            _requestContext = new DotvvmRequestContext(mockContext.Object, configuration, configuration.ServiceProvider, requestType: DotvvmRequestType.Get);
         }
 
 

--- a/src/Tests/AspCore/Middleware/MiddlewareTest.cs
+++ b/src/Tests/AspCore/Middleware/MiddlewareTest.cs
@@ -40,7 +40,7 @@ namespace DotVVM.Framework.Tests.AspCore.Middleware
             mockContext.Setup(m => m.Response).Returns(mockResponse.Object);
 
             var configuration = DotvvmConfiguration.CreateDefault();
-            _requestContext = new DotvvmRequestContext(mockContext.Object, configuration, configuration.ServiceProvider, requestType: DotvvmRequestType.Get);
+            _requestContext = new DotvvmRequestContext(mockContext.Object, configuration, configuration.ServiceProvider, requestType: DotvvmRequestType.Navigate);
         }
 
 

--- a/src/Tests/Runtime/DotvvmControlCollectionTests.cs
+++ b/src/Tests/Runtime/DotvvmControlCollectionTests.cs
@@ -212,6 +212,7 @@ namespace DotVVM.Framework.Tests.Runtime
                     });
                 },
             };
+            root.SetValue(Internal.RequestContextProperty, context);
 
             DotvvmControlCollection.InvokePageLifeCycleEventRecursive(root, LifeCycleEventType.PreRender, context);
 
@@ -250,6 +251,7 @@ namespace DotVVM.Framework.Tests.Runtime
             };
 
             var root = new ControlLifeCycleMock();
+            root.SetValue(Internal.RequestContextProperty, context);
 
             root.RenderAction = (control, _) => {
                 var innerRoot = new ControlLifeCycleMock() { LifecycleRequirements = ControlLifecycleRequirements.None };

--- a/src/Tests/Runtime/DotvvmControlCollectionTests.cs
+++ b/src/Tests/Runtime/DotvvmControlCollectionTests.cs
@@ -14,6 +14,7 @@ namespace DotVVM.Framework.Tests.Runtime
     [TestClass]
     public class DotvvmControlCollectionTests
     {
+        private IDotvvmRequestContext context = DotvvmTestHelper.CreateContext();
 
         [TestMethod]
         public void ControlCollection_ControlsCreatedOnInit()
@@ -34,9 +35,9 @@ namespace DotVVM.Framework.Tests.Runtime
                     });
                 }
             };
-            root.SetValue(Internal.RequestContextProperty, DotvvmTestHelper.CreateContext());
+            root.SetValue(Internal.RequestContextProperty, context);
 
-            DotvvmControlCollection.InvokePageLifeCycleEventRecursive(root, LifeCycleEventType.Init);
+            DotvvmControlCollection.InvokePageLifeCycleEventRecursive(root, LifeCycleEventType.Init, context);
 
             Assert.IsTrue(innerInitCalled);
         }
@@ -67,10 +68,10 @@ namespace DotVVM.Framework.Tests.Runtime
                     });
                 }
             };
-            root.SetValue(Internal.RequestContextProperty, DotvvmTestHelper.CreateContext());
+            root.SetValue(Internal.RequestContextProperty, context);
 
-            DotvvmControlCollection.InvokePageLifeCycleEventRecursive(root, LifeCycleEventType.Init);
-            DotvvmControlCollection.InvokePageLifeCycleEventRecursive(root, LifeCycleEventType.Load);
+            DotvvmControlCollection.InvokePageLifeCycleEventRecursive(root, LifeCycleEventType.Init, context);
+            DotvvmControlCollection.InvokePageLifeCycleEventRecursive(root, LifeCycleEventType.Load, context);
 
             Assert.IsTrue(innerInitCalled);
             Assert.IsTrue(innerLoadCalled);
@@ -105,9 +106,9 @@ namespace DotVVM.Framework.Tests.Runtime
                     });
                 }
             };
-            root.SetValue(Internal.RequestContextProperty, DotvvmTestHelper.CreateContext());
+            root.SetValue(Internal.RequestContextProperty, context);
 
-            DotvvmControlCollection.InvokePageLifeCycleEventRecursive(root, LifeCycleEventType.Init);
+            DotvvmControlCollection.InvokePageLifeCycleEventRecursive(root, LifeCycleEventType.Init, context);
 
             Assert.IsTrue(innerInitCalled);
         }
@@ -142,9 +143,9 @@ namespace DotVVM.Framework.Tests.Runtime
                     });
                 }
             };
-            root.SetValue(Internal.RequestContextProperty, DotvvmTestHelper.CreateContext());
+            root.SetValue(Internal.RequestContextProperty, context);
 
-            DotvvmControlCollection.InvokePageLifeCycleEventRecursive(root, LifeCycleEventType.PreRender);
+            DotvvmControlCollection.InvokePageLifeCycleEventRecursive(root, LifeCycleEventType.PreRender, context);
 
             var index = 0;
             Action<string, LifeCycleEventType, bool> verifyAction = (name, eventType, isEntering) =>
@@ -211,9 +212,8 @@ namespace DotVVM.Framework.Tests.Runtime
                     });
                 },
             };
-            root.SetValue(Internal.RequestContextProperty, DotvvmTestHelper.CreateContext());
 
-            DotvvmControlCollection.InvokePageLifeCycleEventRecursive(root, LifeCycleEventType.PreRender);
+            DotvvmControlCollection.InvokePageLifeCycleEventRecursive(root, LifeCycleEventType.PreRender, context);
 
             var root_New = new ControlLifeCycleMock(eventLog, "root_New");
             root.Children.Add(root_New);
@@ -263,9 +263,8 @@ namespace DotVVM.Framework.Tests.Runtime
                 innerRoot.Children.Add(td2);
                 td2.Children.Add(secondChild);
             };
-            root.SetValue(Internal.RequestContextProperty, DotvvmTestHelper.CreateContext());
 
-            DotvvmControlCollection.InvokePageLifeCycleEventRecursive(root, LifeCycleEventType.PreRenderComplete);
+            DotvvmControlCollection.InvokePageLifeCycleEventRecursive(root, LifeCycleEventType.PreRenderComplete, context);
             root.Render(null, null);
 
             Assert.IsTrue(initCalled);

--- a/src/Tests/Runtime/DotvvmControlTestBase.cs
+++ b/src/Tests/Runtime/DotvvmControlTestBase.cs
@@ -50,7 +50,7 @@ namespace DotVVM.Framework.Tests.Runtime
             view.DataContext = context.ViewModel;
             view.SetValue(Internal.RequestContextProperty, context);
 
-            DotvvmControlCollection.InvokePageLifeCycleEventRecursive(view, LifeCycleEventType.PreRenderComplete);
+            DotvvmControlCollection.InvokePageLifeCycleEventRecursive(view, LifeCycleEventType.PreRenderComplete, context);
             using (var text = new StringWriter())
             {
                 var html = new HtmlWriter(text, context);

--- a/src/Tests/ViewModel/ViewModelValidatorTests.cs
+++ b/src/Tests/ViewModel/ViewModelValidatorTests.cs
@@ -223,7 +223,7 @@ namespace DotVVM.Framework.Tests.ViewModel
         {
             var testViewModel = new TestViewModel()
             {
-                Context = new DotvvmRequestContext(null, DotvvmTestHelper.CreateConfiguration(), null),
+                Context = DotvvmTestHelper.CreateContext(),
                 Child = new TestViewModel2()
                 {
                     Id = 11,
@@ -253,7 +253,7 @@ namespace DotVVM.Framework.Tests.ViewModel
         public void ViewModelValidator_CustomModelStateErrors_OldFormatThrows()
         {
             var testViewModel = new TestViewModel() {
-                Context = new DotvvmRequestContext(null, DotvvmTestHelper.CreateConfiguration(), null),
+                Context = DotvvmTestHelper.CreateContext(),
                 Child = new TestViewModel2() {
                     Id = 11,
                     Code = "Code",
@@ -276,7 +276,7 @@ namespace DotVVM.Framework.Tests.ViewModel
         {
             var testViewModel = new TestViewModel()
             {
-                Context = new DotvvmRequestContext(null, DotvvmTestHelper.CreateConfiguration(), null),
+                Context = DotvvmTestHelper.CreateContext(),
                 Child = new TestViewModel2()
                 {
                     Id = 11,
@@ -316,7 +316,7 @@ namespace DotVVM.Framework.Tests.ViewModel
         public void ViewModelValidator_CustomModelStateErrors_ArbitraryTargetObjectAndLambda()
         {
             var testViewModel = new TestViewModel() {
-                Context = new DotvvmRequestContext(null, DotvvmTestHelper.CreateConfiguration(), null),
+                Context = DotvvmTestHelper.CreateContext(),
                 Child = new TestViewModel2() {
                     Id = 11,
                     Code = "Code",
@@ -360,7 +360,7 @@ namespace DotVVM.Framework.Tests.ViewModel
             var innerViewModel = new TestViewModel2() { Code = "123" };
             var testViewModel = new TestViewModel()
             {
-                Context = new DotvvmRequestContext(null, DotvvmTestHelper.CreateConfiguration(), null),
+                Context = DotvvmTestHelper.CreateContext(),
                 Child = new TestViewModel2()
                 {
                     Id = 11,
@@ -395,7 +395,7 @@ namespace DotVVM.Framework.Tests.ViewModel
         {
             var testViewModel = new TestViewModel()
             {
-                Context = new DotvvmRequestContext(null, DotvvmTestHelper.CreateConfiguration(), null)
+                Context = DotvvmTestHelper.CreateContext()
             };
             var validator = CreateValidator();
             var expander = CreateErrorPathExpander();


### PR DESCRIPTION
The aim is to add prometheus-compatible metrics
to places which can signal a potential problem with
the application (too large VM, compiling too many
bindings or views, ...). The samples project now includes
reference to prometheus-net, so you can go to `/metrics` to see them.

I couldn't find what naming convention should be used for
these .NET metrics, so I used the prometheus conventions
(maybe except label values are in PascalCase, because it's easier that way).
However, prometheus-net seems to have some naming convertor,
which suggest the convention for System.Diagnostics.Metrics
are different (or non-existent...)