### PR TITLE
Fixed error messages for Required and EnforceClientFormat validators

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/validation/validation.ts
+++ b/src/Framework/Framework/Resources/Scripts/validation/validation.ts
@@ -171,7 +171,7 @@ function validateViewModel(viewModel: any, path: string): void {
 function validateRecursive(observable: KnockoutObservable<any>, propertyValue: any, type: TypeDefinition, propertyPath: string) {
     const lastSetError: CoerceResult = (observable as any)[lastSetErrorSymbol];
     if (lastSetError && lastSetError.isError) {
-        ValidationError.attach(lastSetError.message, propertyPath, observable);
+        ValidationError.attachIfNoErrors(lastSetError.message, propertyPath, observable);
     }
     
     if (Array.isArray(type)) {

--- a/src/Framework/Framework/Resources/Scripts/validation/validators.ts
+++ b/src/Framework/Framework/Resources/Scripts/validation/validators.ts
@@ -5,8 +5,22 @@ export type DotvvmValidator = {
 }
 
 export const required: DotvvmValidator = {
-    isValid(value: any): boolean {
-        return !isEmpty(value);
+    isValid(value: any, context, property): boolean {
+        if (isEmpty(value)) {
+            return false;
+        }
+
+        // for value types, the observable may still hold the previous value - we need to look at element states if there is any element with invalid state and empty value
+        const metadata = getValidationMetadata(property);
+        if (metadata) {
+            for (const metaElement of metadata) {
+                if (!metaElement.elementValidationState && "value" in metaElement.element && isEmpty((metaElement.element as any)["value"])) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 }
 export const regex: DotvvmValidator = {
@@ -40,8 +54,12 @@ export const enforceClientFormat: DotvvmValidator = {
         const metadata = getValidationMetadata(property);
         if (metadata) {
             for (const metaElement of metadata) {
-                if (!metaElement.elementValidationState) {
-                    valid = false;
+                if (!metaElement.elementValidationState && "value" in metaElement.element) {
+                    // do not emit the error if the element value is empty and it is allowed to be empty
+                    const elementValue = (metaElement.element as any).value as string;
+                    if ((!allowEmptyStringOrWhitespaces && isEmpty(elementValue)) || (!allowEmptyString && elementValue === "") || !isEmpty(elementValue)) {
+                        valid = false;
+                    }
                 }
             }
         }

--- a/src/Samples/Common/Views/FeatureSamples/Validation/DateTimeValidation.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/Validation/DateTimeValidation.dothtml
@@ -16,22 +16,27 @@
     <p>
         Nullable DateTime with disabled DotvvmClientFormat:
         <dot:TextBox Validator.InvalidCssClass="has-error" Text="{value: Value1}" Validator.Value="{value:  Value1}" />
+        <dot:Validator Value="{value: Value1}" ShowErrorMessageText="true" data-control="validator" />
     </p>
     <p>
         Nullable DateTime:
         <dot:TextBox Validator.InvalidCssClass="has-error" Text="{value: Value2}" Validator.Value="{value:  Value2}" />
+        <dot:Validator Value="{value: Value2}" ShowErrorMessageText="true" data-control="validator" />
     </p>
     <p>
         Nullable DateTime with Required:
         <dot:TextBox Validator.InvalidCssClass="has-error" Text="{value: Value3}" Validator.Value="{value:  Value3}" />
+        <dot:Validator Value="{value: Value3}" ShowErrorMessageText="true" data-control="validator" />
     </p>
     <p>
         Non-nullable:
         <dot:TextBox Validator.InvalidCssClass="has-error" Text="{value: Value4}" Validator.Value="{value:  Value4}" />
+        <dot:Validator Value="{value: Value4}" ShowErrorMessageText="true" data-control="validator" />
     </p>
     <p>
         Non-nullable with Required:
         <dot:TextBox Validator.InvalidCssClass="has-error" Text="{value: Value5}" Validator.Value="{value:  Value5}" />
+        <dot:Validator Value="{value: Value5}" ShowErrorMessageText="true" data-control="validator" />
     </p>
     <dot:Button Text="Validate" Click="{command: ValidateRequiredDateTime()}" ID="ValidateButton" />
 </body>

--- a/src/Samples/Tests/Tests/Feature/ValidationTests.cs
+++ b/src/Samples/Tests/Tests/Feature/ValidationTests.cs
@@ -94,6 +94,7 @@ namespace DotVVM.Samples.Tests.Feature
 
                 var button = browser.First("input[type=button]");
                 var textBoxes = browser.FindElements("input[type=text]").ThrowIfDifferentCountThan(5);
+                var validators = browser.FindElements("span[data-control=validator]").ThrowIfDifferentCountThan(5);
 
                 void testValue(string value)
                 {
@@ -103,37 +104,38 @@ namespace DotVVM.Samples.Tests.Feature
                     }
                     button.Click();
                 }
-                void assertValidators(params bool[] states)
+                void assertValidators(params string[] errors)
                 {
-                    if (states.Length != textBoxes.Count)
+                    if (errors.Length != textBoxes.Count)
                     {
-                        throw new ArgumentException("states");
+                        throw new ArgumentException("errors");
                     }
 
                     for (int i = 0; i < textBoxes.Count; i++)
                     {
-                        if (states[i])
+                        if (!string.IsNullOrEmpty(errors[i]))
                         {
                             AssertUI.HasClass(textBoxes[i], "has-error");
                         }
                         else
                         {
                             AssertUI.HasNotClass(textBoxes[i], "has-error");
+                            AssertUI.TextEquals(validators[i], errors[i]);
                         }
                     }
                 }
 
                 // empty field - Required validators should be triggered
                 testValue("");
-                assertValidators(false, false, true, true, true);
+                assertValidators("", "", "The Value3 field is required.", "Cannot coerce 'null' to type 'DateTime'.", "The Value5 field is required.");
 
                 // correct value - no error
                 testValue("06/14/2017 8:10:35 AM");
-                assertValidators(false, false, false, false, false);
+                assertValidators("", "", "", "", "");
 
                 // incorrect format - all fields should trigger errors except the one where DotvvmClientFormat is disabled
                 testValue("06-14-2017");
-                assertValidators(false, true, true, true, true);
+                assertValidators("", "The field Value2 is invalid.", "The Value3 field is required. The field Value3 is invalid.", "The field Value4 is invalid.", "The field Value5 is invalid.");
             });
         }
 


### PR DESCRIPTION
I noticed that the `Required` validator works on non-nullable value types, but it produces incorrect error messages. 

For example, if you bind a `TextBox` on a `DateTime` property with the `Required` validator and enter an invalid value in the control, the error message which appeared was this: 

```
Cannot coerce 'null' to type 'DateTime'.
``` 

This is an internal error message for developers, not for the end users.

When the control writes the `null` value in the observable via the `dotvvm-textbox-text` binding handler, an error is thrown. The binding handler stores the validation error (as a `lastSetErrorSymbol`) and shows it during the validation together with other errors, and the old value remains in the observable.

I've changed the behavior to be like this:

* The `Required` client-side validator checks whether the observable value is empty. If not, the associated field can still be empty - it will look at the bound elements and if any of them is in an invalid state and its value is empty, it will produce the error. 

* The `EnforceClientFormat` produce a validation error only if it finds an associated element in an invalid state with non-empty value (or with an empty value if such value is not permitted). This condition was added to avoid producing an error when the required validator had already produced it.

* The error from `lastSetErrorSymbol` is displayed only when the property doesn't have any other validation errors. If there is any other error, it would probably be connected to this; thus, we won't show this internal error message to the user. Typically, if the property doesn't have any validation attributes, this internal message from the coercer would be shown. The user will see a meaningful error message if the property has the validation attribute.

Do you have any ideas if this change is safe to do and what we can break by doing this?