### PR TITLE
Route not matched when it has optional parameter with constraint

### DIFF
--- a/src/Framework/Framework/Configuration/DotvvmConfiguration.cs
+++ b/src/Framework/Framework/Configuration/DotvvmConfiguration.cs
@@ -300,31 +300,31 @@ namespace DotVVM.Framework.Configuration
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
         static void RegisterConstraints(DotvvmConfiguration configuration)
         {
-            configuration.RouteConstraints.Add("alpha", GenericRouteParameterType.Create("[a-zA-Z]*?"));
+            configuration.RouteConstraints.Add("alpha", GenericRouteParameterType.Create("[a-zA-Z]+"));
             configuration.RouteConstraints.Add("bool", GenericRouteParameterType.Create<bool>("true|false", bool.TryParse));
-            configuration.RouteConstraints.Add("decimal", GenericRouteParameterType.Create<decimal>("-?[0-9.e]*?", Invariant.TryParse));
-            configuration.RouteConstraints.Add("double", GenericRouteParameterType.Create<double>("-?[0-9.e]*?", Invariant.TryParse));
-            configuration.RouteConstraints.Add("float", GenericRouteParameterType.Create<float>("-?[0-9.e]*?", Invariant.TryParse));
+            configuration.RouteConstraints.Add("decimal", GenericRouteParameterType.Create<decimal>("-?[0-9.e]+", Invariant.TryParse));
+            configuration.RouteConstraints.Add("double", GenericRouteParameterType.Create<double>("-?[0-9.e]+", Invariant.TryParse));
+            configuration.RouteConstraints.Add("float", GenericRouteParameterType.Create<float>("-?[0-9.e]+", Invariant.TryParse));
             configuration.RouteConstraints.Add("guid", GenericRouteParameterType.Create<Guid>("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", Guid.TryParse));
-            configuration.RouteConstraints.Add("int", GenericRouteParameterType.Create<int>("-?[0-9]*?", Invariant.TryParse));
-            configuration.RouteConstraints.Add("posint", GenericRouteParameterType.Create<int>("[0-9]*?", Invariant.TryParse));
+            configuration.RouteConstraints.Add("int", GenericRouteParameterType.Create<int>("-?[0-9]+", Invariant.TryParse));
+            configuration.RouteConstraints.Add("posint", GenericRouteParameterType.Create<int>("[0-9]+", Invariant.TryParse));
             configuration.RouteConstraints.Add("length", new GenericRouteParameterType(p => "[^/]{" + p + "}"));
-            configuration.RouteConstraints.Add("long", GenericRouteParameterType.Create<long>("-?[0-9]*?", Invariant.TryParse));
-            configuration.RouteConstraints.Add("max", new GenericRouteParameterType(p => "-?[0-9.e]*?", (valueString, parameter) => {
+            configuration.RouteConstraints.Add("long", GenericRouteParameterType.Create<long>("-?[0-9]+", Invariant.TryParse));
+            configuration.RouteConstraints.Add("max", new GenericRouteParameterType(p => "-?[0-9.e]+", (valueString, parameter) => {
                 if (parameter is null) throw new Exception("The `max` route constraint must have a numeric parameter.");
                 double value;
                 if (!Invariant.TryParse(valueString, out value)) return ParameterParseResult.Failed;
                 if (double.Parse(parameter, CultureInfo.InvariantCulture) < value) return ParameterParseResult.Failed;
                 return ParameterParseResult.Create(value);
             }));
-            configuration.RouteConstraints.Add("min", new GenericRouteParameterType(p => "-?[0-9.e]*?", (valueString, parameter) => {
+            configuration.RouteConstraints.Add("min", new GenericRouteParameterType(p => "-?[0-9.e]+", (valueString, parameter) => {
                 if (parameter is null) throw new Exception("The `min` route constraint must have a numeric parameter.");
                 double value;
                 if (!Invariant.TryParse(valueString, out value)) return ParameterParseResult.Failed;
                 if (double.Parse(parameter, CultureInfo.InvariantCulture) > value) return ParameterParseResult.Failed;
                 return ParameterParseResult.Create(value);
             }));
-            configuration.RouteConstraints.Add("range", new GenericRouteParameterType(p => "-?[0-9.e]*?", (valueString, parameter) => {
+            configuration.RouteConstraints.Add("range", new GenericRouteParameterType(p => "-?[0-9.e]+", (valueString, parameter) => {
                 if (parameter is null) throw new Exception("The `range` route constraint must have two numeric parameters.");
                 double value;
                 if (!Invariant.TryParse(valueString, out value)) return ParameterParseResult.Failed;

--- a/src/Framework/Framework/Routing/DotvvmRoute.cs
+++ b/src/Framework/Framework/Routing/DotvvmRoute.cs
@@ -99,7 +99,7 @@ namespace DotVVM.Framework.Routing
             foreach (var parameter in parameters)
             {
                 var g = match.Groups["param" + parameter.Key];
-                if (g.Success)
+                if (g.Success && g.Length > 0)
                 {
                     var decodedValue = Uri.UnescapeDataString(g.Value);
                     if (parameter.Value != null)
@@ -110,6 +110,10 @@ namespace DotVVM.Framework.Routing
                     }
                     else
                         values[parameter.Key] = decodedValue;
+                }
+                else if (DefaultValues.TryGetValue(parameter.Key, out var defaultValue))
+                {
+                    values[parameter.Key] = defaultValue;
                 }
             }
             return true;

--- a/src/Tests/Routing/DotvvmRouteTests.cs
+++ b/src/Tests/Routing/DotvvmRouteTests.cs
@@ -169,6 +169,62 @@ namespace DotVVM.Framework.Tests.Routing
         }
 
         [TestMethod]
+        public void DotvvmRoute_IsMatch_OneOptionalSuffixedParameter_WithConstraint_SlashAtTheEnd()
+        {
+            var route = new DotvvmRoute("Article/{Id?:int}", null, null, null, configuration);
+
+            IDictionary<string, object> parameters;
+            var result = route.IsMatch("Article/", out parameters);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(0, parameters.Count);
+        }
+
+        [TestMethod]
+        public void DotvvmRoute_IsMatch_JustOneOptionalParameter()
+        {
+            var route = new DotvvmRoute("{Id?}", null, null, null, configuration);
+
+            Assert.IsTrue(route.IsMatch("", out var params1));
+            Assert.AreEqual(0, params1.Count);
+
+            Assert.IsTrue(route.IsMatch("a", out var params2));
+            Assert.AreEqual(1, params2.Count);
+            Assert.AreEqual("a", params2["Id"]);
+        }
+
+        [TestMethod]
+        public void DotvvmRoute_IsMatch_JustOneOptionalParameterWithConstraint()
+        {
+            var route = new DotvvmRoute("{Id?:int}", null, null, null, configuration);
+
+            Assert.IsTrue(route.IsMatch("", out var params1));
+            Assert.AreEqual(0, params1.Count);
+
+            Assert.IsFalse(route.IsMatch("a", out var params2));
+
+            Assert.IsTrue(route.IsMatch("1", out var params3));
+            Assert.AreEqual(1, params3.Count);
+            Assert.AreEqual(1, params3["Id"]);
+        }
+
+        [TestMethod]
+        public void DotvvmRoute_IsMatch_JustOneOptionalParameterWithConstraint_DefaultValue()
+        {
+            var route = new DotvvmRoute("{Id?:int}", null, new { Id = 0 }, null, configuration);
+
+            Assert.IsTrue(route.IsMatch("", out var params1));
+            Assert.AreEqual(1, params1.Count);
+            Assert.AreEqual(0, params1["Id"]);
+
+            Assert.IsFalse(route.IsMatch("a", out var params2));
+
+            Assert.IsTrue(route.IsMatch("1", out var params3));
+            Assert.AreEqual(1, params3.Count);
+            Assert.AreEqual(1, params3["Id"]);
+        }
+
+        [TestMethod]
         public void DotvvmRoute_IsMatch_OneOptionalParameter()
         {
             var route = new DotvvmRoute("Article/{Id?}/edit", null, null, null, configuration);
@@ -178,6 +234,19 @@ namespace DotVVM.Framework.Tests.Routing
 
             Assert.IsTrue(result);
             Assert.AreEqual(0, parameters.Count);
+        }
+
+        [TestMethod]
+        public void DotvvmRoute_IsMatch_OneOptionalParameter_DefaultValue()
+        {
+            var route = new DotvvmRoute("Article/{Id?}/edit", null, new { Id = 0 }, null, configuration);
+
+            IDictionary<string, object> parameters;
+            var result = route.IsMatch("Article/edit", out parameters);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(1, parameters.Count);
+            Assert.AreEqual(0, parameters["Id"]);
         }
 
         [TestMethod]


### PR DESCRIPTION
There is a bug in route matching for optional parameters with constraints.
If the optional parameter is not present in the URL, the `IsMatch` method sometimes returns it in the `parameters` collection as an empty string, but sometimes it is not present in the collection at all (even when it specifies the default value). 

Additionally, in cases where it returns an empty string, it doesn't satisfy the constraint, and thus the route is not matched.

```
// original behavior
var routeA = new DotvvmRoute("{Id?}", ...);
var result1 = routeA.IsMatch("", out var parameters);         // result1 = true, parameters1 = [ "" ]
var result2 = routeA.IsMatch("/", out var parameters);        // result2 = true, parameters2 = [ ]

var routeB = new DotvvmRoute("{Id?:int}", ...);
var result3 = routeB.IsMatch("", out var parameters);         // result3 = false
```

We have to discuss the solution - maybe it would be better to fix it at some other place.
Also, it will probably be a breaking change.