### PR TITLE
StaticCommand validation: Fix lambda expression based API

### DIFF
--- a/src/Framework/Framework/Hosting/StaticCommandExecutor.cs
+++ b/src/Framework/Framework/Hosting/StaticCommandExecutor.cs
@@ -98,10 +98,11 @@ namespace DotVVM.Framework.Hosting
                     throw new Exception("Could not respond with validation failure because the client did not send validation paths.", innerException);
                 if (error.PropertyPathExtractor != null)
                 {
-                    var path = error.PropertyPathExtractor(configuration);
-                    var hasPropertySegment = path.Count(static c => c == '/') >= 2;
-                    var name = hasPropertySegment ? path.Substring(0, path.IndexOf('/')) : path;
-                    var rest = hasPropertySegment ? path.Substring(name.Length + 1) : string.Empty;
+                    var path = error.PropertyPathExtractor(configuration).TrimStart('/');
+                    var slashIndex = path.IndexOf('/');
+                    var hasPropertySegment = slashIndex >= 0 && slashIndex < path.Length - 1;
+                    var name = hasPropertySegment ? path.Substring(0, slashIndex) : path;
+                    var rest = hasPropertySegment ? path.Substring(slashIndex + 1) : string.Empty;
                     error.ArgumentName = name;
                     error.PropertyPath = rest;
                 }

--- a/src/Framework/Framework/Utils/ExpressionUtils.cs
+++ b/src/Framework/Framework/Utils/ExpressionUtils.cs
@@ -230,12 +230,12 @@ namespace DotVVM.Framework.Utils
         /// </summary>
         public static Expression OptimizeConstants(this Expression ex)
         {
-            var v = new ConstantsOptimizingVisitor();
-            return v.Visit(ex);
+            return ConstantsOptimizingVisitor.Instance.Visit(ex);
         }
 
-        private class ConstantsOptimizingVisitor : ExpressionVisitor
+        private sealed class ConstantsOptimizingVisitor : ExpressionVisitor
         {
+            public static readonly ConstantsOptimizingVisitor Instance = new ConstantsOptimizingVisitor();
             protected override Expression VisitMember(MemberExpression node)
             {
                 if (node.Member.MemberType == MemberTypes.Property)

--- a/src/Tests/Binding/StaticCommandExecutorTests.cs
+++ b/src/Tests/Binding/StaticCommandExecutorTests.cs
@@ -135,5 +135,32 @@ namespace DotVVM.Framework.Tests.Binding
         {
             return true;
         }
+        [TestMethod]
+        public async Task ArgumentPropertyLambdaError()
+        {
+#pragma warning disable CS4014
+            var plan = CreatePlan(() => ValidateArgumentPropertyLambda(null, null));
+#pragma warning restore CS4014
+            var modelState = await InvokeExpectingErrors(plan, (new TestViewModel(), "/MyViewModel"));
+            Assert.AreEqual(3, modelState.Errors.Count);
+            Assert.IsTrue(modelState.Errors[0].IsResolved);
+            Assert.AreEqual("/MyViewModel/IntProp", modelState.Errors[0].PropertyPath);
+            Assert.IsTrue(modelState.Errors[1].IsResolved);
+            Assert.AreEqual("/MyViewModel/VmArray/12/Enum", modelState.Errors[1].PropertyPath);
+            Assert.IsTrue(modelState.Errors[2].IsResolved);
+            Assert.AreEqual("/MyViewModel/LongList/12", modelState.Errors[2].PropertyPath);
+        }
+        [AllowStaticCommand]
+        internal static async Task<bool> ValidateArgumentPropertyLambda(IDotvvmRequestContext context, TestViewModel vm)
+        {
+            var ms = new StaticCommandModelState();
+            ms.AddArgumentError(() => vm.IntProp, "error1");
+            var index = 12;
+            ms.AddArgumentError(() => vm.VmArray[index].Enum, "error2");
+            ms.AddArgumentError(() => vm.LongList[index], "error3");
+            ms.FailOnInvalidModelState();
+            return true;
+        }
+
     }
 }


### PR DESCRIPTION
The AddArgumentError method would not work if more complex expression than single identifier was used. This patch replaces a simple MemberExpression matching with a visitor which replaces display class members with ExpressionExpression. Then the standard JsTranslator can handle the expression and produce a validation path