### PR TITLE
Fix non-unique markup control ID in MarkupControlContainer

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -45,13 +45,13 @@
 
   <PropertyGroup Condition="$(DOTVVM_ROOT) != ''">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-    <RepoRoot>$([MSBuild]::NormalizeDirectory('$(DOTVVM_ROOT)'))</RepoRoot>
+    <RepoRoot>$([MSBuild]::NormalizeDirectory('$(DOTVVM_ROOT)/'))</RepoRoot>
     <BaseOutputPath>$(RepoRoot)artifacts\bin\$(MSBuildProjectName)\</BaseOutputPath>
     <PackageOutputPath>$(RepoRoot)artifacts\packages\</PackageOutputPath>
   </PropertyGroup>
 
   <ItemGroup Condition="$(DOTVVM_ROOT) != ''">
-    <SourceRoot Include="$([MSBuild]::NormalizeDirectory('$(DOTVVM_ROOT)'))" />
+    <SourceRoot Include="$([MSBuild]::NormalizeDirectory('$(DOTVVM_ROOT)/'))" />
   </ItemGroup>
 
   <PropertyGroup Condition="$(DOTVVM_VERSION) != ''">

--- a/src/Framework/Framework/Controls/Infrastructure/MarkupControlContainer.cs
+++ b/src/Framework/Framework/Controls/Infrastructure/MarkupControlContainer.cs
@@ -10,6 +10,7 @@ namespace DotVVM.Framework.Controls.Infrastructure
 {
     /// <summary> Allows using markup controls from code controls or from server-side styles. Use like this <code>new MarkupControlContainer("cc:MyControl", c => c.SetValue(MyControl.NameProperty, "X"))</code> </summary>
     /// <seealso cref="MarkupControlContainer{TMarkupControl}"/>
+    [ControlMarkupOptions(AllowContent = false)]
     public class MarkupControlContainer: DotvvmControl
     {
         public string? MarkupVirtualPath { get; set; }
@@ -41,6 +42,9 @@ namespace DotVVM.Framework.Controls.Infrastructure
 
         protected internal override void OnInit(IDotvvmRequestContext context)
         {
+            if (Children.Count > 0)
+                throw new DotvvmControlException(this, "MarkupControlContainer must not have any children.");
+
             var path = GetMarkupPath(context.Configuration);
             var controlBuilderFactory = context.Services.GetRequiredService<IControlBuilderFactory>();
             var b = controlBuilderFactory.GetControlBuilder(path);
@@ -78,7 +82,7 @@ namespace DotVVM.Framework.Controls.Infrastructure
     }
 
     /// <summary> Allows using markup controls from code controls or from server-side styles. Use like this <code>new <see cref="MarkupControlContainer{TMarkupControl}"/>("cc:MyControl", c => c.Name = "X")</code> </summary>
-    public class MarkupControlContainer<TMarkupControl>: MarkupControlContainer
+    public sealed class MarkupControlContainer<TMarkupControl>: MarkupControlContainer
         where TMarkupControl: DotvvmMarkupControl
     {
         /// <summary> After OnInit is invoked, this property contains the initialized markup control. </summary>

--- a/src/Framework/Framework/Controls/Infrastructure/MarkupControlContainer.cs
+++ b/src/Framework/Framework/Controls/Infrastructure/MarkupControlContainer.cs
@@ -50,6 +50,9 @@ namespace DotVVM.Framework.Controls.Infrastructure
             if (!ExpectedControlType.IsAssignableFrom(controlType))
                 throw new DotvvmControlException(this, $"'{path}' is not of expected type {ExpectedControlType.Name}.");
             var control = (DotvvmMarkupControl)b.builder.Value.BuildControl(controlBuilderFactory, context.Services);
+            // The control has a "unique" ID assigned by the builder, but it's unique inside the markup control, not the current page
+            // Since MarkupControlContainer doesn't need the ID, we can assign the markup control the same ID
+            control.SetValue(Internal.UniqueIDProperty, this.GetValue(Internal.UniqueIDProperty));
             SetProperties?.Invoke(control);
 
             CreatedControl = control;

--- a/src/Tests/ControlTests/CompositeControlTests.cs
+++ b/src/Tests/ControlTests/CompositeControlTests.cs
@@ -186,6 +186,12 @@ namespace DotVVM.Framework.Tests.ControlTests
             );
 
             check.CheckString(r.FormattedHtml, fileExtension: "html");
+
+            var markupControls = r.View.GetAllDescendants().OfType<DotvvmMarkupControl>().ToArray();
+            Assert.AreEqual(5, markupControls.Length);
+            var markupControlIds = markupControls.Select(c => c.GetDotvvmUniqueId().GetValue()).ToArray();
+            Assert.AreEqual(markupControlIds.Length, markupControlIds.Distinct().Count(), $"Markup control IDs are not unique: {string.Join(", ", markupControlIds)}");
+
         }
         [TestMethod]
         public async Task BindingMappingWithEnum()

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -2152,12 +2152,14 @@
     },
     "DotVVM.Framework.Controls.Infrastructure.MarkupControlContainer": {
       "assembly": "DotVVM.Framework",
-      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework"
+      "baseType": "DotVVM.Framework.Controls.DotvvmControl, DotVVM.Framework",
+      "withoutContent": true
     },
     "DotVVM.Framework.Controls.Infrastructure.MarkupControlContainer`1": {
       "assembly": "DotVVM.Framework",
       "baseType": "DotVVM.Framework.Controls.Infrastructure.MarkupControlContainer, DotVVM.Framework",
-      "isAbstract": true
+      "isAbstract": true,
+      "withoutContent": true
     },
     "DotVVM.Framework.Controls.Infrastructure.RawLiteral": {
       "assembly": "DotVVM.Framework",


### PR DESCRIPTION
When MarkupControlContainer was used multiple times, the commands inside the markup control would fail on `DotVVM.Framework.Controls.DotvvmControlException: Multiple controls with the same UniqueID 'c16_c0' were found`

The bug was reported by Jan Berger at [gitter](https://matrix.to/#/!WrfMXMmXzbYrOMCMCo:gitter.im/$dj6mrwJ15DgEzJk2jnIVXqSoXt34JZS3_iubYr1_HJ4?via=gitter.im&via=matrix.org)