### PR TITLE
Refactoring of SelectorHelper into SelectorDiscoveryService

### DIFF
--- a/src/AutoUI/Core/AutoUIExtensions.cs
+++ b/src/AutoUI/Core/AutoUIExtensions.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using DotVVM.AutoUI.Configuration;
 using DotVVM.AutoUI.Controls;
 using DotVVM.AutoUI.Metadata;
+using DotVVM.AutoUI.PropertyHandlers;
 using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.ViewModel.Validation;
@@ -27,6 +28,7 @@ namespace DotVVM.AutoUI
             RegisterResourceFileProviders(services.Services, autoUiConfiguration);
 
             services.Services.Configure<DotvvmConfiguration>(AddAutoUIConfiguration);
+            services.Services.AddSingleton<ISelectorDiscoveryService, SelectorDiscoveryService>();
 
             return services;
         }

--- a/src/AutoUI/Core/Controls/AutoFormBase.cs
+++ b/src/AutoUI/Core/Controls/AutoFormBase.cs
@@ -18,9 +18,13 @@ namespace DotVVM.AutoUI.Controls
     public abstract class AutoFormBase : CompositeControl 
     {
         protected readonly IServiceProvider services;
+
+        private readonly ISelectorDiscoveryService selectorDiscoveryService;
+
         public AutoFormBase(IServiceProvider services)
         {
             this.services = services;
+            this.selectorDiscoveryService = services.GetRequiredService<ISelectorDiscoveryService>();
         }
 
 
@@ -49,6 +53,7 @@ namespace DotVVM.AutoUI.Controls
 
         public static readonly DotvvmCapabilityProperty FieldPropsProperty =
             DotvvmCapabilityProperty.RegisterCapability<FieldProps, AutoFormBase>();
+
 
         protected AutoUIContext CreateAutoUiContext()
         {
@@ -200,7 +205,7 @@ namespace DotVVM.AutoUI.Controls
             {
                 try
                 {
-                    var dataSource = SelectorHelper.DiscoverSelectorDataSourceBinding(context, selector.SelectionType);
+                    var dataSource = selectorDiscoveryService.DiscoverSelectorDataSourceBinding(context, selector.SelectionType);
                     var nonEmptyBinding =
                         dataSource.GetProperty<DataSourceLengthBinding>().Binding.GetProperty<IsMoreThanZeroBindingProperty>().Binding;
                     field.SetValueRaw(HtmlGenericControl.VisibleProperty, nonEmptyBinding);

--- a/src/AutoUI/Core/PropertyHandlers/FormEditors/MultiSelectorCheckBoxFormEditorProvider.cs
+++ b/src/AutoUI/Core/PropertyHandlers/FormEditors/MultiSelectorCheckBoxFormEditorProvider.cs
@@ -3,6 +3,7 @@ using DotVVM.AutoUI.Metadata;
 using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.Utils;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DotVVM.AutoUI.PropertyHandlers.FormEditors;
 
@@ -17,7 +18,8 @@ public class MultiSelectorCheckBoxFormEditorProvider : FormEditorProviderBase
     public override DotvvmControl CreateControl(PropertyDisplayMetadata property, AutoEditor.Props props, AutoUIContext context)
     {
         var selectorConfiguration = property.SelectionConfiguration!;
-        var selectorDataSourceBinding = SelectorHelper.DiscoverSelectorDataSourceBinding(context, selectorConfiguration.SelectionType);
+        var selectorDiscoveryService = context.Services.GetRequiredService<ISelectorDiscoveryService>();
+        var selectorDataSourceBinding = selectorDiscoveryService.DiscoverSelectorDataSourceBinding(context, selectorConfiguration.SelectionType);
         var nestedDataContext = context.CreateChildDataContextStack(selectorConfiguration.SelectionType);
 
         return new Repeater()

--- a/src/AutoUI/Core/PropertyHandlers/FormEditors/SelectorComboBoxFormEditorProvider.cs
+++ b/src/AutoUI/Core/PropertyHandlers/FormEditors/SelectorComboBoxFormEditorProvider.cs
@@ -2,6 +2,7 @@
 using DotVVM.AutoUI.Metadata;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.Utils;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DotVVM.AutoUI.PropertyHandlers.FormEditors
 {
@@ -16,7 +17,8 @@ namespace DotVVM.AutoUI.PropertyHandlers.FormEditors
         public override DotvvmControl CreateControl(PropertyDisplayMetadata property, AutoEditor.Props props, AutoUIContext context)
         {
             var selectorConfiguration = property.SelectionConfiguration!;
-            var selectorDataSourceBinding = SelectorHelper.DiscoverSelectorDataSourceBinding(context, selectorConfiguration.SelectionType);
+            var selectorDiscoveryService = context.Services.GetRequiredService<ISelectorDiscoveryService>();
+            var selectorDataSourceBinding = selectorDiscoveryService.DiscoverSelectorDataSourceBinding(context, selectorConfiguration.SelectionType);
             var nestedDataContext = context.CreateChildDataContextStack(selectorConfiguration.SelectionType);
 
             return new ComboBox()

--- a/src/AutoUI/Core/PropertyHandlers/ISelectorDiscoveryService.cs
+++ b/src/AutoUI/Core/PropertyHandlers/ISelectorDiscoveryService.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using DotVVM.Framework.Binding.Expressions;
+
+namespace DotVVM.AutoUI.PropertyHandlers;
+
+public interface ISelectorDiscoveryService
+{
+    IValueBinding DiscoverSelectorDataSourceBinding(AutoUIContext autoUiContext, Type propertyType);
+}

--- a/src/AutoUI/Core/PropertyHandlers/SelectorDiscoveryService.cs
+++ b/src/AutoUI/Core/PropertyHandlers/SelectorDiscoveryService.cs
@@ -10,10 +10,10 @@ using DotVVM.Framework.Controls;
 
 namespace DotVVM.AutoUI.PropertyHandlers
 {
-    public class SelectorHelper
+    public class SelectorDiscoveryService : ISelectorDiscoveryService 
     {
 
-        public static IValueBinding DiscoverSelectorDataSourceBinding(AutoUIContext autoUiContext, Type propertyType)
+        public IValueBinding DiscoverSelectorDataSourceBinding(AutoUIContext autoUiContext, Type propertyType)
         {
             var viewModelType = typeof(ISelectorViewModel<>).MakeGenericType(propertyType);
 
@@ -49,7 +49,7 @@ namespace DotVVM.AutoUI.PropertyHandlers
             throw new DotvvmControlException($"No property of type {viewModelType.FullName} was found in the viewmodel {autoUiContext.DataContextStack}!");
         }
 
-        private static Expression[] FindSelectorProperties(Expression parent, Type selectorViewModelType)
+        protected virtual Expression[] FindSelectorProperties(Expression parent, Type selectorViewModelType)
         {
             var directProperties = parent.Type
                 .GetProperties(BindingFlags.Instance | BindingFlags.Public)


### PR DESCRIPTION
The `SelectorHelper` is recursively browsing the viewmodel and looks for properties `ISelectionViewModel<TSelectionItem>`.
By default, it looks only into the child objects which implement `IDotvvmViewModel` but I need to be able to extend this behavior to look also into `Tuple` or other tuple-like structures.