### PR TITLE
Unify interfaces for state manipulation

### DIFF
--- a/src/Framework/Framework/Hosting/ErrorPages/ErrorPageTemplate.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/ErrorPageTemplate.cs
@@ -287,10 +287,10 @@ $@"
             {
                 errorColumn = line.Length - 1;
                 errorLength = 0;
-                if (errorColumn < 0)
-                {
-                    errorColumn = 0;
-                }
+            }
+            if (errorColumn < 0)
+            {
+                errorColumn = 0;
             }
             Write("<pre>");
             Write("<span class='lineNumber'>");

--- a/src/Framework/Framework/Resources/Scripts/binding-handlers/markup-controls.ts
+++ b/src/Framework/Framework/Resources/Scripts/binding-handlers/markup-controls.ts
@@ -50,13 +50,6 @@ function createWrapperComputed<T>(accessor: () => KnockoutObservable<T> | T, pro
         }
         x.updateState(updateFunction)
     })
-    defineConstantProperty(computed, "updateState", (updateFunction: (state: any) => any) => {
-        const x = accessor() as any
-        if (compileConstants.debug && typeof x.updateState != "function") {
-            throw new Error(`Cannot update state of property ${propertyDebugInfo}.`)
-        }
-        x.updateState(updateFunction)
-    })
     return computed;
 }
 

--- a/src/Framework/Framework/Resources/Scripts/dotvvm-root.ts
+++ b/src/Framework/Framework/Resources/Scripts/dotvvm-root.ts
@@ -88,6 +88,8 @@ const dotvvmExports = {
     patchState(a: any) {
         getStateManager().patchState(a)
     },
+    setState(a: any) { getStateManager().setState(a) },
+    updateState(updateFunction: StateUpdate<any>) { getStateManager().update(updateFunction) },
     viewModelObservables: {
         get root() { return getViewModelObservable(); }
     },
@@ -132,12 +134,13 @@ if (compileConstants.isSpa) {
 if (compileConstants.debug) {
     (dotvvmExports as any).debug = true
 }
-
-
-
+if (false) {
+    // just check that the types are assignable
+    const test: DotvvmStateContainer<any> = dotvvm
+}
 declare global {
     interface DotvvmGlobalExtensions {}
-    type DotvvmGlobal = DotvvmGlobalExtensions & typeof dotvvmExports & { debug?: true, isSpaReady?: typeof isSpaReady, handleSpaNavigation?: typeof handleSpaNavigation }
+    type DotvvmGlobal = DotvvmGlobalExtensions & typeof dotvvmExports & DotvvmStateContainer<any> & { debug?: true, isSpaReady?: typeof isSpaReady, handleSpaNavigation?: typeof handleSpaNavigation }
 
     const dotvvm: DotvvmGlobal;
 

--- a/src/Framework/Framework/Resources/Scripts/utils/objects.ts
+++ b/src/Framework/Framework/Resources/Scripts/utils/objects.ts
@@ -7,3 +7,9 @@ export const createArray = Array.from;
 export const hasOwnProperty = (obj: any, prop: string) => Object.prototype.hasOwnProperty.call(obj, prop);
 
 export const keys = Object.keys
+
+export function defineConstantProperty(obj: any, name: string, value: any) {
+    Object.defineProperty(obj, name, {
+        value
+    });
+}

--- a/src/Framework/Framework/Resources/Scripts/viewModules/viewModuleManager.ts
+++ b/src/Framework/Framework/Resources/Scripts/viewModules/viewModuleManager.ts
@@ -48,7 +48,8 @@ export function initViewModule(name: string, viewIdOrElement: string | HTMLEleme
     const context = new ModuleContext(
         name,
         [rootElement],
-        properties
+        properties,
+        ko.contextFor(rootElement)?.$rawData
     );
     const moduleInstance = createModuleInstance(handler.module.default, context);
     context.module = moduleInstance;
@@ -255,11 +256,23 @@ function mapCommandResult(result: any) {
 export class ModuleContext implements DotvvmModuleContext {
     public readonly namedCommands: { [name: string]: (...args: any[]) => Promise<any> } = {};
     public module: any;
+    public setState: (state: any) => void;
+    public patchState: (state: any) => void;
+    public updateState: (updateFunction: StateUpdate<any>) => void;
+    public state: any;
     
     constructor(
         public readonly moduleName: string,
         public readonly elements: HTMLElement[],
-        public readonly properties: { [name: string]: any }) {
+        public readonly properties: { [name: string]: any },
+        viewModel: DotvvmObservable<any>) {
+
+        this.setState = viewModel?.setState
+        this.patchState = viewModel?.patchState
+        this.updateState = viewModel?.updateState
+        Object.defineProperty(this, "state", {
+            get: () => viewModel.state
+        })
     }
     
     public registerNamedCommand = (name: string, command: (...args: any[]) => Promise<any>) => {

--- a/src/Framework/Framework/Resources/Scripts/viewModules/viewModuleManager.ts
+++ b/src/Framework/Framework/Resources/Scripts/viewModules/viewModuleManager.ts
@@ -1,3 +1,4 @@
+import { getViewModelObservable } from "../dotvvm-base";
 import { deserialize } from "../serialization/deserialize";
 import { serialize } from "../serialization/serialize";
 import { unmapKnockoutObservables } from "../state-manager";
@@ -49,7 +50,7 @@ export function initViewModule(name: string, viewIdOrElement: string | HTMLEleme
         name,
         [rootElement],
         properties,
-        ko.contextFor(rootElement)?.$rawData
+        rootElement == document.body ? getViewModelObservable() : ko.contextFor(rootElement)?.$rawData
     );
     const moduleInstance = createModuleInstance(handler.module.default, context);
     context.module = moduleInstance;

--- a/src/Framework/Framework/Runtime/DefaultOutputRenderer.cs
+++ b/src/Framework/Framework/Runtime/DefaultOutputRenderer.cs
@@ -35,8 +35,8 @@ namespace DotVVM.Framework.Runtime
             SetCacheHeaders(context.HttpContext);
             using (var html = RenderPage(context, view))
             {
-                context.HttpContext.Response.Headers["Content-Length"] = html.Length.ToString();
                 CheckRenderedResources(context);
+                context.HttpContext.Response.Headers["Content-Length"] = html.Length.ToString();
                 await html.CopyToAsync(context.HttpContext.Response.Body);
             }
         }

--- a/src/Samples/Common/CommonConfiguration.cs
+++ b/src/Samples/Common/CommonConfiguration.cs
@@ -115,6 +115,7 @@ namespace DotVVM.Samples.Common
             resources.RegisterScriptModuleFile("FeatureSamples_Resources_TestViewModule", "Scripts/testViewModule.js");
             resources.RegisterScriptModuleFile("FeatureSamples_Resources_TestViewModule2", "Scripts/testViewModule2.js");
             resources.RegisterScriptModuleFile("FeatureSamples_Resources_TestViewModule3", "Scripts/testViewModule3.js");
+            resources.RegisterScriptModuleFile("FeatureSamples_Resources_StateAwareModule", "Scripts/stateAwareViewModule.js");
 
             resources.Register("FeatureSamples_Resources_Incrementer", new ScriptModuleResource(new FileResourceLocation("~/Scripts/incrementerModule.js")));
 

--- a/src/Samples/Common/DotvvmStartup.cs
+++ b/src/Samples/Common/DotvvmStartup.cs
@@ -259,6 +259,7 @@ namespace DotVVM.Samples.BasicSamples
             config.Markup.AddMarkupControl("cc", "ModuleControl", "Views/FeatureSamples/ViewModules/ModuleControl.dotcontrol");
             config.Markup.AddMarkupControl("cc", "LinkModuleControl", "Views/FeatureSamples/ViewModules/LinkModuleControl.dotcontrol");
             config.Markup.AddMarkupControl("cc", "Incrementer", "Views/FeatureSamples/ViewModules/Incrementer.dotcontrol");
+            config.Markup.AddMarkupControl("cc", "StateIncrementer", "Views/FeatureSamples/ViewModules/StateIncrementer.dotcontrol");
             config.Markup.AddMarkupControl("cc", "TemplatedListControl", "Views/ControlSamples/TemplateHost/TemplatedListControl.dotcontrol");
             config.Markup.AddMarkupControl("cc", "TemplatedMarkupControl", "Views/ControlSamples/TemplateHost/TemplatedMarkupControl.dotcontrol");
             config.Markup.AddCodeControls("cc", typeof(CompositeControlWithTemplate));

--- a/src/Samples/Common/Scripts/stateAwareViewModule.js
+++ b/src/Samples/Common/Scripts/stateAwareViewModule.js
@@ -1,0 +1,21 @@
+
+export default function (context) {
+    return {
+        setViewModelProperty(name, value) {
+            console.assert(context.state !== undefined)
+            console.assert(context.setState)
+            console.assert(context.updateState)
+            console.assert(context.patchState)
+            context.updateState(x => ({ ...x, [name]: value }))
+        },
+        setControlProperty(property, value) {
+            const o = context.properties[property];
+            console.assert(ko.isObservable(o))
+            console.assert(o.state !== undefined)
+            console.assert(o.setState)
+            console.assert(o.updateState)
+            console.assert(o.patchState)
+            context.properties[property].setState(value)
+        }
+    }
+}

--- a/src/Samples/Common/Scripts/testViewModule.js
+++ b/src/Samples/Common/Scripts/testViewModule.js
@@ -79,6 +79,6 @@ class Page {
     }
 
     readControlProperty() {
-        return ko.unwrap(this.context.properties.ControlProperty)
+        return this.context.properties.ControlProperty.state
     }
 }

--- a/src/Samples/Common/ViewModels/FeatureSamples/ViewModules/ModuleStateManipulationViewModel.cs
+++ b/src/Samples/Common/ViewModels/FeatureSamples/ViewModules/ModuleStateManipulationViewModel.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.ViewModules
+{
+    public class ModuleStateManipulationViewModel : DotvvmViewModelBase
+    {
+        public List<Item> Items { get; set; } = new () { new Item() { Value = 0, Label = "Item1" }, new Item() { Value = 0, Label = "Item2" } };
+
+        public int IntProperty { get; set; } = 0;
+
+        public class Item
+        {
+            public int Value { get; set; }
+            public string Label  { get; set; }
+        }
+    }
+}
+

--- a/src/Samples/Common/Views/FeatureSamples/ViewModules/StateIncrementer.dotcontrol
+++ b/src/Samples/Common/Views/FeatureSamples/ViewModules/StateIncrementer.dotcontrol
@@ -1,0 +1,14 @@
+@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.ViewModules.ModuleStateManipulationViewModel.Item
+@property int Property
+@js FeatureSamples_Resources_StateAwareModule
+
+<fieldset>
+    <legend>{{value: Label}}</legend>
+    <span data-ui={value: $"control-{Label}-VM-num"}>{{value: Value}}</span>
+    <span data-ui={value: $"control-{Label}-CP-num"}>{{value: _control.Property}}</span>
+    
+    <dot:Button Click={staticCommand: _js.InvokeAsync("setViewModelProperty", "Value", Value + 1)} Text="ViewModel++" data-ui={value: $"control-{Label}-VM-incrementer"} />
+    <dot:Button Click={staticCommand: _js.InvokeAsync("setViewModelProperty", "Value", Value - 1)} Text="ViewModel--" data-ui={value: $"control-{Label}-VM-decrementer"} />
+    <dot:Button Click={staticCommand: _js.InvokeAsync("setControlProperty", "Property", _control.Property + 1)} Text="Property++" data-ui={value: $"control-{Label}-CP-incrementer"} />
+    <dot:Button Click={staticCommand: _js.InvokeAsync("setControlProperty", "Property", _control.Property - 1)} Text="Property--" data-ui={value: $"control-{Label}-CP-decrementer"} />
+</fieldset>

--- a/src/Samples/Common/Views/FeatureSamples/ViewModules/StateManipulation.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/ViewModules/StateManipulation.dothtml
@@ -1,0 +1,35 @@
+@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.ViewModules.ModuleStateManipulationViewModel
+@js FeatureSamples_Resources_StateAwareModule
+
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title>ViewModule - state manipulation</title>
+</head>
+<body>
+
+
+    <h1> Test of <code>context.state</code>, <code>context.setState</code>, <code>observable.updateState</code>, ... API </h1>
+
+
+    <h3> incrementer in the page </h3>
+
+    <fieldset>
+        <span data-ui=page-num>{{value: IntProperty}}</span>
+        <dot:Button Click={staticCommand: _js.InvokeAsync("setViewModelProperty", "IntProperty", IntProperty + 1)} Text="+" data-ui=page-incrementer />
+        <dot:Button Click={staticCommand: _js.InvokeAsync("setViewModelProperty", "IntProperty", IntProperty - 1)} Text="-" data-ui=page-decrementer />
+    </fieldset>
+
+    <h3> incrementers in markup control </h3>
+
+    <dot:Repeater DataSource={value: Items}>
+        <cc:StateIncrementer Property={value: Value} />
+        <dot:Button Text={value: $"Remove {Label}"} data-ui={value: $"remove-{Label}"}
+            Click={staticCommand: _root.Items.RemoveAt(_index)} />
+    </dot:Repeater>
+
+
+
+</body>
+</html>

--- a/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
@@ -395,6 +395,7 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_ViewModules_ModuleInPageSpaMasterPage = "FeatureSamples/ViewModules/ModuleInPageSpaMasterPage";
         public const string FeatureSamples_ViewModules_ModuleInPageSpaMasterPage2 = "FeatureSamples/ViewModules/ModuleInPageSpaMasterPage2";
         public const string FeatureSamples_ViewModules_ModuleRegistrationPropagation = "FeatureSamples/ViewModules/ModuleRegistrationPropagation";
+        public const string FeatureSamples_ViewModules_StateManipulation = "FeatureSamples/ViewModules/StateManipulation";
         public const string FeatureSamples_Warnings_SelfClosingTags = "FeatureSamples/Warnings/SelfClosingTags";
         }
 }

--- a/src/Samples/Tests/Tests/Feature/ViewModuleTests.cs
+++ b/src/Samples/Tests/Tests/Feature/ViewModuleTests.cs
@@ -348,5 +348,45 @@ namespace DotVVM.Samples.Tests.Feature
             });
 
         }
+
+        [Fact]
+        public void Feature_ViewModules_StateManipulation() =>
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_ViewModules_StateManipulation);
+
+                void ensureValue(string name, int value)
+                {
+                    AssertUI.TextEquals(browser.Single($"span[data-ui='{name}-num']", SelectBy.CssSelector), value.ToString());
+                }
+
+                void increment(string name) =>
+                    browser.Single($"input[data-ui='{name}-incrementer']", SelectBy.CssSelector).Click();
+                void decrement(string name) =>
+                    browser.Single($"input[data-ui='{name}-decrementer']", SelectBy.CssSelector).Click();
+
+                void testControl(string name, int initialValue)
+                {
+                    ensureValue(name, initialValue);
+                    increment(name);
+                    increment(name);
+                    ensureValue(name, initialValue + 2);
+                    decrement(name);
+                    ensureValue(name, initialValue + 1);
+                }
+
+                testControl("page", 0);
+                testControl("control-Item1-VM", 0);
+                testControl("control-Item1-CP", 1);
+                testControl("control-Item2-CP", 0);
+                testControl("control-Item2-VM", 1);
+                testControl("control-Item2-CP", 2);
+
+                browser.Single("input[data-ui='remove-Item1']", SelectBy.CssSelector).Click();
+                browser.WaitFor(() => {
+                    Assert.Empty(browser.FindElements("control-Item1-VM-num"));
+                }, 300);
+                testControl("control-Item2-CP", 3);
+
+            });
     }
 }


### PR DESCRIPTION
Unified interface on dotvvm global, on our observables and on module context to
* `state` readonly property
* `setState(x)`
* `patchState(x)`
* `updateState(s => modify(s))`