### PR TITLE
Fixed warning when building analyzers

### DIFF
--- a/src/Analyzers/Analyzers/ApiUsage/UnsupportedCallSiteAttributeAnalyzer.cs
+++ b/src/Analyzers/Analyzers/ApiUsage/UnsupportedCallSiteAttributeAnalyzer.cs
@@ -15,7 +15,7 @@ namespace DotVVM.Analyzers.ApiUsage
         private const string unsupportedCallSiteAttributeMetadataName = "DotVVM.Framework.CodeAnalysis.UnsupportedCallSiteAttribute";
         private const int callSiteTypeServerUnderlyingValue = 0;
 
-        public static DiagnosticDescriptor DoNotInvokeMethodFromUnsupportedCallSite = new(
+        public static DiagnosticDescriptor DoNotInvokeMethodFromUnsupportedCallSite = new DiagnosticDescriptor(
             DotvvmDiagnosticIds.DoNotInvokeMethodFromUnsupportedCallSiteRuleId,
             unsupportedCallSiteTitle,
             unsupportedCallSiteMessage,


### PR DESCRIPTION
This PR removes the false-positive when building analyzers

See: https://github.com/dotnet/roslyn-analyzers/issues/5828 for more info