### PR TITLE
Fix global extension methods in bindings

### DIFF
--- a/src/Framework/Framework/Compilation/Binding/MemberExpressionFactory.cs
+++ b/src/Framework/Framework/Compilation/Binding/MemberExpressionFactory.cs
@@ -283,7 +283,8 @@ namespace DotVVM.Framework.Compilation.Binding
 
         private IEnumerable<MethodInfo> GetAllExtensionMethods()
         {
-            return extensionMethodsCache.GetExtensionsForNamespaces(importedNamespaces.Select(ns => ns.Namespace).Distinct().ToArray());
+            var globalNamespace = "";
+            return extensionMethodsCache.GetExtensionsForNamespaces(importedNamespaces.Select(ns => ns.Namespace).Append(globalNamespace).Distinct().ToArray());
         }
 
         private List<MethodRecognitionResult> FindValidMethodOverloads(IEnumerable<MethodInfo> methods, string name, bool isExtension, Type[]? typeArguments, Expression[] arguments, IDictionary<string, Expression>? namedArgs)

--- a/src/Framework/Framework/Compilation/ExtensionMethodsCache.cs
+++ b/src/Framework/Framework/Compilation/ExtensionMethodsCache.cs
@@ -66,7 +66,7 @@ namespace DotVVM.Framework.Compilation
                     // check all flags first, these are much cheaper to get than the namespace
                     if (!(type.IsAbstract && type.IsSealed && type.IsClass))
                         continue;
-                    var typeNamespace = type.Namespace;
+                    var typeNamespace = type.Namespace ?? ""; // global namespace is empty string, otherwise we can't put it into Dictionary
                     for (int i = 0; i < namespaces.Length; i++)
                     {
                         if (!namespaces[i].Equals(typeNamespace, StringComparison.Ordinal)) continue;

--- a/src/Tests/Binding/CustomExtensionMethodTests.cs
+++ b/src/Tests/Binding/CustomExtensionMethodTests.cs
@@ -5,7 +5,9 @@ using System.Linq.Expressions;
 using System.Text;
 using DotVVM.Framework.Compilation;
 using DotVVM.Framework.Compilation.Binding;
+using DotVVM.Framework.Compilation.Javascript;
 using DotVVM.Framework.Controls;
+using DotVVM.Framework.Hosting;
 using DotVVM.Framework.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -177,6 +179,22 @@ namespace DotVVM.Framework.Tests.Binding
             var result = Expression.Lambda<Func<int>>(expression).Compile().Invoke();
             Assert.AreEqual(12, result);
         }
+
+        [TestMethod]
+        public void Call_GlobalExtensionMethod()
+        {
+            var expectedMethod = MethodFindingHelper.GetMethodFromExpression(() => default(IDotvvmRequestContext).RedirectToRoute("", null, false, true, "", null));
+            Assert.IsNull(expectedMethod.DeclaringType.Namespace, "The test is not valid if the method is not in the global namespace");
+            var importedTarget = new MethodGroupExpression(
+                Expression.Parameter(typeof(IDotvvmRequestContext)),
+                "RedirectToRoute"
+            );
+
+            var expression = CreateCall(importedTarget, new Expression[] { Expression.Constant("RouteName") }, new NamespaceImport[0]);
+            var methodCall = (MethodCallExpression)expression;
+            Assert.AreEqual(expectedMethod, methodCall.Method);
+        }
+
     }
 
     public static class TestExtensions


### PR DESCRIPTION
Extension methods on types without namespace should be accessible always.

Although it's a bugfix, I'd put it to 4.2. This has a potential to break something and it's low impact (workaround is to use the method as static)