### PR TITLE
Allow hardcoded values and resource bindings in IncludeInPage, Visible properties

### DIFF
--- a/src/Framework/Framework/Controls/DotvvmControl.cs
+++ b/src/Framework/Framework/Controls/DotvvmControl.cs
@@ -115,7 +115,7 @@ namespace DotVVM.Framework.Controls
         /// <remarks>
         /// Essentially wraps Knockout's 'if' binding.
         /// </remarks>
-        [MarkupOptions(AllowHardCodedValue = false)]
+        [MarkupOptions]
         public bool IncludeInPage
         {
             get { return (bool)GetValue(IncludeInPageProperty)!; }

--- a/src/Framework/Framework/Controls/HtmlGenericControl.cs
+++ b/src/Framework/Framework/Controls/HtmlGenericControl.cs
@@ -133,7 +133,7 @@ namespace DotVVM.Framework.Controls
         /// <summary>
         /// Gets or sets whether the control is visible. When set to false, `style="display: none"` will be added to this control.
         /// </summary>
-        [MarkupOptions(AllowHardCodedValue = false)]
+        [MarkupOptions]
         public bool Visible
         {
             get { return (bool)GetValue(VisibleProperty)!; }

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -564,8 +564,7 @@
       },
       "IncludeInPage": {
         "type": "System.Boolean",
-        "defaultValue": true,
-        "onlyBindings": true
+        "defaultValue": true
       }
     },
     "DotVVM.Framework.Controls.EmptyData": {
@@ -1016,8 +1015,7 @@
       },
       "Visible": {
         "type": "System.Boolean",
-        "defaultValue": true,
-        "onlyBindings": true
+        "defaultValue": true
       }
     },
     "DotVVM.Framework.Controls.HtmlLiteral": {


### PR DESCRIPTION
…
It only produced a warning, but still,
hardcoded values and resource bindings are already supported in both properties.