### PR TITLE
Fixed issue in `Validator` in connection with BP

### DIFF
--- a/src/Framework/Framework/Controls/Validator.cs
+++ b/src/Framework/Framework/Controls/Validator.cs
@@ -99,7 +99,9 @@ namespace DotVVM.Framework.Controls
             }
             else
             {
-                throw new DotvvmControlException($"Could not resolve {nameof(ValueProperty)} to a valid value binding.");
+                // Could not resolve ValueProperty to a valid value binding
+                // Note: this can sometimes happen when using AutomaticValidation in BusinessPack
+                writer.AddKnockoutDataBind(validationDataBindName, control, ValueProperty, renderEvenInServerRenderingMode: true);
             }
 
             // render options

--- a/src/Framework/Framework/Controls/Validator.cs
+++ b/src/Framework/Framework/Controls/Validator.cs
@@ -99,9 +99,15 @@ namespace DotVVM.Framework.Controls
             }
             else
             {
-                // Could not resolve ValueProperty to a valid value binding
-                // Note: this can sometimes happen when using AutomaticValidation in BusinessPack
-                writer.AddKnockoutDataBind(validationDataBindName, control, ValueProperty, renderEvenInServerRenderingMode: true);
+                // Note: ValueProperty can sometimes contain null (BusinessPack depends on this behaviour)
+                // However, it certainly should not contain hard-coded values
+
+                var valueRaw = control.GetValueRaw(ValueProperty);
+                if (valueRaw != null)
+                {
+                    // There is a hard-coded value in the ValueProperty
+                    throw new DotvvmControlException($"{nameof(ValueProperty)} can not contain a hard-coded value.");
+                }
             }
 
             // render options


### PR DESCRIPTION
This PR fixes a breaking change that was introduced in PR #1385.

I added there a condition that was supposed to throw an exception if the `Validator.Value` can not be resolved to a valid value binding. A customer found out that it is in fact possible to enter this branch when using BP and its `FormItem` control. BP automatically sets validator properties and I am guessing that in some cases it sets there something a little weird.

This change should revert to the previous behaviour while keeping the improved one if the binding can be actually resolved.

![image](https://user-images.githubusercontent.com/12575176/212870065-0fc5fde7-14d5-4229-93e2-1e3a6149ed5a.png)

