### PR TITLE
Added a better error when someone tries to reuse viewmodels

### DIFF
--- a/src/Framework/Framework/ViewModel/ChildViewModelsCache.cs
+++ b/src/Framework/Framework/ViewModel/ChildViewModelsCache.cs
@@ -4,8 +4,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text;
 using DotVVM.Framework.Compilation.Javascript;
 using DotVVM.Framework.Compilation.Javascript.Ast;
+using DotVVM.Framework.ViewModel.Serialization;
 
 namespace DotVVM.Framework.ViewModel
 {
@@ -47,8 +49,24 @@ namespace DotVVM.Framework.ViewModel
         public static ParametrizedCode RootViewModelPath = new JsSymbolicParameter(JavascriptTranslator.KnockoutViewModelParameter).FormatParametrizedScript();
 
         static ConditionalWeakTable<IDotvvmViewModel, ParametrizedCode> viewModelPaths = new ConditionalWeakTable<IDotvvmViewModel, ParametrizedCode>();
-        public static void SetViewModelClientPath(IDotvvmViewModel viewModel, ParametrizedCode path) =>
-            viewModelPaths.Add(viewModel, path);
+        public static void SetViewModelClientPath(IDotvvmViewModel viewModel, ParametrizedCode path)
+        {
+            try
+            {
+                viewModelPaths.Add(viewModel, path);
+            }
+            catch (ArgumentException e)
+            {
+                var messageBuilder = new StringBuilder();
+                messageBuilder.AppendLine("An attempt to reuse instances of viewmodels detected.");
+                messageBuilder.Append("This is not supported. Ensure that everytime a viewmodel is requested, a new instance is created. ");
+                messageBuilder.Append($"Most commonly, this is caused by overriding the {nameof(DefaultViewModelLoader)}, creating custom ");
+                messageBuilder.Append("IoC container and registering viewmodels as singletons. Note that in some implementations, for example ");
+                messageBuilder.Append($"Castle Windsor, singleton is the default lifestyle when registering viewmodels.");
+
+                throw new InvalidOperationException(messageBuilder.ToString(), e);
+            }
+        }
 
         public static ParametrizedCode? GetViewModelClientPath(IDotvvmViewModel viewModel) =>
             viewModelPaths.TryGetValue(viewModel, out var p) ? p : p;

--- a/src/Framework/Framework/ViewModel/ChildViewModelsCache.cs
+++ b/src/Framework/Framework/ViewModel/ChildViewModelsCache.cs
@@ -58,7 +58,7 @@ namespace DotVVM.Framework.ViewModel
             catch (ArgumentException e)
             {
                 var messageBuilder = new StringBuilder();
-                messageBuilder.AppendLine("An attempt to reuse instances of viewmodels detected.");
+                messageBuilder.AppendLine($"An attempt to reuse an instance of {viewModel.GetType()} detected.");
                 messageBuilder.Append("This is not supported. Ensure that everytime a viewmodel is requested, a new instance is created. ");
                 messageBuilder.Append($"Most commonly, this is caused by overriding the {nameof(DefaultViewModelLoader)}, creating custom ");
                 messageBuilder.Append("IoC container and registering viewmodels as singletons. Note that in some implementations, for example ");


### PR DESCRIPTION
This PR fixes a generic exception `An item with the same key has already been added` when trying to reuse instances of viewmodels. Even though this is still not supported, users will at least receive a message that tells what went wrong and possibly how to fix it.

Relevant to: #1576