### PR TITLE
Removed creation of EditorTemplate when Editable(false)

### DIFF
--- a/src/AutoUI/Core/Controls/AutoGridViewColumn.cs
+++ b/src/AutoUI/Core/Controls/AutoGridViewColumn.cs
@@ -56,7 +56,7 @@ namespace DotVVM.AutoUI.Controls
 
             // editor
 
-            if (props.EditTemplate is null)
+            if (props.EditTemplate is null && (props.IsEditable.HasBinding || props.IsEditable.ValueOrDefault == true))
             {
                 control.EditTemplate = new CloneTemplate(
                     AutoEditor.Build(new AutoEditor.Props()


### PR DESCRIPTION
Suppose I implement `GridViewColumnProvider` for some specific property type. In that case, I still cannot use it in `GridView` until I also make the `FormEditorProvider`. The control tries to generate `EditTemplate` which may not be necessary. 

When the property is marked with `[Editable(false)]`, this PR doesn't create the edit template.