### PR TITLE
Move Head/BodyResourceLinks insertion to compile-time

### DIFF
--- a/src/Framework/Framework/Compilation/Directives/MarkupDirectiveCompilerPipeline.cs
+++ b/src/Framework/Framework/Compilation/Directives/MarkupDirectiveCompilerPipeline.cs
@@ -6,6 +6,7 @@ using DotVVM.Framework.ResourceManagement;
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using DotVVM.Framework.Configuration;
 
 namespace DotVVM.Framework.Compilation.Directives
 {
@@ -14,12 +15,14 @@ namespace DotVVM.Framework.Compilation.Directives
         private readonly IAbstractTreeBuilder treeBuilder;
         private readonly IControlBuilderFactory controlBuilderFactory;
         private readonly DotvvmResourceRepository resourceRepository;
+        private readonly DotvvmConfiguration configuration;
 
-        public MarkupDirectiveCompilerPipeline(IAbstractTreeBuilder treeBuilder, IControlBuilderFactory controlBuilderFactory, DotvvmResourceRepository resourceRepository)
+        public MarkupDirectiveCompilerPipeline(IAbstractTreeBuilder treeBuilder, IControlBuilderFactory controlBuilderFactory, DotvvmResourceRepository resourceRepository, DotvvmConfiguration configuration)
         {
             this.treeBuilder = treeBuilder;
             this.controlBuilderFactory = controlBuilderFactory;
             this.resourceRepository = resourceRepository;
+            this.configuration = configuration;
         }
 
         public MarkupPageMetadata Compile(DothtmlRootNode dothtmlRoot, string fileName)
@@ -50,7 +53,7 @@ namespace DotVVM.Framework.Compilation.Directives
             var injectedServicesResult = serviceCompiler.Compile();
             resolvedDirectives.AddIfAny(serviceCompiler.DirectiveName, injectedServicesResult.Directives);
 
-            var baseTypeCompiler = new BaseTypeDirectiveCompiler(directivesByName, treeBuilder, fileName, imports);
+            var baseTypeCompiler = new BaseTypeDirectiveCompiler(directivesByName, treeBuilder, fileName, imports, configuration);
             var baseTypeResult = baseTypeCompiler.Compile();
             var baseType = baseTypeResult.Artefact;
             resolvedDirectives.AddIfAny(baseTypeCompiler.DirectiveName, baseTypeResult.Directives);

--- a/src/Framework/Framework/Compilation/ResourceLinksVisitor.cs
+++ b/src/Framework/Framework/Compilation/ResourceLinksVisitor.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using DotVVM.Framework.Compilation.ControlTree.Resolved;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Utils;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Binding.Properties;
+using DotVVM.Framework.Binding.Expressions;
+using System.Collections.Immutable;
+using DotVVM.Framework.Compilation.ControlTree;
+using System.Linq;
+
+namespace DotVVM.Framework.Compilation
+{
+    /// <summary> Inserts <see cref="BodyResourceLinks" /> and <see cref="HeadResourceLinks"/> into head or body element </summary>
+    public class ResourceLinksVisitor : ResolvedControlTreeVisitor
+    {
+        private readonly IControlResolver controlResolver;
+
+        private bool headLinksFound = false;
+        private bool bodyLinksFound = false;
+
+        public ResourceLinksVisitor(IControlResolver controlResolver)
+        {
+            this.controlResolver = controlResolver;
+        }
+
+
+        public override void VisitPropertyTemplate(ResolvedPropertyTemplate propertyTemplate)
+        {
+            // skip
+        }
+
+        public override void VisitControl(ResolvedControl control)
+        {
+            if (typeof(HeadResourceLinks).IsAssignableFrom(control.Metadata.Type))
+            {
+                headLinksFound = true;
+            }
+            else if (typeof(BodyResourceLinks).IsAssignableFrom(control.Metadata.Type))
+            {
+                bodyLinksFound = true;
+            }
+            else
+            {
+                base.VisitControl(control);
+            }
+        }
+
+        private ResolvedControl? TryFindElement(ResolvedControl control, string tagName)
+        {
+            // BFS to find the outermost element
+            // in case somebody mistypes <body> element into a <table>, we don't want to insert resources into it
+            var queue = new Queue<ResolvedControl>();
+            queue.Enqueue(control);
+
+            while (queue.Count > 0)
+            {
+                var current = queue.Dequeue();
+                if (current.Metadata.Type == typeof(HtmlGenericControl) && current.ConstructorParameters?[0] is string controlTagName && tagName.Equals(controlTagName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return current;
+                }
+                foreach (var child in current.Content)
+                {
+                    queue.Enqueue(child);
+                }
+            }
+            return null;
+        }
+
+        private ResolvedControl CreateLinksControl(Type type, DataContextStack dataContext)
+        {
+            var metadata = controlResolver.ResolveControl(new ResolvedTypeDescriptor(type));
+            var control = new ResolvedControl((ControlResolverMetadata)metadata, null, dataContext);
+            control.SetProperty(new ResolvedPropertyValue(Internal.UniqueIDProperty, "cAuto" + type.Name));
+            return control;
+        }
+
+        public override void VisitView(ResolvedTreeRoot view)
+        {
+            if (view.MasterPage is {})
+            {
+                // if there is a masterpage, this visitor has already inserted the links into it
+                return;
+            }
+            if (!typeof(Controls.Infrastructure.DotvvmView).IsAssignableFrom(view.ControlBuilderDescriptor.ControlType))
+            {
+                // markup controls
+                return;
+            }
+            if (!headLinksFound)
+            {
+                var headElement = TryFindElement(view, "head");
+                if (headElement is {})
+                {
+                    headElement.Content.Add(CreateLinksControl(typeof(HeadResourceLinks), headElement.DataContextTypeStack));
+                }
+                else
+                {
+                    // no head element found, and no masterpage -> insert it at the document start
+                    view.Content.Insert(0, CreateLinksControl(typeof(HeadResourceLinks), view.DataContextTypeStack));
+                }
+            }
+            if (!bodyLinksFound)
+            {
+                var bodyElement = TryFindElement(view, "body");
+                if (bodyElement is {})
+                {
+                    bodyElement.Content.Add(CreateLinksControl(typeof(BodyResourceLinks), bodyElement.DataContextTypeStack));
+                }
+                else
+                {
+                    // no body element found, and no masterpage -> insert it at the document end
+                    view.Content.Add(CreateLinksControl(typeof(BodyResourceLinks), view.DataContextTypeStack));
+                }
+            }
+            base.VisitView(view);
+        }
+    }
+}

--- a/src/Framework/Framework/Compilation/ViewCompiler/ViewCompilingVisitor.cs
+++ b/src/Framework/Framework/Compilation/ViewCompiler/ViewCompilingVisitor.cs
@@ -20,6 +20,7 @@ namespace DotVVM.Framework.Compilation.ViewCompiler
 
         protected int currentTemplateIndex;
         protected string? controlName;
+        int controlIdIndex = 0;
 
         public Func<IControlBuilderFactory, IServiceProvider, DotvvmControl> BuildCompiledView { get; set; }
 
@@ -247,8 +248,13 @@ namespace DotVVM.Framework.Compilation.ViewCompiler
             // RawLiterals don't need these helper properties unless in root
             if (control.Metadata.Type != typeof(RawLiteral) || control.Parent is ResolvedTreeRoot)
             {
-                // set unique id
-                emitter.EmitSetDotvvmProperty(name, Internal.UniqueIDProperty, name);
+                if (!control.Properties.ContainsKey(Internal.UniqueIDProperty))
+                {
+                    var uniqueId = "c" + controlIdIndex;
+                    controlIdIndex++;
+                    // set unique id
+                    emitter.EmitSetDotvvmProperty(name, Internal.UniqueIDProperty, uniqueId);
+                }
 
                 if (control.DothtmlNode != null && control.DothtmlNode.Tokens.Count > 0)
                 {

--- a/src/Framework/Framework/Controls/HtmlGenericControl.cs
+++ b/src/Framework/Framework/Controls/HtmlGenericControl.cs
@@ -286,12 +286,6 @@ namespace DotVVM.Framework.Controls
         /// </summary>
         protected override void RenderEndTag(IHtmlWriter writer, IDotvvmRequestContext context)
         {
-            // render resource link. If the Render is invoked multiple times the resources are rendered on the first invocation.
-            if (TagName == "head")
-                new HeadResourceLinks().Render(writer, context);
-            else if (TagName == "body")
-                new BodyResourceLinks().Render(writer, context);
-
             if (RendersHtmlTag)
             {
                 writer.RenderEndTag();

--- a/src/Framework/Framework/DependencyInjection/DotVVMServiceCollectionExtensions.cs
+++ b/src/Framework/Framework/DependencyInjection/DotVVMServiceCollectionExtensions.cs
@@ -113,6 +113,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 var requiredResourceControl = controlResolver.ResolveControl(new ResolvedTypeDescriptor(typeof(RequiredResource)));
                 o.TreeVisitors.Add(() => new StyleTreeShufflingVisitor(controlResolver));
                 o.TreeVisitors.Add(() => new ControlPrecompilationVisitor(s));
+                o.TreeVisitors.Add(() => new ResourceLinksVisitor(controlResolver));
                 o.TreeVisitors.Add(() => new LiteralOptimizationVisitor());
                 o.TreeVisitors.Add(() => new BindingRequiredResourceVisitor((ControlResolverMetadata)requiredResourceControl));
                 var requiredGlobalizeControl = controlResolver.ResolveControl(new ResolvedTypeDescriptor(typeof(GlobalizeResource)));

--- a/src/Framework/Framework/Testing/TestHttpRequest.cs
+++ b/src/Framework/Framework/Testing/TestHttpRequest.cs
@@ -25,7 +25,7 @@ namespace DotVVM.Framework.Testing
 
         public string? Path { get; set; }
 
-        public string? PathBase { get; set; }
+        public string? PathBase { get; set; } = "";
         IPathString IHttpRequest.Path => new TestPathString(this.Path);
 
         IPathString IHttpRequest.PathBase => new TestPathString(this.PathBase);

--- a/src/Framework/Testing/ControlTestHelper.cs
+++ b/src/Framework/Testing/ControlTestHelper.cs
@@ -147,6 +147,16 @@ namespace DotVVM.Framework.Testing
                 markup = "<tc:FakeHeadResourceLink />" + markup;
             }
             markup = $"@viewModel {viewModel.ToString().Replace("+", ".")}\n{directives}\n\n{markup}";
+            return await RunPageRaw(markup, markupFiles, fileName, user, culture);
+        }
+        /// <summary> Run page with the exact markup, without any modifications </summary>
+        public async Task<PageRunResult> RunPageRaw(
+            string markup,
+            Dictionary<string, string>? markupFiles = null,
+            [CallerMemberName] string? fileName = null,
+            ClaimsPrincipal? user = null,
+            CultureInfo? culture = null)
+        {
             var request = PreparePage(markup, markupFiles, fileName, user, culture);
             await presenter.ProcessRequest(request);
             return CreatePageResult(request);

--- a/src/Framework/Testing/DotvvmTestHelper.cs
+++ b/src/Framework/Testing/DotvvmTestHelper.cs
@@ -167,7 +167,10 @@ namespace DotVVM.Framework.Testing
             if (checkErrors) CheckForErrors(root.DothtmlNode);
             foreach (var v in visitors)
             {
-                v().VisitView(root);
+                var visitor = v();
+                if (visitor is ResourceLinksVisitor)
+                    continue; // not wanted in parser tests
+                visitor.VisitView(root);
             }
             if (checkErrors)
                 validator.VisitAndAssert(root);

--- a/src/Tests/ControlTests/ResourceLinksTests.cs
+++ b/src/Tests/ControlTests/ResourceLinksTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Threading.Tasks;
+using CheckTestOutput;
+using DotVVM.Framework.Compilation;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Tests.Binding;
+using DotVVM.Framework.ViewModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DotVVM.Framework.Testing;
+using System.Security.Claims;
+
+namespace DotVVM.Framework.Tests.ControlTests
+{
+    [TestClass]
+    public class ResourceLinksTests
+    {
+        static readonly ControlTestHelper cth = new ControlTestHelper(config: config => {
+        });
+        OutputChecker check = new OutputChecker("testoutputs");
+
+        [TestMethod]
+        public async Task OnlyLiteralInBody()
+        {
+            // There was a bug which collapsed the body contents into a `data-bind='text: ...'` binding
+            var r = await cth.RunPageRaw("""
+                @viewModel DotVVM.Framework.Tests.ControlTests.ResourceLinksTests.BasicTestViewModel
+                <head></head>
+                <body>
+                    Id: {{value: Integer}}
+                </body>
+                """);
+
+            check.CheckString(r.OutputString, fileExtension: "html");
+        }
+        [TestMethod]
+        public async Task MultipleBodyElements()
+        {
+            // You can put body into the document by accident. In such case, DotVVM should try to select the outermost one
+            var r = await cth.RunPageRaw("""
+                @viewModel DotVVM.Framework.Tests.ControlTests.ResourceLinksTests.BasicTestViewModel
+                <head></head>
+                <body>
+                    <table>
+                        <body> {{value: Integer}} </body>
+                    </table>
+                </body>
+                """);
+
+            check.CheckString(r.OutputString, fileExtension: "html");
+        }
+        [TestMethod]
+        public async Task NoHeadBodyElements()
+        {
+            // No body and head elements, DotVVM should put the resources at the start and end of the document,
+            // the browser will hopefully correctly infer the head and body elements
+            var r = await cth.RunPageRaw("""
+                @viewModel DotVVM.Framework.Tests.ControlTests.ResourceLinksTests.BasicTestViewModel
+                
+                <div class-a={value: Integer >= 0}>{{value: Integer}}</div>
+                """);
+
+            check.CheckString(r.OutputString, fileExtension: "html");
+        }
+        public class BasicTestViewModel: DotvvmViewModelBase
+        {
+            [Bind(Name = "int")]
+            public int Integer { get; set; } = 10;
+        }
+    }
+}

--- a/src/Tests/ControlTests/testoutputs/AutoUITests.FormInRepeater.html
+++ b/src/Tests/ControlTests/testoutputs/AutoUITests.FormInRepeater.html
@@ -6,18 +6,18 @@
 				<tbody>
 					<tr data-bind="dotvvm-validation: Email, dotvvm-validationOptions: {}">
 						<td class="autoui-label autoui-required">
-							<label data-bind="attr: { for: &quot;c7&quot;+'_'+$index()+'_'+&quot;Email__input&quot; }">Email</label>
+							<label data-bind="attr: { for: &quot;c5&quot;+'_'+$index()+'_'+&quot;Email__input&quot; }">Email</label>
 						</td>
 						<td class="autoui-editor">
-							<input data-bind="attr: { id: &quot;c7&quot;+'_'+$index()+'_'+&quot;Email__input&quot; }, dotvvm-textbox-text: Email" required="required" type="email">
+							<input data-bind="attr: { id: &quot;c5&quot;+'_'+$index()+'_'+&quot;Email__input&quot; }, dotvvm-textbox-text: Email" required="required" type="email">
 						</td>
 					</tr>
 					<tr data-bind="dotvvm-validation: Name, dotvvm-validationOptions: {}">
 						<td class="autoui-label">
-							<label data-bind="attr: { for: &quot;c7&quot;+'_'+$index()+'_'+&quot;Name__input&quot; }">Name</label>
+							<label data-bind="attr: { for: &quot;c5&quot;+'_'+$index()+'_'+&quot;Name__input&quot; }">Name</label>
 						</td>
 						<td class="autoui-editor">
-							<input data-bind="attr: { id: &quot;c7&quot;+'_'+$index()+'_'+&quot;Name__input&quot; }, dotvvm-textbox-text: Name" type="text">
+							<input data-bind="attr: { id: &quot;c5&quot;+'_'+$index()+'_'+&quot;Name__input&quot; }, dotvvm-textbox-text: Name" type="text">
 						</td>
 					</tr>
 				</tbody>

--- a/src/Tests/ControlTests/testoutputs/CompositeControlTests.MenuRepeater.html
+++ b/src/Tests/ControlTests/testoutputs/CompositeControlTests.MenuRepeater.html
@@ -7,32 +7,32 @@
 		<ul data-bind="dotvvm-SSR-foreach: { data: List }">
 			<!-- ko dotvvm-SSR-item: 0 -->
 			<li>
-				<a data-bind="text: $rawData" href="#c11_0_item">list-item1</a>
+				<a data-bind="text: $rawData" href="#c5_0_item">list-item1</a>
 			</li>
 			<!-- /ko -->
 			<!-- ko dotvvm-SSR-item: 1 -->
 			<li>
-				<a data-bind="text: $rawData" href="#c11_1_item">list-item2</a>
+				<a data-bind="text: $rawData" href="#c5_1_item">list-item2</a>
 			</li>
 			<!-- /ko -->
 		</ul>
 		<div data-bind="dotvvm-SSR-foreach: { data: List }">
 			<!-- ko dotvvm-SSR-item: 0 -->
-			<div data-bind="text: $data" id="c11_0_item">list-item1</div>
+			<div data-bind="text: $data" id="c5_0_item">list-item1</div>
 			<!-- /ko -->
 			<!-- ko dotvvm-SSR-item: 1 -->
-			<div data-bind="text: $data" id="c11_1_item">list-item2</div>
+			<div data-bind="text: $data" id="c5_1_item">list-item2</div>
 			<!-- /ko -->
 		</div>
 		
 		<!-- Client -->
 		<ul data-bind="foreach: { data: List }">
 			<li>
-				<a data-bind="text: $rawData, attr: { href: &quot;#&quot;+&quot;c16&quot;+'_'+$index()+'_'+&quot;item&quot; }"></a>
+				<a data-bind="text: $rawData, attr: { href: &quot;#&quot;+&quot;c7&quot;+'_'+$index()+'_'+&quot;item&quot; }"></a>
 			</li>
 		</ul>
 		<div data-bind="foreach: { data: List }">
-			<div data-bind="text: $data, attr: { id: &quot;c16&quot;+'_'+$index()+'_'+&quot;item&quot; }"></div>
+			<div data-bind="text: $data, attr: { id: &quot;c7&quot;+'_'+$index()+'_'+&quot;item&quot; }"></div>
 		</div>
 	</body>
 </html>

--- a/src/Tests/ControlTests/testoutputs/CompositeControlTests.WrappedHierarchyRepeaterControlWithGeneratedIds.html
+++ b/src/Tests/ControlTests/testoutputs/CompositeControlTests.WrappedHierarchyRepeaterControlWithGeneratedIds.html
@@ -5,18 +5,18 @@
 		<ul>
 			<!-- ko dotvvm-SSR-foreach: { data: Hierarchy } -->
 			<!-- ko dotvvm-SSR-item: 0 -->
-			<li data-bind="text: Label" data-id="c8a0_0L_itema0">A</li>
+			<li data-bind="text: Label" data-id="c4a0_0L_itema0">A</li>
 			<!-- /ko -->
 			<!-- ko dotvvm-SSR-item: 1 -->
-			<li data-bind="text: Label" data-id="c8a0_1L_itema0">B</li>
+			<li data-bind="text: Label" data-id="c4a0_1L_itema0">B</li>
 			<!-- /ko -->
 			<!-- ko dotvvm-SSR-foreach: { data: ko.unwrap($foreachCollectionSymbol)[1]().Children } -->
 			<!-- ko dotvvm-SSR-item: 0 -->
-			<li data-bind="text: Label" data-id="c8a0_1_0L_itema0">C</li>
+			<li data-bind="text: Label" data-id="c4a0_1_0L_itema0">C</li>
 			<!-- /ko -->
 			<!-- ko dotvvm-SSR-foreach: { data: ko.unwrap($foreachCollectionSymbol)[0]().Children } -->
 			<!-- ko dotvvm-SSR-item: 0 -->
-			<li data-bind="text: Label" data-id="c8a0_1_0_0L_itema0">D</li>
+			<li data-bind="text: Label" data-id="c4a0_1_0_0L_itema0">D</li>
 			<!-- /ko -->
 			<!-- /ko -->
 			<!-- /ko -->
@@ -25,15 +25,15 @@
 		
 		<!-- CSR -->
 		<ul>
-			<!-- ko template: { foreach: Hierarchy, name: "c12a0-item", hierarchyRole: "Root" } -->
+			<!-- ko template: { foreach: Hierarchy, name: "c5a0-item", hierarchyRole: "Root" } -->
 			<!-- /ko -->
 		</ul>
 		
-		<!-- Resource c12a0-item of type TemplateResource. -->
-		<template id="c12a0-item">
-			<!-- ko with: $item --><li data-bind="text: Label, attr: { &quot;data-id&quot;: &quot;c12a0&quot;+'_'+($indexPath.map(ko.unwrap).join(&quot;_&quot;)+&quot;L&quot;)+'_'+&quot;itema0&quot; }"></li>
+		<!-- Resource c5a0-item of type TemplateResource. -->
+		<template id="c5a0-item">
+			<!-- ko with: $item --><li data-bind="text: Label, attr: { &quot;data-id&quot;: &quot;c5a0&quot;+'_'+($indexPath.map(ko.unwrap).join(&quot;_&quot;)+&quot;L&quot;)+'_'+&quot;itema0&quot; }"></li>
 			<!-- /ko -->
-			<!-- ko template: { foreach: $item().Children, name: "c12a0-item", hierarchyRole: "Child" } -->
+			<!-- ko template: { foreach: $item().Children, name: "c5a0-item", hierarchyRole: "Child" } -->
 			<!-- ko if: Children()?.length -->
 			<!-- /ko -->
 			<!-- /ko --></template>

--- a/src/Tests/ControlTests/testoutputs/CompositeControlTests.WrappedRepeaterControlWithGeneratedIds.html
+++ b/src/Tests/ControlTests/testoutputs/CompositeControlTests.WrappedRepeaterControlWithGeneratedIds.html
@@ -5,16 +5,16 @@
 		<!-- SSR -->
 		<ul data-bind="dotvvm-SSR-foreach: { data: List }">
 			<!-- ko dotvvm-SSR-item: 0 -->
-			<li data-bind="text: $rawData" data-id="c9a0_0_a0">list-item1</li>
+			<li data-bind="text: $rawData" data-id="c5a0_0_a0">list-item1</li>
 			<!-- /ko -->
 			<!-- ko dotvvm-SSR-item: 1 -->
-			<li data-bind="text: $rawData" data-id="c9a0_1_a0">list-item2</li>
+			<li data-bind="text: $rawData" data-id="c5a0_1_a0">list-item2</li>
 			<!-- /ko -->
 		</ul>
 		
 		<!-- CSR -->
 		<ul data-bind="foreach: { data: List }">
-			<li data-bind="text: $rawData, attr: { &quot;data-id&quot;: &quot;c13a0&quot;+'_'+$index()+'_'+&quot;a0&quot; }"></li>
+			<li data-bind="text: $rawData, attr: { &quot;data-id&quot;: &quot;c6a0&quot;+'_'+$index()+'_'+&quot;a0&quot; }"></li>
 		</ul>
 	</body>
 </html>

--- a/src/Tests/ControlTests/testoutputs/HierarchyRepeaterTests.CommandInMarkupControl-client.html
+++ b/src/Tests/ControlTests/testoutputs/HierarchyRepeaterTests.CommandInMarkupControl-client.html
@@ -2,12 +2,12 @@
 <head></head>
 <body>
 
-    <div><!-- ko template: { foreach: HItems, name: "c7-item", hierarchyRole: "Root" } --><!-- /ko --></div>
+    <div><!-- ko template: { foreach: HItems, name: "c5-item", hierarchyRole: "Root" } --><!-- /ko --></div>
 
-    <!-- Resource c7-item of type TemplateResource. -->
-    <template id=c7-item><!-- ko with: $item -->
+    <!-- Resource c5-item of type TemplateResource. -->
+    <template id=c5-item><!-- ko with: $item -->
             <!-- ko with: $rawData --><div>
-            <input type=button onclick='dotvvm.postBack(this,["HItems/[$indexPath]","$parent"],"RR93KduwUKJIXxFp","c7"+&#39;_&#39;+(ko.contextFor(this).$parentContext.$indexPath.map(ko.unwrap).join("_")+"L")+&#39;_&#39;+"c9",null,[],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;' data-bind="value: Label" /></div><!-- /ko -->
-        <!-- /ko --><!-- ko template: { foreach: $item().Children, name: "c7-item", hierarchyRole: "Child" } --><!-- ko if: Children()?.length --><!-- /ko --><!-- /ko --></template>
+            <input type=button onclick='dotvvm.postBack(this,["HItems/[$indexPath]","$parent"],"RR93KduwUKJIXxFp","c5"+&#39;_&#39;+(ko.contextFor(this).$parentContext.$indexPath.map(ko.unwrap).join("_")+"L")+&#39;_&#39;+"c6",null,[],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;' data-bind="value: Label" /></div><!-- /ko -->
+        <!-- /ko --><!-- ko template: { foreach: $item().Children, name: "c5-item", hierarchyRole: "Child" } --><!-- ko if: Children()?.length --><!-- /ko --><!-- /ko --></template>
 
 </body>

--- a/src/Tests/ControlTests/testoutputs/HierarchyRepeaterTests.CommandInMarkupControl-server.html
+++ b/src/Tests/ControlTests/testoutputs/HierarchyRepeaterTests.CommandInMarkupControl-server.html
@@ -4,19 +4,19 @@
 
     <div><!-- ko dotvvm-SSR-foreach: { data: HItems } --><!-- ko dotvvm-SSR-item: 0 -->
             <!-- ko with: $rawData --><div>
-            <input type=button value=A onclick='dotvvm.postBack(this,["HItems/[0]","$parent"],"RR93KduwUKJIXxFp","c7_0L_c9",null,[],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;' /></div><!-- /ko -->
+            <input type=button value=A onclick='dotvvm.postBack(this,["HItems/[0]","$parent"],"RR93KduwUKJIXxFp","c5_0L_c6",null,[],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;' /></div><!-- /ko -->
         <!-- /ko --><!-- ko dotvvm-SSR-foreach: { data: ko.unwrap($foreachCollectionSymbol)[0]().Children } --><!-- ko dotvvm-SSR-item: 0 -->
             <!-- ko with: $rawData --><div>
-            <input type=button value=A_1 onclick='dotvvm.postBack(this,["HItems/[0]/[0]","$parent"],"RR93KduwUKJIXxFp","c7_0_0L_c9",null,[],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;' /></div><!-- /ko -->
+            <input type=button value=A_1 onclick='dotvvm.postBack(this,["HItems/[0]/[0]","$parent"],"RR93KduwUKJIXxFp","c5_0_0L_c6",null,[],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;' /></div><!-- /ko -->
         <!-- /ko --><!-- ko dotvvm-SSR-foreach: { data: ko.unwrap($foreachCollectionSymbol)[0]().Children } --><!-- ko dotvvm-SSR-item: 0 -->
             <!-- ko with: $rawData --><div>
-            <input type=button value=A_1_1 onclick='dotvvm.postBack(this,["HItems/[0]/[0]/[0]","$parent"],"RR93KduwUKJIXxFp","c7_0_0_0L_c9",null,[],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;' /></div><!-- /ko -->
+            <input type=button value=A_1_1 onclick='dotvvm.postBack(this,["HItems/[0]/[0]/[0]","$parent"],"RR93KduwUKJIXxFp","c5_0_0_0L_c6",null,[],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;' /></div><!-- /ko -->
         <!-- /ko --><!-- ko dotvvm-SSR-item: 1 -->
             <!-- ko with: $rawData --><div>
-            <input type=button value=A_1_2 onclick='dotvvm.postBack(this,["HItems/[0]/[0]/[1]","$parent"],"RR93KduwUKJIXxFp","c7_0_0_1L_c9",null,[],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;' /></div><!-- /ko -->
+            <input type=button value=A_1_2 onclick='dotvvm.postBack(this,["HItems/[0]/[0]/[1]","$parent"],"RR93KduwUKJIXxFp","c5_0_0_1L_c6",null,[],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;' /></div><!-- /ko -->
         <!-- /ko --><!-- /ko --><!-- /ko --><!-- ko dotvvm-SSR-item: 1 -->
             <!-- ko with: $rawData --><div>
-            <input type=button value=B onclick='dotvvm.postBack(this,["HItems/[1]","$parent"],"RR93KduwUKJIXxFp","c7_1L_c9",null,[],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;' /></div><!-- /ko -->
+            <input type=button value=B onclick='dotvvm.postBack(this,["HItems/[1]","$parent"],"RR93KduwUKJIXxFp","c5_1L_c6",null,[],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;' /></div><!-- /ko -->
         <!-- /ko --><!-- /ko --></div>
 
 

--- a/src/Tests/ControlTests/testoutputs/RepeaterTests.IdGeneration.html
+++ b/src/Tests/ControlTests/testoutputs/RepeaterTests.IdGeneration.html
@@ -29,25 +29,25 @@
 		
 		<!-- client rendering - implicit id -->
 		<div data-bind="foreach: { data: Items }">
-			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number), attr: { id: &quot;c24&quot;+'_'+$index()+'_'+&quot;client-div&quot; }"></div>
+			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number), attr: { id: &quot;c10&quot;+'_'+$index()+'_'+&quot;client-div&quot; }"></div>
 		</div>
 		
 		<!-- server rendering - implicit id -->
 		<div data-bind="dotvvm-SSR-foreach: { data: Items }">
 			<!-- ko dotvvm-SSR-item: 0 -->
-			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c31_0_server-div">1</div>
+			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c12_0_server-div">1</div>
 			
 			<!-- /ko -->
 			<!-- ko dotvvm-SSR-item: 1 -->
-			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c31_1_server-div">2</div>
+			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c12_1_server-div">2</div>
 			
 			<!-- /ko -->
 			<!-- ko dotvvm-SSR-item: 2 -->
-			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c31_2_server-div">3</div>
+			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c12_2_server-div">3</div>
 			
 			<!-- /ko -->
 			<!-- ko dotvvm-SSR-item: 3 -->
-			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c31_3_server-div">4</div>
+			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c12_3_server-div">4</div>
 			
 			<!-- /ko -->
 		</div>

--- a/src/Tests/ControlTests/testoutputs/RepeaterTests.IdGeneration_CreatedAtRuntime.html
+++ b/src/Tests/ControlTests/testoutputs/RepeaterTests.IdGeneration_CreatedAtRuntime.html
@@ -29,25 +29,25 @@
 		
 		<!-- client rendering - implicit id -->
 		<div data-bind="foreach: { data: Items }">
-			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number), attr: { id: &quot;c24a0&quot;+'_'+$index()+'_'+&quot;client-div&quot; }"></div>
+			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number), attr: { id: &quot;c10a0&quot;+'_'+$index()+'_'+&quot;client-div&quot; }"></div>
 		</div>
 		
 		<!-- server rendering - implicit id  -->
 		<div data-bind="dotvvm-SSR-foreach: { data: Items }">
 			<!-- ko dotvvm-SSR-item: 0 -->
-			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c31a0_0_server-div">1</div>
+			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c12a0_0_server-div">1</div>
 			
 			<!-- /ko -->
 			<!-- ko dotvvm-SSR-item: 1 -->
-			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c31a0_1_server-div">2</div>
+			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c12a0_1_server-div">2</div>
 			
 			<!-- /ko -->
 			<!-- ko dotvvm-SSR-item: 2 -->
-			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c31a0_2_server-div">3</div>
+			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c12a0_2_server-div">3</div>
 			
 			<!-- /ko -->
 			<!-- ko dotvvm-SSR-item: 3 -->
-			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c31a0_3_server-div">4</div>
+			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c12a0_3_server-div">4</div>
 			
 			<!-- /ko -->
 		</div>

--- a/src/Tests/ControlTests/testoutputs/ResourceLinksTests.MultipleBodyElements.html
+++ b/src/Tests/ControlTests/testoutputs/ResourceLinksTests.MultipleBodyElements.html
@@ -1,0 +1,48 @@
+<head>
+    <!-- Resource knockout of type ScriptResource. Pointing to EmbeddedResourceLocation. -->
+    <script src=/dotvvmResource/knockout/knockout defer></script>
+    <!-- Resource dotvvm.internal of type ScriptModuleResource. Pointing to EmbeddedResourceLocation. -->
+    <script src=/dotvvmResource/dotvvm--internal/dotvvm--internal type=module defer></script>
+    <!-- Resource dotvvm of type InlineScriptResource. -->
+    
+    <!-- Resource dotvvm.debug of type ScriptResource. Pointing to EmbeddedResourceLocation. -->
+    <script src=/dotvvmResource/dotvvm--debug/dotvvm--debug defer></script>
+    <!-- Resource globalize of type ScriptResource. Pointing to EmbeddedResourceLocation. -->
+    <script src=/dotvvmResource/globalize/globalize defer></script>
+    <!-- Resource globalize:en-US of type ScriptResource. Pointing to JQueryGlobalizeResourceLocation. -->
+    <script src="/dotvvmResource/globalize---en-US/globalize---en-US" defer></script>
+</head>
+<body>
+    <table>
+        <body data-bind="text: dotvvm.globalize.bindingNumberToString(int)()"></body>
+    </table>
+
+<input type=hidden id=__dot_viewmodel_root value='{
+  "viewModel": {
+    "$type": "fKoeixwzvquoS2QC",
+    "int": 10,
+    "$csrfToken": "Not a CSRF token."
+  },
+  "url": "/testpage",
+  "virtualDirectory": "",
+  "renderedResources": [
+    "knockout",
+    "dotvvm.internal",
+    "dotvvm",
+    "dotvvm.debug",
+    "globalize",
+    "globalize:en-US"
+  ],
+  "typeMetadata": {
+    "fKoeixwzvquoS2QC": {
+      "type": "object",
+      "debugName": "ResourceLinksTests.BasicTestViewModel",
+      "properties": {
+        "int": {
+          "type": "Int32",
+          "debugName": "Integer"
+        }
+      }
+    }
+  }
+}' /><script defer src="data:text/javascript;base64,d2luZG93LmRvdHZ2bS5pbml0KCJlbi1VUyIpOw=="></script></body>

--- a/src/Tests/ControlTests/testoutputs/ResourceLinksTests.NoHeadBodyElements.html
+++ b/src/Tests/ControlTests/testoutputs/ResourceLinksTests.NoHeadBodyElements.html
@@ -1,0 +1,44 @@
+
+    <!-- Resource knockout of type ScriptResource. Pointing to EmbeddedResourceLocation. -->
+    <script src=/dotvvmResource/knockout/knockout defer></script>
+    <!-- Resource dotvvm.internal of type ScriptModuleResource. Pointing to EmbeddedResourceLocation. -->
+    <script src=/dotvvmResource/dotvvm--internal/dotvvm--internal type=module defer></script>
+    <!-- Resource dotvvm of type InlineScriptResource. -->
+    
+    <!-- Resource dotvvm.debug of type ScriptResource. Pointing to EmbeddedResourceLocation. -->
+    <script src=/dotvvmResource/dotvvm--debug/dotvvm--debug defer></script>
+    <!-- Resource globalize of type ScriptResource. Pointing to EmbeddedResourceLocation. -->
+    <script src=/dotvvmResource/globalize/globalize defer></script>
+    <!-- Resource globalize:en-US of type ScriptResource. Pointing to JQueryGlobalizeResourceLocation. -->
+    <script src="/dotvvmResource/globalize---en-US/globalize---en-US" defer></script>
+
+<div class=a data-bind="css: { a: int() &gt;= 0 }, text: dotvvm.globalize.bindingNumberToString(int)"></div>
+<input type=hidden id=__dot_viewmodel_root value='{
+  "viewModel": {
+    "$type": "fKoeixwzvquoS2QC",
+    "int": 10,
+    "$csrfToken": "Not a CSRF token."
+  },
+  "url": "/testpage",
+  "virtualDirectory": "",
+  "renderedResources": [
+    "knockout",
+    "dotvvm.internal",
+    "dotvvm",
+    "dotvvm.debug",
+    "globalize",
+    "globalize:en-US"
+  ],
+  "typeMetadata": {
+    "fKoeixwzvquoS2QC": {
+      "type": "object",
+      "debugName": "ResourceLinksTests.BasicTestViewModel",
+      "properties": {
+        "int": {
+          "type": "Int32",
+          "debugName": "Integer"
+        }
+      }
+    }
+  }
+}' /><script defer src="data:text/javascript;base64,d2luZG93LmRvdHZ2bS5pbml0KCJlbi1VUyIpOw=="></script>

--- a/src/Tests/ControlTests/testoutputs/ResourceLinksTests.OnlyLiteralInBody.html
+++ b/src/Tests/ControlTests/testoutputs/ResourceLinksTests.OnlyLiteralInBody.html
@@ -1,0 +1,40 @@
+<head>
+    <!-- Resource knockout of type ScriptResource. Pointing to EmbeddedResourceLocation. -->
+    <script src=/dotvvmResource/knockout/knockout defer></script>
+    <!-- Resource dotvvm.internal of type ScriptModuleResource. Pointing to EmbeddedResourceLocation. -->
+    <script src=/dotvvmResource/dotvvm--internal/dotvvm--internal type=module defer></script>
+    <!-- Resource dotvvm of type InlineScriptResource. -->
+    
+    <!-- Resource dotvvm.debug of type ScriptResource. Pointing to EmbeddedResourceLocation. -->
+    <script src=/dotvvmResource/dotvvm--debug/dotvvm--debug defer></script>
+</head>
+<body>
+    Id: <!-- ko text: int --><!-- /ko -->
+
+<input type=hidden id=__dot_viewmodel_root value='{
+  "viewModel": {
+    "$type": "fKoeixwzvquoS2QC",
+    "int": 10,
+    "$csrfToken": "Not a CSRF token."
+  },
+  "url": "/testpage",
+  "virtualDirectory": "",
+  "renderedResources": [
+    "knockout",
+    "dotvvm.internal",
+    "dotvvm",
+    "dotvvm.debug"
+  ],
+  "typeMetadata": {
+    "fKoeixwzvquoS2QC": {
+      "type": "object",
+      "debugName": "ResourceLinksTests.BasicTestViewModel",
+      "properties": {
+        "int": {
+          "type": "Int32",
+          "debugName": "Integer"
+        }
+      }
+    }
+  }
+}' /><script defer src="data:text/javascript;base64,d2luZG93LmRvdHZ2bS5pbml0KCJlbi1VUyIpOw=="></script></body>

--- a/src/Tests/Runtime/ControlTree/ServerSideStyleTests.cs
+++ b/src/Tests/Runtime/ControlTree/ServerSideStyleTests.cs
@@ -514,6 +514,7 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
             Assert.AreEqual(1, e.Content.Count);
 
             var gridView = e.Content[0];
+            Assert.AreEqual(typeof(GridView), gridView.Metadata.Type);
             var columns = gridView.GetProperty(GridView.ColumnsProperty)!.GetValue() as List<ResolvedControl>;
             Assert.AreEqual(3, columns!.Count);
 

--- a/src/Tests/Runtime/DefaultViewCompilerTests.cs
+++ b/src/Tests/Runtime/DefaultViewCompilerTests.cs
@@ -35,12 +35,11 @@ test <dot:Literal Text='test' />";
             var page = CompileMarkup(markup);
 
             Assert.IsInstanceOfType(page, typeof(DotvvmView));
-            Assert.AreEqual(2, page.Children.Count);
 
-            Assert.IsInstanceOfType(page.Children[0], typeof(RawLiteral));
-            Assert.AreEqual("test ", ((RawLiteral)page.Children[0]).EncodedText);
-            Assert.IsInstanceOfType(page.Children[1], typeof(Literal));
-            Assert.AreEqual("test", ((Literal)page.Children[1]).Text);
+            var rawLiteral = page.Children.OfType<RawLiteral>().Single();
+            var literal = page.Children.OfType<Literal>().Single();
+            Assert.AreEqual("test ", rawLiteral.EncodedText);
+            Assert.AreEqual("test", literal.Text);
         }
 
         [TestMethod]
@@ -50,13 +49,13 @@ test <dot:Literal Text='test' />";
             var page = CompileMarkup(markup);
 
             Assert.IsInstanceOfType(page, typeof(DotvvmView));
-            Assert.AreEqual(2, page.Children.Count);
 
-            Assert.IsInstanceOfType(page.Children[0], typeof(RawLiteral));
-            Assert.AreEqual("test ", ((RawLiteral)page.Children[0]).EncodedText);
-            Assert.IsInstanceOfType(page.Children[1], typeof(Literal));
+            var rawLiteral = page.Children.OfType<RawLiteral>().Single();
+            var literal = page.Children.OfType<Literal>().Single();
 
-            var binding = ((Literal)page.Children[1]).GetBinding(Literal.TextProperty) as ValueBindingExpression;
+            Assert.AreEqual("test ", rawLiteral.EncodedText);
+
+            var binding = literal.GetBinding(Literal.TextProperty) as ValueBindingExpression;
             Assert.IsNotNull(binding);
             Assert.AreEqual("FirstName", binding.GetProperty<OriginalStringBindingProperty>().Code);
         }
@@ -68,13 +67,12 @@ test <dot:Literal Text='test' />";
             var page = CompileMarkup(markup);
 
             Assert.IsInstanceOfType(page, typeof(DotvvmView));
-            Assert.AreEqual(2, page.Children.Count);
+            
+            var rawLiteral = page.Children.OfType<RawLiteral>().Single();
+            var literal = page.Children.OfType<Literal>().Single();
 
-            Assert.IsInstanceOfType(page.Children[0], typeof(RawLiteral));
-            Assert.AreEqual("test ", ((RawLiteral)page.Children[0]).EncodedText);
-            Assert.IsInstanceOfType(page.Children[1], typeof(Literal));
-
-            var binding = ((Literal)page.Children[1]).GetBinding(Literal.TextProperty) as ValueBindingExpression;
+            Assert.AreEqual("test ", rawLiteral.EncodedText);
+            var binding = literal.GetBinding(Literal.TextProperty) as ValueBindingExpression;
             Assert.IsNotNull(binding);
             Assert.AreEqual("FirstName", binding.GetProperty<OriginalStringBindingProperty>().Code);
         }
@@ -87,15 +85,13 @@ test <dot:Literal Text='test' />";
             var page = CompileMarkup(markup);
 
             Assert.IsInstanceOfType(page, typeof(DotvvmView));
-            Assert.AreEqual(1, page.Children.Count);
+            var placeholder = page.Children.OfType<PlaceHolder>().Single();
 
-            Assert.IsInstanceOfType(page.Children[0], typeof(PlaceHolder));
-
-            Assert.AreEqual(2, page.Children[0].Children.Count);
-            Assert.IsTrue(page.Children[0].Children[0] is RawLiteral);
-            Assert.IsTrue(page.Children[0].Children[1] is Literal);
-            Assert.AreEqual("test ", ((RawLiteral)page.Children[0].Children[0]).EncodedText);
-            Assert.AreEqual("", ((Literal)page.Children[0].Children[1]).Text);
+            Assert.AreEqual(2, placeholder.Children.Count);
+            Assert.IsTrue(placeholder.Children[0] is RawLiteral);
+            Assert.IsTrue(placeholder.Children[1] is Literal);
+            Assert.AreEqual("test ", ((RawLiteral)placeholder.Children[0]).EncodedText);
+            Assert.AreEqual("", ((Literal)placeholder.Children[1]).Text);
         }
 
 
@@ -144,12 +140,11 @@ test <dot:Literal><a /></dot:Literal>";
             var page = CompileMarkup(markup);
 
             Assert.IsInstanceOfType(page, typeof(DotvvmView));
-            Assert.AreEqual(1, page.Children.Count, string.Join(", ", page.Children.Select(c => c.GetType().Name)));
-
-            Assert.IsInstanceOfType(page.Children[0], typeof(Repeater));
+            Assert.AreEqual(1, page.Children.Count(c => c is not BodyResourceLinks and not HeadResourceLinks), string.Join(", ", page.Children.Select(c => c.GetType().Name)));
+            var repeater = page.Children.OfType<Repeater>().Single();
 
             DotvvmControl placeholder = new PlaceHolder();
-            ((Repeater)page.Children[0]).ItemTemplate.BuildContent(context, placeholder);
+            repeater.ItemTemplate.BuildContent(context, placeholder);
 
             Assert.AreEqual(3, placeholder.Children.Count);
             Assert.IsTrue(string.IsNullOrWhiteSpace(((RawLiteral)placeholder.Children[0]).EncodedText));
@@ -169,17 +164,16 @@ test <dot:Literal><a /></dot:Literal>";
 
             Assert.IsInstanceOfType(page, typeof(DotvvmView));
 
-            var button1 = page.Children[0];
-            Assert.IsInstanceOfType(button1, typeof(Button));
-            Assert.IsFalse((bool)button1.GetValue(Controls.Validation.EnabledProperty));
+            var buttons = page.Children.OfType<Button>().ToList();
+            Assert.AreEqual(3, buttons.Count);
+            Assert.IsInstanceOfType(buttons[0], typeof(Button));
+            Assert.IsFalse((bool)buttons[0].GetValue(Controls.Validation.EnabledProperty));
 
-            var button2 = page.Children[1];
-            Assert.IsInstanceOfType(button2, typeof(Button));
-            Assert.IsTrue((bool)button2.GetValue(Controls.Validation.EnabledProperty));
+            Assert.IsInstanceOfType(buttons[1], typeof(Button));
+            Assert.IsTrue((bool)buttons[1].GetValue(Controls.Validation.EnabledProperty));
 
-            var button3 = page.Children[2];
-            Assert.IsInstanceOfType(button3, typeof(Button));
-            Assert.IsTrue((bool)button3.GetValue(Controls.Validation.EnabledProperty));
+            Assert.IsInstanceOfType(buttons[2], typeof(Button));
+            Assert.IsTrue((bool)buttons[2].GetValue(Controls.Validation.EnabledProperty));
         }
 
 
@@ -196,9 +190,9 @@ test <dot:Literal><a /></dot:Literal>";
             });
 
             Assert.IsInstanceOfType(page, typeof(DotvvmView));
-            Assert.IsInstanceOfType(page.Children[0], typeof(DotvvmView));
+            var control = page.Children.OfType<DotvvmMarkupControl>().Single();
 
-            var literal = page.Children[0].Children[0];
+            var literal = control.Children.OfType<PlaceHolder>().Single().Children.OfType<Literal>().Single();
             Assert.IsInstanceOfType(literal, typeof(Literal));
             Assert.AreEqual("aaa", ((Literal)literal).Text);
         }
@@ -214,9 +208,9 @@ test <dot:Literal><a /></dot:Literal>";
             });
 
             Assert.IsInstanceOfType(page, typeof(DotvvmView));
-            Assert.IsInstanceOfType(page.Children[0], typeof(TestControl));
+            var control = page.Children.OfType<TestControl>().Single();
 
-            var literal = page.Children[0].Children[0].Children[0];
+            var literal = control.Children[0].Children[0];
             Assert.IsInstanceOfType(literal, typeof(Literal));
             Assert.AreEqual("aaa", ((Literal)literal).Text);
         }
@@ -232,12 +226,11 @@ test <dot:Literal><a /></dot:Literal>";
             });
 
             Assert.IsInstanceOfType(page, typeof(DotvvmView));
-            Assert.IsInstanceOfType(page.Children[0], typeof(TestMarkupDIControl));
 
-            var control = (TestMarkupDIControl)page.Children[0];
+            var control = page.Children.OfType<TestMarkupDIControl>().Single();
             Assert.IsNotNull(control.config);
 
-            var literal = page.Children[0].Children[0].Children[0];
+            var literal = control.Children[0].Children[0];
             Assert.IsInstanceOfType(literal, typeof(Literal));
             Assert.AreEqual("aaa", ((Literal)literal).Text);
         }
@@ -253,25 +246,26 @@ test <dot:Literal><a /></dot:Literal>";
 </dot:Repeater>";
             var page = CompileMarkup(markup, new Dictionary<string, string>()
             {
-                { "test3.dothtml", "@viewModel System.Char, mscorlib\r\n<dot:Literal Text='aaa' />" }
+                { "test3.dotcontrol", "@viewModel System.Char, mscorlib\r\n<dot:Literal Text='aaa' />" }
             });
 
             Assert.IsInstanceOfType(page, typeof(DotvvmView));
-            Assert.IsInstanceOfType(page.Children[0], typeof(Repeater));
+            var repeater = page.Children.OfType<Repeater>().Single();
 
             var container = new PlaceHolder();
-            ((Repeater)page.Children[0]).ItemTemplate.BuildContent(context, container);
+            repeater.ItemTemplate.BuildContent(context, container);
 
-            var literal1 = container.Children[0];
+            var content = container.Children;
+            var literal1 = content[0];
             Assert.IsInstanceOfType(literal1, typeof(RawLiteral));
             Assert.IsTrue(string.IsNullOrWhiteSpace(((RawLiteral)literal1).EncodedText));
 
-            var markupControl = container.Children[1];
-            Assert.IsInstanceOfType(markupControl, typeof(DotvvmView));
-            Assert.IsInstanceOfType(markupControl.Children[0], typeof(Literal));
-            Assert.AreEqual("aaa", ((Literal)markupControl.Children[0]).Text);
+            var markupControl = content[1];
+            Assert.IsInstanceOfType(markupControl, typeof(DotvvmMarkupControl));
+            var literal = (Literal)((PlaceHolder)markupControl.Children[0]).Children[0];
+            Assert.AreEqual("aaa", literal.Text);
 
-            var literal2 = container.Children[2];
+            var literal2 = content[2];
             Assert.IsInstanceOfType(literal2, typeof(RawLiteral));
             Assert.IsTrue(string.IsNullOrWhiteSpace(((RawLiteral)literal2).EncodedText));
         }
@@ -287,23 +281,23 @@ test <dot:Literal><a /></dot:Literal>";
 </dot:Repeater>";
             var page = CompileMarkup(markup, new Dictionary<string, string>()
             {
-                { "test4.dothtml", "@viewModel System.Char, mscorlib\r\n<dot:Literal Text='aaa' />" }
+                { "test4.dotcontrol", "@viewModel System.Char, mscorlib\r\n<dot:Literal Text='aaa' />" }
             }, compileTwice: true);
 
             Assert.IsInstanceOfType(page, typeof(DotvvmView));
-            Assert.IsInstanceOfType(page.Children[0], typeof(Repeater));
+            var repeater = page.Children.OfType<Repeater>().Single();
 
             var container = new PlaceHolder();
-            ((Repeater)page.Children[0]).ItemTemplate.BuildContent(context, container);
+            repeater.ItemTemplate.BuildContent(context, container);
 
             var literal1 = container.Children[0];
             Assert.IsInstanceOfType(literal1, typeof(RawLiteral));
             Assert.IsTrue(string.IsNullOrWhiteSpace(((RawLiteral)literal1).EncodedText));
 
             var markupControl = container.Children[1];
-            Assert.IsInstanceOfType(markupControl, typeof(DotvvmView));
-            Assert.IsInstanceOfType(markupControl.Children[0], typeof(Literal));
-            Assert.AreEqual("aaa", ((Literal)markupControl.Children[0]).Text);
+            Assert.IsInstanceOfType(markupControl, typeof(DotvvmMarkupControl));
+            var literal = (Literal)((PlaceHolder)markupControl.Children[0]).Children[0];
+            Assert.AreEqual("aaa", literal.Text);
 
             var literal2 = container.Children[2];
             Assert.IsInstanceOfType(literal2, typeof(RawLiteral));
@@ -488,8 +482,8 @@ test <dot:Literal><a /></dot:Literal>";
                 config.ApplicationPhysicalPath = Path.GetTempPath();
                 config.Markup.Controls.Add(new DotvvmControlConfiguration() { TagPrefix = "cc", TagName = "Test1", Src = "test1.dothtml" });
                 config.Markup.Controls.Add(new DotvvmControlConfiguration() { TagPrefix = "cc", TagName = "Test2", Src = "test2.dothtml" });
-                config.Markup.Controls.Add(new DotvvmControlConfiguration() { TagPrefix = "cc", TagName = "Test3", Src = "test3.dothtml" });
-                config.Markup.Controls.Add(new DotvvmControlConfiguration() { TagPrefix = "cc", TagName = "Test4", Src = "test4.dothtml" });
+                config.Markup.Controls.Add(new DotvvmControlConfiguration() { TagPrefix = "cc", TagName = "Test3", Src = "test3.dotcontrol" });
+                config.Markup.Controls.Add(new DotvvmControlConfiguration() { TagPrefix = "cc", TagName = "Test4", Src = "test4.dotcontrol" });
                 config.Markup.Controls.Add(new DotvvmControlConfiguration() { TagPrefix = "cc", TagName = "Test5", Src = "test5.dothtml" });
                 config.Markup.AddCodeControls("ff", typeof(TestControl));
                 config.Markup.AddAssembly(typeof(DefaultViewCompilerTests).Assembly.GetName().Name);


### PR DESCRIPTION
We used to insert the ResourceLink at the end of
HtmlGenericControl Render, when head or body element was rendered. After this change, the component is inserted compile time into the proper head or body element. This solves the following problems

* when body contained only literals, LiteralOptimizationVisitor would collapse them into a `text: ...` binding, which removed all the resources inside
* when <body> is accidentaly used in the page, resources are rendered on some random place
* when no body or head tag is found, it would crash Now I'm not sure we want to support this, the error message is reasonable (suggests adding head and body elements) and this "smartness" might now cause problems in markup controls declared as views

The change contains large number of test edits for the following reason
* new component is inserted into all trees, changing unique ids
* BodyResourceLink and HeadResourceLinks are added to the pages, so I needed to ignore them when the control tree is being checked.