### PR TITLE
Refactor RadioButton to unify client/server rendering

### DIFF
--- a/src/Framework/Framework/Controls/CheckableControlBase.cs
+++ b/src/Framework/Framework/Controls/CheckableControlBase.cs
@@ -194,13 +194,15 @@ namespace DotVVM.Framework.Controls
             }
 
             // handle enabled attribute
-            writer.AddKnockoutDataBind("enable", this, EnabledProperty, () =>
+            var enabled = this.GetValueRaw(EnabledProperty);
+            if (enabled is IValueBinding enabledBinding)
             {
-                if (!Enabled)
-                {
-                    writer.AddAttribute("disabled", "disabled");
-                }
-            });
+                writer.AddKnockoutDataBind("enable", this, enabledBinding);
+            }
+            if (false.Equals(KnockoutHelper.TryEvaluateValueBinding(this, enabled)))
+            {
+                writer.AddAttribute("disabled", "disabled");
+            }
 
             if (!string.IsNullOrEmpty(InputCssClass))
             {

--- a/src/Framework/Framework/Controls/KnockoutBindingGroup.cs
+++ b/src/Framework/Framework/Controls/KnockoutBindingGroup.cs
@@ -41,6 +41,12 @@ namespace DotVVM.Framework.Controls
                 Add(name, nestedGroup.ToString());
         }
 
+        public void Add(string name, DotvvmBindableObject contextControl, IValueBinding binding)
+        {
+            var expression = binding.GetKnockoutBindingExpression(contextControl);
+            Add(name, expression);
+        }
+
         [Obsolete("Use Add or AddValue instead")]
         public virtual void Add(string name, string expression, bool surroundWithDoubleQuotes)
         {

--- a/src/Framework/Framework/Controls/KnockoutHelper.cs
+++ b/src/Framework/Framework/Controls/KnockoutHelper.cs
@@ -15,6 +15,24 @@ namespace DotVVM.Framework.Controls
 {
     public static class KnockoutHelper
     {
+        /// <summary> If value is a binding, evaluates it. If the binding is a value binding, any thrown exceptions are suppressed </summary>
+        internal static object? TryEvaluateValueBinding(DotvvmBindableObject control, object? valueOrBinding)
+        {
+            if (valueOrBinding is IStaticValueBinding b)
+            {
+                try
+                {
+                    return b.Evaluate(control);
+                }
+                catch when (b is IValueBinding)
+                {
+                    return null;
+                }
+            }
+            return valueOrBinding;
+        }
+
+
         /// <summary>
         /// Adds the data-bind attribute to the next HTML element that is being rendered. The binding expression is taken from the specified property. If in server rendering mode, the binding is also not rendered.
         /// </summary>

--- a/src/Samples/Common/Views/FeatureSamples/FormControlsEnabled/FormControlsEnabled.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/FormControlsEnabled/FormControlsEnabled.dothtml
@@ -34,9 +34,9 @@
         <dot:ListBox ID="lb1-enabled" Enabled="{value: true}" DataSource="{value: Items}" SelectedValue="{value: SelectedItem}" />
         <dot:ListBox ID="lb1-disabled" Enabled="{value: false}" DataSource="{value: Items}" SelectedValue="{value: SelectedItem}" />
         <br />
-        <dot:RadioButton ID="rb1-default" CheckedValue="{value: false}" />
-        <dot:RadioButton ID="rb1-enabled" CheckedValue="{value: false}" Enabled="{value: true}" />
-        <dot:RadioButton ID="rb1-disabled" CheckedValue="{value: false}" Enabled="{value: false}" />
+        <dot:RadioButton ID="rb1-default" CheckedItem={value: false} CheckedValue={value: true} />
+        <dot:RadioButton ID="rb1-enabled" CheckedItem={value: false} CheckedValue={value: true} Enabled={value: true} />
+        <dot:RadioButton ID="rb1-disabled" CheckedItem={value: false} CheckedValue={value: true} Enabled={value: false} />
         <br />
         <dot:TextBox ID="tb1-default" Text="Test" />
         <dot:TextBox ID="tb1-enabled" Enabled="{value: true}" Text="Test" />
@@ -64,9 +64,9 @@
             <dot:ListBox ID="lb2-enabled" Enabled="{value: true}" DataSource="{value: _root.Items}" SelectedValue="{value: _root.SelectedItem}" />
             <dot:ListBox ID="lb2-disabled" Enabled="{value: false}" DataSource="{value: _root.Items}" SelectedValue="{value: _root.SelectedItem}" />
             <br />
-            <dot:RadioButton ID="rb2-default" CheckedValue="{value: false}" />
-            <dot:RadioButton ID="rb2-enabled" CheckedValue="{value: false}" Enabled="{value: true}" />
-            <dot:RadioButton ID="rb2-disabled" CheckedValue="{value: false}" Enabled="{value: false}" />
+            <dot:RadioButton ID="rb2-default" CheckedItem={value: false} CheckedValue={value: true} />
+            <dot:RadioButton ID="rb2-enabled" CheckedItem={value: false} CheckedValue={value: true} Enabled={value: true} />
+            <dot:RadioButton ID="rb2-disabled" CheckedItem={value: false} CheckedValue={value: true} Enabled={value: false} />
             <br />
             <dot:TextBox ID="tb2-default" Text="Test" />
             <dot:TextBox ID="tb2-enabled" Enabled="{value: true}" Text="Test" />
@@ -99,9 +99,9 @@
                     <dot:ListBox ID="lb-enabled" Enabled="{value: true}" DataSource="{value: _root.Items}" SelectedValue="{value: _root.SelectedItem}" />
                     <dot:ListBox ID="lb-disabled" Enabled="{value: false}" DataSource="{value: _root.Items}" SelectedValue="{value: _root.SelectedItem}" />
                     <br />
-                    <dot:RadioButton ID="rb-default" CheckedValue="{value: false}" />
-                    <dot:RadioButton ID="rb-enabled" CheckedValue="{value: false}" Enabled="{value: true}" />
-                    <dot:RadioButton ID="rb-disabled" CheckedValue="{value: false}" Enabled="{value: false}" />
+                    <dot:RadioButton ID="rb-default" CheckedItem={value: false} CheckedValue={value: true} />
+                    <dot:RadioButton ID="rb-enabled" CheckedItem={value: false} CheckedValue={value: true} Enabled={value: true} />
+                    <dot:RadioButton ID="rb-disabled" CheckedItem={value: false} CheckedValue={value: true} Enabled={value: false} />
                     <br />
                     <dot:TextBox ID="tb-default" Text="Test" />
                     <dot:TextBox ID="tb-enabled" Enabled="{value: true}" Text="Test" />

--- a/src/Tests/ControlTests/SimpleControlTests.cs
+++ b/src/Tests/ControlTests/SimpleControlTests.cs
@@ -230,9 +230,9 @@ namespace DotVVM.Framework.Tests.ControlTests
                     <dot:RadioButton CheckedItem={value: NullableString} GroupName=g1 Enabled={value: Integer < 0} CheckedValue=C />
 
                     <!-- checked boolean -->
-                    <dot:RadioButton Checked={value: Bool} />
+                    <dot:RadioButton Checked={value: Bool} CheckedValue={resource:true} />
                     <!-- checked readonly -->
-                    <dot:RadioButton Checked={value: Integer > 0} Enabled=false />
+                    <dot:RadioButton Checked={value: Integer > 0} Enabled=false CheckedValue={resource:true} />
                     <!-- dynamic group name -->
                     <dot:RadioButton CheckedItem={value: NullableString} GroupName={value: "G" + Integer} Enabled={value: Integer < 0} CheckedValue=C another-bound-attribute={value: Integer} />
                 </span>

--- a/src/Tests/ControlTests/SimpleControlTests.cs
+++ b/src/Tests/ControlTests/SimpleControlTests.cs
@@ -216,6 +216,34 @@ namespace DotVVM.Framework.Tests.ControlTests
         }
 
         [TestMethod]
+        [DataRow(RenderMode.Server)]
+        [DataRow(RenderMode.Client)]
+        public async Task RadioButton(RenderMode mode)
+        {
+            var r = await cth.RunPage(typeof(BasicTestViewModel), $$"""
+                <span RenderSettings.Mode={{mode}}>
+                    <!-- basic CheckedValue usage -->
+                    <dot:RadioButton CheckedItem={value: NullableString} GroupName=g1 CheckedValue=A />
+                    <!-- disabled + label -->
+                    <dot:RadioButton CheckedItem={value: NullableString} GroupName=g1 Text="Radio with label" Enabled=false CheckedValue=B />
+                    <!-- disabled dynamically -->
+                    <dot:RadioButton CheckedItem={value: NullableString} GroupName=g1 Enabled={value: Integer < 0} CheckedValue=C />
+
+                    <!-- checked boolean -->
+                    <dot:RadioButton Checked={value: Bool} />
+                    <!-- checked readonly -->
+                    <dot:RadioButton Checked={value: Integer > 0} Enabled=false />
+                    <!-- dynamic group name -->
+                    <dot:RadioButton CheckedItem={value: NullableString} GroupName={value: "G" + Integer} Enabled={value: Integer < 0} CheckedValue=C another-bound-attribute={value: Integer} />
+                </span>
+                """,
+                fileName: $"SimpleControls_RadioButton_{mode}.dothtml"
+            );
+
+            check.CheckString(r.OutputString, fileExtension: "html");
+        }
+
+        [TestMethod]
         public async Task CommandBinding()
         {
             var r = await cth.RunPage(typeof(BasicTestViewModel), @"
@@ -414,6 +442,8 @@ namespace DotVVM.Framework.Tests.ControlTests
             public int[] IntArray { get; set; }
 
             public string UrlSuffix { get; set; } = "#something";
+
+            public bool Bool { get; set; } = true;
 
             public GridViewDataSet<CustomerData> Customers { get; set; } = new GridViewDataSet<CustomerData>() {
                 RowEditOptions = {

--- a/src/Tests/ControlTests/testoutputs/SimpleControlTests.RadioButton.html
+++ b/src/Tests/ControlTests/testoutputs/SimpleControlTests.RadioButton.html
@@ -11,9 +11,9 @@
     <input disabled=disabled type=radio name=g1 data-bind='enable: int() &lt; 0, checked: NullableString, checkedValue: "C"' />
 
     <!-- checked boolean -->
-    <input checked type=radio name data-bind="checked: Bool" />
+    <input checked type=radio name data-bind="checked: Bool, checkedValue: true" />
     <!-- checked readonly -->
-    <input disabled=disabled checked type=radio name data-bind="checked: int() &gt; 0" />
+    <input disabled=disabled checked type=radio name data-bind="checked: int() &gt; 0, checkedValue: true" />
     <!-- dynamic group name -->
     <input another-bound-attribute=10000000 disabled=disabled type=radio name=G10000000 data-bind='attr: { "another-bound-attribute": int, name: "G" + int() }, enable: int() &lt; 0, checked: NullableString, checkedValue: "C"' />
 </span>

--- a/src/Tests/ControlTests/testoutputs/SimpleControlTests.RadioButton.html
+++ b/src/Tests/ControlTests/testoutputs/SimpleControlTests.RadioButton.html
@@ -1,0 +1,22 @@
+
+
+<head></head>
+<body>
+<span>
+    <!-- basic CheckedValue usage -->
+    <input type=radio name=g1 data-bind='checked: NullableString, checkedValue: "A"' />
+    <!-- disabled + label -->
+    <label><input disabled=disabled type=radio name=g1 data-bind='checked: NullableString, checkedValue: "B"' /><span>Radio with label</span></label>
+    <!-- disabled dynamically -->
+    <input disabled=disabled type=radio name=g1 data-bind='enable: int() &lt; 0, checked: NullableString, checkedValue: "C"' />
+
+    <!-- checked boolean -->
+    <input checked type=radio name data-bind="checked: Bool" />
+    <!-- checked readonly -->
+    <input disabled=disabled checked type=radio name data-bind="checked: int() &gt; 0" />
+    <!-- dynamic group name -->
+    <input another-bound-attribute=10000000 disabled=disabled type=radio name=G10000000 data-bind='attr: { "another-bound-attribute": int, name: "G" + int() }, enable: int() &lt; 0, checked: NullableString, checkedValue: "C"' />
+</span>
+
+
+</body>

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -1239,8 +1239,7 @@
       },
       "GroupName": {
         "type": "System.String",
-        "defaultValue": "",
-        "onlyHardcoded": true
+        "defaultValue": ""
       }
     },
     "DotVVM.Framework.Controls.RenderSettings": {


### PR DESCRIPTION
* all properties (Checked, Enabled, GroupName) will render both knockout expression and the value
* if value binding is used and evaluation fails, the exception is ignored (as in HtmlGenericControl, new helper method was added for this)
* GroupName now allows value bindings - this might be useful for usage in client-side Repeater

resolves #1538