### PR TITLE
Relax the constraint on React version

### DIFF
--- a/src/Framework/JsComponent.React/package-lock.json
+++ b/src/Framework/JsComponent.React/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dotvvm-jscomponent-react",
-  "version": "4.0.0-experimental-0004",
+  "version": "4.1.0-experimental-0005",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dotvvm-jscomponent-react",
-      "version": "4.0.0-experimental-0004",
+      "version": "4.1.0-experimental-0005",
       "license": "Apache-2.0",
       "dependencies": {
         "dotvvm-types": "^4.1.0-preview10-final"
@@ -18,8 +18,8 @@
         "typescript": "^4.9.3"
       },
       "peerDependencies": {
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/@types/knockout": {

--- a/src/Framework/JsComponent.React/package.json
+++ b/src/Framework/JsComponent.React/package.json
@@ -1,12 +1,12 @@
 {
   "name": "dotvvm-jscomponent-react",
-  "version": "4.0.0-experimental-0004",
+  "version": "4.1.0-experimental-0006",
   "description": "This package adds helper methods for the registration of react controls into DotVVM.",
   "module": "dist/dotvvm-react.js",
   "types": "dist/declarations/dotvvm-react.d.ts",
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": ">=16",
+    "react-dom": ">=16"
   },
   "devDependencies": {
     "@types/knockout": "^3.4.71",

--- a/src/Samples/Common/yarn.lock
+++ b/src/Samples/Common/yarn.lock
@@ -625,8 +625,8 @@ __metadata:
   dependencies:
     dotvvm-types: ^4.1.0-preview10-final
   peerDependencies:
-    react: ^17.0.2
-    react-dom: ^17.0.2
+    react: ">=16"
+    react-dom: ">=16"
   languageName: node
   linkType: soft
 


### PR DESCRIPTION
We used to assert that React 17 is used. We don't use any advanced React feature, so this constraint is irrelevant. I set it to 16, since that was the first open source release (with the patents)