### PR TITLE
Version updated to 4.1.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
     <Authors>RIGANTI</Authors>
     <Description>DotVVM is an open source ASP.NET-based framework which allows to build interactive web apps easily by using mostly C# and HTML.</Description>
     <PackageTags>dotvvm;asp.net;mvvm;owin;dotnetcore</PackageTags>
-    <Version>4.0.0</Version>
+    <Version>4.1.0</Version>
     <PackageIcon>package-icon.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/riganti/dotvvm.git</RepositoryUrl>


### PR DESCRIPTION
This should go to version 4.1, and we should update it in `main` to `4.2`.

If someone references DotVVM from the source code and uses some NuGet package (e. g. commercial controls), the compiler complains that the package needs DotVVM 4.1, but it sees the version built from the source code as 4.0. 

