### PR TITLE
REST API binding - IncludedInPage behavior fixed

### DIFF
--- a/.github/setup/action.yml
+++ b/.github/setup/action.yml
@@ -34,9 +34,6 @@ runs:
         3.1.x
   - if: ${{ runner.os == 'Windows' }}
     uses: microsoft/setup-msbuild@v1.1
-  - if: ${{ runner.os == 'Windows' }}
-    run: choco install dotnetcore-3.1-windowshosting -y
-    shell: pwsh
 
   # restore packages
   - if: ${{ runner.os == 'Windows' }}

--- a/.github/uitest/action.yml
+++ b/.github/uitest/action.yml
@@ -31,6 +31,13 @@ runs:
       --config "${{ inputs.build-configuration }}"
       --environment "${{ inputs.runtime-environment }}"
     shell: bash
+
+  - if: ${{ runner.os == 'Windows' }}
+    run: choco install dotnet-aspnetcoremodule-v2 -y
+    shell: pwsh
+  - if: ${{ runner.os == 'Windows' }}
+    run: iisreset
+    shell: pwsh
   - if: ${{ runner.os == 'Windows' }}
     name: uitest.ps1
     run: .\.github\uitest\uitest.ps1

--- a/.github/uitest/uitest.ps1
+++ b/.github/uitest/uitest.ps1
@@ -164,6 +164,21 @@ function Test-Sample {
                 Sleep 5
             }
         }
+		
+		# print out all log files
+		Export-IISConfiguration -PhysicalPath c:\inetpub -DontExportKeys -Force
+		foreach ($log in dir c:\inetpub\*.config) {
+			write-host $log
+			get-content $log | write-host
+		}
+		foreach ($log in dir c:\inetpub\logs\logfiles\*\*.log) {
+			write-host $log
+			get-content $log | write-host
+		}
+		foreach ($log in dir $root\artifacts\**\*.log) {
+			write-host $log
+			get-content $log | write-host
+		}
         throw "The sample '${sampleName}' failed to start."
     }
 }

--- a/src/Framework/Framework/Resources/Scripts/api/api.ts
+++ b/src/Framework/Framework/Resources/Scripts/api/api.ts
@@ -10,18 +10,39 @@ type ApiComputed<T> =
         refreshValue: () => PromiseLike<any>
     };
 
-type CachedValue = {
+class CachedValue {
     _stateManager?: StateManager<any>
     _isLoading?: boolean
     _promise?: PromiseLike<any>
-    _referenceCount: number
+    _elements: HTMLElement[] = []
+
+    constructor(public _cache: Cache) {
+    }
+
+    registerElement(element: HTMLElement, sharingKeyValue: string) {
+        if (!this._elements.includes(element)) {
+            this._elements.push(element);
+
+            ko.utils.domNodeDisposal.addDisposeCallback(element, () => {
+                this.unregisterElement(element, sharingKeyValue);
+            });
+        }
+    }
+
+    unregisterElement(element: HTMLElement, sharingKeyValue: string) {
+        const oldElementIndex = this._elements.indexOf(element);
+        if (oldElementIndex >= 0) {
+            this._elements.splice(oldElementIndex, 1);
+        }
+        if (!this._elements.length) {
+            delete this._cache[sharingKeyValue];
+        }
+    }
 }
 
 type Cache = { [k: string]: CachedValue }
 
-const cachedValues: {
-    [key: string]: KnockoutObservable<any>
-} = {};
+const cachedValues: Cache = {};
 
 export function invoke<T>(
     target: any,
@@ -33,7 +54,7 @@ export function invoke<T>(
     sharingKeyProvider: (args: any[]) => string[],
     lifetimeElement: HTMLElement
 ): ApiComputed<T> {
-    const cache: Cache = cacheElement ? ((<any> cacheElement)["apiCachedValues"] ??= {}) : cachedValues;
+    const cache: Cache = cacheElement ? ((<any>cacheElement)["apiCachedValues"] ??= {}) : cachedValues;
     const $type: TypeDefinition = { type: "dynamic" }
 
     let args: any[];
@@ -48,17 +69,14 @@ export function invoke<T>(
         let oldKey = sharingKeyValue
         sharingKeyValue = methodName + ":" + sharingKeyProvider(args)
         const oldCached = cachedValue
-        cachedValue = cache[sharingKeyValue] ??= {_referenceCount: 0}
+        cachedValue = cache[sharingKeyValue] ??= new CachedValue(cache)
         if (cachedValue === oldCached) {
             return
         }
-        
-        cachedValue._referenceCount++
+
+        cachedValue.registerElement(lifetimeElement, sharingKeyValue);
         if (oldCached) {
-            oldCached._referenceCount--
-            if (oldCached._referenceCount <= 0) {
-                delete cache[oldKey]
-            }
+            oldCached.unregisterElement(lifetimeElement, oldKey);
         }
 
         if (cachedValue._stateManager == null)
@@ -69,6 +87,7 @@ export function invoke<T>(
         }
         stateManager(cachedValue._stateManager)
     }
+    
     function reloadApi(): PromiseLike<any> {
         if (!cachedValue._isLoading) {
             cachedValue._isLoading = true

--- a/src/Samples/Api.AspNetCore/web.config
+++ b/src/Samples/Api.AspNetCore/web.config
@@ -5,7 +5,7 @@
       <handlers>
         <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
       </handlers>
-      <aspNetCore processPath="dotnet" arguments=".\DotVVM.Samples.BasicSamples.Api.AspNetCore.dll" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" hostingModel="inprocess">
+      <aspNetCore processPath="dotnet" arguments=".\DotVVM.Samples.BasicSamples.Api.AspNetCore.dll" stdoutLogEnabled="true" stdoutLogFile=".\logs\stdout" hostingModel="inprocess">
         <environmentVariables>
           <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Development" />
         </environmentVariables>

--- a/src/Samples/Common/DotVVM.Samples.Common.csproj
+++ b/src/Samples/Common/DotVVM.Samples.Common.csproj
@@ -79,6 +79,7 @@
     <None Remove="Views\FeatureSamples\Api\ApiInSpa_PageB.dothtml" />
     <None Remove="Views\FeatureSamples\Api\ApiRefresh.dothtml" />
     <None Remove="Views\FeatureSamples\Api\CollectionOddEvenWithRestApi.dothtml" />
+    <None Remove="Views\FeatureSamples\Api\IncludedInPage.dothtml" />
     <None Remove="Views\FeatureSamples\Attribute\ToStringConversion.dothtml" />
     <None Remove="Views\FeatureSamples\AutoUI\AutoEditor.dothtml" />
     <None Remove="Views\FeatureSamples\AutoUI\AutoForm.dothtml" />

--- a/src/Samples/Common/ViewModels/FeatureSamples/Api/IncludedInPageViewModel.cs
+++ b/src/Samples/Common/ViewModels/FeatureSamples/Api/IncludedInPageViewModel.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.Api
+{
+    public class IncludedInPageViewModel : DotvvmViewModelBase
+    {
+        public bool Visible { get; set; }
+
+        public int RefreshCounter { get; set; }
+    }
+}
+

--- a/src/Samples/Common/Views/FeatureSamples/Api/IncludedInPage.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/Api/IncludedInPage.dothtml
@@ -1,0 +1,51 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.Api.IncludedInPageViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+
+    <h1>API and IncludeInPage</h1>
+
+    <dot:Button Text="Refresh data" Click="{staticCommand: _root.RefreshCounter = _root.RefreshCounter + 1}" data-ui="refresh-counter" />
+
+    <dot:Button Text="Open dialog static command" Click="{staticCommand: _root.Visible = true}" data-ui="open-static-command" />
+    <dot:Button Text="Open dialog command" Click="{command: _root.Visible = true}" data-ui="open-command" />
+
+    <dialog IncludeInPage="{value: _root.Visible}" open="{value: _root.Visible}">
+
+        <dot:GridView DataSource="{value: _api.RefreshOnChange(_apiCore.GetOrdersAll(11), _root.RefreshCounter)}"
+                      data-ui="grid">
+            <dot:GridViewTemplateColumn>{{value: Number}}</dot:GridViewTemplateColumn>
+        </dot:GridView>
+
+        <dot:Button Text="Close dialog static command" Click="{staticCommand: _root.Visible = false}" data-ui="close-static-command" />
+        <dot:Button Text="Close dialog command" Click="{command: _root.Visible = false}" data-ui="close-command" />
+
+    </dialog>
+
+    <h3>Request log</h3>
+    <ol ID="request-log" ClientIDMode="Static">
+    </ol>
+
+    <script type="text/javascript">
+        var fetchBackup = window.fetch;
+        window.fetch = function (url, init) {
+            if (typeof url === "string" && url.indexOf("/api/Orders") >= 0) {
+                var ol = document.getElementById("request-log");
+                var li = document.createElement("li");
+                li.innerText = init.method + " " + url.substring(url.indexOf("/api/Orders"));
+                ol.appendChild(li);
+            }
+            return fetchBackup.apply(window, arguments);
+        };
+    </script>
+
+</body>
+</html>
+
+

--- a/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
@@ -203,6 +203,7 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_Api_GetCollection = "FeatureSamples/Api/GetCollection";
         public const string FeatureSamples_Api_GridViewDataSetAspNetCore = "FeatureSamples/Api/GridViewDataSetAspNetCore";
         public const string FeatureSamples_Api_GridViewDataSetOwin = "FeatureSamples/Api/GridViewDataSetOwin";
+        public const string FeatureSamples_Api_IncludedInPage = "FeatureSamples/Api/IncludedInPage";
         public const string FeatureSamples_AttachedProperties_AttachedProperties = "FeatureSamples/AttachedProperties/AttachedProperties";
         public const string FeatureSamples_Attribute_SpecialCharacters = "FeatureSamples/Attribute/SpecialCharacters";
         public const string FeatureSamples_Attribute_ToStringConversion = "FeatureSamples/Attribute/ToStringConversion";


### PR DESCRIPTION
I fixed another problem in REST API bindings reported by a customer.

When the binding is used in an element with `IncludeInPage` set to `false`, the binding is not evaluated - that is correct.
When the element appears on the page, the binding is evaluated at that moment - that is also correct.

However, when the element disappears and re-appears on the page, the binding wasn't refreshed.
The problem was that the reference counting wasn't working well as the binding often evaluates multiple times on the same element so it was incremented multiple times, but decremented only once. I changed that to an array of elements so it is easier to recognize whether the binding was already counted or not.