### PR TITLE
Remove Moq dependency from tests

### DIFF
--- a/src/Framework/Testing/DotvvmTestHelper.cs
+++ b/src/Framework/Testing/DotvvmTestHelper.cs
@@ -85,7 +85,7 @@ namespace DotVVM.Framework.Testing
             }
         }
 
-        public static void RegisterMoqServices(IServiceCollection services)
+        public static void RegisterMockServices(IServiceCollection services)
         {
             services.TryAddSingleton<IViewModelProtector, FakeProtector>();
             services.TryAddSingleton<ICsrfProtector, FakeCsrfProtector>();
@@ -112,7 +112,7 @@ namespace DotVVM.Framework.Testing
             DotvvmConfiguration.CreateDefault(s => {
                 s.AddSingleton<ITestSingletonService, TestSingletonService>();
                 customServices?.Invoke(s);
-                RegisterMoqServices(s);
+                RegisterMockServices(s);
             });
 
         public static TestDotvvmRequestContext CreateContext(

--- a/src/Tests/DotVVM.Framework.Tests.csproj
+++ b/src/Tests/DotVVM.Framework.Tests.csproj
@@ -53,7 +53,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.0" PrivateAssets="all" />

--- a/src/Tests/Runtime/DotvvmControlRenderedHtmlTests.cs
+++ b/src/Tests/Runtime/DotvvmControlRenderedHtmlTests.cs
@@ -12,7 +12,6 @@ using DotVVM.Framework.Hosting;
 using DotVVM.Framework.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 
 namespace DotVVM.Framework.Tests.Runtime
 {
@@ -143,14 +142,7 @@ namespace DotVVM.Framework.Tests.Runtime
         public void HtmlGenericControl_MetaTag_RenderContentAttribute()
         {
             var context = CreateContext(new object());
-            var mockHttpContext = new Mock<IHttpContext>();
-            var mockHttpRequest = new Mock<IHttpRequest>();
-            var mockPathBase = new Mock<IPathString>();
-
-            mockPathBase.Setup(p => p.Value).Returns("home");
-            mockHttpRequest.Setup(p => p.PathBase).Returns(mockPathBase.Object);
-            mockHttpContext.Setup(p => p.Request).Returns(mockHttpRequest.Object);
-            context.HttpContext = mockHttpContext.Object;
+            context.HttpContext = new TestHttpContext { Request = { PathBase = "home" } };
 
             var clientHtml = InvokeLifecycleAndRender(new HtmlGenericControl("meta").SetAttribute("content", "~/test"), context);
 

--- a/src/Tests/Runtime/DotvvmPropertyTests.cs
+++ b/src/Tests/Runtime/DotvvmPropertyTests.cs
@@ -23,7 +23,7 @@ namespace DotVVM.Framework.Tests.Runtime
     [TestClass]
     public class DotvvmPropertyTests
     {
-        public class MoqComponent : DotvvmBindableObject
+        public class MockComponent : DotvvmBindableObject
         {
             public object? Property
             {
@@ -31,7 +31,7 @@ namespace DotVVM.Framework.Tests.Runtime
                 set { SetValue(PropertyProperty, value); }
             }
             public static DotvvmProperty PropertyProperty
-                = DotvvmProperty.Register<object, MoqComponent>(t => t.Property);
+                = DotvvmProperty.Register<object, MockComponent>(t => t.Property);
         }
 
         DotvvmConfiguration config => DotvvmTestHelper.DefaultConfig;
@@ -41,8 +41,8 @@ namespace DotVVM.Framework.Tests.Runtime
         public void DotvvmProperty_PropertyRegisteredTwiceThrowException()
         {
             Assert.ThrowsException<DotvvmProperty.PropertyAlreadyExistsException>(() => {
-                _ = MoqComponent.PropertyProperty; // calls the static ctor
-                DotvvmProperty.Register<bool, MoqComponent>(t => t.Property);
+                _ = MockComponent.PropertyProperty; // calls the static ctor
+                DotvvmProperty.Register<bool, MockComponent>(t => t.Property);
             });
         }
 

--- a/src/Tests/ViewModel/DefaultViewModelSerializerTests.cs
+++ b/src/Tests/ViewModel/DefaultViewModelSerializerTests.cs
@@ -16,7 +16,6 @@ using DotVVM.Framework.ViewModel;
 using DotVVM.Framework.ViewModel.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 using Newtonsoft.Json.Linq;
 using DotVVM.Framework.Testing;
 


### PR DESCRIPTION
We were on old enough version to not be affected by the spyware, but we only used the lib in 2 places so it's easy to rip out.

See https://github.com/moq/moq/issues/1372 for context