### PR TITLE
Allow samples to start in dotnet invariant culture mode

### DIFF
--- a/src/Samples/Common/DotvvmStartup.cs
+++ b/src/Samples/Common/DotvvmStartup.cs
@@ -39,9 +39,27 @@ namespace DotVVM.Samples.BasicSamples
         public const string GitHubTokenEnvName = "GITHUB_TOKEN";
         public const string GitHubTokenConfigName = "githubApiToken";
 
+        private bool IsInInvariantCultureMode()
+        {
+            // Makes the samples run even if only invariant culture is enabled
+            // This is useful for testing older versions of .NET Core which rely on ICU which is no longer installed
+            try
+            {
+                new System.Globalization.CultureInfo("en-US");
+                return false;
+            }
+            catch (System.Globalization.CultureNotFoundException)
+            {
+                return true;
+            }
+        }
+
         public void Configure(DotvvmConfiguration config, string applicationPath)
         {
-            config.DefaultCulture = "en-US";
+            if (!IsInInvariantCultureMode())
+            {
+                config.DefaultCulture = "en-US";
+            }
 
             AddControls(config);
             AddStyles(config);


### PR DESCRIPTION
when System.Globalization.Invariant runtime switch or DOTNET_SYSTEM_GLOBALIZATION_INVARIANT env variables are set, only invariant culture is supported. This mode useful to supress some "incompatible ICU" errors.
Obviously samples relying on cultures won't work,
this isn't attempt to make it fully work, just to make it easier to debug dotvvm on older .NET Core versions