### PR TITLE
Document DotvvmModuleContext

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/global-declarations.ts
+++ b/src/Framework/Framework/Resources/Scripts/global-declarations.ts
@@ -322,3 +322,16 @@ type DotvvmViewModule = {
 
     [commandName: DotvvmViewModuleCommandName]: (...args: any[]) => Promise<any> | any
 }
+
+type DotvvmModuleContext = {
+    /** Name of the resource defining the view module */
+    moduleName: string
+    /** Instance of the view module */
+    module: any
+    /** List of element where this module is mounted. It will be `document.body` for pages and the wrapper tag for markup controls. Most likely, only one element is in the collection. */
+    elements: HTMLElement[]
+    /** Properties of the markup control which were sent to the client */
+    properties: { [name: string]: any }
+    /** <dot:NamedCommand /> declared in the dothtml/dotcontrol view. */
+    namedCommands: { [name: string]: (...args: any[]) => Promise<any> }
+}

--- a/src/Framework/Framework/Resources/Scripts/viewModules/viewModuleManager.ts
+++ b/src/Framework/Framework/Resources/Scripts/viewModules/viewModuleManager.ts
@@ -253,8 +253,8 @@ function mapCommandResult(result: any) {
     return result
 }
 
-export class ModuleContext {
-    private readonly namedCommands: { [name: string]: (...args: any[]) => Promise<any> } = {};
+export class ModuleContext implements DotvvmModuleContext {
+    public readonly namedCommands: { [name: string]: (...args: any[]) => Promise<any> } = {};
     public module: any;
     
     constructor(


### PR DESCRIPTION
It is already referred to from documentation, but the TS type was missing. I made the namedCommands field public, since it's already being used by pretty much everyone.