### PR TITLE
Replace typeMetadata after cleaning controls in SPA navigate

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/postback/postbackCore.ts
+++ b/src/Framework/Framework/Resources/Scripts/postback/postbackCore.ts
@@ -135,9 +135,8 @@ async function processPostbackResponse(options: PostbackOptions, context: any, p
 
     let isSuccess = false;
     if (result.action == "successfulCommand") {
-        updateTypeInfo(result.typeMetadata)
         result.viewModel = updater.patchViewModel(getState(), mapUpdatableProperties(result.viewModel))
-        updater.updateViewModelAndControls(result);
+        updater.updateViewModelAndControls(result, updateTypeInfo);
         events.postbackViewModelUpdated.trigger({
             ...options,
             response,

--- a/src/Framework/Framework/Resources/Scripts/postback/updater.ts
+++ b/src/Framework/Framework/Resources/Scripts/postback/updater.ts
@@ -46,7 +46,7 @@ export function restoreUpdatedControls(resultObject: any, updatedControls: any) 
     }
 }
 
-export function updateViewModelAndControls(resultObject: any) {
+export function updateViewModelAndControls(resultObject: any, updateTypeInfo: (t: TypeMap) => void) {
     // store server-side cached viewmodel
     if (resultObject.viewModelCacheId) {
         updateViewModelCache(resultObject.viewModelCacheId, resultObject.viewModel);
@@ -58,6 +58,7 @@ export function updateViewModelAndControls(resultObject: any) {
     const updatedControls = cleanUpdatedControls(resultObject);
 
     // update viewmodel
+    updateTypeInfo(resultObject.typeMetadata);
     replaceViewModel(resultObject.viewModel);
 
     // remove updated controls which were previously removed from DOM

--- a/src/Framework/Framework/Resources/Scripts/spa/navigation.ts
+++ b/src/Framework/Framework/Resources/Scripts/spa/navigation.ts
@@ -57,8 +57,7 @@ export async function navigateCore(url: string, options: PostbackOptions, handle
             if (compileConstants.isSpa) {
                 clearApiCachedValues();
             }
-            replaceTypeInfo(response.result.typeMetadata);
-            updater.updateViewModelAndControls(response.result);
+            updater.updateViewModelAndControls(response.result, replaceTypeInfo);
             isSpaReady(true);
         } else if (response.result.action === "redirect") {
             await handleRedirect(options, response.result, response.response!);


### PR DESCRIPTION
If the control touched viewmodel in the dispose logic, it would fail with "Cannot find type metadata..." error.

cc @martindybal 
