### PR TITLE
AutoUi GetPropertiesToDisplay no longer internal

### DIFF
--- a/src/AutoUI/Core/Controls/AutoFormBase.cs
+++ b/src/AutoUI/Core/Controls/AutoFormBase.cs
@@ -61,7 +61,7 @@ namespace DotVVM.AutoUI.Controls
         /// <summary>
         /// Gets the list of properties that should be displayed.
         /// </summary>
-        protected static PropertyDisplayMetadata[] GetPropertiesToDisplay(AutoUIContext context, FieldSelectorProps props)
+        protected internal static PropertyDisplayMetadata[] GetPropertiesToDisplay(AutoUIContext context, FieldSelectorProps props)
         {
             var entityPropertyListProvider = context.Services.GetRequiredService<IEntityPropertyListProvider>();
             var properties = entityPropertyListProvider.GetProperties(context.EntityType, context.CreateViewContext());

--- a/src/AutoUI/Core/Controls/AutoFormBase.cs
+++ b/src/AutoUI/Core/Controls/AutoFormBase.cs
@@ -61,7 +61,7 @@ namespace DotVVM.AutoUI.Controls
         /// <summary>
         /// Gets the list of properties that should be displayed.
         /// </summary>
-        internal static PropertyDisplayMetadata[] GetPropertiesToDisplay(AutoUIContext context, FieldSelectorProps props)
+        protected static PropertyDisplayMetadata[] GetPropertiesToDisplay(AutoUIContext context, FieldSelectorProps props)
         {
             var entityPropertyListProvider = context.Services.GetRequiredService<IEntityPropertyListProvider>();
             var properties = entityPropertyListProvider.GetProperties(context.EntityType, context.CreateViewContext());


### PR DESCRIPTION
It would be nice to access `GetPropertiesToDisplay` in all derived classes when building new custom form. I am building form that is based on grid, so I do not want to inherit from `AutoForm`.