### PR TITLE
Added support for `DateOnly`, `TimeOnly` in VM serializability analysis

### DIFF
--- a/src/Analyzers/Analyzers.Tests/Serializability/ViewModelSerializabilityTest.cs
+++ b/src/Analyzers/Analyzers.Tests/Serializability/ViewModelSerializabilityTest.cs
@@ -194,6 +194,8 @@ namespace DotVVM.Analyzers.Tests.Serializability
             public object Object { get; set; }
             public string String { get; set; }
             public DateTime DateTime { get; set; }
+            public DateOnly DateOnly { get; set; }
+            public TimeOnly TimeOnly { get; set; }
             public TimeSpan TimeSpan { get; set; }
             public Guid Guid { get; set; }
         }

--- a/src/Analyzers/Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
+++ b/src/Analyzers/Analyzers.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
@@ -29,6 +29,7 @@ namespace DotVVM.Analyzers.Tests
             var test = new Test
             {
                 TestCode = source,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60
             };
 
             test.ExpectedDiagnostics.AddRange(expected);

--- a/src/Analyzers/Analyzers/Serializability/TypeSymbolExtensions.cs
+++ b/src/Analyzers/Analyzers/Serializability/TypeSymbolExtensions.cs
@@ -82,6 +82,8 @@ namespace DotVVM.Analyzers.Serializability
             cacheBuilder.Add(compilation.GetTypeByMetadataName("System.Guid")!);
             cacheBuilder.Add(compilation.GetTypeByMetadataName("System.TimeSpan")!);
             cacheBuilder.Add(compilation.GetTypeByMetadataName("System.DateTimeOffset")!);
+            cacheBuilder.Add(compilation.GetTypeByMetadataName("System.DateOnly")!);
+            cacheBuilder.Add(compilation.GetTypeByMetadataName("System.TimeOnly")!);
 
             return cacheBuilder.ToImmutableHashSet(SymbolEqualityComparer.Default);
         }


### PR DESCRIPTION
This PR extends supported types in serializability analysis. Support for the types was added in #1471.