### PR TITLE
Extend DotvvmFeatureFlag API, improve validation

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -45,13 +45,13 @@
 
   <PropertyGroup Condition="$(DOTVVM_ROOT) != ''">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-    <RepoRoot>$([MSBuild]::NormalizeDirectory('$(DOTVVM_ROOT)'))</RepoRoot>
+    <RepoRoot>$([MSBuild]::NormalizeDirectory('$(DOTVVM_ROOT)/'))</RepoRoot>
     <BaseOutputPath>$(RepoRoot)artifacts\bin\$(MSBuildProjectName)\</BaseOutputPath>
     <PackageOutputPath>$(RepoRoot)artifacts\packages\</PackageOutputPath>
   </PropertyGroup>
 
   <ItemGroup Condition="$(DOTVVM_ROOT) != ''">
-    <SourceRoot Include="$([MSBuild]::NormalizeDirectory('$(DOTVVM_ROOT)'))" />
+    <SourceRoot Include="$([MSBuild]::NormalizeDirectory('$(DOTVVM_ROOT)/'))" />
   </ItemGroup>
 
   <PropertyGroup Condition="$(DOTVVM_VERSION) != ''">

--- a/src/Framework/Framework/Configuration/DotvvmExperimentalFeaturesConfiguration.cs
+++ b/src/Framework/Framework/Configuration/DotvvmExperimentalFeaturesConfiguration.cs
@@ -9,13 +9,13 @@ namespace DotVVM.Framework.Configuration
 
         // Add a DotvvmExperimentalFeatureFlag property for each experimental feature here
         [JsonProperty("lazyCsrfToken")]
-        public DotvvmFeatureFlag LazyCsrfToken { get; private set; } = new DotvvmFeatureFlag();
+        public DotvvmFeatureFlag LazyCsrfToken { get; private set; } = new DotvvmFeatureFlag("LazyCsrfToken");
 
         [JsonProperty("serverSideViewModelCache")]
-        public DotvvmFeatureFlag ServerSideViewModelCache { get; private set; } = new DotvvmFeatureFlag();
+        public DotvvmFeatureFlag ServerSideViewModelCache { get; private set; } = new DotvvmFeatureFlag("ServerSideViewModelCache");
 
         [JsonProperty("explicitAssemblyLoading")]
-        public DotvvmGlobalFeatureFlag ExplicitAssemblyLoading { get; private set; } = new DotvvmGlobalFeatureFlag();
+        public DotvvmGlobalFeatureFlag ExplicitAssemblyLoading { get; private set; } = new DotvvmGlobalFeatureFlag("ExplicitAssemblyLoading");
 
         public void Freeze()
         {

--- a/src/Framework/Framework/Configuration/DotvvmFeatureFlag.cs
+++ b/src/Framework/Framework/Configuration/DotvvmFeatureFlag.cs
@@ -5,10 +5,24 @@ using Newtonsoft.Json;
 
 namespace DotVVM.Framework.Configuration
 {
-    /// <summary> Enables certain DotVVM feature for the entire application or only for certain routes. </summary>
-    public class DotvvmFeatureFlag
+    /// <summary> Enables or disables certain DotVVM feature for the entire application or only for certain routes. </summary>
+    public class DotvvmFeatureFlag: IDotvvmFeatureFlagAdditiveConfiguration
     {
+        [JsonIgnore]
+        public string FlagName { get; }
 
+        public DotvvmFeatureFlag(string flagName, bool enabled = false)
+        {
+            FlagName = flagName;
+            Enabled = enabled;
+        }
+
+        [Obsolete("Please specify the feature flag name")]
+        public DotvvmFeatureFlag(): this("Unknown")
+        {
+        }
+
+        /// <summary> Gets or set the default state of this feature flag. If the current route doesn't match any <see cref="IncludedRoutes" /> or <see cref="ExcludedRoutes" />, it will  </summary>
         [JsonProperty("enabled")]
         public bool Enabled
         {
@@ -21,6 +35,7 @@ namespace DotVVM.Framework.Configuration
         }
         private bool _enabled = false;
 
+        /// <summary> List of routes where the feature flag is always enabled. </summary>
         [JsonProperty("includedRoutes")]
         public ISet<string> IncludedRoutes
         {
@@ -31,8 +46,9 @@ namespace DotVVM.Framework.Configuration
                 _includedRoutes = value;
             }
         }
-        private ISet<string> _includedRoutes = new FreezableSet<string>();
+        private ISet<string> _includedRoutes = new FreezableSet<string>(comparer: StringComparer.OrdinalIgnoreCase);
 
+        /// <summary> List of routes where the feature flag is always disabled. </summary>
         [JsonProperty("excludedRoutes")]
         public ISet<string> ExcludedRoutes
         {
@@ -43,16 +59,29 @@ namespace DotVVM.Framework.Configuration
                 _excludedRoutes = value;
             }
         }
-        private ISet<string> _excludedRoutes = new FreezableSet<string>();
+        private ISet<string> _excludedRoutes = new FreezableSet<string>(comparer: StringComparer.OrdinalIgnoreCase);
 
-        public void EnableForAllRoutes()
+        /// <summary> Enables the feature flag for all routes, even if it has been previously disabled. </summary>
+        public IDotvvmFeatureFlagAdditiveConfiguration EnableForAllRoutes()
         {
             ThrowIfFrozen();
             IncludedRoutes.Clear();
             ExcludedRoutes.Clear();
             Enabled = true;
+            return this;
         }
 
+        /// <summary> Disables the feature flag for all routes, even if it has been previously enabled. </summary>
+        public IDotvvmFeatureFlagAdditiveConfiguration DisableForAllRoutes()
+        {
+            ThrowIfFrozen();
+            IncludedRoutes.Clear();
+            ExcludedRoutes.Clear();
+            Enabled = false;
+            return this;
+        }
+
+        /// <summary> Enables the feature flag only for the specified routes, and disables for all other (Clears any previous rules). </summary>
         public void EnableForRoutes(params string[] routes)
         {
             ThrowIfFrozen();
@@ -66,6 +95,7 @@ namespace DotVVM.Framework.Configuration
             }
         }
 
+        /// <summary> Enables the feature flag for all routes except the specified ones (Clears any previous rules). </summary>
         public void EnableForAllRoutesExcept(params string[] routes)
         {
             ThrowIfFrozen();
@@ -79,11 +109,54 @@ namespace DotVVM.Framework.Configuration
             }
         }
 
+        /// <summary> Include the specified route in this feature flag. Enables the feature for the route. </summary>
+        public IDotvvmFeatureFlagAdditiveConfiguration IncludeRoute(string routeName)
+        {
+            ThrowIfFrozen();
+            if (Enabled)
+                throw new InvalidOperationException($"Cannot include route '{routeName}' because the feature flag {this.FlagName} is enabled by default.");
+            if (ExcludedRoutes.Contains(routeName))
+                throw new InvalidOperationException($"Cannot include route '{routeName}' because it is already in the list of excluded routes.");
+            IncludedRoutes.Add(routeName);
+            return this;
+        }
+        /// <summary> Include the specified routes in this feature flag. Enables the feature for the routes. </summary>
+        public IDotvvmFeatureFlagAdditiveConfiguration IncludeRoutes(params string[] routeNames)
+        {
+            foreach (var routeName in routeNames)
+            {
+                IncludeRoute(routeName);
+            }
+            return this;
+        }
+        /// <summary> Exclude the specified route from this feature flag. Disables the feature for the route. </summary>
+        public IDotvvmFeatureFlagAdditiveConfiguration ExcludeRoute(string routeName)
+        {
+            ThrowIfFrozen();
+            if (!Enabled)
+                throw new InvalidOperationException($"Cannot exclude route '{routeName}' because the feature flag {this.FlagName} is disabled by default.");
+            if (IncludedRoutes.Contains(routeName))
+                throw new InvalidOperationException($"Cannot exclude route '{routeName}' because it is already in the list of included routes.");
+            ExcludedRoutes.Add(routeName);
+            return this;
+        }
+        /// <summary> Exclude the specified routes from this feature flag. Disables the feature for the routes. </summary>
+        public IDotvvmFeatureFlagAdditiveConfiguration ExcludeRoutes(params string[] routeNames)
+        {
+            foreach (var routeName in routeNames)
+            {
+                ExcludeRoute(routeName);
+            }
+            return this;
+        }
+
+        /// <summary> Return true if there exists a route where this feature flag is enabled. </summary>
         public bool IsEnabledForAnyRoute()
         {
             return Enabled || IncludedRoutes.Count > 0;
         }
 
+        /// <summary> Return true if this feature flag is enabled for the specified route. </summary>
         public bool IsEnabledForRoute(string? routeName)
         {
             return (Enabled && !ExcludedRoutes.Contains(routeName!)) || (!Enabled && IncludedRoutes.Contains(routeName!));
@@ -93,7 +166,7 @@ namespace DotVVM.Framework.Configuration
         private void ThrowIfFrozen()
         {
             if (isFrozen)
-                FreezableUtils.Error(nameof(DotvvmFeatureFlag));
+                FreezableUtils.Error($"{nameof(DotvvmFeatureFlag)} {this.FlagName}");
         }
         public void Freeze()
         {
@@ -101,5 +174,24 @@ namespace DotVVM.Framework.Configuration
             FreezableSet.Freeze(ref this._excludedRoutes);
             FreezableSet.Freeze(ref this._includedRoutes);
         }
+
+        public override string ToString()
+        {
+            var exceptIn = Enabled ? ExcludedRoutes : IncludedRoutes;
+            var exceptInStr = exceptIn.Count > 0 ? $", except in {string.Join(", ", exceptIn)}" : "";
+            return $"Feature flag {this.FlagName}: {(Enabled ? "Enabled" : "Disabled")}{exceptInStr}";
+        }
+    }
+
+    public interface IDotvvmFeatureFlagAdditiveConfiguration
+    {
+        /// <summary> Include the specified route in this feature flag. Enables the feature for the route. </summary>
+        IDotvvmFeatureFlagAdditiveConfiguration IncludeRoute(string routeName);
+        /// <summary> Include the specified routes in this feature flag. Enables the feature for the routes. </summary>
+        IDotvvmFeatureFlagAdditiveConfiguration IncludeRoutes(params string[] routeNames);
+        /// <summary> Exclude the specified route from this feature flag. Disables the feature for the route. </summary>
+        IDotvvmFeatureFlagAdditiveConfiguration ExcludeRoute(string routeName);
+        /// <summary> Exclude the specified routes from this feature flag. Disables the feature for the routes. </summary>
+        IDotvvmFeatureFlagAdditiveConfiguration ExcludeRoutes(params string[] routeNames);
     }
 }

--- a/src/Framework/Framework/Configuration/DotvvmGlobalFeatureFlag.cs
+++ b/src/Framework/Framework/Configuration/DotvvmGlobalFeatureFlag.cs
@@ -1,10 +1,23 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace DotVVM.Framework.Configuration
 {
+    /// <summary> Enables or disables certain DotVVM feature for the entire application. </summary>
     public class DotvvmGlobalFeatureFlag
     {
+        [JsonIgnore]
+        public string FlagName { get; }
 
+        public DotvvmGlobalFeatureFlag(string flagName)
+        {
+            FlagName = flagName;
+        }
+
+        [Obsolete("Please specify the feature flag name")]
+        public DotvvmGlobalFeatureFlag(): this("Unknown") { }
+
+        /// <summary> Gets or sets whether the feature is enabled or disabled. </summary>
         [JsonProperty("enabled")]
         public bool Enabled
         {
@@ -17,11 +30,13 @@ namespace DotVVM.Framework.Configuration
         }
         private bool _enabled = false;
 
+        /// <summary> Enables the feature for this application. </summary>
         public void Enable()
         {
             ThrowIfFrozen();
             Enabled = true;
         }
+        /// <summary> Disables the feature for this application </summary>
         public void Disable()
         {
             ThrowIfFrozen();
@@ -32,12 +47,14 @@ namespace DotVVM.Framework.Configuration
         private void ThrowIfFrozen()
         {
             if (isFrozen)
-                FreezableUtils.Error(nameof(DotvvmFeatureFlag));
+                FreezableUtils.Error($"{nameof(DotvvmGlobalFeatureFlag)} {this.FlagName}");
         }
 
         public void Freeze()
         {
             this.isFrozen = true;
         }
+
+        public override string ToString() => $"Feature flag {FlagName}: {(Enabled ? "Enabled" : "Disabled")}";
     }
 }

--- a/src/Framework/Framework/Configuration/DotvvmSecurityConfiguration.cs
+++ b/src/Framework/Framework/Configuration/DotvvmSecurityConfiguration.cs
@@ -27,49 +27,49 @@ namespace DotVVM.Framework.Configuration
         /// When enabled, uses `X-Frame-Options: SAMEORIGIN` instead of DENY
         /// </summary>
         [JsonProperty("frameOptionsSameOrigin", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public DotvvmFeatureFlag FrameOptionsSameOrigin { get; } = new();
+        public DotvvmFeatureFlag FrameOptionsSameOrigin { get; } = new("FrameOptionsSameOrigin");
 
         /// <summary>
         /// When enabled, does not add `X-Frame-Options: DENY` header. Enabling will force DotVVM to use SameSite=None on the session cookie
         /// </summary>
         [JsonProperty("frameOptionsCrossOrigin", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public DotvvmFeatureFlag FrameOptionsCrossOrigin { get; } = new();
+        public DotvvmFeatureFlag FrameOptionsCrossOrigin { get; } = new("FrameOptionsCrossOrigin");
 
         /// <summary>
         /// When enabled, adds the `X-XSS-Protection: 1; mode=block` header, which enables some basic XSS filtering in browsers. This is enabled by default.
         /// </summary>
         [JsonProperty("xssProtectionHeader", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public DotvvmFeatureFlag XssProtectionHeader { get; } = new() { Enabled = true };
+        public DotvvmFeatureFlag XssProtectionHeader { get; } = new("XssProtectionHeader", true);
 
         /// <summary>
         /// When enabled, adds the `X-Content-Type-Options: nosniff` header, which prevents browsers from incorrectly detecting non-scripts as scripts. This is enabled by default.
         /// </summary>
         [JsonProperty("contentTypeOptionsHeader", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public DotvvmFeatureFlag ContentTypeOptionsHeader { get; } = new() { Enabled = true };
+        public DotvvmFeatureFlag ContentTypeOptionsHeader { get; } = new("ContentTypeOptionsHeader", true);
 
         /// <summary>
         /// Verifies Sec-Fetch headers on the GET request coming to dothtml pages. The request must have `Sec-Fetch-Dest: document` or `Sec-Fetch-Site: same-origin` if the request is for SPA. If the FrameOptionsSameOrigin is enabled, DotVVM will also allow `Sec-Fetch-Dest: document` and if FrameOptionsSameOrigin is enabled, DotVVM will also allow iframe from an cross-site request. This protects agains cross-site page scraping. Also prevents potential XSS bug to scrape the non-SPA pages.
         /// </summary>
         [JsonProperty("verifySecFetchForPages", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public DotvvmFeatureFlag VerifySecFetchForPages { get; } = new() { Enabled = true };
+        public DotvvmFeatureFlag VerifySecFetchForPages { get; } = new("VerifySecFetchForPages", true);
 
         /// <summary>
         /// Verifies Sec-Fetch headers on the POST request executing staticCommands and commands. The request must have `Sec-Fetch-Site: same-origin`. This protects again cross-site malicious requests even if SameSite cookies and CSRF tokens would fail. It also prevents websites on a subdomain to perform postbacks.
         /// </summary>
         [JsonProperty("verifySecFetchForCommands", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public DotvvmFeatureFlag VerifySecFetchForCommands { get; } = new() { Enabled = true };
+        public DotvvmFeatureFlag VerifySecFetchForCommands { get; } = new("VerifySecFetchForCommands", true);
 
         /// <summary>
         /// Requires that requests to dotvvm pages always have the Sec-Fetch-* headers. This may offer a slight protection against server-side request forgery attacks and against attacks exploiting obsolete web browsers (MS IE and Apple IE)
         /// </summary>
         [JsonProperty("requireSecFetchHeaders", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public DotvvmFeatureFlag RequireSecFetchHeaders { get; } = new();
+        public DotvvmFeatureFlag RequireSecFetchHeaders { get; } = new("RequireSecFetchHeaders", false);
 
         /// <summary>
         /// Include the Referrer-Policy header which disables referrers in the default configuration. Enabled by default.
         /// </summary>
         [JsonProperty("referrerPolicy", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public DotvvmFeatureFlag ReferrerPolicy { get; } = new() { Enabled = true };
+        public DotvvmFeatureFlag ReferrerPolicy { get; } = new("ReferrerPolicy", true);
 
         /// <summary> Value of the referrer-policy header. By default it's no-referrer, if you want referrers on your domain set this to `same-origin`. See for more info: <see href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy" /> </summary>
         [DefaultValue("no-referrer")]

--- a/src/Framework/Framework/Hosting/DotvvmPresenter.cs
+++ b/src/Framework/Framework/Hosting/DotvvmPresenter.cs
@@ -507,12 +507,12 @@ namespace DotVVM.Framework.Hosting
                     if (site == "same-origin")
                         await context.RejectRequest($"""
                             Same site iframe are disabled in this application.
-                            If you are the developer, you can enable iframes by setting DotvvmConfiguration.Security.FrameOptionsSameOrigin.EnableForRoute("{route}")
+                            If you are the developer, you can enable iframes by setting DotvvmConfiguration.Security.FrameOptionsSameOrigin.IncludeRoute("{route}")
                             """);
                     else
                         await context.RejectRequest($"""
                         Cross site iframe are disabled in this application.
-                        If you are the developer, you can enable cross-site iframes by setting DotvvmConfiguration.Security.FrameOptionsCrossOrigin.EnableForRoute("{route}"). Note that it's not recommended to enable cross-site iframes for sites / pages where security is important (due to Clickjacking)
+                        If you are the developer, you can enable cross-site iframes by setting DotvvmConfiguration.Security.FrameOptionsCrossOrigin.IncludeRoute("{route}"). Note that it's not recommended to enable cross-site iframes for sites / pages where security is important (due to Clickjacking)
                         """);
                 }
             }
@@ -542,7 +542,7 @@ namespace DotVVM.Framework.Hosting
                         await context.RejectRequest($"""
                             Pages can not be loaded using Javascript for security reasons.
                             Try refreshing the page to get rid of the error.
-                            If you are the developer, you can disable this check by setting DotvvmConfiguration.Security.VerifySecFetchForPages.DisableForRoute("{route}"). [dest: {dest}, site: {site}]
+                            If you are the developer, you can disable this check by setting DotvvmConfiguration.Security.VerifySecFetchForPages.ExcludeRoute("{route}"). [dest: {dest}, site: {site}]
                             """);
                     if (site != "same-origin")
                         await context.RejectRequest($"Cross site SPA requests are disabled.");

--- a/src/Framework/Framework/Routing/DotvvmRouteTable.cs
+++ b/src/Framework/Framework/Routing/DotvvmRouteTable.cs
@@ -17,7 +17,6 @@ namespace DotVVM.Framework.Routing
         private readonly List<KeyValuePair<string, RouteBase>> list
             = new List<KeyValuePair<string, RouteBase>>();
 
-        // for faster checking of duplicates when adding entries
         private readonly Dictionary<string, RouteBase> dictionary
             = new Dictionary<string, RouteBase>(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, DotvvmRouteTable> routeTableGroups

--- a/src/Tests/DotVVM.Framework.Tests.csproj
+++ b/src/Tests/DotVVM.Framework.Tests.csproj
@@ -57,6 +57,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.0" PrivateAssets="all" />
     <PackageReference Include="System.Linq.Expressions" Version="4.3.0" />
+    <PackageReference Include="xunit.assert" Version="2.4.2" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/src/Tests/GlobalUsings.cs
+++ b/src/Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using XAssert = Xunit.Assert;

--- a/src/Tests/Runtime/ConfigurationValidationTests.cs
+++ b/src/Tests/Runtime/ConfigurationValidationTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using CheckTestOutput;
+using DotVVM.Framework.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DotVVM.Framework.Testing;
+using DotVVM.Framework.Routing;
+
+namespace DotVVM.Framework.Tests.Runtime
+{
+    [TestClass]
+    public class ConfigurationValidationTests
+    {
+        OutputChecker check = new OutputChecker("config-tests");
+
+        public ConfigurationValidationTests()
+        {
+        }
+
+        [TestMethod]
+        public void FeatureFlag_ValidOperations()
+        {
+            var flag = new DotvvmFeatureFlag("myFlag");
+            flag.EnableForAllRoutes();
+            Assert.IsTrue(flag.Enabled);
+            XAssert.Empty(flag.IncludedRoutes);
+            XAssert.Empty(flag.ExcludedRoutes);
+
+            flag.ExcludeRoute("a");
+            Assert.IsTrue(flag.Enabled);
+            XAssert.Contains("a", flag.ExcludedRoutes);
+            
+
+            flag.DisableForAllRoutes()
+                .IncludeRoute("a")
+                .IncludeRoute("b");
+            Assert.IsFalse(flag.Enabled);
+            XAssert.Contains("a", flag.IncludedRoutes);
+            XAssert.Contains("b", flag.IncludedRoutes);
+            XAssert.Empty(flag.ExcludedRoutes);
+
+            flag.EnableForRoutes("x", "y");
+            Assert.IsFalse(flag.Enabled);
+            XAssert.Equal(new [] { "x", "y" }, flag.IncludedRoutes);
+            XAssert.Empty(flag.ExcludedRoutes);
+        }
+
+        [TestMethod]
+        public void FeatureFlag_InvalidInclude()
+        {
+            var flag = new DotvvmFeatureFlag("myFlag");
+            var e = XAssert.ThrowsAny<Exception>(() => flag.EnableForAllRoutes().IncludeRoute("a"));
+            XAssert.Equal("Cannot include route 'a' because the feature flag myFlag is enabled by default.", e.Message);
+        }
+
+        [TestMethod]
+        public void FeatureFlag_InvalidExclude()
+        {
+            var flag = new DotvvmFeatureFlag("myFlag");
+            var e = XAssert.ThrowsAny<Exception>(() => flag.DisableForAllRoutes().ExcludeRoute("a"));
+            XAssert.Equal("Cannot exclude route 'a' because the feature flag myFlag is disabled by default.", e.Message);
+        }
+
+        [TestMethod]
+        public void ValidateMissingRoutes()
+        {
+            var config = DotvvmTestHelper.CreateConfiguration();
+
+            config.RouteTable.Add("a", "a", null, null, presenterFactory: _ => throw new NotImplementedException());
+
+            config.Security.XssProtectionHeader.ExcludeRoute("A");
+            config.Security.XssProtectionHeader.ExcludeRoute("b");
+            config.Security.RequireSecFetchHeaders.IncludeRoute("b");
+            config.Security.RequireSecFetchHeaders.IncludeRoute("c");
+            config.ExperimentalFeatures.LazyCsrfToken.IncludeRoute("b");
+
+            check.CheckException(() => config.AssertConfigurationIsValid());
+        }
+    }
+}

--- a/src/Tests/Runtime/config-tests/ConfigurationValidationTests.ValidateMissingRoutes.txt
+++ b/src/Tests/Runtime/config-tests/ConfigurationValidationTests.ValidateMissingRoutes.txt
@@ -1,0 +1,3 @@
+DotvvmConfigurationException occurred: Route 'b' included in feature flag RequireSecFetchHeaders, LazyCsrfToken and excluded in feature flag XssProtectionHeader is not registered in the RouteTable
+Route 'c' included in feature flag RequireSecFetchHeaders is not registered in the RouteTable
+    at void DotVVM.Framework.Routing.RouteHelper.ValidateFeatureFlags(DotvvmConfiguration config)


### PR DESCRIPTION
The API was originally designed for features which are disabled by default,
but it's now being used for features enabled by default (mainly security headers).

For this reason I'm adding the DisableForAllRoutes method. DisableForRoutes is not neccesary,
EnableForAllRoutesExcept has exactly this semantic. The name might be a bit confusing in
this context, but I'm not sure adding a synonym will help.

Instead I'm adding methods for incrementaly including/excluding additional routes:
* IncludeRoute(string) / IncludeRoutes(string[])
* ExcludeRoute(string) / ExcludeRoutes(string[])

These new methods can be used in fluent style to save some keystrokes, for example

```
config.Security.FrameOptionsCrossOrigin
    .DisableForAllRoutes()
    .IncludeRoute("route1")
    .IncludeRoute("route2");
```