### PR TITLE
Fix AttributeList in precompiled control

### DIFF
--- a/src/Framework/Framework/Compilation/Styles/ResolvedControlHelper.cs
+++ b/src/Framework/Framework/Compilation/Styles/ResolvedControlHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using DotVVM.Framework.Binding;
@@ -145,6 +145,7 @@ namespace DotVVM.Framework.Compilation.Styles
             value is ValueOrBinding vob && IsAllowedPropertyValue(vob.UnwrapToObject()) ||
             value is null ||
             ReflectionUtils.IsPrimitiveType(value.GetType()) ||
+            value is HtmlGenericControl.AttributeList ||
             IsImmutableObject(value.GetType()) ||
             value is Array && ReflectionUtils.IsPrimitiveType(value.GetType().GetElementType()!);
 

--- a/src/Tests/ControlTests/testoutputs/CompositeControlTests.ControlWithMultipleEnumClasses.precompiled.html
+++ b/src/Tests/ControlTests/testoutputs/CompositeControlTests.ControlWithMultipleEnumClasses.precompiled.html
@@ -1,0 +1,20 @@
+<html>
+	<head></head>
+	<body>
+		
+		<!-- static value -->
+		<div class="class-a class-d"></div>
+		
+		<!-- value binding + resource binding -->
+		<div class="class-c class-d" data-bind="class: EnumForCssClasses()+&quot; class-d&quot;"></div>
+		
+		<!-- value binding + static -->
+		<div class="class-c class-d" data-bind="class: EnumForCssClasses()+&quot; class-d&quot;"></div>
+		
+		<!-- static + value binding -->
+		<div class="class-d class-c" data-bind="class: &quot;class-d &quot;+EnumForCssClasses()"></div>
+		
+		<!-- both value bindings -->
+		<div class="class-d class-c" data-bind="class: (TrueBool() ? &quot;class-d&quot; : &quot;class-a&quot;)+&quot; &quot;+EnumForCssClasses()"></div>
+	</body>
+</html>


### PR DESCRIPTION
This is a stupid fix, since it propagates the AttributeList into the runtime HtmlGenericControl, instead of merging the attributes compile-time. However, doing that requires other significant changes in AttributeValueMergers, and I'd better not do it in a patch release