### PR TITLE
type inferrer: Fix unification with mutliple candidates

### DIFF
--- a/src/Framework/Framework/Compilation/Inference/TypeInferer.cs
+++ b/src/Framework/Framework/Compilation/Inference/TypeInferer.cs
@@ -81,6 +81,7 @@ namespace DotVVM.Framework.Compilation.Inference
             var tempInstantiations = new Dictionary<string, Type>();
             foreach (var candidate in context.Target.Candidates!.Where(c => c.GetParameters().Length > index))
             {
+                tempInstantiations.Clear();
                 var parameters = candidate.GetParameters();
                 var parameterType = parameters[index].ParameterType;
 
@@ -95,7 +96,6 @@ namespace DotVVM.Framework.Compilation.Inference
                         continue;
 
                     // Try to infer instantiation based on given argument
-                    tempInstantiations.Clear();
                     var result = TryInferInstantiation(parameterType, argumentType, tempInstantiations);
                     if (!result)
                         continue;

--- a/src/Tests/Binding/BindingCompilationTests.cs
+++ b/src/Tests/Binding/BindingCompilationTests.cs
@@ -417,6 +417,19 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        [DataRow("DelegateInvoker2('string', arg => StringProp = arg)", "plain", "string")]
+        [DataRow("DelegateInvoker2(1, a => StringProp = a)", "plain", "1")]
+        [DataRow("DelegateInvoker2(1, a => StringProp = a + 0.5)", "plain", "1.5")]
+        [DataRow("DelegateInvoker2('string', (i, a) => StringProp = (i + a))", "with int", "0string")]
+        public void BindingCompiler_Valid_LambdaParameter_TypeFromOtherArg(string expr, string expectedResult, string stringPropResult)
+        {
+            var viewModel = new TestLambdaCompilation();
+            var result = ExecuteBinding(expr, viewModel);
+            Assert.AreEqual(expectedResult, result, message: "Result mismatch");
+            Assert.AreEqual(stringPropResult, viewModel.StringProp, message: "StringProp mismatch");
+        }
+
+        [TestMethod]
         [DataRow("(int? arg) => arg.Value + 1", typeof(Func<int?, int>))]
         [DataRow("(double? arg) => arg.Value + 0.1", typeof(Func<double?, double>))]
         public void BindingCompiler_Valid_LambdaParameter_Nullable(string expr, Type type)
@@ -1123,6 +1136,9 @@ namespace DotVVM.Framework.Tests.Binding
 
         public string ActionInvoker(Action<string> action) { action(default); return "Action"; }
         public string Action2Invoker(Action<string, string> action) { action(default, default); return "Action"; }
+
+        public string DelegateInvoker2<T>(T x, Action<T> func) { func(x); return "plain"; }
+        public string DelegateInvoker2<T>(T x, Action<int, T> action) { action(0, x); return "with int"; }
     }
 
     class TestViewModel2

--- a/src/Tests/Runtime/ControlTree/ValueConversionTests.cs
+++ b/src/Tests/Runtime/ControlTree/ValueConversionTests.cs
@@ -30,16 +30,27 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
         [TestMethod]
         public void ValueConversion_DoubleInStrangeCulture()
         {
+            try
+            {
 
-
-#if !NETCOREAPP1_0
-            System.Threading.Thread.CurrentThread.CurrentCulture =
-            System.Threading.Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("cs-CZ");
-#else
-            CultureInfo.CurrentCulture = CultureInfo.CurrentUICulture = new CultureInfo("cs-CZ");
-#endif
-            Assert.AreEqual(1.2, double.Parse("1,2"));
-            Assert.AreEqual(1.2, ReflectionUtils.ConvertValue("1.2", typeof(double)));
+    #if !NETCOREAPP1_0
+                System.Threading.Thread.CurrentThread.CurrentCulture =
+                System.Threading.Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("cs-CZ");
+    #else
+                CultureInfo.CurrentCulture = CultureInfo.CurrentUICulture = new CultureInfo("cs-CZ");
+    #endif
+                Assert.AreEqual(1.2, double.Parse("1,2"));
+                Assert.AreEqual(1.2, ReflectionUtils.ConvertValue("1.2", typeof(double)));
+            }
+            finally
+            {
+    #if !NETCOREAPP1_0
+                System.Threading.Thread.CurrentThread.CurrentCulture =
+                System.Threading.Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+    #else
+                CultureInfo.CurrentCulture = CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+    #endif
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
The tempInstantiations was leaking between different candidate
overloads, which lead to an exception being thrown from
Dictionary.Add method