### PR TITLE
Markup file - added last change date parameter to the constructor

### DIFF
--- a/src/Framework/Framework/Hosting/MarkupFile.cs
+++ b/src/Framework/Framework/Hosting/MarkupFile.cs
@@ -67,11 +67,12 @@ namespace DotVVM.Framework.Hosting
             };
         }
 
-        public MarkupFile(string fileName, string fullPath, string contents)
+        public MarkupFile(string fileName, string fullPath, string contents, DateTime lastWriteDateTimeUtc = default)
         {
             FileName = fileName;
             FullPath = fullPath;
             ReadContent = () => contents;
+            LastWriteDateTimeUtc = lastWriteDateTimeUtc;
         }
 
         public override bool Equals(object? obj)


### PR DESCRIPTION
I've found that I need to be able to set a last change date to `MarkupFile` to be able to provide a "hot-reload" experience for generated markup files. 