### PR TITLE
Fix overload resolution with constrained generic method

### DIFF
--- a/src/Framework/Framework/Compilation/Binding/MemberExpressionFactory.cs
+++ b/src/Framework/Framework/Compilation/Binding/MemberExpressionFactory.cs
@@ -360,7 +360,17 @@ namespace DotVVM.Framework.Compilation.Binding
                         else return null;
                     }
                 }
-                method = method.MakeGenericMethod(typeArgs);
+                try
+                {
+                    method = method.MakeGenericMethod(typeArgs);
+                }
+                catch (ArgumentException e) when (e.GetBaseException() is System.Security.VerificationException)
+                {
+                    // Verifies that the type constraints are satisfied by the type arguments.
+                    // We could implement partial verification using GetGenericParameterConstraints(), but
+                    // that doesn't give us (AFAIK) information about `new()`, constraint (and probably others).
+                    return null;
+                }
                 parameters = method.GetParameters();
             }
             else if (typeArguments != null) return null;


### PR DESCRIPTION
For example, given two methods M1(int a) and M1<T>(T a) where T: IEnumerable, dotvvm would try to call MakeGenericMethod on the second overload, which throws an exception and fails the entire binding compilation. Now the exception is handled and other overloads are tried before failing compilation with "could not find overload" error.

Note that I tried to verify the constraints before calling the MakeGenericMethod, but it seems impossible to figure out some C# type constraints from reflection, for example new() and unmanaged. MakeGenericMethod at least checks new(), but it doesn't check unmanaged either. At least now we can blame the bug one someone else.

This change has the disadvantage that if you only had one overload, you'd get a nice error explaining why the type parameters could not be assigned. Now you'll only get a generic "no matching overload" error

cc @martindybal 