### PR TITLE
MarkupFile constructor allows creating the file with specified content

### DIFF
--- a/src/Framework/Framework/Hosting/MarkupFile.cs
+++ b/src/Framework/Framework/Hosting/MarkupFile.cs
@@ -67,7 +67,7 @@ namespace DotVVM.Framework.Hosting
             };
         }
 
-        internal MarkupFile(string fileName, string fullPath, string contents)
+        public MarkupFile(string fileName, string fullPath, string contents)
         {
             FileName = fileName;
             FullPath = fullPath;


### PR DESCRIPTION
I believe the constructor is safe enough and can provide useful extensibility point if anyone needs to build DotHTML markup dynamically.