### PR TITLE
Run module initialization in dotvvm.init event

### DIFF
--- a/src/Framework/Framework/ResourceManagement/ViewModuleInitResource.cs
+++ b/src/Framework/Framework/ResourceManagement/ViewModuleInitResource.cs
@@ -29,7 +29,15 @@ namespace DotVVM.Framework.ResourceManagement
             this.ReferencedModules = referencedModules.ToArray();
             this.Dependencies = dependencies;
 
-            this.registrationScript = string.Join("\r\n", this.ReferencedModules.Select(m => $"dotvvm.viewModules.init({KnockoutHelper.MakeStringLiteral(m)}, {KnockoutHelper.MakeStringLiteral(viewId)}, document.body);"));
+            var initCalls = this.ReferencedModules.Select(m => $"dotvvm.viewModules.init({KnockoutHelper.MakeStringLiteral(m)}, {KnockoutHelper.MakeStringLiteral(viewId)}, document.body);");
+
+            // Run the module init in the init event
+            // * dotvvm.state will be available
+            // * executed before applying bindings to the controls, so the page module will initialize before control modules 
+            this.registrationScript =
+                "dotvvm.events.init.subscribeOnce(() => {\n" +
+                "    " + string.Join("\n", initCalls) + "\n" +
+                "})";
         }
 
         public void Render(IHtmlWriter writer, IDotvvmRequestContext context, string resourceName)

--- a/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModule.html
+++ b/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModule.html
@@ -15,7 +15,9 @@
 		<script type="module">import * as m0 from '/dotvvmResource/myModule/myModule';dotvvm.viewModules.registerMany({'myModule': m0});</script>
 		
 		<!-- Resource viewModule.init.6DLlOTYMqGV5yPAJoz5k_moKDBgEmZ3_HLLQ2zKDo74 of type ViewModuleInitResource. -->
-		<script type="module">dotvvm.viewModules.init("myModule", "p0", document.body);</script>
+		<script type="module">dotvvm.events.init.subscribeOnce(() => {
+    dotvvm.viewModules.init("myModule", "p0", document.body);
+})</script>
 	</head>
 	<body>
 		<input id="__dot_viewmodel_root" type="hidden" value="{

--- a/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModuleInControl.html
+++ b/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModuleInControl.html
@@ -18,7 +18,9 @@
 		<script type="module">import * as m0 from '/dotvvmResource/viewModule/viewModule';dotvvm.viewModules.registerMany({'viewModule': m0});</script>
 		
 		<!-- Resource viewModule.init.HIj399FcjVwbyaIvDKFctn7Ghr0UMajY-haUgZypcHs of type ViewModuleInitResource. -->
-		<script type="module">dotvvm.viewModules.init("viewModule", "p0", document.body);</script>
+		<script type="module">dotvvm.events.init.subscribeOnce(() => {
+    dotvvm.viewModules.init("viewModule", "p0", document.body);
+})</script>
 	</head>
 	<body>
 		<div data-bind="dotvvm-with-view-modules: { modules: [&quot;controlModule&quot;] }">


### PR DESCRIPTION
This allows using dotvvm.state (etc.) already in the module constructor.

resolves  #1592