### PR TITLE
Automatically add starting assembly to config.Markup.Assemblies

### DIFF
--- a/src/Framework/Framework/Configuration/DotvvmMarkupConfiguration.cs
+++ b/src/Framework/Framework/Configuration/DotvvmMarkupConfiguration.cs
@@ -129,6 +129,15 @@ namespace DotVVM.Framework.Configuration
             }
         }
 
+        /// <summary> Adds the assembly to the list of required assemblies. </summary>
+        public void AddAssembly(Assembly assembly)
+        {
+            if (assembly is null) throw new ArgumentNullException(nameof(assembly));
+            if (assembly.FullName is null) throw new ArgumentException("Assembly does not have a FullName", nameof(assembly));
+            AddAssembly(assembly.FullName);
+        }
+
+
         /// <summary>
         /// Registers markup control
         /// </summary>

--- a/src/Framework/Hosting.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/src/Framework/Hosting.AspNetCore/ApplicationBuilderExtensions.cs
@@ -71,6 +71,7 @@ namespace Microsoft.AspNetCore.Builder
 
             var startupTracer = app.ApplicationServices.GetRequiredService<IStartupTracer>();
             startupTracer.TraceEvent(StartupTracingConstants.DotvvmConfigurationUserConfigureStarted);
+            config.Markup.AddAssembly(startup.GetType().Assembly);
             startup.Configure(config, applicationRootPath);
             startupTracer.TraceEvent(StartupTracingConstants.DotvvmConfigurationUserConfigureFinished);
 

--- a/src/Framework/Hosting.Owin/AppBuilderExtensions.cs
+++ b/src/Framework/Hosting.Owin/AppBuilderExtensions.cs
@@ -121,6 +121,7 @@ namespace Owin
             config.ApplicationPhysicalPath = applicationRootPath;
 
             startupTracer.TraceEvent(StartupTracingConstants.DotvvmConfigurationUserConfigureStarted);
+            config.Markup.AddAssembly(startup.GetType().Assembly);
             startup.Configure(config, applicationRootPath);
             startupTracer.TraceEvent(StartupTracingConstants.DotvvmConfigurationUserConfigureFinished);
 


### PR DESCRIPTION
This simplifies usage with explicit assembly loading