### PR TITLE
Log compilation warnings to ILogger

### DIFF
--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlNode.cs
@@ -33,10 +33,9 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
         }
 
 
-        public bool HasNodeErrors
-        {
-            get { return nodeErrors != null && nodeErrors.Count > 0; }
-        }
+        public bool HasNodeErrors => nodeErrors != null && nodeErrors.Count > 0;
+
+        public bool HasNodeWarnings => nodeWarnings != null && nodeWarnings.Count > 0;
 
         public abstract void Accept(IDothtmlSyntaxTreeVisitor visitor);
 


### PR DESCRIPTION
Currently, warnings from the compilation stage are only shown in VS Extension. This makes them also visible the Asp.Net Core log.

![image](https://github.com/riganti/dotvvm/assets/7894687/140a09f4-badb-4077-b381-2ee44af96868)
