### PR TITLE
AutoUI: nested contexts should contain _index and _collection

### DIFF
--- a/src/AutoUI/Core/AutoUIContext.cs
+++ b/src/AutoUI/Core/AutoUIContext.cs
@@ -63,6 +63,7 @@ namespace DotVVM.AutoUI
             });
         }
 
+        [Obsolete("This method probably doesn't do what you'd expect - It does not work correctly for collection elements, because it will miss _index parameter. Please use the `BindingHelper.GetDataContextType(Repeater.ItemTemplateProperty, repeater, context.DataContextStack)` method for the specific property where the binding is being placed (Repeater is just example). If the type is changed using DotvvmBindableObject.DataContext property, use the DataContextStack.Create method.")]
         public DataContextStack CreateChildDataContextStack(DataContextStack dataContextStack, params Type[] nestedDataContextTypes)
         {
             foreach (var type in nestedDataContextTypes)
@@ -72,6 +73,7 @@ namespace DotVVM.AutoUI
             return dataContextStack;
         }
 
+        [Obsolete("This method probably doesn't do what you'd expect - It does not work correctly for collection elements, because it will miss _index parameter. Please use the `BindingHelper.GetDataContextType(Repeater.ItemTemplateProperty, repeater, context.DataContextStack)` method for the specific property where the binding is being placed (Repeater is just example). If the type is changed using DotvvmBindableObject.DataContext property, use the DataContextStack.Create method.")]
         public DataContextStack CreateChildDataContextStack(params Type[] nestedDataContextTypes) =>
             CreateChildDataContextStack(DataContextStack, nestedDataContextTypes);
 

--- a/src/AutoUI/Core/PropertyHandlers/FormEditors/MultiSelectorCheckBoxFormEditorProvider.cs
+++ b/src/AutoUI/Core/PropertyHandlers/FormEditors/MultiSelectorCheckBoxFormEditorProvider.cs
@@ -1,5 +1,6 @@
 ﻿using DotVVM.AutoUI.Controls;
 using DotVVM.AutoUI.Metadata;
+using DotVVM.Framework.Binding;
 using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.Utils;
@@ -20,15 +21,16 @@ public class MultiSelectorCheckBoxFormEditorProvider : FormEditorProviderBase
         var selectorConfiguration = property.SelectionConfiguration!;
         var selectorDiscoveryService = context.Services.GetRequiredService<ISelectorDiscoveryService>();
         var selectorDataSourceBinding = selectorDiscoveryService.DiscoverSelectorDataSourceBinding(context, selectorConfiguration.SelectionType);
-        var nestedDataContext = context.CreateChildDataContextStack(selectorConfiguration.SelectionType);
-
-        return new Repeater()
+        var repeater = new Repeater()
             .SetCapability(props.Html)
             .SetProperty(c => c.WrapperTagName, "ul")
-            .SetProperty(c => c.DataSource, selectorDataSourceBinding)
+            .SetProperty(c => c.DataSource, selectorDataSourceBinding);
+
+        var nestedDataContext = BindingHelper.GetDataContextType(Repeater.ItemTemplateProperty, repeater, context.DataContextStack).NotNull();
+
+        return repeater
             .SetProperty(c => c.ItemTemplate, new CloneTemplate(
                 new HtmlGenericControl("li")
-                    .SetProperty(Internal.DataContextTypeProperty, nestedDataContext)
                     .AppendChildren(
                         new CheckBox()
                             .SetProperty(c => c.Text, context.BindingService.Cache.CreateValueBinding<string>("DisplayName", nestedDataContext))

--- a/src/AutoUI/Core/PropertyHandlers/FormEditors/SelectorComboBoxFormEditorProvider.cs
+++ b/src/AutoUI/Core/PropertyHandlers/FormEditors/SelectorComboBoxFormEditorProvider.cs
@@ -1,5 +1,6 @@
 ﻿using DotVVM.AutoUI.Controls;
 using DotVVM.AutoUI.Metadata;
+using DotVVM.Framework.Binding;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.Utils;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,11 +20,14 @@ namespace DotVVM.AutoUI.PropertyHandlers.FormEditors
             var selectorConfiguration = property.SelectionConfiguration!;
             var selectorDiscoveryService = context.Services.GetRequiredService<ISelectorDiscoveryService>();
             var selectorDataSourceBinding = selectorDiscoveryService.DiscoverSelectorDataSourceBinding(context, selectorConfiguration.SelectionType);
-            var nestedDataContext = context.CreateChildDataContextStack(selectorConfiguration.SelectionType);
-
-            return new ComboBox()
+            
+            var comboBox = new ComboBox()
                 .SetCapability(props.Html)
-                .SetProperty(c => c.DataSource, selectorDataSourceBinding)
+                .SetProperty(c => c.DataSource, selectorDataSourceBinding);
+
+            var nestedDataContext = BindingHelper.GetDataContextType(ComboBox.ItemValueBindingProperty, comboBox, context.DataContextStack).NotNull();
+
+            return comboBox
                 .SetProperty(c => c.ItemTextBinding, context.BindingService.Cache.CreateValueBinding<string>("DisplayName", nestedDataContext))
                 .SetProperty(c => c.ItemValueBinding, context.BindingService.Cache.CreateValueBinding("Value", nestedDataContext))
                 .SetProperty(c => c.SelectedValue, props.Property)


### PR DESCRIPTION
We had slight mismatches in the data context types of selector bindings - the control context normally includes _index and _collection extension parameters, but the bindings created by AutoUI did not. This didn't cause any issues, since ComboBox doesn't check it and
the multi selector contained a DataContextType override.

However, if the same logic was used as is in other places (BP), it was crashing with data context type mismatch exception.