### PR TITLE
Initialization of DotVVM in a single file

### DIFF
--- a/src/Framework/Hosting.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/src/Framework/Hosting.AspNetCore/ApplicationBuilderExtensions.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Builder
         /// if <see cref="HostEnvironmentEnvExtensions.IsDevelopment" /> returns <c>true</c>.
         /// </param>
         /// <param name="modifyConfiguration">An action that allows modifying configuration before it's frozen.</param>
-        public static DotvvmConfiguration UseDotVVM(this IApplicationBuilder app, IDotvvmStartup startup, string? applicationRootPath, bool? useErrorPages, Action<DotvvmConfiguration> modifyConfiguration = null)
+        public static DotvvmConfiguration UseDotVVM(this IApplicationBuilder app, IDotvvmStartup startup, string applicationRootPath, bool? useErrorPages, Action<DotvvmConfiguration> modifyConfiguration = null)
         {
             var env = app.ApplicationServices.GetRequiredService<HostingEnv>();
             var tokenMiddleware = Task.Run(() => ActivatorUtilities.CreateInstance<DotvvmCsrfTokenMiddleware>(app.ApplicationServices));

--- a/src/Framework/Hosting.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/src/Framework/Hosting.AspNetCore/ApplicationBuilderExtensions.cs
@@ -6,14 +6,11 @@ using DotVVM.Framework.Compilation;
 using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Hosting;
 using DotVVM.Framework.Hosting.Middlewares;
-using DotVVM.Framework.Runtime.Filters;
 using DotVVM.Framework.Runtime.Tracing;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using DotVVM.Framework.Diagnostics;
 using DotVVM.Framework.Compilation.ControlTree;
-using DotVVM.Framework.Routing;
 
 #if NET5_0_OR_GREATER
 using HostingEnv = Microsoft.AspNetCore.Hosting.IWebHostEnvironment;
@@ -104,15 +101,5 @@ namespace Microsoft.AspNetCore.Builder
 
             return config;
         }
-
-#if NET6_0
-        public static DotvvmConfiguration UseDotVVM(this IApplicationBuilder app, string? applicationRootPath = null, bool? useErrorPages = null, Action<DotvvmConfiguration> modifyConfiguration = null)
-        {
-            var startup = app.ApplicationServices.GetRequiredService<IDotvvmStartup>();
-            var config = app.UseDotVVM(startup, applicationRootPath, useErrorPages, modifyConfiguration);
-            config.AssertConfigurationIsValid();
-            return config;
-        }
-#endif
     }
 }

--- a/src/Framework/Hosting.AspNetCore/WebApplicationBuilderExtensions.cs
+++ b/src/Framework/Hosting.AspNetCore/WebApplicationBuilderExtensions.cs
@@ -1,0 +1,56 @@
+﻿#if NET6_0
+#nullable enable
+using System;
+using DotVVM.Framework.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static class WebApplicationBuilderExtensions
+{
+    public static WebApplicationBuilder AddDotVVM(this WebApplicationBuilder builder, Action<IDotvvmServiceCollection>? setupServices = null, Action<DotvvmConfiguration>? setupConfiguration = null)
+    {
+        builder.Services.AddDataProtection();
+        builder.Services.AddAuthorization();
+        builder.Services.AddWebEncoders();
+        builder.Services.AddAuthentication();
+        builder.Services.AddHttpContextAccessor();
+
+        builder.Services.AddDotVVM(new DelegateDotvvmServiceConfigurator(setupServices));
+        builder.Services.AddSingleton<IDotvvmStartup>(new DelegateDotvvmStartup(setupConfiguration));
+        return builder;
+    }
+}
+
+internal class DelegateDotvvmServiceConfigurator : IDotvvmServiceConfigurator
+{
+    private readonly Action<IDotvvmServiceCollection>? setupServices;
+
+    public DelegateDotvvmServiceConfigurator(Action<IDotvvmServiceCollection>? setupServices)
+    {
+        this.setupServices = setupServices;
+    }
+
+    public void ConfigureServices(IDotvvmServiceCollection options)
+    {
+        options.AddDefaultTempStorages("temp");
+
+        setupServices?.Invoke(options);
+    }
+}
+
+internal class DelegateDotvvmStartup : IDotvvmStartup
+{
+    private readonly Action<DotvvmConfiguration>? setupConfiguration;
+
+    public DelegateDotvvmStartup(Action<DotvvmConfiguration>? setupConfiguration)
+    {
+        this.setupConfiguration = setupConfiguration;
+    }
+
+    public void Configure(DotvvmConfiguration config, string applicationPath)
+    {
+        setupConfiguration?.Invoke(config);
+    }
+}
+#endif

--- a/src/Framework/Hosting.AspNetCore/WebApplicationBuilderExtensions.cs
+++ b/src/Framework/Hosting.AspNetCore/WebApplicationBuilderExtensions.cs
@@ -8,49 +8,50 @@ namespace Microsoft.AspNetCore.Builder;
 
 public static class WebApplicationBuilderExtensions
 {
-    public static WebApplicationBuilder AddDotVVM(this WebApplicationBuilder builder, Action<IDotvvmServiceCollection>? setupServices = null, Action<DotvvmConfiguration>? setupConfiguration = null)
+    /// <summary>
+    /// Adds DotVVM services with all its dependencies including authorization and data protection to the specified <see cref="WebApplicationBuilder" />.
+    /// </summary>
+    /// <param name="builder">The <see cref="WebApplicationBuilder" /> to add services to.</param>
+    // ReSharper disable once InconsistentNaming
+    public static WebApplicationBuilder AddDotVVM<TServiceConfigurator>(this WebApplicationBuilder builder)
+        where TServiceConfigurator : IDotvvmServiceConfigurator, new()
+    {
+        AddDotvvmServiceDependencies(builder);
+        builder.Services.AddDotVVM<TServiceConfigurator>();
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds DotVVM services with all its dependencies including authorization and data protection to the specified <see cref="WebApplicationBuilder" />.
+    /// </summary>
+    /// <param name="builder">The <see cref="WebApplicationBuilder" /> to add services to.</param>
+    /// <param name="configurator">The <see cref="IDotvvmServiceConfigurator"/> instance.</param>
+    public static WebApplicationBuilder AddDotVVM(this WebApplicationBuilder builder, IDotvvmServiceConfigurator configurator)
+    {
+        AddDotvvmServiceDependencies(builder);
+        builder.Services.AddDotVVM(configurator);
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds DotVVM services with all its dependencies including authorization and data protection to the specified <see cref="WebApplicationBuilder" />.
+    /// </summary>
+    /// <param name="builder">The <see cref="WebApplicationBuilder" /> to add services to.</param>
+    // ReSharper disable once InconsistentNaming
+    public static WebApplicationBuilder AddDotVVM(this WebApplicationBuilder builder)
+    {
+        AddDotvvmServiceDependencies(builder);
+        builder.Services.AddDotVVM();
+        return builder;
+    }
+
+    private static void AddDotvvmServiceDependencies(WebApplicationBuilder builder)
     {
         builder.Services.AddDataProtection();
         builder.Services.AddAuthorization();
         builder.Services.AddWebEncoders();
         builder.Services.AddAuthentication();
         builder.Services.AddHttpContextAccessor();
-
-        builder.Services.AddDotVVM(new DelegateDotvvmServiceConfigurator(setupServices));
-        builder.Services.AddSingleton<IDotvvmStartup>(new DelegateDotvvmStartup(setupConfiguration));
-        return builder;
-    }
-}
-
-internal class DelegateDotvvmServiceConfigurator : IDotvvmServiceConfigurator
-{
-    private readonly Action<IDotvvmServiceCollection>? setupServices;
-
-    public DelegateDotvvmServiceConfigurator(Action<IDotvvmServiceCollection>? setupServices)
-    {
-        this.setupServices = setupServices;
-    }
-
-    public void ConfigureServices(IDotvvmServiceCollection options)
-    {
-        options.AddDefaultTempStorages("temp");
-
-        setupServices?.Invoke(options);
-    }
-}
-
-internal class DelegateDotvvmStartup : IDotvvmStartup
-{
-    private readonly Action<DotvvmConfiguration>? setupConfiguration;
-
-    public DelegateDotvvmStartup(Action<DotvvmConfiguration>? setupConfiguration)
-    {
-        this.setupConfiguration = setupConfiguration;
-    }
-
-    public void Configure(DotvvmConfiguration config, string applicationPath)
-    {
-        setupConfiguration?.Invoke(config);
     }
 }
 #endif

--- a/src/Framework/Hosting.AspNetCore/WebApplicationBuilderExtensions.cs
+++ b/src/Framework/Hosting.AspNetCore/WebApplicationBuilderExtensions.cs
@@ -51,7 +51,6 @@ public static class WebApplicationBuilderExtensions
         builder.Services.AddAuthorization();
         builder.Services.AddWebEncoders();
         builder.Services.AddAuthentication();
-        builder.Services.AddHttpContextAccessor();
     }
 }
 #endif


### PR DESCRIPTION
Added extension methods which support configuration of the app in one file without `DotvvmStartup`.

```
var builder = WebApplication.CreateBuilder(args);
builder.AddDotVVM(options =>
{
    // register DotVVM services
    options.AddAutoUI();
    ...
});

var app = builder.Build();
app.UseDotVVM(..., config => 
{
   // fine-tune DotvvmConfiguration 
});
app.UseStaticFiles();
app.Run();
```