### PR TITLE
Add member shadowing detection routine

### DIFF
--- a/src/Framework/Framework/ViewModel/Serialization/ViewModelSerializationMap.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/ViewModelSerializationMap.cs
@@ -53,14 +53,11 @@ namespace DotVVM.Framework.ViewModel.Serialization
             var hashset = new HashSet<string>();
             foreach (var propertyMap in Properties)
             {
-                if (!hashset.Contains(propertyMap.Name))
+                if (!hashset.Add(propertyMap.Name))
                 {
-                    hashset.Add(propertyMap.Name);
-                    continue;
+                    throw new InvalidOperationException($"Detected member shadowing on property \"{propertyMap.Name}\" " +
+                        $"while building serialization map for \"{Type.ToCode()}\"");
                 }
-
-                throw new InvalidOperationException($"Detected member shadowing on property \"{propertyMap.Name}\" " +
-                    $"while building serialization map for \"{Type.ToCode()}\"");
             }
         }
 

--- a/src/Framework/Framework/ViewModel/Serialization/ViewModelSerializationMap.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/ViewModelSerializationMap.cs
@@ -45,6 +45,23 @@ namespace DotVVM.Framework.ViewModel.Serialization
             Constructor = constructor;
             Properties = properties.ToImmutableArray();
             OriginalProperties = Properties.Select(p => (p.Name, p.Type, p.BindDirection, p.ViewModelProtection)).ToArray();
+            ValidatePropertyMap();
+        }
+
+        private void ValidatePropertyMap()
+        {
+            var hashset = new HashSet<string>();
+            foreach (var propertyMap in Properties)
+            {
+                if (!hashset.Contains(propertyMap.Name))
+                {
+                    hashset.Add(propertyMap.Name);
+                    continue;
+                }
+
+                throw new InvalidOperationException($"Detected member shadowing on property \"{propertyMap.Name}\" " +
+                    $"while building serialization map for \"{Type.ToCode()}\"");
+            }
         }
 
         public void ResetFunctions()

--- a/src/Tests/ViewModel/ViewModelSerializationMapperTests.cs
+++ b/src/Tests/ViewModel/ViewModelSerializationMapperTests.cs
@@ -5,6 +5,7 @@ using DotVVM.Framework.Configuration;
 using DotVVM.Framework.ViewModel;
 using DotVVM.Framework.ViewModel.Serialization;
 using DotVVM.Framework.ViewModel.Validation;
+using FastExpressionCompiler;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 
@@ -32,6 +33,30 @@ namespace DotVVM.Framework.Tests.ViewModel
             Assert.AreEqual("jsonProperty3", map.Property("BindWithoutNameJsonPropertyWithName").Name);
         }
 
+        [TestMethod]
+        public void ViewModelSerializationMapper_Name_MemberShadowing()
+        {
+            var mapper = new ViewModelSerializationMapper(new ViewModelValidationRuleTranslator(),
+                new AttributeViewModelValidationMetadataProvider(),
+                new DefaultPropertySerialization(),
+                DotvvmConfiguration.CreateDefault());
+
+            Assert.ThrowsException<InvalidOperationException>(() => mapper.GetMap(typeof(MemberShadowingViewModelB)),
+                $"Detected member shadowing on property \"{nameof(MemberShadowingViewModelB.Property)}\" " +
+                $"while building serialization map for \"{typeof(MemberShadowingViewModelB).ToCode()}\"");
+        }
+
+        public class MemberShadowingViewModelA
+        {
+            public object Property { get; set; }
+        }
+
+        public class MemberShadowingViewModelB : MemberShadowingViewModelA
+        {
+#pragma warning disable CS0108 // Member hides inherited member; missing new keyword
+            public string Property { get; set; }
+#pragma warning restore CS0108 // Member hides inherited member; missing new keyword
+        }
 
         public class JsonPropertyVsBindAttribute
         {


### PR DESCRIPTION
This PR adds a routine that checks for member shadowing. Even though users get the following warning from Roslyn: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0108, I have already seen a couple of reports that crash during runtime on something similar to this:

![image](https://user-images.githubusercontent.com/12575176/230029035-856926d9-b89c-46a2-b728-158ee1d34265.png)

While it is still not supported, this change should throw a more descriptive exception that points directly to the source of this issue and also does the check a bit sooner.