### PR TITLE
Run all JsComponent interactions asynchronously

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/binding-handlers/textbox-text.ts
+++ b/src/Framework/Framework/Resources/Scripts/binding-handlers/textbox-text.ts
@@ -3,6 +3,7 @@ import * as globalize from '../DotVVM.Globalize'
 import { DotvvmValidationElementMetadata, DotvvmValidationObservableMetadata, getValidationMetadata } from '../validation/common';
 import { lastSetErrorSymbol } from '../state-manager';
 import { hackInvokeNotifySubscribers } from '../utils/knockout';
+import { defer } from '../utils/promise';
 
 // handler dotvvm-textbox-text
 export default {
@@ -30,7 +31,7 @@ export default {
                 }
                 metadata = (obs as any).dotvvmMetadata;
             }
-            setTimeout(() => {
+            defer(() => {
                 // remove element from collection when its removed from dom
                 ko.utils.domNodeDisposal.addDisposeCallback(element, () => {
                     for (const meta of metadata) {
@@ -40,7 +41,7 @@ export default {
                         }
                     }
                 });
-            }, 0);
+            });
 
             const valueUpdateHandler = () => {
                 const obs = valueAccessor();

--- a/src/Framework/Framework/Resources/Scripts/postback/queue.ts
+++ b/src/Framework/Framework/Resources/Scripts/postback/queue.ts
@@ -1,3 +1,5 @@
+import { defer } from "../utils/promise";
+
 export const updateProgressChangeCounter = ko.observable(0);
 export const postbackQueues: {
     [name: string]: {
@@ -31,6 +33,6 @@ export function runNextInQueue(queueName: string) {
     const queue = getPostbackQueue(queueName);
     if (queue.queue.length > 0) {
         const callback = queue.queue.shift()!;
-        Promise.resolve().then(callback)
+        defer(callback)
     }
 }

--- a/src/Framework/Framework/Resources/Scripts/postback/updater.ts
+++ b/src/Framework/Framework/Resources/Scripts/postback/updater.ts
@@ -2,6 +2,7 @@ import { getElementByDotvvmId } from '../utils/dom'
 import { replaceViewModel, updateViewModelCache, clearViewModelCache, getStateManager } from '../dotvvm-base'
 import { keys } from '../utils/objects';
 import { logInfoVerbose } from '../utils/logging';
+import { defer } from '../utils/promise';
 
 const diffEqual = {}
 
@@ -41,7 +42,7 @@ export function restoreUpdatedControls(resultObject: any, updatedControls: any) 
             } else {
                 updatedControl.parent.appendChild(element);
             }
-            Promise.resolve().then(() => ko.applyBindings(updatedControl.dataContext, element))
+            defer(() => ko.applyBindings(updatedControl.dataContext, element))
         }
     }
 }

--- a/src/Framework/Framework/Resources/Scripts/utils/promise.ts
+++ b/src/Framework/Framework/Resources/Scripts/utils/promise.ts
@@ -1,0 +1,2 @@
+/** Runs the callback in the next event loop cycle */ 
+export const defer = <T>(callback: () => T) => Promise.resolve().then(callback)


### PR DESCRIPTION
Initialization, update and dispose of JsComponent
is now executed in the next event loop cycle - i.e. after all other knockout components have been initialized. The main reason for this is to NOT handle
exceptions from the JS component and avoid
crashing the entire page when one component fails to load.