### PR TITLE
Fix weird glitch in async static command invocation

### DIFF
--- a/src/Framework/Framework/Utils/TaskUtils.cs
+++ b/src/Framework/Framework/Utils/TaskUtils.cs
@@ -32,7 +32,7 @@ namespace DotVVM.Framework.Utils
 
 
             // throw exception without the TargetInvocationException wrapper
-            if (!task.IsCompletedSuccessfully)
+            if (task.Status != TaskStatus.RanToCompletion)
                 task.Wait();
 
             return resultProperty.GetValue(task);

--- a/src/Framework/Framework/Utils/TaskUtils.cs
+++ b/src/Framework/Framework/Utils/TaskUtils.cs
@@ -13,22 +13,29 @@ namespace DotVVM.Framework.Utils
         }
 
         public static object? GetResult(Task task)
-            => IsVoidTask(task) ? null : ((dynamic)task).Result;
-
-        private static bool IsVoidTask(Task task)
         {
             var type = task.GetType();
-
-            var resultProperty = type.GetProperty("Result");
-            if (type != typeof(Task) && resultProperty != null)
+            if (type == typeof(Task))
             {
-                var taskResultPropertyName = resultProperty.PropertyType.Name;
-                return taskResultPropertyName == "VoidTaskResult" || taskResultPropertyName == "VoidResult";
+                return null;
             }
 
-            return true;
+            var resultProperty = type.GetProperty("Result");
+            if (resultProperty is null)
+                return null;
+
+            var taskResultPropertyName = resultProperty.PropertyType.Name;
+            if (taskResultPropertyName == "VoidTaskResult" || taskResultPropertyName == "VoidResult")
+            {
+                return null;
+            }
+
+
+            // throw exception without the TargetInvocationException wrapper
+            if (!task.IsCompletedSuccessfully)
+                task.Wait();
+
+            return resultProperty.GetValue(task);
         }
-
-
     }
 }


### PR DESCRIPTION
For some reason, I was getting "Property Result does not exist" error in the dynamic invocation. I couldn't replicate it in the framework - we already have a number of tests for async static commands.

However, we were already accessing Result property using reflection, so this change should make anything noticably slower