### PR TITLE
Extract generic type data context change attribute

### DIFF
--- a/src/Framework/Framework/Binding/ExtractGenericArgumentDataContextChangeAttribute.cs
+++ b/src/Framework/Framework/Binding/ExtractGenericArgumentDataContextChangeAttribute.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.Utils;
+using FastExpressionCompiler;
 
 namespace DotVVM.Framework.Binding;
 

--- a/src/Framework/Framework/Binding/ExtractGenericArgumentDataContextChangeAttribute.cs
+++ b/src/Framework/Framework/Binding/ExtractGenericArgumentDataContextChangeAttribute.cs
@@ -51,7 +51,7 @@ public class ExtractGenericArgumentDataContextChangeAttribute : DataContextChang
         }
         else if (implementations.Count > 1)
         {
-            throw new Exception($"The data context {dataContext} has multiple implementations of {GenericType}! Cannot decide which one to extract:\n" + string.Join("\n", implementations));
+            throw new Exception($"The data context {dataContext.ToCode()} has multiple implementations of {GenericType.ToCode()}! Cannot decide which one to extract:\n" + string.Join("\n", implementations.Select(t => t.ToCode())));
         }
         return implementations[0].GetGenericArguments()[TypeArgumentIndex];
     }

--- a/src/Framework/Framework/Binding/ExtractGenericArgumentDataContextChangeAttribute.cs
+++ b/src/Framework/Framework/Binding/ExtractGenericArgumentDataContextChangeAttribute.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Linq;
+using DotVVM.Framework.Compilation.ControlTree;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Utils;
+
+namespace DotVVM.Framework.Binding;
+
+public class ExtractGenericArgumentDataContextChangeAttribute : DataContextChangeAttribute
+{
+    public Type GenericType { get; }
+    public int TypeArgumentIndex { get; }
+    public override int Order { get; }
+
+    public ExtractGenericArgumentDataContextChangeAttribute(Type genericType, int typeArgumentIndex, int order = 0)
+    {
+        if (!genericType.IsGenericTypeDefinition)
+        {
+            throw new ArgumentException($"The {nameof(genericType)} argument must be a generic type definition!", nameof(genericType));
+        }
+        if (typeArgumentIndex < 0 || typeArgumentIndex >= genericType.GetGenericArguments().Length)
+        {
+            throw new ArgumentOutOfRangeException(nameof(typeArgumentIndex), $"The {nameof(typeArgumentIndex)} is not a valid index of a type argument!");
+        }
+
+        GenericType = genericType;
+        TypeArgumentIndex = typeArgumentIndex;
+        Order = order;
+    }
+
+    public override ITypeDescriptor? GetChildDataContextType(ITypeDescriptor dataContext, IDataContextStack controlContextStack, IAbstractControl control, IPropertyDescriptor? property = null)
+    {
+        var implementations = dataContext.FindGenericImplementations(GenericType).ToList();
+        if (implementations.Count == 0)
+        {
+            throw new Exception($"The data context {dataContext.CSharpFullName} doesn't implement {GenericType}!");
+        }
+        else if (implementations.Count > 1)
+        {
+            throw new Exception($"The data context {dataContext.CSharpFullName} has multiple implementations of {GenericType}! Cannot decide which one to extract:\n" + string.Join("\n", implementations.Select(t => t.CSharpFullName)));
+        }
+        return implementations[0].GetGenericArguments()![TypeArgumentIndex];
+    }
+
+    public override Type? GetChildDataContextType(Type dataContext, DataContextStack controlContextStack, DotvvmBindableObject control, DotvvmProperty? property = null)
+    {
+        var implementations = ReflectionUtils.GetBaseTypesAndInterfaces(dataContext).ToList();
+        if (implementations.Count == 0)
+        {
+            throw new Exception($"The data context {dataContext} doesn't implement {GenericType}!");
+        }
+        else if (implementations.Count > 1)
+        {
+            throw new Exception($"The data context {dataContext} has multiple implementations of {GenericType}! Cannot decide which one to extract:\n" + string.Join("\n", implementations));
+        }
+        return implementations[0].GetGenericArguments()[TypeArgumentIndex];
+    }
+}

--- a/src/Framework/Framework/Compilation/ControlTree/ITypeDescriptor.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ITypeDescriptor.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using DotVVM.Framework.Controls;
 
 namespace DotVVM.Framework.Compilation.ControlTree
@@ -31,5 +33,9 @@ namespace DotVVM.Framework.Compilation.ControlTree
         ITypeDescriptor? TryGetPropertyType(string propertyName);
 
         ITypeDescriptor MakeGenericType(params ITypeDescriptor[] typeArguments);
+
+        IEnumerable<ITypeDescriptor> FindGenericImplementations(Type genericType);
+
+        ITypeDescriptor[]? GetGenericArguments();
     }
 }

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedTypeDescriptor.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedTypeDescriptor.cs
@@ -138,6 +138,25 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
             return new ResolvedTypeDescriptor(genericType);
         }
 
+        public IEnumerable<ITypeDescriptor> FindGenericImplementations(Type genericType)
+        {
+            return ReflectionUtils.GetBaseTypesAndInterfaces(Type)
+                .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == genericType)
+                .Select(t => new ResolvedTypeDescriptor(t));
+        }
+
+        public ITypeDescriptor[]? GetGenericArguments()
+        {
+            if (!Type.IsGenericType)
+            {
+                return null;
+            }
+
+            return Type.GetGenericArguments()
+                .Select(t => new ResolvedTypeDescriptor(t))
+                .ToArray();
+        }
+
         public override string ToString() => Type.ToString();
 
 

--- a/src/Framework/Framework/Utils/ReflectionUtils.cs
+++ b/src/Framework/Framework/Utils/ReflectionUtils.cs
@@ -600,15 +600,15 @@ namespace DotVVM.Framework.Utils
 
         public static IEnumerable<Type> GetBaseTypesAndInterfaces(Type type)
         {
+            foreach (var i in type.GetInterfaces())
+            {
+                yield return i;
+            }
+
             while (type.BaseType is { } baseType)
             {
                 yield return baseType;
                 type = baseType;
-            }
-
-            foreach (var i in type.GetInterfaces())
-            {
-                yield return i;
             }
         }
     }

--- a/src/Framework/Framework/Utils/ReflectionUtils.cs
+++ b/src/Framework/Framework/Utils/ReflectionUtils.cs
@@ -597,5 +597,19 @@ namespace DotVVM.Framework.Utils
             }
             return sb.ToString();
         }
+
+        public static IEnumerable<Type> GetBaseTypesAndInterfaces(Type type)
+        {
+            while (type.BaseType is { } baseType)
+            {
+                yield return baseType;
+                type = baseType;
+            }
+
+            foreach (var i in type.GetInterfaces())
+            {
+                yield return i;
+            }
+        }
     }
 }

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/ControlWithOverriddenRules.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/ControlWithOverriddenRules.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using DotVVM.Framework.Binding;
 using DotVVM.Framework.Compilation.ControlTree.Resolved;
 using DotVVM.Framework.Compilation.Validation;
 using DotVVM.Framework.Controls;
@@ -22,6 +23,19 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree.DefaultControlTreeResolver
     [ControlMarkupOptions(AlternativeNames = new [] { "AlternativeNameControl", "AlternativeNameControl2" })]
     public class ControlWithAlternativeNames : DotvvmControl
     {
+    }
+
+    public class ControlWithExtractGenericArgument : DotvvmControl
+    {
+
+        [ExtractGenericArgumentDataContextChange(typeof(IEnumerable<>), 0)]
+        public string Text
+        {
+            get { return (string)GetValue(TextProperty); }
+            set { SetValue(TextProperty, value); }
+        }
+        public static readonly DotvvmProperty TextProperty
+            = DotvvmProperty.Register<string, ControlWithExtractGenericArgument>(c => c.Text, null);
     }
 }
 

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/DefaultControlTreeResolverTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/DefaultControlTreeResolverTests.cs
@@ -667,6 +667,20 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
 
         }
 
+        [TestMethod]
+        public void ResolvedTree_DataContextChange_ExtractGenericArgument()
+        {
+            var prop = ControlWithExtractGenericArgument.TextProperty;
+
+            var root = ParseSource(@"@viewModel System.Collections.Generic.List<System.String>
+<cc:ControlWithExtractGenericArgument Text={value: _this} />");
+
+            var binding = root.Content.Single().Properties[prop] as ResolvedPropertyBinding;
+            Assert.IsNotNull(binding);
+
+            Assert.AreEqual(typeof(string), binding.Binding.DataContextTypeStack.DataContextType);
+            Assert.AreEqual(typeof(List<string>), binding.Binding.DataContextTypeStack.Parent!.DataContextType);
+        }
 
         [TestMethod]
         public void DefaultViewCompiler_ControlUsageValidator()
@@ -766,4 +780,5 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
             Assert.AreEqual(2, nonLiterals[0].Metadata.AlternativeNames!.Count);
         }
     }
+
 }


### PR DESCRIPTION
This PR adds a new `ExtractGenericArgumentDataContextChangeAttribute`, which looks at base types or implemented interfaces of the current data context type (e. g. `IGroupingDataSet<T>`) and extracts the type argument on a specified index.