### PR TITLE
Unify client/server evaluation in HtmlGenericControl

### DIFF
--- a/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
+++ b/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
@@ -270,9 +270,22 @@ namespace DotVVM.Framework.Controls
             }
             return control;
         }
+        /// <summary> Appends a css class to this control if the <paramref name="condition"/> is true. </summary>
         public static TControl AddCssClass<TControl>(this TControl control, string className, ValueOrBinding<bool>? condition)
             where TControl : IObjectWithCapability<HtmlCapability> =>
             condition is null ? control : AddCssClass(control, className, condition.Value);
+
+        /// <summary> Appends a css class to this control if the <paramref name="condition"/> is true. </summary>
+        public static TControl AddCssClass<TControl>(this TControl control, string className, IStaticValueBinding<bool>? condition)
+            where TControl : IObjectWithCapability<HtmlCapability>
+        {
+            if (condition is {})
+            {
+                var p = control.GetCssClassesDictionary();
+                p.SetBinding(className, condition);
+            }
+            return control;
+        }
 
         /// <summary> Adds a css inline style - the `style` attribute. Returns <paramref name="control"/> for fluent API usage. </summary>
         public static TControl AddCssStyle<TControl>(this TControl control, string name, string? styleValue)
@@ -306,6 +319,19 @@ namespace DotVVM.Framework.Controls
             }
             return control;
         }
+
+        /// <summary> Adds a css inline style - the `style` attribute. Returns <paramref name="control"/> for fluent API usage. </summary>
+        public static TControl AddCssStyle<TControl, T>(this TControl control, string name, IStaticValueBinding<T>? styleValue)
+            where TControl : IObjectWithCapability<HtmlCapability>
+        {
+            if (styleValue is {})
+            {
+                var p = control.GetCssStylesDictionary();
+                p.SetBinding(name, styleValue);
+            }
+            return control;
+        }
+
 
         /// <summary> Sets all properties from the capability into this control. If the control does not support the capability, exception is thrown. Returns <paramref name="control"/> for fluent API usage. </summary>
         public static TControl SetCapability<TControl, TCapability>(this TControl control, [AllowNull] TCapability capability, string prefix = "")

--- a/src/Framework/Framework/Controls/HtmlGenericControl.cs
+++ b/src/Framework/Framework/Controls/HtmlGenericControl.cs
@@ -443,10 +443,17 @@ namespace DotVVM.Framework.Controls
                         attributeBindingGroup ??= new KnockoutBindingGroup();
                         attributeBindingGroup.Add(attributeName, knockoutExpression);
                     }
-                    if (!r.RenderOnServer(this))
-                        continue;
+                    // TODO: maybe we could still skip server-side rendering data-attributes?
                 }
-                AddHtmlAttribute(writer, attributeName, valueRaw);
+
+                try
+                {
+                    AddHtmlAttribute(writer, attributeName, valueRaw);
+                }
+                catch (Exception) when (knockoutExpression is {})
+                {
+                    // suppress errors in value bindings
+                }
 
                 if (attributeName.Equals("id", StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/Framework/Framework/Controls/HtmlGenericControl.cs
+++ b/src/Framework/Framework/Controls/HtmlGenericControl.cs
@@ -263,9 +263,9 @@ namespace DotVVM.Framework.Controls
                     writer.AddAttribute("style", "display:none");
                 }
             }
-            catch (Exception e) when (valueBinding is {} && !r.RenderOnServer(this))
+            catch (Exception) when (valueBinding is {})
             {
-                // suppress value binding error in client-side rendering
+                // suppress value binding errors
             }
         }
 

--- a/src/Framework/Framework/Controls/HtmlGenericControl.cs
+++ b/src/Framework/Framework/Controls/HtmlGenericControl.cs
@@ -443,7 +443,6 @@ namespace DotVVM.Framework.Controls
                         attributeBindingGroup ??= new KnockoutBindingGroup();
                         attributeBindingGroup.Add(attributeName, knockoutExpression);
                     }
-                    // TODO: maybe we could still skip server-side rendering data-attributes?
                 }
 
                 try

--- a/src/Framework/Framework/Controls/HtmlGenericControl.cs
+++ b/src/Framework/Framework/Controls/HtmlGenericControl.cs
@@ -250,12 +250,22 @@ namespace DotVVM.Framework.Controls
         protected virtual void AddVisibleAttributeOrBinding(in RenderState r, IHtmlWriter writer)
         {
             var v = r.Visible;
-            if (v is IValueBinding binding)
-                writer.AddKnockoutDataBind("visible", binding.GetKnockoutBindingExpression(this));
-
-            if (false.Equals(EvalPropertyValue(VisibleProperty, v)))
+            var valueBinding = v as IValueBinding;
+            if (valueBinding is {})
             {
-                writer.AddAttribute("style", "display:none");
+                writer.AddKnockoutDataBind("visible", valueBinding.GetKnockoutBindingExpression(this));
+            }
+
+            try
+            {
+                if (false.Equals(EvalPropertyValue(VisibleProperty, v)))
+                {
+                    writer.AddAttribute("style", "display:none");
+                }
+            }
+            catch (Exception e) when (valueBinding is {} && !r.RenderOnServer(this))
+            {
+                // suppress value binding error in client-side rendering
             }
         }
 

--- a/src/Framework/Framework/Controls/HtmlGenericControl.cs
+++ b/src/Framework/Framework/Controls/HtmlGenericControl.cs
@@ -373,9 +373,17 @@ namespace DotVVM.Framework.Controls
                     AddHtmlAttribute(writer, name, i.Value);
                 }
             }
-            else if (value is IStaticValueBinding)
+            else if (value is IStaticValueBinding binding)
             {
-                AddHtmlAttribute(writer, name, ((IStaticValueBinding)value).Evaluate(this));
+                var evaluatedBinding = binding.Evaluate(this);
+                // while directly set null is written out as empty attribute, null returned
+                // from a binding is skipped. This allows binding to conditionally add attributes.
+                // * direct null behave this way for historical reasons
+                // * binding null behaves this way because it's what knockout.js does client-side anyway
+                if (evaluatedBinding is not null)
+                {
+                    AddHtmlAttribute(writer, name, evaluatedBinding);
+                }
             }
             else if (value is bool boolValue)
             {

--- a/src/Framework/Testing/ControlTestHelper.cs
+++ b/src/Framework/Testing/ControlTestHelper.cs
@@ -33,7 +33,7 @@ namespace DotVVM.Framework.Testing
         private readonly FakeMarkupFileLoader fileLoader;
         private readonly DotvvmPresenter presenter;
 
-        IControlBuilderFactory controlBuilderFactory => Configuration.ServiceProvider.GetRequiredService<IControlBuilderFactory>();
+        IControlBuilderFactory controlBuilderFactory => GetService<IControlBuilderFactory>();
 
         public ControlTestHelper(bool debug = true, Action<DotvvmConfiguration>? config = null, Action<IDotvvmServiceCollection>? services = null)
         {
@@ -48,6 +48,8 @@ namespace DotVVM.Framework.Testing
             config?.Invoke(this.Configuration);
             presenter = (DotvvmPresenter)this.Configuration.ServiceProvider.GetRequiredService<IDotvvmPresenter>();
         }
+
+        public T GetService<T>() => Configuration.ServiceProvider.GetRequiredService<T>();
 
         public (ControlBuilderDescriptor descriptor, Lazy<IControlBuilder> builder) CompilePage(
             string markup,

--- a/src/Tests/ControlTests/HtmlGenericControlTests.cs
+++ b/src/Tests/ControlTests/HtmlGenericControlTests.cs
@@ -43,6 +43,8 @@ namespace DotVVM.Framework.Tests.ControlTests
             }
         }
 
+        // Test that all HtmlGenericControl properties are bindable and the value binding is evaluated both client-side and server-side, regardless of the RenderMode.
+        // Errors in value bindings are suppressed, to allow bindings which can't be evaluated server-side
         [DataTestMethod]
         [DataRow(RenderMode.Client)]
         [DataRow(RenderMode.Server)]
@@ -55,16 +57,6 @@ namespace DotVVM.Framework.Tests.ControlTests
             var str = RenderToString(control);
             Assert.AreEqual("""<div data-bind='attr: { "data-test": dotvvm.viewModules.call("p1", "testMethod", [], false) }'></div>""", str);
         }
-
-        // [TestMethod]
-        // public void ServerSideInvokeFails_Attribute()
-        // {
-        //     var control = new HtmlGenericControl("div")
-        //         .SetProperty(RenderSettings.ModeProperty, RenderMode.Server)
-        //         .SetAttribute("data-test", bindingService.Cache.CreateValueBinding<string>("_js.Invoke<string>('testMethod')", defaultDataContext));
-
-        //     var exception = Assert.ThrowsException<DotvvmControlException>(() => RenderToString(control));
-        // }
 
         [DataTestMethod]
         [DataRow(RenderMode.Client)]
@@ -113,15 +105,13 @@ namespace DotVVM.Framework.Tests.ControlTests
                 .SetAttribute("data-test", bindingService.Cache.CreateValueBinding<string>("String", defaultDataContext));
 
             var str = RenderToString(control);
-            // TODO: should it behave differently for server-side rendering?
-            // Assert.AreEqual($$"""<div {{(renderMode == RenderMode.Server ? "data-test=some-string " : "")}}data-bind='attr: { "data-test": String }'></div>""", str);
             Assert.AreEqual($$"""<div data-test=some-string data-bind='attr: { "data-test": String }'></div>""", str);
         }
 
         [DataTestMethod]
         [DataRow(RenderMode.Client)]
         [DataRow(RenderMode.Server)]
-        public void ValueBinding_Visible(RenderMode renderMode) // RenderMode should not matter
+        public void ValueBinding_Visible(RenderMode renderMode)
         {
             var control = new HtmlGenericControl("div")
                 .SetProperty(RenderSettings.ModeProperty, renderMode)
@@ -134,7 +124,7 @@ namespace DotVVM.Framework.Tests.ControlTests
         [DataTestMethod]
         [DataRow(RenderMode.Client)]
         [DataRow(RenderMode.Server)]
-        public void ValueBinding_Class(RenderMode renderMode) // RenderMode should not matter
+        public void ValueBinding_Class(RenderMode renderMode)
         {
             var control = new HtmlGenericControl("div")
                 .SetProperty(RenderSettings.ModeProperty, renderMode)
@@ -147,7 +137,7 @@ namespace DotVVM.Framework.Tests.ControlTests
         [DataTestMethod]
         [DataRow(RenderMode.Client)]
         [DataRow(RenderMode.Server)]
-        public void ValueBinding_Style(RenderMode renderMode) // RenderMode should not matter
+        public void ValueBinding_Style(RenderMode renderMode)
         {
             var control = new HtmlGenericControl("div")
                 .SetProperty(RenderSettings.ModeProperty, renderMode)

--- a/src/Tests/ControlTests/HtmlGenericControlTests.cs
+++ b/src/Tests/ControlTests/HtmlGenericControlTests.cs
@@ -45,7 +45,7 @@ namespace DotVVM.Framework.Tests.ControlTests
 
         [DataTestMethod]
         [DataRow(RenderMode.Client)]
-        // [DataRow(RenderMode.Server)]
+        [DataRow(RenderMode.Server)]
         public void JsInvoke_Attribute(RenderMode renderMode)
         {
             var control = new HtmlGenericControl("div")
@@ -114,8 +114,8 @@ namespace DotVVM.Framework.Tests.ControlTests
 
             var str = RenderToString(control);
             // TODO: should it behave differently for server-side rendering?
-            Assert.AreEqual($$"""<div {{(renderMode == RenderMode.Server ? "data-test=some-string " : "")}}data-bind='attr: { "data-test": String }'></div>""", str);
-            // Assert.AreEqual($$"""<div data-test=some-string data-bind='attr: { "data-test": String }'></div>""", str);
+            // Assert.AreEqual($$"""<div {{(renderMode == RenderMode.Server ? "data-test=some-string " : "")}}data-bind='attr: { "data-test": String }'></div>""", str);
+            Assert.AreEqual($$"""<div data-test=some-string data-bind='attr: { "data-test": String }'></div>""", str);
         }
 
         [DataTestMethod]

--- a/src/Tests/ControlTests/HtmlGenericControlTests.cs
+++ b/src/Tests/ControlTests/HtmlGenericControlTests.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Threading.Tasks;
+using CheckTestOutput;
+using DotVVM.Framework.Compilation;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Tests.Binding;
+using DotVVM.Framework.ViewModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DotVVM.Framework.Testing;
+using System.Security.Claims;
+using System.Collections;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Compilation.ControlTree;
+using DotVVM.Framework.Hosting;
+
+namespace DotVVM.Framework.Tests.ControlTests
+{
+    [TestClass]
+    public class HtmlGenericControlTests
+    {
+        static readonly ControlTestHelper cth = new ControlTestHelper(config: config => {
+        });
+        static readonly BindingCompilationService bindingService = cth.GetService<BindingCompilationService>();
+        static readonly IDotvvmRequestContext defaultContext = DotvvmTestHelper.CreateContext(cth.Configuration);
+        static readonly DataContextStack defaultDataContext = DataContextStack.Create(typeof(BasicTestViewModel), extensionParameters: new [] { new JsExtensionParameter("p1", false) });
+        readonly OutputChecker check = new OutputChecker("testoutputs");
+
+        string RenderToString(DotvvmControl control, object viewModel = null, IDotvvmRequestContext context = null)
+        {
+            context ??= defaultContext;
+            viewModel ??= new BasicTestViewModel();
+
+            control.SetValue(Internal.RequestContextProperty, context);
+            control.DataContext = viewModel;
+            using  (var sw = new System.IO.StringWriter())
+            {
+                var html = new HtmlWriter(sw, context);
+                control.Render(html, context);
+                return sw.ToString();
+            }
+        }
+
+        [TestMethod]
+        public void ClientSideInvoke_Attribute()
+        {
+            var control = new HtmlGenericControl("div")
+                .SetProperty(RenderSettings.ModeProperty, RenderMode.Client)
+                .SetAttribute("data-test", bindingService.Cache.CreateValueBinding<string>("_js.Invoke<string>('testMethod')", defaultDataContext));
+
+            var str = RenderToString(control);
+            Assert.AreEqual("""<div data-bind='attr: { "data-test": dotvvm.viewModules.call("p1", "testMethod", [], false) }'></div>""", str);
+        }
+        [TestMethod]
+        public void ClientSideInvoke_Visible()
+        {
+            var control = new HtmlGenericControl("div")
+                .SetProperty(RenderSettings.ModeProperty, RenderMode.Client)
+                .SetProperty(c => c.Visible, bindingService.Cache.CreateValueBinding<bool>("_js.Invoke<bool>('testMethod')", defaultDataContext));
+
+            var str = RenderToString(control);
+            Assert.AreEqual("""<div data-bind='visible: dotvvm.viewModules.call("p1", "testMethod", [], false)'></div>""", str);
+        }
+        [TestMethod]
+        public void ClientSideInvoke_Class()
+        {
+            var control = new HtmlGenericControl("div")
+                .SetProperty(RenderSettings.ModeProperty, RenderMode.Client)
+                .AddCssClass("test-class", bindingService.Cache.CreateValueBinding<bool>("_js.Invoke<bool>('testMethod')", defaultDataContext));
+
+            var str = RenderToString(control);
+            Assert.AreEqual("""<div data-bind='css: { "test-class": dotvvm.viewModules.call("p1", "testMethod", [], false) }'></div>""", str);
+        }
+        [TestMethod]
+        public void ClientSideInvoke_Style()
+        {
+            var control = new HtmlGenericControl("div")
+                .SetProperty(RenderSettings.ModeProperty, RenderMode.Client)
+                .AddCssStyle("width", bindingService.Cache.CreateValueBinding<int>("_js.Invoke<int>('testMethod')", defaultDataContext));
+
+            var str = RenderToString(control);
+            Assert.AreEqual("""<div data-bind='style: { width: dotvvm.viewModules.call("p1", "testMethod", [], false) }'></div>""", str);
+        }
+
+        [TestMethod]
+        public void ServerSideInvokeFails_Attribute()
+        {
+            var control = new HtmlGenericControl("div")
+                .SetProperty(RenderSettings.ModeProperty, RenderMode.Server)
+                .SetAttribute("data-test", bindingService.Cache.CreateValueBinding<string>("_js.Invoke<string>('testMethod')", defaultDataContext));
+
+            var exception = Assert.ThrowsException<DotvvmControlException>(() => RenderToString(control));
+        }
+
+        [TestMethod]
+        public void ServerSideInvokeFails_Visible()
+        {
+            var control = new HtmlGenericControl("div")
+                .SetProperty(RenderSettings.ModeProperty, RenderMode.Server)
+                .SetProperty(c => c.Visible, bindingService.Cache.CreateValueBinding<bool>("_js.Invoke<bool>('testMethod')", defaultDataContext));
+
+            var exception = Assert.ThrowsException<DotvvmControlException>(() => RenderToString(control));
+        }
+        [TestMethod]
+        [Ignore] // TODO?
+        public void ServerSideInvokeFails_Class()
+        {
+            var control = new HtmlGenericControl("div")
+                .SetProperty(RenderSettings.ModeProperty, RenderMode.Server)
+                .AddCssClass("test-class", bindingService.Cache.CreateValueBinding<bool>("_js.Invoke<bool>('testMethod')", defaultDataContext));
+
+            var exception = Assert.ThrowsException<Exception>(() => RenderToString(control));
+        }
+        [TestMethod]
+        [Ignore] // TODO?
+        public void ServerSideInvokeFails_Style()
+        {
+            var control = new HtmlGenericControl("div")
+                .SetProperty(RenderSettings.ModeProperty, RenderMode.Server)
+                .AddCssStyle("width", bindingService.Cache.CreateValueBinding<int>("_js.Invoke<int>('testMethod')", defaultDataContext));
+
+            var exception = Assert.ThrowsException<Exception>(() => RenderToString(control));
+        }
+
+        [DataTestMethod]
+        [DataRow(RenderMode.Client)]
+        [DataRow(RenderMode.Server)]
+        public void ValueBinding_Attribute(RenderMode renderMode)
+        {
+            var control = new HtmlGenericControl("div")
+                .SetProperty(RenderSettings.ModeProperty, renderMode)
+                .SetAttribute("data-test", bindingService.Cache.CreateValueBinding<string>("String", defaultDataContext));
+
+            var str = RenderToString(control);
+            // TODO: should it behave differently for server-side rendering?
+            Assert.AreEqual($$"""<div {{(renderMode == RenderMode.Server ? "data-test=some-string " : "")}}data-bind='attr: { "data-test": String }'></div>""", str);
+        }
+
+        [DataTestMethod]
+        [DataRow(RenderMode.Client)]
+        [DataRow(RenderMode.Server)]
+        public void ValueBinding_Visible(RenderMode renderMode) // RenderMode should not matter
+        {
+            var control = new HtmlGenericControl("div")
+                .SetProperty(RenderSettings.ModeProperty, renderMode)
+                .SetProperty(c => c.Visible, bindingService.Cache.CreateValueBinding<bool>("Integer == 99", defaultDataContext));
+
+            var str = RenderToString(control);
+            Assert.AreEqual("""<div style=display:none data-bind="visible: Integer() == 99"></div>""", str);
+        }
+
+        [DataTestMethod]
+        [DataRow(RenderMode.Client)]
+        [DataRow(RenderMode.Server)]
+        public void ValueBinding_Class(RenderMode renderMode) // RenderMode should not matter
+        {
+            var control = new HtmlGenericControl("div")
+                .SetProperty(RenderSettings.ModeProperty, renderMode)
+                .AddCssClass("test-class", bindingService.Cache.CreateValueBinding<bool>("Integer > 0", defaultDataContext));
+
+            var str = RenderToString(control);
+            Assert.AreEqual("""<div class=test-class data-bind='css: { "test-class": Integer() &gt; 0 }'></div>""", str);
+        }
+
+        [DataTestMethod]
+        [DataRow(RenderMode.Client)]
+        [DataRow(RenderMode.Server)]
+        public void ValueBinding_Style(RenderMode renderMode) // RenderMode should not matter
+        {
+            var control = new HtmlGenericControl("div")
+                .SetProperty(RenderSettings.ModeProperty, renderMode)
+                .AddCssStyle("width", bindingService.Cache.CreateValueBinding<int>("Integer", defaultDataContext));
+
+            var str = RenderToString(control);
+            Assert.AreEqual("""<div style=width:123 data-bind="style: { width: Integer }"></div>""", str);
+        }
+
+        public class BasicTestViewModel: DotvvmViewModelBase
+        {
+            public int Integer { get; set; } = 123;
+            public bool Boolean { get; set; } = false;
+            public string String { get; set; } = "some-string";
+        }
+    }
+}

--- a/src/Tests/ControlTests/HtmlGenericControlTests.cs
+++ b/src/Tests/ControlTests/HtmlGenericControlTests.cs
@@ -43,85 +43,64 @@ namespace DotVVM.Framework.Tests.ControlTests
             }
         }
 
-        [TestMethod]
-        public void ClientSideInvoke_Attribute()
+        [DataTestMethod]
+        [DataRow(RenderMode.Client)]
+        // [DataRow(RenderMode.Server)]
+        public void JsInvoke_Attribute(RenderMode renderMode)
         {
             var control = new HtmlGenericControl("div")
-                .SetProperty(RenderSettings.ModeProperty, RenderMode.Client)
+                .SetProperty(RenderSettings.ModeProperty, renderMode)
                 .SetAttribute("data-test", bindingService.Cache.CreateValueBinding<string>("_js.Invoke<string>('testMethod')", defaultDataContext));
 
             var str = RenderToString(control);
             Assert.AreEqual("""<div data-bind='attr: { "data-test": dotvvm.viewModules.call("p1", "testMethod", [], false) }'></div>""", str);
         }
-        [TestMethod]
-        public void ClientSideInvoke_Visible()
+
+        // [TestMethod]
+        // public void ServerSideInvokeFails_Attribute()
+        // {
+        //     var control = new HtmlGenericControl("div")
+        //         .SetProperty(RenderSettings.ModeProperty, RenderMode.Server)
+        //         .SetAttribute("data-test", bindingService.Cache.CreateValueBinding<string>("_js.Invoke<string>('testMethod')", defaultDataContext));
+
+        //     var exception = Assert.ThrowsException<DotvvmControlException>(() => RenderToString(control));
+        // }
+
+        [DataTestMethod]
+        [DataRow(RenderMode.Client)]
+        [DataRow(RenderMode.Server)]
+        public void JsInvoke_Visible(RenderMode renderMode)
         {
             var control = new HtmlGenericControl("div")
-                .SetProperty(RenderSettings.ModeProperty, RenderMode.Client)
+                .SetProperty(RenderSettings.ModeProperty, renderMode)
                 .SetProperty(c => c.Visible, bindingService.Cache.CreateValueBinding<bool>("_js.Invoke<bool>('testMethod')", defaultDataContext));
 
             var str = RenderToString(control);
             Assert.AreEqual("""<div data-bind='visible: dotvvm.viewModules.call("p1", "testMethod", [], false)'></div>""", str);
         }
-        [TestMethod]
-        public void ClientSideInvoke_Class()
+        [DataTestMethod]
+        [DataRow(RenderMode.Client)]
+        [DataRow(RenderMode.Server)]
+        public void JsInvoke_Class(RenderMode renderMode)
         {
             var control = new HtmlGenericControl("div")
-                .SetProperty(RenderSettings.ModeProperty, RenderMode.Client)
+                .SetProperty(RenderSettings.ModeProperty, renderMode)
                 .AddCssClass("test-class", bindingService.Cache.CreateValueBinding<bool>("_js.Invoke<bool>('testMethod')", defaultDataContext));
 
             var str = RenderToString(control);
             Assert.AreEqual("""<div data-bind='css: { "test-class": dotvvm.viewModules.call("p1", "testMethod", [], false) }'></div>""", str);
         }
-        [TestMethod]
-        public void ClientSideInvoke_Style()
+        [DataTestMethod]
+        [DataRow(RenderMode.Client)]
+        [DataRow(RenderMode.Server)]
+        public void JsInvoke_Style(RenderMode renderMode)
         {
             var control = new HtmlGenericControl("div")
-                .SetProperty(RenderSettings.ModeProperty, RenderMode.Client)
+                .SetProperty(RenderSettings.ModeProperty, renderMode)
                 .AddCssStyle("width", bindingService.Cache.CreateValueBinding<int>("_js.Invoke<int>('testMethod')", defaultDataContext));
 
             var str = RenderToString(control);
             Assert.AreEqual("""<div data-bind='style: { width: dotvvm.viewModules.call("p1", "testMethod", [], false) }'></div>""", str);
-        }
-
-        [TestMethod]
-        public void ServerSideInvokeFails_Attribute()
-        {
-            var control = new HtmlGenericControl("div")
-                .SetProperty(RenderSettings.ModeProperty, RenderMode.Server)
-                .SetAttribute("data-test", bindingService.Cache.CreateValueBinding<string>("_js.Invoke<string>('testMethod')", defaultDataContext));
-
-            var exception = Assert.ThrowsException<DotvvmControlException>(() => RenderToString(control));
-        }
-
-        [TestMethod]
-        public void ServerSideInvokeFails_Visible()
-        {
-            var control = new HtmlGenericControl("div")
-                .SetProperty(RenderSettings.ModeProperty, RenderMode.Server)
-                .SetProperty(c => c.Visible, bindingService.Cache.CreateValueBinding<bool>("_js.Invoke<bool>('testMethod')", defaultDataContext));
-
-            var exception = Assert.ThrowsException<DotvvmControlException>(() => RenderToString(control));
-        }
-        [TestMethod]
-        [Ignore] // TODO?
-        public void ServerSideInvokeFails_Class()
-        {
-            var control = new HtmlGenericControl("div")
-                .SetProperty(RenderSettings.ModeProperty, RenderMode.Server)
-                .AddCssClass("test-class", bindingService.Cache.CreateValueBinding<bool>("_js.Invoke<bool>('testMethod')", defaultDataContext));
-
-            var exception = Assert.ThrowsException<Exception>(() => RenderToString(control));
-        }
-        [TestMethod]
-        [Ignore] // TODO?
-        public void ServerSideInvokeFails_Style()
-        {
-            var control = new HtmlGenericControl("div")
-                .SetProperty(RenderSettings.ModeProperty, RenderMode.Server)
-                .AddCssStyle("width", bindingService.Cache.CreateValueBinding<int>("_js.Invoke<int>('testMethod')", defaultDataContext));
-
-            var exception = Assert.ThrowsException<Exception>(() => RenderToString(control));
         }
 
         [DataTestMethod]
@@ -136,6 +115,7 @@ namespace DotVVM.Framework.Tests.ControlTests
             var str = RenderToString(control);
             // TODO: should it behave differently for server-side rendering?
             Assert.AreEqual($$"""<div {{(renderMode == RenderMode.Server ? "data-test=some-string " : "")}}data-bind='attr: { "data-test": String }'></div>""", str);
+            // Assert.AreEqual($$"""<div data-test=some-string data-bind='attr: { "data-test": String }'></div>""", str);
         }
 
         [DataTestMethod]

--- a/src/Tests/ControlTests/RepeaterTests.cs
+++ b/src/Tests/ControlTests/RepeaterTests.cs
@@ -149,7 +149,7 @@ namespace DotVVM.Framework.Tests.ControlTests
     {
         public static DotvvmControl GetContents(
             HtmlCapability htmlCapability,
-            [ControlPropertyTypeDataContextChange("DataSource"), CollectionElementDataContextChange(1)]
+            [ControlPropertyBindingDataContextChange("DataSource"), CollectionElementDataContextChange(1)]
             ITemplate itemTemplate,
             IValueBinding<IEnumerable> dataSource
         )

--- a/src/Tests/ControlTests/testoutputs/CompositeControlTests.BasicWrappedHtmlControl.html
+++ b/src/Tests/ControlTests/testoutputs/CompositeControlTests.BasicWrappedHtmlControl.html
@@ -9,7 +9,7 @@
 		<div class="x" data-anotherattr="123" data-testattr=""></div>
 		
 		<!-- value bindings -->
-		<div data-bind="css: { x: int() < 0 }, style: { width: float() * 100 + &quot;px&quot; }, attr: { &quot;data-attr&quot;: int }" style="width:11.111px"></div>
+		<div data-attr="10000000" data-bind="css: { x: int() < 0 }, style: { width: float() * 100 + &quot;px&quot; }, attr: { &quot;data-attr&quot;: int }" style="width:11.111px"></div>
 		
 		<!-- class value binding (compile-time attribute merging should work) -->
 		<div class="big even"></div>

--- a/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.CapabilityReads.html
+++ b/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.CapabilityReads.html
@@ -2,9 +2,9 @@
 	<head></head>
 	<body>
 		<div class="z" data-test1="has-z-class"></div>
-		<div class="z" data-bind="css: { z: int() > 1 }, attr: { &quot;data-test1&quot;: int() > 1 ? &quot;has-z-class&quot; : &quot;no-z-class&quot; }"></div>
+		<div class="z" data-bind="css: { z: int() > 1 }, attr: { &quot;data-test1&quot;: int() > 1 ? &quot;has-z-class&quot; : &quot;no-z-class&quot; }" data-test1="has-z-class"></div>
 		<div class="z" data-test1="has-z-class"></div>
-		<div data-bind="visible: int() > 1, attr: { &quot;data-visible-copy&quot;: int() > 1 ? &quot;yes&quot; : &quot;no&quot; }"></div>
+		<div data-bind="visible: int() > 1, attr: { &quot;data-visible-copy&quot;: int() > 1 ? &quot;yes&quot; : &quot;no&quot; }" data-visible-copy="yes"></div>
 		<div data-visible-copy="yes"></div>
 	</body>
 </html>

--- a/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.PostbackHandlers.html
+++ b/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.PostbackHandlers.html
@@ -6,7 +6,7 @@
 		Two handlers
 		<input data-msg="ahoj" onclick="dotvvm.postBack(this,[],&quot;2suRIvLX7+StPC7x&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,{message:&quot;ahoj&quot;}]],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
 		Two handlers, value binding message
-		<input data-bind="attr: { &quot;data-msg&quot;: Label }" onclick="dotvvm.postBack(this,[],&quot;b80b5Lh9K50jj3q2&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,(c,d)=>({message:(d).Label()})]],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
+		<input data-bind="attr: { &quot;data-msg&quot;: Label }" data-msg="My Label" onclick="dotvvm.postBack(this,[],&quot;b80b5Lh9K50jj3q2&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,(c,d)=>({message:(d).Label()})]],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
 		Two handlers, resource binding message
 		<input data-msg="My Label" onclick="dotvvm.postBack(this,[],&quot;mH2HraWjqc1sx3p+&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,{message:&quot;My Label&quot;}]],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
 		Two handlers, default message

--- a/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.StyleBindingMapping.html
+++ b/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.StyleBindingMapping.html
@@ -6,10 +6,10 @@
 		resource binding
 		<div class="a class123-some-class" data-custom-class-attr="some-class"></div>
 		value binding
-		<div data-bind="class: &quot;a class123-&quot; + (SomeClass() ?? &quot;&quot;), attr: { &quot;data-custom-class-attr&quot;: SomeClass }"></div>
+		<div class="a class123-some-class" data-bind="class: &quot;a class123-&quot; + (SomeClass() ?? &quot;&quot;), attr: { &quot;data-custom-class-attr&quot;: SomeClass }" data-custom-class-attr="some-class"></div>
 		checkbox with checkbox-checked class
-		<input data-bind="class: int() > 10 == true ? &quot;checkbox-checked&quot; : &quot;&quot;, dotvvm-CheckState: int() > 10" type="checkbox">
-		<input data-bind="class: Boolean() == true ? &quot;checkbox-checked&quot; : &quot;&quot;, dotvvm-CheckState: Boolean" type="checkbox">
+		<input class="checkbox-checked" data-bind="class: int() > 10 == true ? &quot;checkbox-checked&quot; : &quot;&quot;, dotvvm-CheckState: int() > 10" type="checkbox">
+		<input class="" data-bind="class: Boolean() == true ? &quot;checkbox-checked&quot; : &quot;&quot;, dotvvm-CheckState: Boolean" type="checkbox">
 		a div with visible class
 		<div class="hide" data-bind="css: { hide: !Boolean() }"></div>
 		<input data-bind="css: { hide: Label() == &quot;hidden&quot; }, dotvvm-textbox-text: Label" type="text">

--- a/src/Tests/ControlTests/testoutputs/SimpleControlTests.HtmlControl.html
+++ b/src/Tests/ControlTests/testoutputs/SimpleControlTests.HtmlControl.html
@@ -4,7 +4,7 @@
 		just some attributes
 		<span class="x" id="a" onclick="alert(1)"></span>
 		just some attributes with binding
-		<span data-bind="class: &quot;xx-&quot; + int() + &quot; another-class&quot;, attr: { id: &quot;xx&quot; + int() }"></span>
+		<span class="xx-10000000 another-class" data-bind="class: &quot;xx-&quot; + int() + &quot; another-class&quot;, attr: { id: &quot;xx&quot; + int() }"></span>
 		visible after loaded
 		<div data-bind="visible: true" style="display:none">
 			X


### PR DESCRIPTION
Unifies how client/server rendering mode behaves in all HtmlGenericControl properties to "always render both".

* Applies to Visible, Attributes, CssClasses, CssStyles
* When property contains value binding, knockout binding is added
* The property is always rendered server-side
* When value binding evaluation fails on server, the exception is suppressed.

The behavior is unchanged in `CssClasses` and `CssStyles`, I have added the try catch to Visible and Attributes are now rendered in server-side mode. Technically, this is a **breaking change**, so we should definitely announce it, but the impact should be small - In most cases, what is rendered server-side is irrelevant to normal page behavior, it only affect indexers and page load performance.

I have also changed how returning `null` behaves in Attributes. Before it added an empty attribute, which is inconsistent with the client-side behavior of knockout JS (and it is also annoying, since most attributes in client-side templates will return `null` and thus would be present empty). Now, `null` returned from a binding skips rendering of that attribute. Behavior of hardcoded `null`s is unchanged - it will still render an empty attribute.

resolves #1635