### PR TITLE
Fixed issue where duplicities were returned after upgrading to SDK 7.0.200

### DIFF
--- a/src/Framework/Framework/Compilation/CompiledAssemblyCache.cs
+++ b/src/Framework/Framework/Compilation/CompiledAssemblyCache.cs
@@ -147,10 +147,10 @@ namespace DotVVM.Framework.Compilation
                 {
                     if (allAssembliesCache.TryGetTarget(out var a2) && a2 != null)
                         return a2;
-                
+
 #if DotNetCore
                     // auto-loads all referenced assemblies recursively
-                    var newA = DependencyContext.Default.GetDefaultAssemblyNames().Select(Assembly.Load).ToArray();
+                    var newA = DependencyContext.Default.GetDefaultAssemblyNames().Select(Assembly.Load).Distinct().ToArray();
 #else
                     // this doesn't load new assemblies, but it is done in InvokeStaticConstructorsOnAllControls
                     var newA = AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic).ToArray();


### PR DESCRIPTION
This PR fixes a weird breaking change where `DotVVM.Framework`, `DotVVM.Framework.Hosting` and `DotVVM.Framework.Testing` were returned twice. I am not sure whether something changed in our configuration but the only change that I was able to observe is GitHub Actions started using 7.0.200 instead of 7.0.102 SDKs