### PR TITLE
Fix NRE when IncludeInPage={resource: null}

### DIFF
--- a/src/Framework/Framework/Controls/DotvvmControl.cs
+++ b/src/Framework/Framework/Controls/DotvvmControl.cs
@@ -250,7 +250,7 @@ namespace DotVVM.Framework.Controls
         /// <returns>true means that rendering of the rest of this control should be skipped</returns>
         protected bool RenderBeforeControl(in RenderState r, IHtmlWriter writer, IDotvvmRequestContext context)
         {
-            if (r.IncludeInPage != null && !(r.IncludeInPage is IValueBinding) && !this.IncludeInPage)
+            if (r.IncludeInPage != null && !(r.IncludeInPage is IValueBinding) && false.Equals(this.GetValue(IncludeInPageProperty)))
                 return true;
 
             if (r.DataContext != null)

--- a/src/Tests/ControlTests/SimpleControlTests.cs
+++ b/src/Tests/ControlTests/SimpleControlTests.cs
@@ -143,6 +143,30 @@ namespace DotVVM.Framework.Tests.ControlTests
         }
 
         [TestMethod]
+        public async Task IncludeInPage()
+        {
+            var r = await cth.RunPage(typeof(BasicTestViewModel), """
+                not included
+                <div IncludeInPage={resource: NullableString != null} />
+
+                included
+                <div IncludeInPage={resource: NullableString == null} />
+
+                returns null -> included
+                <div IncludeInPage={resource: NullBoolean} />
+
+                value binding
+                <div IncludeInPage={value: Integer < 0} />
+
+                value binding + DataContext
+                <div IncludeInPage={value: _this > 0} DataContext={value: Integer} />
+                """
+            );
+
+            check.CheckString(r.OutputString, fileExtension: "html");
+        }
+
+        [TestMethod]
         public async Task TextBox()
         {
             var r = await cth.RunPage(typeof(BasicTestViewModel), @"
@@ -384,6 +408,8 @@ namespace DotVVM.Framework.Tests.ControlTests
             public string Label { get; } = "My Label";
 
             public string NullableString { get; } = null;
+
+            public bool? NullBoolean { get; } = null;
 
             public int[] IntArray { get; set; }
 

--- a/src/Tests/ControlTests/testoutputs/SimpleControlTests.IncludeInPage.html
+++ b/src/Tests/ControlTests/testoutputs/SimpleControlTests.IncludeInPage.html
@@ -1,0 +1,21 @@
+
+
+<head></head>
+<body>
+not included
+
+
+included
+<div></div>
+
+returns null -> included
+<div></div>
+
+value binding
+<!-- ko if: int() < 0 --><div></div><!-- /ko -->
+
+value binding + DataContext
+<!-- ko with: int --><!-- ko if: $data > 0 --><div></div><!-- /ko --><!-- /ko -->
+
+
+</body>


### PR DESCRIPTION
This happens easily due to the automatic null propagation. When null is returned, we stick to the default value and do include control