### PR TITLE
Add the DotvvmGlobalExtensions interface

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/dotvvm-root.ts
+++ b/src/Framework/Framework/Resources/Scripts/dotvvm-root.ts
@@ -140,7 +140,7 @@ declare global {
     const dotvvm: DotvvmGlobalExtensions & typeof dotvvmExports & {debug?: true, isSpaReady?: typeof isSpaReady, handleSpaNavigation?: typeof handleSpaNavigation};
 
     interface Window {
-        dotvvm: typeof dotvvmExports
+        dotvvm: DotvvmGlobalExtensions & typeof dotvvmExports
     }
 }
 

--- a/src/Framework/Framework/Resources/Scripts/dotvvm-root.ts
+++ b/src/Framework/Framework/Resources/Scripts/dotvvm-root.ts
@@ -132,8 +132,12 @@ if (compileConstants.debug) {
     (dotvvmExports as any).debug = true
 }
 
+
+
 declare global {
-    const dotvvm: typeof dotvvmExports & {debug?: true, isSpaReady?: typeof isSpaReady, handleSpaNavigation?: typeof handleSpaNavigation};
+    interface DotvvmGlobalExtensions {}
+
+    const dotvvm: DotvvmGlobalExtensions & typeof dotvvmExports & {debug?: true, isSpaReady?: typeof isSpaReady, handleSpaNavigation?: typeof handleSpaNavigation};
 
     interface Window {
         dotvvm: typeof dotvvmExports

--- a/src/Framework/Framework/Resources/Scripts/dotvvm-root.ts
+++ b/src/Framework/Framework/Resources/Scripts/dotvvm-root.ts
@@ -136,11 +136,12 @@ if (compileConstants.debug) {
 
 declare global {
     interface DotvvmGlobalExtensions {}
+    type DotvvmGlobal = DotvvmGlobalExtensions & typeof dotvvmExports & { debug?: true, isSpaReady?: typeof isSpaReady, handleSpaNavigation?: typeof handleSpaNavigation }
 
-    const dotvvm: DotvvmGlobalExtensions & typeof dotvvmExports & {debug?: true, isSpaReady?: typeof isSpaReady, handleSpaNavigation?: typeof handleSpaNavigation};
+    const dotvvm: DotvvmGlobal;
 
     interface Window {
-        dotvvm: DotvvmGlobalExtensions & typeof dotvvmExports
+        dotvvm: DotvvmGlobal
     }
 }
 


### PR DESCRIPTION
Adds an extension point for the `window.dotvvm` global object. This is would benefit BusinessPack, which could then use `window.dotvvm.bp`.