### PR TITLE
LocalizableString needs only BindingCompilationService, not the entire context

### DIFF
--- a/src/AutoUI/Core/Controls/AutoFormBase.cs
+++ b/src/AutoUI/Core/Controls/AutoFormBase.cs
@@ -119,7 +119,7 @@ namespace DotVVM.AutoUI.Controls
 
             if (property.IsDefaultLabelAllowed)
             {
-                return new Label(id).AppendChildren(new Literal(property.GetDisplayName().ToBinding(autoUiContext)));
+                return new Label(id).AppendChildren(new Literal(property.GetDisplayName().ToBinding(autoUiContext.BindingService)));
             }
             return null;
         }

--- a/src/AutoUI/Core/Controls/AutoGridViewColumn.cs
+++ b/src/AutoUI/Core/Controls/AutoGridViewColumn.cs
@@ -45,7 +45,7 @@ namespace DotVVM.AutoUI.Controls
 
             if (props.HeaderTemplate is null && props.HeaderText is null)
             {
-                props = props with { HeaderText = propertyMetadata.GetDisplayName().ToBinding(context) };
+                props = props with { HeaderText = propertyMetadata.GetDisplayName().ToBinding(context.BindingService) };
             }
 
             var control = CreateColumn(context, props, propertyMetadata);

--- a/src/AutoUI/Core/Controls/BulmaForm.cs
+++ b/src/AutoUI/Core/Controls/BulmaForm.cs
@@ -39,7 +39,7 @@ namespace DotVVM.AutoUI.Controls
                 }
 
                 var help = property.Description is { } description
-                    ? new HtmlGenericControl("div").AddCssClass("help").SetProperty(c => c.InnerText, description.ToBinding(context)!)
+                    ? new HtmlGenericControl("div").AddCssClass("help").SetProperty(c => c.InnerText, description.ToBinding(context.BindingService)!)
                     : null;
                 var validator = new Validator()
                     .AddCssClass("help is-danger")

--- a/src/AutoUI/Core/Metadata/LocalizableString.cs
+++ b/src/AutoUI/Core/Metadata/LocalizableString.cs
@@ -37,12 +37,12 @@ namespace DotVVM.AutoUI.Metadata
             }
         }
 
-        public ValueOrBinding<string> ToBinding(AutoUIContext context)
+        public ValueOrBinding<string> ToBinding(BindingCompilationService bindingCompilationService)
         {
             if (IsLocalized)
             {
                 var binding = new ResourceBindingExpression<string>(
-                    context.BindingService,
+                    bindingCompilationService,
                     new object[] {
                         new ParsedExpressionBindingProperty(
                             ExpressionUtils.Replace(() => this.Localize())

--- a/src/AutoUI/Core/PropertyHandlers/FormEditors/CheckBoxEditorProvider.cs
+++ b/src/AutoUI/Core/PropertyHandlers/FormEditors/CheckBoxEditorProvider.cs
@@ -22,7 +22,7 @@ namespace DotVVM.AutoUI.PropertyHandlers.FormEditors
                 .AddCssClasses(ControlCssClass, property.Styles?.FormControlCssClass)
                 .SetProperty(c => c.Changed, props.Changed)
                 .SetProperty(c => c.Checked, props.Property)
-                .SetProperty(c => c.Text, property.GetDisplayName().ToBinding(context))
+                .SetProperty(c => c.Text, property.GetDisplayName().ToBinding(context.BindingService))
                 .SetProperty(c => c.Enabled, props.Enabled);
             return checkBox;
         }

--- a/src/AutoUI/Core/PropertyHandlers/FormEditors/EnumComboBoxFormEditorProvider.cs
+++ b/src/AutoUI/Core/PropertyHandlers/FormEditors/EnumComboBoxFormEditorProvider.cs
@@ -34,8 +34,8 @@ namespace DotVVM.AutoUI.PropertyHandlers.FormEditors
                     var title = LocalizableString.CreateNullable(displayAttribute?.Description, displayAttribute?.ResourceType);
                     return (name, displayName, title);
                 })
-                .Select(e => new SelectorItem(e.displayName.ToBinding(context), new(Enum.Parse(enumType, e.name)))
-                                .AddAttribute("title", e.title?.ToBinding(context)));
+                .Select(e => new SelectorItem(e.displayName.ToBinding(context.BindingService), new(Enum.Parse(enumType, e.name)))
+                                .AddAttribute("title", e.title?.ToBinding(context.BindingService)));
 
             var control = new ComboBox()
                 .SetCapability(props.Html)

--- a/src/AutoUI/Core/PropertyHandlers/FormEditors/TextBoxEditorProvider.cs
+++ b/src/AutoUI/Core/PropertyHandlers/FormEditors/TextBoxEditorProvider.cs
@@ -34,8 +34,8 @@ namespace DotVVM.AutoUI.PropertyHandlers.FormEditors
                 .SetCapability(props.Html)
                 .AddCssClasses(ControlCssClass, property.Styles?.FormControlCssClass)
                 .SetProperty(t => t.Text, props.Property)
-                .SetAttribute("placeholder", property.Placeholder?.ToBinding(context))
-                .SetAttribute("title", property.Description?.ToBinding(context))
+                .SetAttribute("placeholder", property.Placeholder?.ToBinding(context.BindingService))
+                .SetAttribute("title", property.Description?.ToBinding(context.BindingService))
                 .SetProperty(t => t.FormatString, property.FormatString)
                 .SetProperty(t => t.Enabled, props.Enabled)
                 .SetProperty(t => t.Changed, props.Changed);


### PR DESCRIPTION
I noticed that the `LocalizableString` class depends on the `AutoUIContext` but it only needs `BindingCompilationService`. 
I've refactored this, and I think we should put it in 4.1 to avoid breaking API in the future.