### PR TITLE
Remove runtime dependency from compiler pipeline

### DIFF
--- a/src/Framework/Framework/Binding/ViewModuleReferenceInfo.cs
+++ b/src/Framework/Framework/Binding/ViewModuleReferenceInfo.cs
@@ -18,15 +18,21 @@ namespace DotVVM.Framework.Binding
     public sealed class ViewModuleReferenceInfo
     {
         public string[] ReferencedModules { get; }
+
         /// <summary>The modules are referenced under an Id to the dotvvm client-side runtime. The same ID must be used in the invocation from the _js literal.</summary>
-        public string ViewId { get; }
+        public string ViewId
+        {
+            get => viewId ?? throw new ArgumentException($"{nameof(ViewId)} has not been set.");
+            internal set => viewId = value;
+        }
+        private string? viewId;
 
         /// <summary> Whether control id should be used instead of ViewId to identify the modules. </summary>
         public bool IsMarkupControl { get; }
 
-        public ViewModuleReferenceInfo(string viewId, string[] referencedModules, bool isMarkupControl)
+        public ViewModuleReferenceInfo(string? viewId, string[] referencedModules, bool isMarkupControl)
         {
-            this.ViewId = viewId;
+            this.viewId = viewId;
             this.IsMarkupControl = isMarkupControl;
 
             // sort modules so the ID is deterministic

--- a/src/Framework/Framework/Binding/ViewModuleReferenceInfo.cs
+++ b/src/Framework/Framework/Binding/ViewModuleReferenceInfo.cs
@@ -20,19 +20,14 @@ namespace DotVVM.Framework.Binding
         public string[] ReferencedModules { get; }
 
         /// <summary>The modules are referenced under an Id to the dotvvm client-side runtime. The same ID must be used in the invocation from the _js literal.</summary>
-        public string ViewId
-        {
-            get => viewId ?? throw new ArgumentException($"{nameof(ViewId)} has not been set.");
-            internal set => viewId = value;
-        }
-        private string? viewId;
+        public string? ViewId { get; internal set; }
 
         /// <summary> Whether control id should be used instead of ViewId to identify the modules. </summary>
         public bool IsMarkupControl { get; }
 
         public ViewModuleReferenceInfo(string? viewId, string[] referencedModules, bool isMarkupControl)
         {
-            this.viewId = viewId;
+            this.ViewId = viewId;
             this.IsMarkupControl = isMarkupControl;
 
             // sort modules so the ID is deterministic
@@ -59,6 +54,9 @@ namespace DotVVM.Framework.Binding
                     throw new Exception($"The resource named '{moduleResourceName}' referenced by the @js directive must be of the ScriptModuleResource type!");
                 return moduleResource.Dependencies;
             }).Distinct().ToArray();
+
+            if (ViewId == null)
+                throw new ArgumentException($"{nameof(ViewId)} has not been set.");
 
             return (
                 new ViewModuleImportResource(ReferencedModules, ImportResourceName, dependencies),

--- a/src/Framework/Framework/Compilation/ControlTree/BindingExtensionParameter.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/BindingExtensionParameter.cs
@@ -182,12 +182,20 @@ namespace DotVVM.Framework.Compilation.ControlTree
 
     public class JsExtensionParameter : BindingExtensionParameter
     {
-        public string Id { get; }
-        public bool IsMarkupControl { get; }
-        public JsExtensionParameter(string id, bool isMarkupControl) : base("_js", new ResolvedTypeDescriptor(typeof(JsBindingApi)), true)
+        public string Id
         {
-            this.Id = id;
-            this.IsMarkupControl = isMarkupControl;
+            get => id ?? throw new ArgumentException($"{nameof(Id)} has not been set.");
+            internal set => id = value;
+        }
+        private string? id;
+
+        public bool IsMarkupControl { get; }
+
+        public JsExtensionParameter(string? id, bool isMarkupControl)
+            : base("_js", new ResolvedTypeDescriptor(typeof(JsBindingApi)), true)
+        {
+            this.id = id;
+            IsMarkupControl = isMarkupControl;
         }
         public override Expression GetServerEquivalent(Expression controlParameter)
         {

--- a/src/Framework/Framework/Compilation/ControlTree/BindingExtensionParameter.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/BindingExtensionParameter.cs
@@ -182,19 +182,14 @@ namespace DotVVM.Framework.Compilation.ControlTree
 
     public class JsExtensionParameter : BindingExtensionParameter
     {
-        public string Id
-        {
-            get => id ?? throw new ArgumentException($"{nameof(Id)} has not been set.");
-            internal set => id = value;
-        }
-        private string? id;
+        public string? Id { get; internal set; }
 
         public bool IsMarkupControl { get; }
 
         public JsExtensionParameter(string? id, bool isMarkupControl)
             : base("_js", new ResolvedTypeDescriptor(typeof(JsBindingApi)), true)
         {
-            this.id = id;
+            Id = id;
             IsMarkupControl = isMarkupControl;
         }
         public override Expression GetServerEquivalent(Expression controlParameter)
@@ -204,6 +199,9 @@ namespace DotVVM.Framework.Compilation.ControlTree
 
         public override JsExpression GetJsTranslation(JsExpression dataContext)
         {
+            if (Id == null)
+                throw new ArgumentException($"{nameof(Id)} has not been set.");
+
             return new JsIdentifierExpression("dotvvm").Member("viewModules").WithAnnotation(new ViewModuleAnnotation(Id, IsMarkupControl));
         }
 

--- a/src/Framework/Framework/Compilation/ControlTree/ControlTreeResolverBase.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ControlTreeResolverBase.cs
@@ -11,6 +11,8 @@ using DotVVM.Framework.Utils;
 using DotVVM.Framework.Binding;
 using System.Diagnostics.CodeAnalysis;
 using DotVVM.Framework.Compilation.Directives;
+using DotVVM.Framework.Compilation.Binding;
+using DotVVM.Framework.Compilation.ViewCompiler;
 
 namespace DotVVM.Framework.Compilation.ControlTree
 {
@@ -58,14 +60,28 @@ namespace DotVVM.Framework.Compilation.ControlTree
             }.Concat(directiveMetadata.InjectedServices)
              .Concat(directiveMetadata.ViewModuleResult is null ? new BindingExtensionParameter[0] : new[] { directiveMetadata.ViewModuleResult.ExtensionParameter }).ToArray());
 
-            var view = treeBuilder.BuildTreeRoot(this, viewMetadata, root, dataContextTypeStack, directiveMetadata.Directives, directiveMetadata.MasterPage);
+            // Resolve master page
+            IAbstractControlBuilderDescriptor? masterPage = null;
+            if (directiveMetadata.MasterPageDirective is IAbstractDirective masterPageDirective)
+            {
+                masterPage = ResolveMasterPage(fileName, masterPageDirective);
+                ValidateMasterPage(directiveMetadata.ViewModelType, masterPageDirective, masterPage);
+            }
+
+            var view = treeBuilder.BuildTreeRoot(this, viewMetadata, root, dataContextTypeStack, directiveMetadata.Directives, masterPage);
             view.FileName = fileName;
 
             if (directiveMetadata.ViewModuleResult is { })
             {
+                // Resolve viewmodul IDs
+                var viewModuleId = AssignViewModuleId(masterPage);
+                var viewModuleCompilationResult = directiveMetadata.ViewModuleResult;
+                viewModuleCompilationResult.ExtensionParameter.Id = viewModuleId;
+                viewModuleCompilationResult.Reference.ViewId = viewModuleId;
+
                 treeBuilder.AddProperty(
                     view,
-                    treeBuilder.BuildPropertyValue(Internal.ReferencedViewModuleInfoProperty, directiveMetadata.ViewModuleResult.Reference, null),
+                    treeBuilder.BuildPropertyValue(Internal.ReferencedViewModuleInfoProperty, viewModuleCompilationResult.Reference, null),
                     out _
                 );
             }
@@ -73,7 +89,39 @@ namespace DotVVM.Framework.Compilation.ControlTree
             ResolveRootContent(root, view, viewMetadata);
 
             return view;
-        }     
+        }
+
+        protected abstract IAbstractControlBuilderDescriptor? ResolveMasterPage(string currentFile, IAbstractDirective masterPageDirective);
+
+        protected virtual void ValidateMasterPage(ITypeDescriptor? viewModel, IAbstractDirective masterPageDirective, IAbstractControlBuilderDescriptor? masterPage)
+        {
+            if (masterPage is null || viewModel is null)
+            {
+                return;
+            }
+
+            if (masterPage.DataContextType is ResolvedTypeDescriptor typeDescriptor && typeDescriptor.Type == typeof(UnknownTypeSentinel))
+            {
+                masterPageDirective!.DothtmlNode!.AddError("Could not resolve the type of viewmodel for the specified master page. " +
+                    $"This usually means that there is an error with the @viewModel directive in the master page file: \"{masterPage.FileName}\". " +
+                    $"Make sure that the provided viewModel type is correct and visible for DotVVM.");
+            }
+            else if (!masterPage.DataContextType.IsAssignableFrom(viewModel))
+            {
+                masterPageDirective!.DothtmlNode!.AddError($"The viewmodel {viewModel.Name} is not assignable to the viewmodel of the master page {masterPage.DataContextType.Name}.");
+            }
+        }
+
+        protected virtual string AssignViewModuleId(IAbstractControlBuilderDescriptor? masterPage)
+        {
+            var numberOfMasterPages = 0;
+            while (masterPage != null)
+            {
+                masterPage = masterPage.MasterPage;
+                numberOfMasterPages += 1;
+            }
+            return "p" + numberOfMasterPages;
+        }
 
         /// <summary>
         /// Resolves the content of the root node.

--- a/src/Framework/Framework/Compilation/ControlTree/ControlTreeResolverBase.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ControlTreeResolverBase.cs
@@ -73,7 +73,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
 
             if (directiveMetadata.ViewModuleResult is { })
             {
-                // Resolve viewmodul IDs
+                // Resolve viewmodule IDs
                 var viewModuleId = AssignViewModuleId(masterPage);
                 var viewModuleCompilationResult = directiveMetadata.ViewModuleResult;
                 viewModuleCompilationResult.ExtensionParameter.Id = viewModuleId;

--- a/src/Framework/Framework/Compilation/Directives/MarkupDirectiveCompilerPipeline.cs
+++ b/src/Framework/Framework/Compilation/Directives/MarkupDirectiveCompilerPipeline.cs
@@ -12,13 +12,11 @@ namespace DotVVM.Framework.Compilation.Directives
     public class MarkupDirectiveCompilerPipeline : IMarkupDirectiveCompilerPipeline
     {
         private readonly IAbstractTreeBuilder treeBuilder;
-        private readonly IControlBuilderFactory controlBuilderFactory;
         private readonly DotvvmResourceRepository resourceRepository;
 
-        public MarkupDirectiveCompilerPipeline(IAbstractTreeBuilder treeBuilder, IControlBuilderFactory controlBuilderFactory, DotvvmResourceRepository resourceRepository)
+        public MarkupDirectiveCompilerPipeline(IAbstractTreeBuilder treeBuilder, DotvvmResourceRepository resourceRepository)
         {
             this.treeBuilder = treeBuilder;
-            this.controlBuilderFactory = controlBuilderFactory;
             this.resourceRepository = resourceRepository;
         }
 
@@ -41,7 +39,7 @@ namespace DotVVM.Framework.Compilation.Directives
             if (!string.IsNullOrEmpty(viewModelType.Error)) { dothtmlRoot.AddError(viewModelType.Error!); }
             resolvedDirectives.AddIfAny(viewModelDirectiveCompiler.DirectiveName, viewModelTypeResult.Directives);
 
-            var masterPageDirectiveCompiler = new MasterPageDirectiveCompiler(directivesByName, treeBuilder, controlBuilderFactory, viewModelType.TypeDescriptor);
+            var masterPageDirectiveCompiler = new MasterPageDirectiveCompiler(directivesByName, treeBuilder);
             var masterPageDirectiveResult = masterPageDirectiveCompiler.Compile();
             var masterPage = masterPageDirectiveResult.Artefact;
             resolvedDirectives.AddIfAny(masterPageDirectiveCompiler.DirectiveName, masterPageDirectiveResult.Directives);
@@ -58,7 +56,6 @@ namespace DotVVM.Framework.Compilation.Directives
             var viewModuleDirectiveCompiler = new ViewModuleDirectiveCompiler(
                 directivesByName,
                 treeBuilder,
-                masterPage,
                 !baseType.IsEqualTo(ResolvedTypeDescriptor.Create(typeof(DotvvmView))),
                 resourceRepository);
             var viewModuleResult = viewModuleDirectiveCompiler.Compile();

--- a/src/Framework/Framework/Compilation/Directives/MarkupPageMetadata.cs
+++ b/src/Framework/Framework/Compilation/Directives/MarkupPageMetadata.cs
@@ -1,15 +1,14 @@
-﻿using DotVVM.Framework.Compilation.ControlTree;
-using DotVVM.Framework.Binding;
+﻿using System.Collections.Generic;
 using System.Collections.Immutable;
-using DotVVM.Framework.Compilation.ViewCompiler;
-using System.Collections.Generic;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Compilation.ControlTree;
 
 namespace DotVVM.Framework.Compilation.Directives
 {
     public record MarkupPageMetadata(
            IReadOnlyDictionary<string, IReadOnlyList<IAbstractDirective>> Directives,
            ImmutableList<NamespaceImport> Imports,
-           IAbstractControlBuilderDescriptor? MasterPage,
+           IAbstractDirective? MasterPageDirective,
            ImmutableList<InjectedServiceExtensionParameter> InjectedServices,
            ITypeDescriptor BaseType,
            ITypeDescriptor? ViewModelType,

--- a/src/Framework/Framework/Compilation/Directives/MasterPageDirectiveCompiler.cs
+++ b/src/Framework/Framework/Compilation/Directives/MasterPageDirectiveCompiler.cs
@@ -1,72 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using DotVVM.Framework.Compilation.Parser.Dothtml.Parser;
+﻿using System.Collections.Generic;
+using System.Linq;
 using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Compilation.Parser;
-using System.Linq;
-using DotVVM.Framework.Compilation.ViewCompiler;
-using DotVVM.Framework.Compilation.ControlTree.Resolved;
-using DotVVM.Framework.Compilation.Binding;
+using DotVVM.Framework.Compilation.Parser.Dothtml.Parser;
 
 namespace DotVVM.Framework.Compilation.Directives
 {
-    public class MasterPageDirectiveCompiler : DirectiveCompiler<IAbstractDirective, IAbstractControlBuilderDescriptor?>
+    public class MasterPageDirectiveCompiler : DirectiveCompiler<IAbstractDirective, IAbstractDirective?>
     {
-        private readonly IControlBuilderFactory controlBuilderFactory;
-        private readonly ITypeDescriptor? viewModel;
-
-        public MasterPageDirectiveCompiler(IReadOnlyDictionary<string, IReadOnlyList<DothtmlDirectiveNode>> directiveNodesByName, IAbstractTreeBuilder treeBuilder, IControlBuilderFactory controlBuilderFactory, ITypeDescriptor? viewModel)
+        public MasterPageDirectiveCompiler(IReadOnlyDictionary<string, IReadOnlyList<DothtmlDirectiveNode>> directiveNodesByName, IAbstractTreeBuilder treeBuilder)
             : base(directiveNodesByName, treeBuilder)
         {
-            this.controlBuilderFactory = controlBuilderFactory;
-            this.viewModel = viewModel;
         }
 
         public override string DirectiveName => ParserConstants.MasterPageDirective;
 
-        protected override IAbstractControlBuilderDescriptor? CreateArtefact(IReadOnlyList<IAbstractDirective> resolvedDirectives)
+        protected override IAbstractDirective? CreateArtefact(IReadOnlyList<IAbstractDirective> resolvedDirectives)
         {
-            var masterPageDirective = resolvedDirectives.FirstOrDefault();
-
-            if(masterPageDirective == null)
-            {
-                return null;
-            }
-
-            try
-            {
-                var masterPage = controlBuilderFactory.GetControlBuilder(masterPageDirective.Value).descriptor;
-                ValidateMasterPage(viewModel, masterPageDirective, masterPage);
-                return masterPage;
-            }
-            catch (Exception e)
-            {
-                // The resolver should not just crash on an invalid directive
-                masterPageDirective.DothtmlNode!.AddError(e.Message);
-                return null;
-            }
+            return resolvedDirectives.FirstOrDefault();
         }
 
         protected override IAbstractDirective Resolve(DothtmlDirectiveNode d) => TreeBuilder.BuildDirective(d);
-
-        protected virtual void ValidateMasterPage(ITypeDescriptor? viewModel, IAbstractDirective masterPageDirective, IAbstractControlBuilderDescriptor? masterPage)
-        {
-            if (masterPage is null || viewModel is null)
-            {
-                return;
-            }
-
-            if (masterPage.DataContextType is ResolvedTypeDescriptor typeDescriptor && typeDescriptor.Type == typeof(UnknownTypeSentinel))
-            {
-                masterPageDirective!.DothtmlNode!.AddError("Could not resolve the type of viewmodel for the specified master page. " +
-                    $"This usually means that there is an error with the @viewModel directive in the master page file: \"{masterPage.FileName}\". " +
-                    $"Make sure that the provided viewModel type is correct and visible for DotVVM.");
-            }
-            else if (!masterPage.DataContextType.IsAssignableFrom(viewModel))
-            {
-                masterPageDirective!.DothtmlNode!.AddError($"The viewmodel {viewModel.Name} is not assignable to the viewmodel of the master page {masterPage.DataContextType.Name}.");
-            }
-        }
     }
-
 }

--- a/src/Framework/Framework/Compilation/Directives/ViewModuleDirectiveCompiler.cs
+++ b/src/Framework/Framework/Compilation/Directives/ViewModuleDirectiveCompiler.cs
@@ -5,20 +5,17 @@ using DotVVM.Framework.Compilation.Parser;
 using System.Linq;
 using DotVVM.Framework.Binding;
 using DotVVM.Framework.ResourceManagement;
-using DotVVM.Framework.Compilation.ViewCompiler;
 
 namespace DotVVM.Framework.Compilation.Directives
 {
     public class ViewModuleDirectiveCompiler : DirectiveCompiler<IAbstractViewModuleDirective, ViewModuleCompilationResult?>
     {
-        private readonly IAbstractControlBuilderDescriptor? masterPage;
         private readonly bool isMarkupControl;
         private readonly DotvvmResourceRepository resourceRepo;
 
-        public ViewModuleDirectiveCompiler(IReadOnlyDictionary<string, IReadOnlyList<DothtmlDirectiveNode>> directiveNodesByName, IAbstractTreeBuilder treeBuilder, IAbstractControlBuilderDescriptor? masterPage, bool isMarkupControl, DotvvmResourceRepository resourceRepo)
+        public ViewModuleDirectiveCompiler(IReadOnlyDictionary<string, IReadOnlyList<DothtmlDirectiveNode>> directiveNodesByName, IAbstractTreeBuilder treeBuilder, bool isMarkupControl, DotvvmResourceRepository resourceRepo)
             : base(directiveNodesByName, treeBuilder)
         {
-            this.masterPage = masterPage;
             this.isMarkupControl = isMarkupControl;
             this.resourceRepo = resourceRepo;
         }
@@ -27,11 +24,10 @@ namespace DotVVM.Framework.Compilation.Directives
 
         protected override ViewModuleCompilationResult? CreateArtefact(IReadOnlyList<IAbstractViewModuleDirective> resolvedDirectives)
         {
-            var id = AssignViewModuleId(masterPage);
-            return ResolveImportedViewModules(resolvedDirectives, id);
+            return ResolveImportedViewModules(resolvedDirectives);
         }
 
-        private ViewModuleCompilationResult? ResolveImportedViewModules(IReadOnlyList<IAbstractViewModuleDirective> moduleDirectives, string id)
+        private ViewModuleCompilationResult? ResolveImportedViewModules(IReadOnlyList<IAbstractViewModuleDirective> moduleDirectives)
         {
             if (moduleDirectives.Count == 0)
             {
@@ -58,21 +54,13 @@ namespace DotVVM.Framework.Compilation.Directives
                 })
                 .ToArray();
 
-            return new ViewModuleCompilationResult(new JsExtensionParameter(id, isMarkupControl), new ViewModuleReferenceInfo(id, resources, isMarkupControl));
+            return new ViewModuleCompilationResult(
+                new JsExtensionParameter(null, isMarkupControl),
+                new ViewModuleReferenceInfo(null, resources, isMarkupControl));
         }
 
-        protected virtual string AssignViewModuleId(IAbstractControlBuilderDescriptor? masterPage)
-        {
-            var numberOfMasterPages = 0;
-            while (masterPage != null)
-            {
-                masterPage = masterPage.MasterPage;
-                numberOfMasterPages += 1;
-            }
-            return "p" + numberOfMasterPages;
-        }
         protected override IAbstractViewModuleDirective Resolve(DothtmlDirectiveNode directiveNode) =>
             TreeBuilder.BuildViewModuleDirective(directiveNode, modulePath: directiveNode.Value, resourceName: directiveNode.Value);
-}
+    }
 
 }

--- a/src/Framework/Framework/Controls/Content.cs
+++ b/src/Framework/Framework/Controls/Content.cs
@@ -54,6 +54,9 @@ namespace DotVVM.Framework.Controls
                 var settings = DefaultSerializerSettingsProvider.Instance.GetSettingsCopy();
                 settings.StringEscapeHandling = StringEscapeHandling.EscapeHtml;
 
+                if (viewModule.ViewId == null)
+                    throw new ArgumentException($"ViewModule's property {nameof(viewModule.ViewId)} has not been set.");
+
                 writer.WriteKnockoutDataBindComment("dotvvm-with-view-modules",
                     $"{{ viewId: {KnockoutHelper.MakeStringLiteral(viewModule.ViewId)}, modules: {JsonConvert.SerializeObject(viewModule.ReferencedModules, settings)} }}"
                 );

--- a/src/Framework/Framework/Controls/ViewModuleHelpers.cs
+++ b/src/Framework/Framework/Controls/ViewModuleHelpers.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using DotVVM.Framework.Binding;
 using DotVVM.Framework.Binding.Expressions;
@@ -15,6 +16,9 @@ namespace DotVVM.Framework.Controls
             }
             else
             {
+                if (viewModuleInfo.ViewId == null)
+                    throw new ArgumentException($"ViewModule's property {nameof(viewModuleInfo.ViewId)} has not been set.");
+
                 return KnockoutHelper.MakeStringLiteral(viewModuleInfo.ViewId);
             }
         }


### PR DESCRIPTION
This PR fixes a couple of problems introduced to the compiler pipeline's internal API in version 4.1. These fixes make it significantly easier to adopt DotVVM 4.1 for VS Extension.

**What was not ideal**:
* `IMarkupDirectiveCompilerPipeline` required `IControlBuilderFactory` whose implementation directly depends on runtime information (`CompiledAssemblyCache` and others)
* The runtime information was needed to achieve three things:
  * Master page is being resolved almost immediately
  * Resolved master page is used to validate its viewmodel
  * Resolved master page is used to assign view modul IDs (if any modules are present)

**Changes in this PR**:
* Master page is being resolved by `DefaultControlTreeResolver`, which is called by `ControlTreeResolverBase.ResolveTree(...)`
* Master page is validated in the `ResolveTree(...)` method as well
* ViewModul IDs are assigned in the `ResolveTree(...)` method too