### PR TITLE
Fix issue where property directive compiled without errors on a regular page

### DIFF
--- a/src/Framework/Framework/Compilation/Directives/BaseTypeDirectiveCompiler.cs
+++ b/src/Framework/Framework/Compilation/Directives/BaseTypeDirectiveCompiler.cs
@@ -14,7 +14,7 @@ namespace DotVVM.Framework.Compilation.Directives
 
     public class BaseTypeDirectiveCompiler : DirectiveCompiler<IAbstractBaseTypeDirective, ITypeDescriptor>
     {
-        private readonly string fileName;
+        private readonly bool isMarkupControl;
         private readonly ImmutableList<NamespaceImport> imports;
 
         public override string DirectiveName => ParserConstants.BaseTypeDirective;
@@ -23,10 +23,10 @@ namespace DotVVM.Framework.Compilation.Directives
         protected virtual ITypeDescriptor DotvvmMarkupControlType => new ResolvedTypeDescriptor(typeof(DotvvmMarkupControl));
 
         public BaseTypeDirectiveCompiler(
-            DirectiveDictionary directiveNodesByName, IAbstractTreeBuilder treeBuilder, string fileName, ImmutableList<NamespaceImport> imports)
+            DirectiveDictionary directiveNodesByName, IAbstractTreeBuilder treeBuilder, bool isMarkupControl, ImmutableList<NamespaceImport> imports)
             : base(directiveNodesByName, treeBuilder)
         {
-            this.fileName = fileName;
+            this.isMarkupControl = isMarkupControl;
             this.imports = imports;
         }
 
@@ -35,7 +35,7 @@ namespace DotVVM.Framework.Compilation.Directives
 
         protected override ITypeDescriptor CreateArtefact(ImmutableList<IAbstractBaseTypeDirective> resolvedDirectives)
         {
-            var wrapperType = GetDefaultWrapperType();
+            var wrapperType = GetDefaultWrapperType(isMarkupControl);
 
             var baseControlDirective = resolvedDirectives.SingleOrDefault();
 
@@ -70,15 +70,8 @@ namespace DotVVM.Framework.Compilation.Directives
         /// <summary>
         /// Gets the default type of the wrapper for the view.
         /// </summary>
-        private ITypeDescriptor GetDefaultWrapperType()
-        {
-            if (fileName.EndsWith(".dotcontrol", StringComparison.Ordinal))
-            {
-                return DotvvmMarkupControlType;
-            }
-
-            return DotvvmViewType;
-        }
+        private ITypeDescriptor GetDefaultWrapperType(bool isMarkupControl) =>
+            isMarkupControl ? DotvvmMarkupControlType : DotvvmViewType;
     }
 
 }

--- a/src/Framework/Framework/Compilation/Directives/MarkupDirectiveCompilerPipeline.cs
+++ b/src/Framework/Framework/Compilation/Directives/MarkupDirectiveCompilerPipeline.cs
@@ -4,6 +4,7 @@ using DotVVM.Framework.Controls.Infrastructure;
 using DotVVM.Framework.ResourceManagement;
 using System.Collections.Immutable;
 using DotVVM.Framework.Compilation.Parser.Dothtml.Parser;
+using System;
 
 namespace DotVVM.Framework.Compilation.Directives
 {
@@ -20,11 +21,18 @@ namespace DotVVM.Framework.Compilation.Directives
             this.resourceRepository = resourceRepository;
         }
 
+        protected override bool IsMarkupControl(string fileName)
+        {
+            if (fileName.EndsWith(".dotcontrol", StringComparison.OrdinalIgnoreCase))
+                return true;
+            return false;
+        }
+
         protected override DefaultDirectiveResolver CreateDefaultResolver(DirectiveDictionary directivesByName)
             => new(directivesByName, treeBuilder);
 
-        protected override PropertyDeclarationDirectiveCompiler CreatePropertyDirectiveCompiler(DirectiveDictionary directivesByName, ImmutableList<NamespaceImport> imports, ITypeDescriptor baseType)
-            => new ResolvedPropertyDeclarationDirectiveCompiler (directivesByName, treeBuilder, baseType, imports);
+        protected override PropertyDeclarationDirectiveCompiler CreatePropertyDirectiveCompiler(DirectiveDictionary directivesByName, bool isMarkupControl, ImmutableList<NamespaceImport> imports, ITypeDescriptor baseType)
+            => new ResolvedPropertyDeclarationDirectiveCompiler (directivesByName, treeBuilder, isMarkupControl, baseType, imports);
 
         protected override ViewModuleDirectiveCompiler CreateViewModuleDirectiveCompiler(DirectiveDictionary directivesByName, ITypeDescriptor baseType)
             => new(
@@ -33,8 +41,8 @@ namespace DotVVM.Framework.Compilation.Directives
                         !baseType.IsEqualTo(ResolvedTypeDescriptor.Create(typeof(DotvvmView))),
                         resourceRepository);
 
-        protected override BaseTypeDirectiveCompiler CreateBaseTypeCompiler(string fileName, DirectiveDictionary directivesByName, ImmutableList<NamespaceImport> imports)
-            => new BaseTypeDirectiveCompiler (directivesByName, treeBuilder, fileName, imports);
+        protected override BaseTypeDirectiveCompiler CreateBaseTypeCompiler(bool isMarkupControl, DirectiveDictionary directivesByName, ImmutableList<NamespaceImport> imports)
+            => new BaseTypeDirectiveCompiler (directivesByName, treeBuilder, isMarkupControl, imports);
         protected override ServiceDirectiveCompiler CreateServiceCompiler(DirectiveDictionary directivesByName, ImmutableList<NamespaceImport> imports)
             => new(directivesByName, treeBuilder, imports);
         protected override MasterPageDirectiveCompiler CreateMasterPageDirectiveCompiler(DirectiveDictionary directivesByName)

--- a/src/Framework/Framework/Compilation/Directives/MarkupDirectiveCompilerPipeline.cs
+++ b/src/Framework/Framework/Compilation/Directives/MarkupDirectiveCompilerPipeline.cs
@@ -4,7 +4,9 @@ using DotVVM.Framework.Controls.Infrastructure;
 using DotVVM.Framework.ResourceManagement;
 using System.Collections.Immutable;
 using DotVVM.Framework.Compilation.Parser.Dothtml.Parser;
+using DotVVM.Framework.Configuration;
 using System;
+using System.Linq;
 
 namespace DotVVM.Framework.Compilation.Directives
 {
@@ -14,18 +16,20 @@ namespace DotVVM.Framework.Compilation.Directives
     {
         private readonly IAbstractTreeBuilder treeBuilder;
         private readonly DotvvmResourceRepository resourceRepository;
+        private readonly DotvvmConfiguration configuration;
 
-        public MarkupDirectiveCompilerPipeline(IAbstractTreeBuilder treeBuilder, DotvvmResourceRepository resourceRepository) : base()
+        public MarkupDirectiveCompilerPipeline(IAbstractTreeBuilder treeBuilder, DotvvmConfiguration configuration) : base()
         {
             this.treeBuilder = treeBuilder;
-            this.resourceRepository = resourceRepository;
+            this.resourceRepository = configuration.Resources;
+            this.configuration = configuration;
         }
 
         protected override bool IsMarkupControl(string fileName)
         {
             if (fileName.EndsWith(".dotcontrol", StringComparison.OrdinalIgnoreCase))
                 return true;
-            return false;
+            return configuration.Markup.Controls.Any(c => c.Src == fileName);
         }
 
         protected override DefaultDirectiveResolver CreateDefaultResolver(DirectiveDictionary directivesByName)

--- a/src/Framework/Framework/Compilation/Directives/MarkupDirectiveCompilerPipelineBase.cs
+++ b/src/Framework/Framework/Compilation/Directives/MarkupDirectiveCompilerPipelineBase.cs
@@ -17,6 +17,8 @@ namespace DotVVM.Framework.Compilation.Directives
                 .GroupBy(d => d.Name, StringComparer.OrdinalIgnoreCase)
                 .ToImmutableDictionary(d => d.Key, d => d.ToImmutableList(), StringComparer.OrdinalIgnoreCase);
 
+            var isMarkupControl = IsMarkupControl(fileName);
+
             var resolvedDirectives = new Dictionary<string, ImmutableList<IAbstractDirective>>();
 
             var importCompiler = CreateImportCompiler(directivesByName);
@@ -39,19 +41,19 @@ namespace DotVVM.Framework.Compilation.Directives
             var injectedServicesResult = serviceCompiler.Compile();
             resolvedDirectives.AddIfAny(serviceCompiler.DirectiveName, injectedServicesResult.Directives);
 
-            var baseTypeCompiler = CreateBaseTypeCompiler(fileName, directivesByName, imports);
+            var baseTypeCompiler = CreateBaseTypeCompiler(isMarkupControl, directivesByName, imports);
             var baseTypeResult = baseTypeCompiler.Compile();
             var baseType = baseTypeResult.Artefact;
             resolvedDirectives.AddIfAny(baseTypeCompiler.DirectiveName, baseTypeResult.Directives);
 
-            var propertyDirectiveCompiler = CreatePropertyDirectiveCompiler(directivesByName, imports, baseType);
+            var propertyDirectiveCompiler = CreatePropertyDirectiveCompiler(directivesByName, isMarkupControl, imports, baseType);
             var propertyResult = propertyDirectiveCompiler.Compile();
             resolvedDirectives.AddIfAny(propertyDirectiveCompiler.DirectiveName, propertyResult.Directives);
 
             var viewModuleDirectiveCompiler = CreateViewModuleDirectiveCompiler(directivesByName, propertyResult.Artefact.ModifiedMarkupControlType);
             var viewModuleResult = viewModuleDirectiveCompiler.Compile();
             resolvedDirectives.AddIfAny(viewModuleDirectiveCompiler.DirectiveName, viewModuleResult.Directives);
-           
+
             var defaultResolver = CreateDefaultResolver(directivesByName);
 
             foreach (var directiveGroup in directivesByName)
@@ -73,12 +75,13 @@ namespace DotVVM.Framework.Compilation.Directives
                 propertyResult.Artefact.Properties);
         }
 
+        protected abstract bool IsMarkupControl(string fileName);
         protected abstract DefaultDirectiveResolver CreateDefaultResolver(DirectiveDictionary directivesByName);
-        protected abstract PropertyDeclarationDirectiveCompiler CreatePropertyDirectiveCompiler(DirectiveDictionary directivesByName, ImmutableList<NamespaceImport> imports, ITypeDescriptor baseType);
+        protected abstract PropertyDeclarationDirectiveCompiler CreatePropertyDirectiveCompiler(DirectiveDictionary directivesByName, bool isMarkupControl, ImmutableList<NamespaceImport> imports, ITypeDescriptor baseType);
         protected abstract ViewModuleDirectiveCompiler CreateViewModuleDirectiveCompiler(DirectiveDictionary directivesByName, ITypeDescriptor baseType);
         protected abstract MasterPageDirectiveCompiler CreateMasterPageDirectiveCompiler(DirectiveDictionary directivesByName);
         protected abstract ServiceDirectiveCompiler CreateServiceCompiler(DirectiveDictionary directivesByName, ImmutableList<NamespaceImport> imports);
-        protected abstract BaseTypeDirectiveCompiler CreateBaseTypeCompiler(string fileName, DirectiveDictionary directivesByName, ImmutableList<NamespaceImport> imports);
+        protected abstract BaseTypeDirectiveCompiler CreateBaseTypeCompiler(bool isMarkupControl, DirectiveDictionary directivesByName, ImmutableList<NamespaceImport> imports);
         protected abstract ImportDirectiveCompiler CreateImportCompiler(DirectiveDictionary directivesByName);
         protected abstract ViewModelDirectiveCompiler CreateViewModelDirectiveCompiler(string fileName, DirectiveDictionary directivesByName, ImmutableList<NamespaceImport> imports);
     }

--- a/src/Framework/Framework/Compilation/Directives/PropertyDeclarationDirectiveCompiler.cs
+++ b/src/Framework/Framework/Compilation/Directives/PropertyDeclarationDirectiveCompiler.cs
@@ -21,20 +21,27 @@ namespace DotVVM.Framework.Compilation.Directives
     {
         private readonly ITypeDescriptor controlWrapperType;
         private readonly ImmutableList<NamespaceImport> imports;
+        private readonly bool isMarkupControl;
 
         protected virtual ITypeDescriptor DotvvmMarkupControlType => new ResolvedTypeDescriptor(typeof(DotvvmMarkupControl));
 
         public override string DirectiveName => ParserConstants.PropertyDeclarationDirective;
 
-        public PropertyDeclarationDirectiveCompiler(ImmutableDictionary<string, ImmutableList<DothtmlDirectiveNode>> directiveNodesByName, IAbstractTreeBuilder treeBuilder, ITypeDescriptor controlWrapperType, ImmutableList<NamespaceImport> imports)
+        public PropertyDeclarationDirectiveCompiler(ImmutableDictionary<string, ImmutableList<DothtmlDirectiveNode>> directiveNodesByName, IAbstractTreeBuilder treeBuilder, bool isMarkupControl, ITypeDescriptor controlWrapperType, ImmutableList<NamespaceImport> imports)
             : base(directiveNodesByName, treeBuilder)
         {
+            this.isMarkupControl = isMarkupControl;
             this.controlWrapperType = controlWrapperType;
             this.imports = imports;
         }
 
         protected override IAbstractPropertyDeclarationDirective Resolve(DothtmlDirectiveNode directiveNode)
         {
+            if (!isMarkupControl)
+            {
+                directiveNode.AddError("Can not use the @property directive outside of a markup control");
+            }
+
             var valueSyntaxRoot = ParseDirective(directiveNode, p => p.ReadPropertyDirectiveValue());
 
             var declaration = valueSyntaxRoot as PropertyDeclarationBindingParserNode;
@@ -87,7 +94,7 @@ namespace DotVVM.Framework.Compilation.Directives
             }
 
             var attributePropertyReference = assignment.FirstExpression as MemberAccessBindingParserNode;
-            var initializer = assignment.SecondExpression; 
+            var initializer = assignment.SecondExpression;
             var attributeTypeReference = attributePropertyReference?.TargetExpression;
             var attributePropertyNameReference = attributePropertyReference?.MemberNameExpression;
 
@@ -111,7 +118,7 @@ namespace DotVVM.Framework.Compilation.Directives
 
         protected override PropertyDirectiveCompilerResult CreateArtefact(ImmutableList<IAbstractPropertyDeclarationDirective> directives)
         {
-            var generatedWrapperType = directives.Any()
+            var generatedWrapperType = directives.Any() && isMarkupControl
                     ? (CreateDynamicDeclaringType(controlWrapperType, directives) ?? controlWrapperType)
                     : controlWrapperType;
 

--- a/src/Framework/Framework/Compilation/Directives/ResolvedPropertyDeclarationDirectiveCompiler.cs
+++ b/src/Framework/Framework/Compilation/Directives/ResolvedPropertyDeclarationDirectiveCompiler.cs
@@ -16,9 +16,9 @@ namespace DotVVM.Framework.Compilation.Directives
 
         public ResolvedPropertyDeclarationDirectiveCompiler(
             ImmutableDictionary<string, ImmutableList<DothtmlDirectiveNode>> directiveNodesByName,
-            IAbstractTreeBuilder treeBuilder, ITypeDescriptor controlWrapperType,
+            IAbstractTreeBuilder treeBuilder, bool isMarkupControl, ITypeDescriptor controlWrapperType,
             ImmutableList<NamespaceImport> imports)
-            : base(directiveNodesByName, treeBuilder, controlWrapperType, imports)
+            : base(directiveNodesByName, treeBuilder, isMarkupControl, controlWrapperType, imports)
         {
         }
 

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/CompilationWarningsTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/CompilationWarningsTests.cs
@@ -188,30 +188,6 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
             Assert.AreEqual(1, literal.DothtmlNode.NodeWarnings.Count());
             Assert.AreEqual("Evaluation of method \"ToBrowserLocalTime\" on server-side may yield unexpected results.", literal.DothtmlNode.NodeWarnings.First());
         }
-
-        [TestMethod]
-        public void DefaultViewCompiler_DotvvmView_Used_As_Control_Warning()
-        {
-            var files = new FakeMarkupFileLoader();
-            files.MarkupFiles["TestControl.dothtml"] = """
-                @viewModel object
-                test
-            """;
-            var config = DotvvmTestHelper.CreateConfiguration(s => {
-                s.AddSingleton<IMarkupFileLoader>(files);
-            });
-            config.Markup.AddMarkupControl("cc", "TestControl", "TestControl.dothtml");
-
-            var markup = DotvvmTestHelper.ParseResolvedTree("""
-                @viewModel object
-                <cc:TestControl Styles.Tag=this />
-            """, configuration: config);
-            var control = markup.Content.SelectRecursively(c => c.Content).Single(c => c.Properties.ContainsKey(Styles.TagProperty));
-            Assert.AreEqual(typeof(DotvvmView), control.Metadata.Type);
-            var element = (DothtmlElementNode)control.DothtmlNode;
-            XAssert.Contains("The markup control <cc:TestControl> has a baseType DotvvmView", element.TagNameNode.NodeWarnings.First());
-            Assert.AreEqual(1, element.TagNameNode.NodeWarnings.Count());
-        }
     }
 
 }

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/PropertyDirectiveTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/PropertyDirectiveTests.cs
@@ -12,7 +12,8 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
         {
             var root = ParseSource(@$"
 @viewModel object
-@property string MyProperty, , DotVVM., DotVVM.Fra = , DotVVM.Framework.Controls.MarkupOptionsAttribute.Required = t");
+@property string MyProperty, , DotVVM., DotVVM.Fra = , DotVVM.Framework.Controls.MarkupOptionsAttribute.Required = t",
+                fileName: "x.dotcontrol");
 
             var property = root.Directives["property"].SingleOrDefault() as IAbstractPropertyDeclarationDirective;
 
@@ -32,7 +33,8 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
         {
             var root = ParseSource(@$"
 @viewModel object
-@property string MyProperty, DotVVM.Framework.Controls.MarkupOptionsAttribute.Required = 1");
+@property string MyProperty, DotVVM.Framework.Controls.MarkupOptionsAttribute.Required = 1",
+                fileName: "x.dotcontrol");
 
             var property = root.Directives["property"].SingleOrDefault() as IAbstractPropertyDeclarationDirective;
 
@@ -52,7 +54,8 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
         {
             var root = ParseSource(@$"
 @viewModel object
-@property string a=[, MarkupOptionsAttribute.Required = true");
+@property string a=[, MarkupOptionsAttribute.Required = true",
+                fileName: "x.dotcontrol");
 
             var property = root.Directives["property"].SingleOrDefault() as IAbstractPropertyDeclarationDirective;
 
@@ -69,7 +72,7 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
             var root = ParseSource("""
 @viewModel object
 @property string[] MyProperty=["",""], MarkupOptionsAttribute.Required = true, MarkupOptionsAttribute.AllowBinding = false
-""");
+""", fileName: "x.dotcontrol");
 
             var property = root.Directives["property"].SingleOrDefault() as IAbstractPropertyDeclarationDirective;
 
@@ -114,7 +117,7 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
         {
             var root = ParseSource(@"@viewModel object
 @property invalidType MyProperty
-");
+", fileName: "x.dotcontrol");
 
             var property = root.Directives["property"].Single() as IAbstractPropertyDeclarationDirective;
 
@@ -127,7 +130,7 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
         {
             var root = ParseSource(@"@viewModel object
 @property string MyProperty, DotVVM.Framework.Controls.NonExistingAttribute.Required = true
-");
+", fileName: "x.dotcontrol");
 
             var property = root.Directives["property"].Single() as IAbstractPropertyDeclarationDirective;
 

--- a/src/Tests/Runtime/DefaultViewCompilerTests.cs
+++ b/src/Tests/Runtime/DefaultViewCompilerTests.cs
@@ -196,9 +196,9 @@ test <dot:Literal><a /></dot:Literal>";
             });
 
             Assert.IsInstanceOfType(page, typeof(DotvvmView));
-            Assert.IsInstanceOfType(page.Children[0], typeof(DotvvmView));
+            Assert.IsInstanceOfType(page.Children[0], typeof(DotvvmMarkupControl));
 
-            var literal = page.Children[0].Children[0];
+            var literal = page.Children[0].Children[0].Children[0];
             Assert.IsInstanceOfType(literal, typeof(Literal));
             Assert.AreEqual("aaa", ((Literal)literal).Text);
         }
@@ -267,9 +267,10 @@ test <dot:Literal><a /></dot:Literal>";
             Assert.IsTrue(string.IsNullOrWhiteSpace(((RawLiteral)literal1).EncodedText));
 
             var markupControl = container.Children[1];
-            Assert.IsInstanceOfType(markupControl, typeof(DotvvmView));
-            Assert.IsInstanceOfType(markupControl.Children[0], typeof(Literal));
-            Assert.AreEqual("aaa", ((Literal)markupControl.Children[0]).Text);
+            Assert.IsInstanceOfType(markupControl, typeof(DotvvmMarkupControl));
+            Assert.IsInstanceOfType(markupControl.Children[0], typeof(PlaceHolder));
+            Assert.IsInstanceOfType(markupControl.Children[0].Children[0], typeof(Literal));
+            Assert.AreEqual("aaa", ((Literal)markupControl.Children[0].Children[0]).Text);
 
             var literal2 = container.Children[2];
             Assert.IsInstanceOfType(literal2, typeof(RawLiteral));
@@ -301,9 +302,10 @@ test <dot:Literal><a /></dot:Literal>";
             Assert.IsTrue(string.IsNullOrWhiteSpace(((RawLiteral)literal1).EncodedText));
 
             var markupControl = container.Children[1];
-            Assert.IsInstanceOfType(markupControl, typeof(DotvvmView));
-            Assert.IsInstanceOfType(markupControl.Children[0], typeof(Literal));
-            Assert.AreEqual("aaa", ((Literal)markupControl.Children[0]).Text);
+            Assert.IsInstanceOfType(markupControl, typeof(DotvvmMarkupControl));
+            Assert.IsInstanceOfType(markupControl.Children[0], typeof(PlaceHolder));
+            Assert.IsInstanceOfType(markupControl.Children[0].Children[0], typeof(Literal));
+            Assert.AreEqual("aaa", ((Literal)markupControl.Children[0].Children[0]).Text);
 
             var literal2 = container.Children[2];
             Assert.IsInstanceOfType(literal2, typeof(RawLiteral));


### PR DESCRIPTION
This PR fixes an issue where `@property ...` directive compiles just fine in a regular page. This feature is meant to be within markup controls only