### PR TITLE
Switch custom primitive types to a marker interface

### DIFF
--- a/src/Framework/Core/ViewModel/CustomPrimitiveTypeAttribute.cs
+++ b/src/Framework/Core/ViewModel/CustomPrimitiveTypeAttribute.cs
@@ -3,6 +3,7 @@
 namespace DotVVM.Framework.ViewModel;
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+[Obsolete("Implement IDotvvmPrimitiveType.", error: true)]
 public class CustomPrimitiveTypeAttribute : Attribute
 {
 }

--- a/src/Framework/Core/ViewModel/CustomPrimitiveTypeAttribute.cs
+++ b/src/Framework/Core/ViewModel/CustomPrimitiveTypeAttribute.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace DotVVM.Framework.ViewModel;
-
-[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
-[Obsolete("Implement IDotvvmPrimitiveType.", error: true)]
-public class CustomPrimitiveTypeAttribute : Attribute
-{
-}

--- a/src/Framework/Core/ViewModel/IDotvvmPrimitiveType.cs
+++ b/src/Framework/Core/ViewModel/IDotvvmPrimitiveType.cs
@@ -1,0 +1,8 @@
+namespace DotVVM.Framework.ViewModel;
+
+/// <summary>
+/// Marker interface instructing DotVVM to treat the type as a primitive type.
+/// The type is required to have a static TryParse(string, [IFormatProvider,] out T) method and expected to implement ToString() method which is compatible with the TryParse method.
+/// Primitive types are then serialized as string in client-side view models.
+/// </summary>
+public interface IDotvvmPrimitiveType { }

--- a/src/Framework/Framework/Configuration/CustomPrimitiveTypeRegistration.cs
+++ b/src/Framework/Framework/Configuration/CustomPrimitiveTypeRegistration.cs
@@ -21,7 +21,7 @@ namespace DotVVM.Framework.Configuration
         {
             if (ReflectionUtils.IsCollection(type) || ReflectionUtils.IsDictionary(type))
             {
-                throw new DotvvmConfigurationException($"The type {type} is marked with {nameof(CustomPrimitiveTypeAttribute)}, but it cannot be used as a custom primitive type. Custom primitive types cannot be collections, dictionaries, and cannot be primitive types already supported by DotVVM.");
+                throw new DotvvmConfigurationException($"The type {type} implements {nameof(IDotvvmPrimitiveType)}, but it cannot be used as a custom primitive type. Custom primitive types cannot be collections, dictionaries, and cannot be primitive types already supported by DotVVM.");
             }
 
             Type = type;
@@ -38,7 +38,7 @@ namespace DotVVM.Framework.Configuration
                                      new[] { typeof(string), typeof(IFormatProvider), type.MakeByRefType() }, null)
                                  ?? type.GetMethod("TryParse", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy, null,
                                      new[] { typeof(string), type.MakeByRefType() }, null)
-                                 ?? throw new DotvvmConfigurationException($"The type {type} is marked with {nameof(CustomPrimitiveTypeAttribute)} but it does not contain a public static method TryParse(string, IFormatProvider, out {type}) or TryParse(string, out {type})!");
+                                 ?? throw new DotvvmConfigurationException($"The type {type} implements {nameof(IDotvvmPrimitiveType)} but it does not contain a public static method TryParse(string, IFormatProvider, out {type}) or TryParse(string, out {type})!");
 
             var inputParameter = Expression.Parameter(typeof(string), "arg");
             var resultVariable = Expression.Variable(type, "result");

--- a/src/Framework/Framework/Controls/HtmlGenericControl.cs
+++ b/src/Framework/Framework/Controls/HtmlGenericControl.cs
@@ -13,6 +13,7 @@ using System.Runtime.Serialization;
 using System.Text;
 using DotVVM.Framework.Compilation.Javascript;
 using FastExpressionCompiler;
+using DotVVM.Framework.ViewModel;
 
 namespace DotVVM.Framework.Controls
 {
@@ -405,7 +406,10 @@ namespace DotVVM.Framework.Controls
                 Enum enumValue => ReflectionUtils.ToEnumString(enumValue.GetType(), enumValue.ToString()),
                 Guid guid => guid.ToString(),
                 _ when ReflectionUtils.IsNumericType(value.GetType()) => Convert.ToString(value, CultureInfo.InvariantCulture) ?? "",
-                _ when ReflectionUtils.TryGetCustomPrimitiveTypeRegistration(value.GetType()) is {} registration => registration.ToStringMethod(value),
+                IDotvvmPrimitiveType => value switch {
+                    IFormattable f => f.ToString(null, CultureInfo.InvariantCulture),
+                    _ => value.ToString() ?? ""
+                },
                 System.Collections.IEnumerable =>
                     throw new NotSupportedException($"Attribute value of type '{value.GetType().ToCode(stripNamespace: true)}' is not supported. Consider concatenating the values into a string or use the HtmlGenericControl.AttributeList if you need to pass multiple values."),
                 _ =>

--- a/src/Framework/Framework/Utils/ReflectionUtils.cs
+++ b/src/Framework/Framework/Utils/ReflectionUtils.cs
@@ -382,7 +382,7 @@ namespace DotVVM.Framework.Utils
         public static CustomPrimitiveTypeRegistration? TryGetCustomPrimitiveTypeRegistration(Type type)
         {
             if (IsCustomPrimitiveType(type))
-                return CustomPrimitiveTypes.GetOrAdd(type, TryDiscoverCustomPrimitiveType);
+                return CustomPrimitiveTypes.GetOrAdd(type, DiscoverCustomPrimitiveType);
             else
                 return null;
         }
@@ -396,7 +396,7 @@ namespace DotVVM.Framework.Utils
                 || IsCustomPrimitiveType(type);
         }
 
-        private static CustomPrimitiveTypeRegistration TryDiscoverCustomPrimitiveType(Type type)
+        private static CustomPrimitiveTypeRegistration DiscoverCustomPrimitiveType(Type type)
         {
             Debug.Assert(typeof(IDotvvmPrimitiveType).IsAssignableFrom(type));
             return new CustomPrimitiveTypeRegistration(type);

--- a/src/Framework/Framework/ViewModel/Validation/ViewModelValidator.cs
+++ b/src/Framework/Framework/ViewModel/Validation/ViewModelValidator.cs
@@ -81,7 +81,7 @@ namespace DotVVM.Framework.ViewModel.Validation
                         if (propertyResult != ValidationResult.Success)
                         {
                             var propertyPath =
-                                ReflectionUtils.IsCustomPrimitiveType(viewModelType) ? pathPrefix.TrimEnd('/') : pathPrefix + property.Name;
+                                viewModel is IDotvvmPrimitiveType ? pathPrefix.TrimEnd('/') : pathPrefix + property.Name;
                             yield return new ViewModelValidationError(rule.ErrorMessage, propertyPath, rootObject);
                         }
                     }

--- a/src/Samples/Common/Controls/ControlWithCustomPrimitiveTypeProperties.cs
+++ b/src/Samples/Common/Controls/ControlWithCustomPrimitiveTypeProperties.cs
@@ -42,8 +42,7 @@ namespace DotVVM.Samples.Common.Controls
 
     }
 
-    [CustomPrimitiveType]
-    public struct Point : IFormattable 
+    public struct Point : IFormattable, IDotvvmPrimitiveType
     {
         public int X { get; set; }
         public int Y { get; set; }

--- a/src/Samples/Common/ViewModels/FeatureSamples/CustomPrimitiveTypes/SampleId.cs
+++ b/src/Samples/Common/ViewModels/FeatureSamples/CustomPrimitiveTypes/SampleId.cs
@@ -4,8 +4,7 @@ using DotVVM.Framework.ViewModel;
 
 namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.CustomPrimitiveTypes
 {
-    [CustomPrimitiveType]
-    public record SampleId : TypeId<SampleId>
+    public record SampleId : TypeId<SampleId>, IDotvvmPrimitiveType
     {
         public SampleId(Guid idValue) : base(idValue)
         {

--- a/src/Tests/Binding/BindingCompilationTests.cs
+++ b/src/Tests/Binding/BindingCompilationTests.cs
@@ -1201,11 +1201,10 @@ namespace DotVVM.Framework.Tests.Binding
     }
 
 
-    [CustomPrimitiveType]
     record struct VehicleNumber(
         [property: Range(100, 999)]
         int Value
-    )
+    ): IDotvvmPrimitiveType
     {
         public override string ToString() => Value.ToString();
         public static bool TryParse(string s, out VehicleNumber result)


### PR DESCRIPTION
This allows for efficient checks if a value is primitive without the need for cache hashtable containing all types we encounter