### PR TITLE
Fix context.properties in markup control modules

### DIFF
--- a/src/Framework/Framework/Controls/DotvvmMarkupControl.cs
+++ b/src/Framework/Framework/Controls/DotvvmMarkupControl.cs
@@ -68,7 +68,7 @@ namespace DotVVM.Framework.Controls
             base.OnPreInit(context);
         }
 
-        int knockoutCommentsToEnd = 0;
+        bool closeKoComment = false;
 
         protected override void AddAttributesToRender(IHtmlWriter writer, IDotvvmRequestContext context)
         {
@@ -110,14 +110,15 @@ namespace DotVVM.Framework.Controls
                 properties.Add(pg.Name, js.ToString());
             }
 
+
+            var koComment = new List<string>();
             if (!properties.IsEmpty)
             {
                 if (RendersHtmlTag)
                     writer.AddKnockoutDataBind("dotvvm-with-control-properties", properties);
                 else
                 {
-                    writer.WriteKnockoutDataBindComment("dotvvm-with-control-properties", properties.ToString());
-                    knockoutCommentsToEnd++;
+                    koComment.Add("dotvvm-with-control-properties: " + properties.ToString());
                 }
             }
 
@@ -131,9 +132,16 @@ namespace DotVVM.Framework.Controls
                     writer.AddKnockoutDataBind("dotvvm-with-view-modules", binding);
                 else
                 {
-                    writer.WriteKnockoutDataBindComment("dotvvm-with-view-modules", binding);
-                    knockoutCommentsToEnd++;
+                    koComment.Add("dotvvm-with-view-modules: " + binding);
                 }
+            }
+
+            if (closeKoComment = koComment.Count > 0)
+            {
+                // the WriteKnockoutDataBindEndComment doesn't support multiple comments in one element, which is needed for viewmodules and properties working properly together
+                writer.WriteUnencodedText("<!-- ko ");
+                writer.WriteUnencodedText(string.Join(", ", koComment));
+                writer.WriteUnencodedText(" -->");
             }
 
 
@@ -144,10 +152,9 @@ namespace DotVVM.Framework.Controls
         {
             base.RenderEndTag(writer, context);
 
-            while (knockoutCommentsToEnd > 0)
+            if (closeKoComment)
             {
                 writer.WriteKnockoutDataBindEndComment();
-                knockoutCommentsToEnd--;
             }
         }
 

--- a/src/Framework/Framework/Resources/Scripts/binding-handlers/markup-controls.ts
+++ b/src/Framework/Framework/Resources/Scripts/binding-handlers/markup-controls.ts
@@ -34,13 +34,13 @@ function createWrapperComputed<T>(accessor: () => KnockoutObservable<T> | T, pro
     return computed;
 }
 
-function prepareViewModuleContexts(element: HTMLElement, value: any) {
+function prepareViewModuleContexts(element: HTMLElement, value: any, properties: object) {
     if (compileConstants.debug && value.modules.length == 0) {
         throw new Error(`dotvvm-with-view-modules binding was used without any modules.`)
     }
     const contexts: any = {};
     for (const viewModuleName of value.modules) {
-        contexts[viewModuleName] = manager.initViewModule(viewModuleName, value.viewId ?? element, element);
+        contexts[viewModuleName] = manager.initViewModule(viewModuleName, value.viewId ?? element, element, properties);
     }
     if (typeof value.viewId !== "string") {
         if (compileConstants.debug && value.viewId != null) {
@@ -83,7 +83,7 @@ export default {
             const viewModuleBinding = allBindings.get('dotvvm-with-view-modules')
             if (viewModuleBinding)
             {
-                newContext.$viewModules = prepareViewModuleContexts(element, viewModuleBinding)
+                newContext.$viewModules = prepareViewModuleContexts(element, viewModuleBinding, newContext.$control)
             }
 
             const innerBindingContext = bindingContext!.extend(newContext);
@@ -96,7 +96,7 @@ export default {
             if (allBindings.has('dotvvm-with-control-properties'))
                 return;
 
-            const contexts = prepareViewModuleContexts(element, valueAccessor());
+            const contexts = prepareViewModuleContexts(element, valueAccessor(), {});
 
             const innerBindingContext = bindingContext!.extend({ $viewModules: contexts });
             ko.applyBindingsToDescendants(innerBindingContext, element);

--- a/src/Framework/Framework/Resources/Scripts/viewModules/viewModuleManager.ts
+++ b/src/Framework/Framework/Resources/Scripts/viewModules/viewModuleManager.ts
@@ -28,7 +28,7 @@ export function registerViewModules(modules: { [name: string]: any }) {
     }
 }
 
-export function initViewModule(name: string, viewIdOrElement: string | HTMLElement, rootElement: HTMLElement): ModuleContext {
+export function initViewModule(name: string, viewIdOrElement: string | HTMLElement, rootElement: HTMLElement, properties: object = {}): ModuleContext {
     if (compileConstants.debug && rootElement == null) { throw new Error("rootElement has to have a value"); }
 
     const handler = ensureModuleHandler(name);
@@ -45,11 +45,10 @@ export function initViewModule(name: string, viewIdOrElement: string | HTMLEleme
         throw new Error(`The module ${name} referenced in the @js directive must have a default export that is a function.`);
     }
 
-    const elementContext = ko.contextFor(rootElement);
     const context = new ModuleContext(
         name,
         [rootElement],
-        elementContext && elementContext.$control ? { ...elementContext.$control } : {}
+        properties
     );
     const moduleInstance = createModuleInstance(handler.module.default, context);
     context.module = moduleInstance;

--- a/src/Samples/Common/Scripts/testViewModule.js
+++ b/src/Samples/Common/Scripts/testViewModule.js
@@ -77,4 +77,8 @@ class Page {
         queryParameters.map(qp => { queryParamObject[qp.Key] = qp.Value; });
         return queryParamObject;
     }
+
+    readControlProperty() {
+        return ko.unwrap(this.context.properties.ControlProperty)
+    }
 }

--- a/src/Samples/Common/Views/FeatureSamples/ViewModules/ModuleControl.dotcontrol
+++ b/src/Samples/Common/Views/FeatureSamples/ViewModules/ModuleControl.dotcontrol
@@ -2,6 +2,8 @@
 @js FeatureSamples_Resources_TestViewModule
 @import DotVVM.Samples.Common.ViewModels.FeatureSamples.ViewModules
 
+@property int ControlProperty
+
 <h2>_js.Invoke</h2>
 <p>
     <dot:Button Text="noArgs" Click="{staticCommand: _js.Invoke("noArgs")}" />
@@ -25,6 +27,10 @@
 <p>
     Value: <dot:TextBox data-ui="serialized-input" Text={value: ChildObject.Test} />
     Serialized: <dot:TextBox data-ui="serialized-result" Text={value: _js.Invoke<string>("serializeArgsTest", 10, ChildObject.Test)} />
+</p>
+<p>
+    Value: {{value: Value}} ← {{value: _control.ControlProperty}}
+    <dot:Button Text="setControlProperty" Click="{staticCommand: Value = _js.InvokeAsync<int>("readControlProperty")}" />
 </p>
 
 <dot:NamedCommand Name="SetResultCommand" Command="{staticCommand: (int a1, string a2, TestObject a3) => Result = a1.ToString() + "_" + a2 + "_" + a3.Test}" />

--- a/src/Samples/Common/Views/FeatureSamples/ViewModules/ModuleInMarkupControlTwice.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/ViewModules/ModuleInMarkupControlTwice.dothtml
@@ -9,13 +9,13 @@
 </head>
 <body>
 
-    <cc:ModuleControl DataContext="{value: Page}" class="control1" />
+    <cc:ModuleControl DataContext="{value: Page}" class="control1" ControlProperty={value: _root.Page2 == null ? 11 : _root.Page2.Value + 1} />
 
     <div class="toggle">
         <dot:Button Text="Toggle Second Module" Click="{command: ToggleSecond()}" />
     </div>
 
-    <cc:ModuleControl DataContext="{value: Page2}" class="control2" />
+    <cc:ModuleControl DataContext="{value: Page2}" class="control2" ControlProperty={value: _root.Page.Value + 1} />
 
     <h2>Event log</h2>
     <pre ID="log">


### PR DESCRIPTION
`ko.contextFor(element)` will return the parent context, only elements inside the control have the `$control` in their context. No such element is guaranteed to exist, so I added a parameter to the `initViewModule` function