### PR TITLE
Fixed directives to be case-insensitive again

### DIFF
--- a/src/Framework/Framework/Compilation/Directives/MarkupDirectiveCompilerPipeline.cs
+++ b/src/Framework/Framework/Compilation/Directives/MarkupDirectiveCompilerPipeline.cs
@@ -24,7 +24,9 @@ namespace DotVVM.Framework.Compilation.Directives
 
         public MarkupPageMetadata Compile(DothtmlRootNode dothtmlRoot, string fileName)
         {
-            var directivesByName = dothtmlRoot.Directives.GroupBy(d => d.Name, StringComparer.OrdinalIgnoreCase).ToDictionary(d => d.Key, d => (IReadOnlyList<DothtmlDirectiveNode>)d.ToList());
+            var directivesByName = dothtmlRoot.Directives
+                .GroupBy(d => d.Name, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(d => d.Key, d => (IReadOnlyList<DothtmlDirectiveNode>)d.ToList(), StringComparer.OrdinalIgnoreCase);
 
             var resolvedDirectives = new Dictionary<string, IReadOnlyList<IAbstractDirective>>();
 

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/ViewModelDirectiveTest.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/ViewModelDirectiveTest.cs
@@ -88,5 +88,16 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
             Assert.IsFalse(root.Directives.Any(d => d.Value.Any(dd => dd.DothtmlNode.HasNodeErrors)));
             Assert.AreEqual(typeof(TestViewModel), root.DataContextTypeStack.DataContextType);
         }
+
+        [TestMethod]
+        [DataRow("@viewModel")]
+        [DataRow("@viewmodel")]
+        public void ResolvedTree_ViewModel_DirectiveIdentifier_CaseInsensitivity(string directive)
+        {
+            var root = ParseSource($"{directive} System.String");
+
+            Assert.IsFalse(root.Directives.Any(d => d.Value.Any(dd => dd.DothtmlNode.HasNodeErrors)));
+            Assert.AreEqual(typeof(string), root.DataContextTypeStack.DataContextType);
+        }
     }
 }


### PR DESCRIPTION
This PR fixes a bug that forces users to specify directives with exact casing (for example, `@viewModel` is valid and `@viewmodel` is not). The breaking change was introduced in one of the preview builds (4.0 - 4.1-preview)

![image](https://user-images.githubusercontent.com/12575176/212704632-90d73b9a-0960-46b4-b4f8-aa469e133feb.png)
