### PR TITLE
Migrate most translations to Linq.Expressions based API

### DIFF
--- a/src/Framework/Framework/Binding/BindingCollectionInfo.cs
+++ b/src/Framework/Framework/Binding/BindingCollectionInfo.cs
@@ -30,10 +30,10 @@ namespace DotVVM.Framework.Binding
                     builder: a => a[0].CastTo<JsObjectExpression>().Properties.Single(p => p.Name == name).Expression.Clone(),
                     check: (_m, a, _a) => a?.GetParameterAnnotation() is BindingParameterAnnotation ann && ann.ExtensionParameter is BindingCollectionInfoExtensionParameter
                 );
-            methods.AddPropertyGetterTranslator(typeof(BindingCollectionInfo), nameof(Index), memberAccess(nameof(Index)));
-            methods.AddPropertyGetterTranslator(typeof(BindingCollectionInfo), nameof(IsFirst), memberAccess(nameof(IsFirst)));
-            methods.AddPropertyGetterTranslator(typeof(BindingCollectionInfo), nameof(IsOdd), memberAccess(nameof(IsOdd)));
-            methods.AddPropertyGetterTranslator(typeof(BindingCollectionInfo), nameof(IsEven), memberAccess(nameof(IsEven)));
+            methods.AddPropertyTranslator(() => new BindingCollectionInfo(0).Index, memberAccess(nameof(Index)));
+            methods.AddPropertyTranslator(() => new BindingCollectionInfo(0).IsFirst, memberAccess(nameof(IsFirst)));
+            methods.AddPropertyTranslator(() => new BindingCollectionInfo(0).IsOdd, memberAccess(nameof(IsOdd)));
+            methods.AddPropertyTranslator(() => new BindingCollectionInfo(0).IsEven, memberAccess(nameof(IsEven)));
         }
     }
 }

--- a/src/Framework/Framework/Binding/BindingPageInfo.cs
+++ b/src/Framework/Framework/Binding/BindingPageInfo.cs
@@ -20,11 +20,11 @@ namespace DotVVM.Framework.Binding
 
         internal static void RegisterJavascriptTranslations(JavascriptTranslatableMethodCollection methods)
         {
-            methods.AddPropertyGetterTranslator(typeof(BindingPageInfo), nameof(EvaluatingOnServer),
+            methods.AddPropertyTranslator(() => new BindingPageInfo().EvaluatingOnServer,
                 new GenericMethodCompiler(_ => new JsLiteral(false)));
-            methods.AddPropertyGetterTranslator(typeof(BindingPageInfo), nameof(EvaluatingOnClient),
+            methods.AddPropertyTranslator(() => new BindingPageInfo().EvaluatingOnClient,
                 new GenericMethodCompiler(_ => new JsLiteral(true)));
-            methods.AddPropertyGetterTranslator(typeof(BindingPageInfo), nameof(IsPostbackRunning),
+            methods.AddPropertyTranslator(() => new BindingPageInfo().IsPostbackRunning,
                 new GenericMethodCompiler(_ => new JsIdentifierExpression("dotvvm").Member("isPostbackRunning").Invoke()));
         }
     }

--- a/src/Framework/Framework/Binding/HelperNamespace/BindingApi.cs
+++ b/src/Framework/Framework/Binding/HelperNamespace/BindingApi.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using DotVVM.Framework.Compilation.Javascript;
 using DotVVM.Framework.Compilation.Javascript.Ast;
 using Newtonsoft.Json;
+using Generic = DotVVM.Framework.Compilation.Javascript.MethodFindingHelper.Generic;
 
 namespace DotVVM.Framework.Binding.HelperNamespace
 {
@@ -18,7 +19,7 @@ namespace DotVVM.Framework.Binding.HelperNamespace
 
         public static void RegisterJavascriptTranslations(JavascriptTranslatableMethodCollection methods)
         {
-            methods.AddMethodTranslator(typeof(BindingApi), nameof(RefreshOnChange),
+            methods.AddMethodTranslator(() => new BindingApi().RefreshOnChange(new Generic.T(), null),
                 new GenericMethodCompiler(a =>
                     new JsIdentifierExpression("dotvvm").Member("api").Member("refreshOn").Invoke(
                             a[1].WithAnnotation(ShouldBeObservableAnnotation.Instance),
@@ -27,7 +28,7 @@ namespace DotVVM.Framework.Binding.HelperNamespace
                         .WithAnnotation(a[1].Annotation<ViewModelInfoAnnotation>())
                         .WithAnnotation(a[1].Annotation<MayBeNullAnnotation>())
                 ));
-            methods.AddMethodTranslator(typeof(BindingApi), nameof(RefreshOnEvent),
+            methods.AddMethodTranslator(() => new BindingApi().RefreshOnEvent(new Generic.T(), "e"),
                 new GenericMethodCompiler(a =>
                     new JsIdentifierExpression("dotvvm").Member("api").Member("refreshOn").Invoke(
                             a[1].WithAnnotation(ShouldBeObservableAnnotation.Instance),
@@ -36,7 +37,7 @@ namespace DotVVM.Framework.Binding.HelperNamespace
                         .WithAnnotation(a[1].Annotation<ViewModelInfoAnnotation>())
                         .WithAnnotation(a[1].Annotation<MayBeNullAnnotation>())
                 ));
-            methods.AddMethodTranslator(typeof(BindingApi), nameof(PushEvent),
+            methods.AddMethodTranslator(() => new BindingApi().PushEvent("e"),
                 new GenericMethodCompiler(a =>
                     new JsIdentifierExpression("dotvvm").Member("eventHub").Member("notify").Invoke(a[1])
                 ));

--- a/src/Framework/Framework/Binding/HelperNamespace/Enums.cs
+++ b/src/Framework/Framework/Binding/HelperNamespace/Enums.cs
@@ -7,6 +7,7 @@ namespace DotVVM.Framework.Binding.HelperNamespace
     public static class Enums
     {
         public static string[] GetNames<TEnum>()
+            where TEnum : struct, Enum
         {
             return Enum.GetNames(typeof(TEnum));
         }

--- a/src/Framework/Framework/Compilation/Inference/TypeInferer.cs
+++ b/src/Framework/Framework/Compilation/Inference/TypeInferer.cs
@@ -81,6 +81,7 @@ namespace DotVVM.Framework.Compilation.Inference
             var tempInstantiations = new Dictionary<string, Type>();
             foreach (var candidate in context.Target.Candidates!.Where(c => c.GetParameters().Length > index))
             {
+                tempInstantiations.Clear();
                 var parameters = candidate.GetParameters();
                 var parameterType = parameters[index].ParameterType;
 
@@ -95,7 +96,6 @@ namespace DotVVM.Framework.Compilation.Inference
                         continue;
 
                     // Try to infer instantiation based on given argument
-                    tempInstantiations.Clear();
                     var result = TryInferInstantiation(parameterType, argumentType, tempInstantiations);
                     if (!result)
                         continue;

--- a/src/Framework/Framework/Compilation/Javascript/Ast/JsAstHelpers.cs
+++ b/src/Framework/Framework/Compilation/Javascript/Ast/JsAstHelpers.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Compilation.Javascript.Ast
 {
@@ -22,6 +23,8 @@ namespace DotVVM.Framework.Compilation.Javascript.Ast
         {
             return new JsIndexerExpression(target, argument);
         }
+        public static JsExpression Indexer(this JsExpression target, int argument) =>
+            target.Indexer(new JsLiteral(BoxingUtils.Box(argument)));
 
         public static JsExpression Unary(this JsExpression target, UnaryOperatorType type, bool isPrefix = true) =>
             new JsUnaryExpression(type, target, isPrefix);

--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -160,7 +160,6 @@ namespace DotVVM.Framework.Compilation.Javascript
         public void AddDefaultMethodTranslators()
         {
             var lengthMethod = new GenericMethodCompiler(a => a[0].Member("length"));
-            // AddPropertyGetterTranslator(typeof(Array), nameof(Array.Length), lengthMethod);
             AddMethodTranslator(() => default(Array)!.Length, lengthMethod);
             AddMethodTranslator(() => default(ICollection)!.Count, lengthMethod);
             AddMethodTranslator(() => default(ICollection<Generic.T>)!.Count, lengthMethod);
@@ -169,6 +168,7 @@ namespace DotVVM.Framework.Compilation.Javascript
             AddMethodTranslator(() => Enums.GetNames<Generic.Enum>(), new EnumGetNamesMethodTranslator());
             var identityTranslator = new GenericMethodCompiler(a => a[1]);
             AddMethodTranslator(() => BoxingUtils.Box(default(bool)), identityTranslator);
+            AddMethodTranslator(() => BoxingUtils.Box(default(bool?)), identityTranslator);
             AddMethodTranslator(() => BoxingUtils.Box(default(int)), identityTranslator);
             AddMethodTranslator(() => BoxingUtils.Box(default(int?)), identityTranslator);
 
@@ -191,8 +191,8 @@ namespace DotVVM.Framework.Compilation.Javascript
             AddPropertyTranslator(() => default(IDictionary<Generic.T, Generic.T>)![null!], new GenericMethodCompiler(dictionaryGetIndexer), new GenericMethodCompiler(dictionarySetIndexer));
             AddPropertyTranslator(() => default(IReadOnlyDictionary<Generic.T, Generic.T>)![null!], new GenericMethodCompiler(dictionaryGetIndexer));
             AddMethodTranslator(() => default(Array)!.SetValue(null, 1), new GenericMethodCompiler(arrayElementSetter));
-            AddPropertyTranslator(() => default(Generic.Struct?)!.Value, new GenericMethodCompiler((JsExpression[] args, MethodInfo method) => args[0]));
-            AddPropertyTranslator(() => default(Generic.Struct?)!.HasValue,
+            AddPropertyTranslator(() => default(Nullable<Generic.Struct>)!.Value, new GenericMethodCompiler((JsExpression[] args, MethodInfo method) => args[0]));
+            AddPropertyTranslator(() => default(Nullable<Generic.Struct>)!.HasValue,
                 new GenericMethodCompiler(args => new JsBinaryExpression(args[0], BinaryOperatorType.NotEqual, new JsLiteral(null))));
 
             JsBindingApi.RegisterJavascriptTranslations(this);
@@ -266,7 +266,7 @@ namespace DotVVM.Framework.Compilation.Javascript
                         .Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance))
                         .WithAnnotation(ResultIsObservableAnnotation.Instance)
             ));
-            AddMethodTranslator(() => default(DateOnly?).ToString(), new GenericMethodCompiler(
+            AddMethodTranslator(() => default(Nullable<DateOnly>).ToString(), new GenericMethodCompiler(
                 args => new JsIdentifierExpression("dotvvm").Member("globalize").Member("bindingDateOnlyToString")
                         .WithAnnotation(new GlobalizeResourceBindingProperty())
                         .Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance))
@@ -284,7 +284,7 @@ namespace DotVVM.Framework.Compilation.Javascript
                         .Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance))
                         .WithAnnotation(ResultIsObservableAnnotation.Instance)
             ));
-            AddMethodTranslator(() => default(TimeOnly?).ToString(), new GenericMethodCompiler(
+            AddMethodTranslator(() => default(Nullable<TimeOnly>).ToString(), new GenericMethodCompiler(
                 args => new JsIdentifierExpression("dotvvm").Member("globalize").Member("bindingTimeOnlyToString")
                         .WithAnnotation(new GlobalizeResourceBindingProperty())
                         .Invoke(args[0].WithAnnotation(ShouldBeObservableAnnotation.Instance))
@@ -652,7 +652,7 @@ namespace DotVVM.Framework.Compilation.Javascript
 
             AddMethodTranslator(() => DateTime.UtcNow.ToBrowserLocalTime(), new GenericMethodCompiler(args =>
                 new JsIdentifierExpression("dotvvm").Member("translations").Member("dateTime").Member("toBrowserLocalTime").Invoke(args[1].WithAnnotation(ShouldBeObservableAnnotation.Instance)).WithAnnotation(ResultIsObservableAnnotation.Instance)));
-            AddMethodTranslator(() => default(DateTime?).ToBrowserLocalTime(), new GenericMethodCompiler(args =>
+            AddMethodTranslator(() => default(Nullable<DateTime>).ToBrowserLocalTime(), new GenericMethodCompiler(args =>
                 new JsIdentifierExpression("dotvvm").Member("translations").Member("dateTime").Member("toBrowserLocalTime").Invoke(args[1].WithAnnotation(ShouldBeObservableAnnotation.Instance)).WithAnnotation(ResultIsObservableAnnotation.Instance)));
         }
 

--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -125,10 +125,11 @@ namespace DotVVM.Framework.Compilation.Javascript
         public void AddMethodTranslator([AllowNull] MethodInfo method, IJavascriptMethodTranslator translator)
         {
             if (method is null) throw new ArgumentNullException(nameof(method));
-            if (!MethodTranslators.TryAdd(method, translator))
+            if (MethodTranslators.ContainsKey(method))
             {
                 throw new Exception($"Method {ReflectionUtils.FormatMethodInfo(method)} is already registered.");
             }
+            MethodTranslators.Add(method, translator);
             if (method.DeclaringType!.IsInterface)
                 Interfaces.Add(method.DeclaringType);
         }

--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslationVisitor.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslationVisitor.cs
@@ -239,7 +239,7 @@ namespace DotVVM.Framework.Compilation.Javascript
         {
             var result = TryTranslateMethodCall(expression.Method, expression.Object, expression.Arguments.ToArray());
             if (result == null)
-                throw new NotSupportedException($"Method { expression.Method.DeclaringType!.Name }.{ expression.Method.Name } cannot be translated to Javascript");
+                throw new NotSupportedException($"Method {ReflectionUtils.FormatMethodInfo(expression.Method)} cannot be translated to Javascript");
             return result;
         }
 

--- a/src/Framework/Framework/Compilation/Javascript/MemberInfoHelper.cs
+++ b/src/Framework/Framework/Compilation/Javascript/MemberInfoHelper.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace DotVVM.Framework.Compilation.Javascript
+{
+    static class MethodFindingHelper
+    {
+        public static MethodBase GetMethodFromExpression<T>(Expression<Func<T>> expression)
+        {
+            return GetMethodFromExpression((Expression)expression);
+        }
+        static MethodBase GetMethodFromExpression(Expression expression)
+        {
+            var originalExpression = expression;
+            if (expression.NodeType == ExpressionType.Lambda)
+                expression = ((LambdaExpression)expression).Body;
+
+            while (expression.NodeType == ExpressionType.Convert && expression is UnaryExpression unary && unary.Method is null)
+                expression = unary.Operand;
+
+            if (TryGetPropertyFromExpression(expression) is { } property)
+                return property switch {
+                    PropertyInfo {GetMethod:{}} p => p.GetMethod,
+                    _ => throw new NotSupportedException($"Unsupported member type {property}")
+                };
+
+            return expression switch {
+                MethodCallExpression call => call.Method,
+                BinaryExpression { Method: { } } binary => binary.Method,
+                BinaryExpression { NodeType: ExpressionType.Assign } assign =>
+                    TryGetPropertyFromExpression(assign.Left) switch {
+                        PropertyInfo {SetMethod: {}} p => p.SetMethod,
+                        null => throw new NotSupportedException($"Cannot get member from {originalExpression}"),
+                        var p => throw new NotSupportedException($"Unsupported assigned member type {p}")
+                    },
+                UnaryExpression { Method: {}} unary => unary.Method,
+                NewExpression { Constructor: { } } newExpression => newExpression.Constructor,
+                _ => throw new NotSupportedException($"Cannot get member from {originalExpression}")
+            };
+        }
+
+        static MemberInfo? TryGetPropertyFromExpression(Expression expression)
+        {
+            if (expression is MemberExpression memberExpression)
+                return memberExpression.Member;
+            else if (expression is IndexExpression index)
+                return index.Indexer;
+            else
+                return null;
+        }
+
+        public static MethodInfo Genericize(MethodInfo m)
+        {
+            if (m.DeclaringType.IsGenericType)
+            {
+                var def = m.DeclaringType.GetGenericTypeDefinition();
+                var args = m.DeclaringType.GetGenericArguments();
+                var parameters = def.GetGenericArguments();
+                var newType = def.MakeGenericType(
+                    args.Zip(parameters, (argument, parameter) =>
+                        argument == typeof(Generic) ? parameter : argument).ToArray()
+                );
+                var methods = newType.GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+                m = methods.Single(mm => m.MetadataToken == mm.MetadataToken);
+
+            }
+            if (m.IsGenericMethod)
+            {
+                var def = m.GetGenericMethodDefinition();
+                var args = m.GetGenericArguments();
+                var parameters = def.GetGenericArguments();
+                var newType = def.MakeGenericMethod(
+                    args.Zip(parameters, (argument, parameter) =>
+                        argument == typeof(Generic) ? parameter : argument).ToArray()
+                );
+                return def;
+            }
+            return m;
+        }
+
+
+        public enum Generic {}
+    }
+}

--- a/src/Framework/Framework/Compilation/Javascript/MemberInfoHelper.cs
+++ b/src/Framework/Framework/Compilation/Javascript/MemberInfoHelper.cs
@@ -45,14 +45,7 @@ namespace DotVVM.Framework.Compilation.Javascript
             return expression switch {
                 MethodCallExpression call => DevirtualizeMethod(call.Method, call.Object?.Type),
                 BinaryExpression { Method: { } } binary => binary.Method,
-                BinaryExpression { NodeType: ExpressionType.Assign } assign =>
-                    TryGetPropertyFromExpression(assign.Left) switch {
-                        PropertyInfo {SetMethod: {}} p => p.SetMethod,
-                        null => throw new NotSupportedException($"Cannot get member from {originalExpression}"),
-                        var p => throw new NotSupportedException($"Unsupported assigned member type {p}")
-                    },
                 UnaryExpression { Method: {}} unary => unary.Method,
-                NewExpression { Constructor: { } } newExpression => newExpression.Constructor,
                 _ => throw new NotSupportedException($"Cannot get member from {originalExpression}")
             };
         }

--- a/src/Framework/Framework/Compilation/Javascript/MemberInfoHelper.cs
+++ b/src/Framework/Framework/Compilation/Javascript/MemberInfoHelper.cs
@@ -61,7 +61,7 @@ namespace DotVVM.Framework.Compilation.Javascript
         {
             if (expression is MemberExpression memberExpression)
                 return memberExpression.Member;
-            else if (expression is MethodCallExpression { Method: { IsSpecialName: true } method } && method.Name.StartsWith("get_"))
+            else if (expression is MethodCallExpression { Method: { IsSpecialName: true, DeclaringType: {} } method } && method.Name.StartsWith("get_"))
                 return method.DeclaringType.GetProperty(method.Name.Substring(4));
             else if (expression is IndexExpression index)
                 return index.Indexer;
@@ -103,6 +103,8 @@ namespace DotVVM.Framework.Compilation.Javascript
 
         public static PropertyInfo Generalize(PropertyInfo p)
         {
+            if (p.DeclaringType is null)
+                return p;
             var newType = Generalize(p.DeclaringType);
             if (newType == p.DeclaringType)
                 return p;
@@ -119,7 +121,7 @@ namespace DotVVM.Framework.Compilation.Javascript
             };
         public static ConstructorInfo Generalize(ConstructorInfo c)
         {
-            var newType = Generalize(c.DeclaringType);
+            var newType = Generalize(c.DeclaringType!);
             if (newType == c.DeclaringType)
                 return c;
             var constructors = newType.GetConstructors(BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
@@ -127,7 +129,7 @@ namespace DotVVM.Framework.Compilation.Javascript
         }
         public static MethodInfo Generalize(MethodInfo m)
         {
-            if (m.DeclaringType.IsGenericType)
+            if (m.DeclaringType is {} && m.DeclaringType.IsGenericType)
             {
                 var newType = Generalize(m.DeclaringType);
                 if (newType != m.DeclaringType)

--- a/src/Framework/Framework/Compilation/Javascript/MemberInfoHelper.cs
+++ b/src/Framework/Framework/Compilation/Javascript/MemberInfoHelper.cs
@@ -5,20 +5,36 @@ using System.Reflection;
 
 namespace DotVVM.Framework.Compilation.Javascript
 {
-    static class MethodFindingHelper
+    public static class MethodFindingHelper
     {
         public static MethodBase GetMethodFromExpression<T>(Expression<Func<T>> expression)
         {
-            return GetMethodFromExpression((Expression)expression);
+            return Generalize(GetMethodFromExpression(expression.Body));
+        }
+        public static MethodBase GetMethodFromExpression(Expression<Action> expression)
+        {
+            return Generalize(GetMethodFromExpression(expression.Body));
+        }
+        public static PropertyInfo GetPropertyFromExpression<T>(Expression<Func<T>> expression)
+        {
+            var p = TryGetPropertyFromExpression(UnwrapConversions(expression.Body)) as PropertyInfo;
+            if (p is null)
+                throw new NotSupportedException($"Cannot get PropertyInfo from {expression.Body}");
+            return Generalize(p);
+        }
+        static Expression UnwrapConversions(Expression e)
+        {
+            if (e.NodeType == ExpressionType.Lambda)
+                e = ((LambdaExpression)e).Body;
+
+            while (e.NodeType == ExpressionType.Convert && e is UnaryExpression unary && unary.Method is null)
+                e = unary.Operand;
+            return e;
         }
         static MethodBase GetMethodFromExpression(Expression expression)
         {
             var originalExpression = expression;
-            if (expression.NodeType == ExpressionType.Lambda)
-                expression = ((LambdaExpression)expression).Body;
-
-            while (expression.NodeType == ExpressionType.Convert && expression is UnaryExpression unary && unary.Method is null)
-                expression = unary.Operand;
+            expression = UnwrapConversions(expression);
 
             if (TryGetPropertyFromExpression(expression) is { } property)
                 return property switch {
@@ -45,42 +61,87 @@ namespace DotVVM.Framework.Compilation.Javascript
         {
             if (expression is MemberExpression memberExpression)
                 return memberExpression.Member;
+            else if (expression is MethodCallExpression { Method: { IsSpecialName: true } method } && method.Name.StartsWith("get_"))
+                return method.DeclaringType.GetProperty(method.Name.Substring(4));
             else if (expression is IndexExpression index)
                 return index.Indexer;
             else
                 return null;
         }
 
-        public static MethodInfo Genericize(MethodInfo m)
+        public static Type Generalize(Type t)
+        {
+            if (!t.IsGenericType)
+                return t;
+            var args = t.GetGenericArguments();
+            if (!args.Any(a => a.DeclaringType == typeof(Generic)))
+                return t;
+            var def = t.GetGenericTypeDefinition();
+            var parameters = def.GetGenericArguments();
+            var newType = def.MakeGenericType(
+                args.Zip(parameters, (argument, parameter) =>
+                    argument.DeclaringType == typeof(Generic) ? parameter : argument).ToArray()
+            );
+            return newType;
+        }
+
+        public static PropertyInfo Generalize(PropertyInfo p)
+        {
+            var newType = Generalize(p.DeclaringType);
+            if (newType == p.DeclaringType)
+                return p;
+
+            var properties = newType.GetProperties(BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            return properties.Single(pp => p.MetadataToken == pp.MetadataToken);
+        }
+
+        public static MethodBase Generalize(MethodBase m) =>
+            m switch {
+                MethodInfo mi => Generalize(mi),
+                ConstructorInfo ci => Generalize(ci),
+                _ => throw new NotSupportedException($"Unsupported method type {m}")
+            };
+        public static ConstructorInfo Generalize(ConstructorInfo c)
+        {
+            var newType = Generalize(c.DeclaringType);
+            if (newType == c.DeclaringType)
+                return c;
+            var constructors = newType.GetConstructors(BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            return constructors.Single(mm => c.MetadataToken == mm.MetadataToken);
+        }
+        public static MethodInfo Generalize(MethodInfo m)
         {
             if (m.DeclaringType.IsGenericType)
             {
-                var def = m.DeclaringType.GetGenericTypeDefinition();
-                var args = m.DeclaringType.GetGenericArguments();
-                var parameters = def.GetGenericArguments();
-                var newType = def.MakeGenericType(
-                    args.Zip(parameters, (argument, parameter) =>
-                        argument == typeof(Generic) ? parameter : argument).ToArray()
-                );
-                var methods = newType.GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
-                m = methods.Single(mm => m.MetadataToken == mm.MetadataToken);
-
+                var newType = Generalize(m.DeclaringType);
+                if (newType != m.DeclaringType)
+                {
+                    var methods = newType.GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+                    m = methods.Single(mm => m.MetadataToken == mm.MetadataToken);
+                }
             }
             if (m.IsGenericMethod)
             {
-                var def = m.GetGenericMethodDefinition();
                 var args = m.GetGenericArguments();
-                var parameters = def.GetGenericArguments();
-                var newType = def.MakeGenericMethod(
-                    args.Zip(parameters, (argument, parameter) =>
-                        argument == typeof(Generic) ? parameter : argument).ToArray()
-                );
-                return def;
+                if (args.Any(a => a.DeclaringType == typeof(Generic)))
+                {
+                    var def = m.GetGenericMethodDefinition();
+                    var parameters = def.GetGenericArguments();
+                    var newType = def.MakeGenericMethod(
+                        args.Zip(parameters, (argument, parameter) =>
+                            argument.DeclaringType == typeof(Generic) ? parameter : argument).ToArray()
+                    );
+                    return def;
+                }
             }
             return m;
         }
 
 
-        public enum Generic {}
+        public static class Generic {
+            public record T { }
+            public enum Enum { Something }
+            public record struct Struct { }
+        }
     }
 }

--- a/src/Framework/Framework/Utils/ReflectionUtils.cs
+++ b/src/Framework/Framework/Utils/ReflectionUtils.cs
@@ -587,7 +587,7 @@ namespace DotVVM.Framework.Utils
                 if (!first)
                     sb.Append(", ");
                 first = false;
-                sb.Append(p.Name).Append(" ").Append(p.ParameterType.ToCode(stripNamespace: stripNamespace));
+                sb.Append(p.ParameterType.ToCode(stripNamespace: stripNamespace)).Append(" ").Append(p.Name);
             }
             sb.Append(")");
             if (method is MethodInfo methodInfo && methodInfo.ReturnType != typeof(void))

--- a/src/Framework/Framework/Utils/ReflectionUtils.cs
+++ b/src/Framework/Framework/Utils/ReflectionUtils.cs
@@ -573,5 +573,29 @@ namespace DotVVM.Framework.Utils
         internal static bool IsInitOnly(this PropertyInfo prop) =>
             prop.SetMethod is { ReturnParameter: {} returnParameter } &&
             returnParameter.GetRequiredCustomModifiers().Any(t => t == typeof(System.Runtime.CompilerServices.IsExternalInit));
+
+        public static string FormatMethodInfo(MethodBase method, bool stripNamespace = false)
+        {
+            var sb = new StringBuilder();
+            sb.Append(method.DeclaringType?.ToCode(stripNamespace: stripNamespace) ?? "?");
+            sb.Append(".");
+            sb.Append(method.Name);
+            sb.Append("(");
+            var first = true;
+            foreach (var p in method.GetParameters())
+            {
+                if (!first)
+                    sb.Append(", ");
+                first = false;
+                sb.Append(p.Name).Append(" ").Append(p.ParameterType.ToCode(stripNamespace: stripNamespace));
+            }
+            sb.Append(")");
+            if (method is MethodInfo methodInfo && methodInfo.ReturnType != typeof(void))
+            {
+                sb.Append(" -> ");
+                sb.Append(methodInfo.ReturnType.ToCode(stripNamespace: stripNamespace));
+            }
+            return sb.ToString();
+        }
     }
 }

--- a/src/Samples/Common/CommonConfiguration.cs
+++ b/src/Samples/Common/CommonConfiguration.cs
@@ -41,8 +41,7 @@ namespace DotVVM.Samples.Common
             services.Configure<DotvvmResourceRepository>(RegisterResources);
 
             services.Configure<JavascriptTranslatorConfiguration>(c => {
-                c.MethodCollection.AddMethodTranslator(typeof(JavaScriptUtils),
-                   nameof(JavaScriptUtils.LimitLength),
+                c.MethodCollection.AddMethodTranslator(() => JavaScriptUtils.LimitLength("", 0),
                    new GenericMethodCompiler((a) => new JsIdentifierExpression("limitLength").Invoke(a)));
             });
 

--- a/src/Tests/Runtime/testoutputs/RuntimeErrorTests.InitResolverFailure.txt
+++ b/src/Tests/Runtime/testoutputs/RuntimeErrorTests.InitResolverFailure.txt
@@ -1,5 +1,5 @@
-BindingPropertyException occurred: Could not initialize binding as it is missing a required property KnockoutExpressionBindingProperty: Method Object.ToString cannot be translated to Javascript. Binding: {value: value(DotVVM.Framework.Configuration.DotvvmConfiguration).ToString()}.
+BindingPropertyException occurred: Could not initialize binding as it is missing a required property KnockoutExpressionBindingProperty: Method object.ToString() -> string cannot be translated to Javascript. Binding: {value: value(DotVVM.Framework.Configuration.DotvvmConfiguration).ToString()}.
     at void DotVVM.Framework.Tests.Runtime.RuntimeErrorTests.InitResolverFailure()+() => { }
 
-NotSupportedException occurred: Method Object.ToString cannot be translated to Javascript
+NotSupportedException occurred: Method object.ToString() -> string cannot be translated to Javascript
     at JsExpression DotVVM.Framework.Compilation.Javascript.JavascriptTranslationVisitor.TranslateMethodCall(MethodCallExpression expression)

--- a/src/Tests/Runtime/testoutputs/RuntimeErrorTests.PropertyResolverFailure.txt
+++ b/src/Tests/Runtime/testoutputs/RuntimeErrorTests.PropertyResolverFailure.txt
@@ -1,5 +1,5 @@
-BindingPropertyException occurred: Unable to get property KnockoutExpressionBindingProperty: Method Object.ToString cannot be translated to Javascript. Binding: {value: value(DotVVM.Framework.Configuration.DotvvmConfiguration).ToString()}.
+BindingPropertyException occurred: Unable to get property KnockoutExpressionBindingProperty: Method object.ToString() -> string cannot be translated to Javascript. Binding: {value: value(DotVVM.Framework.Configuration.DotvvmConfiguration).ToString()}.
     at void DotVVM.Framework.Tests.Runtime.RuntimeErrorTests.PropertyResolverFailure()+() => { }
 
-NotSupportedException occurred: Method Object.ToString cannot be translated to Javascript
+NotSupportedException occurred: Method object.ToString() -> string cannot be translated to Javascript
     at JsExpression DotVVM.Framework.Compilation.Javascript.JavascriptTranslationVisitor.TranslateMethodCall(MethodCallExpression expression)


### PR DESCRIPTION
Added a new Linq.Expressions based API for identifying MethodInfo in JS translation registration and migrated most current translations to it.  This should bring stability across different .NET versions, since the method overloads are fixed on build. New overload in .NET might break the build of DotVVM.Framework, but existing nupkg will not crash on startup

Translations which were not migrated were mostly relying on the `allowMultipleMethods: true` feature. Using that should be stable already and I didn't want to rewrite the code by explicitly listing all overloads
