### PR TITLE
Fix repeated initialization of JS translator collection

### DIFF
--- a/src/Framework/Framework/Compilation/Binding/StaticCommandBindingCompiler.cs
+++ b/src/Framework/Framework/Compilation/Binding/StaticCommandBindingCompiler.cs
@@ -35,9 +35,12 @@ namespace DotVVM.Framework.Compilation.Binding
         JavascriptTranslator CreateTranslator(DataContextStack dataContext)
         {
             var staticCommandTranslator = ActivatorUtilities.CreateInstance<StaticCommandMethodTranslator>(services, dataContext);
-            var configForStaticCommands = new JavascriptTranslatorConfiguration();
-            configForStaticCommands.Translators.Add(this.translatorConfiguration);
-            configForStaticCommands.Translators.Add(staticCommandTranslator);
+            var configForStaticCommands = new CompositeJavascriptTranslator {
+                Translators = {
+                    this.translatorConfiguration,
+                    staticCommandTranslator
+                }
+            };
 
             return new JavascriptTranslator(configForStaticCommands, serializationMapper);
         }

--- a/src/Framework/Framework/Configuration/DotvvmMarkupConfiguration.cs
+++ b/src/Framework/Framework/Configuration/DotvvmMarkupConfiguration.cs
@@ -196,6 +196,8 @@ namespace DotVVM.Framework.Configuration
             foreach (var t in this.HtmlAttributeTransforms)
                 t.Value.Freeze();
             _defaultDirectives.Freeze();
+
+            JavascriptTranslator.Freeze();
         }
     }
 }

--- a/src/Framework/Framework/Configuration/FreezableList.cs
+++ b/src/Framework/Framework/Configuration/FreezableList.cs
@@ -70,7 +70,7 @@ namespace DotVVM.Framework.Configuration
         }
         public bool Contains(T item) => list.Contains(item);
         public void CopyTo(T[] array, int arrayIndex) => list.CopyTo(array, arrayIndex);
-        public IEnumerator<T> GetEnumerator() => list.GetEnumerator();
+        public List<T>.Enumerator GetEnumerator() => list.GetEnumerator();
         public int IndexOf(T item) => list.IndexOf(item);
         public void Insert(int index, T item)
         {
@@ -87,6 +87,7 @@ namespace DotVVM.Framework.Configuration
             ThrowIfFrozen();
             list.RemoveAt(index);
         }
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() => list.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => list.GetEnumerator();
         public void CopyTo(Array array, int index) => ((ICollection)list).CopyTo(array, index);
     }

--- a/src/Framework/Framework/ViewModel/Validation/ValidationErrorFactory.cs
+++ b/src/Framework/Framework/ViewModel/Validation/ValidationErrorFactory.cs
@@ -58,7 +58,7 @@ namespace DotVVM.Framework.ViewModel.Validation
 
 
         private static JavascriptTranslator defaultJavaScriptTranslator = new JavascriptTranslator(
-            Options.Create(new JavascriptTranslatorConfiguration()),
+            new JavascriptTranslatorConfiguration(),
             new ViewModelSerializationMapper(new ViewModelValidationRuleTranslator(), new AttributeViewModelValidationMetadataProvider(), new DefaultPropertySerialization(), DotvvmConfiguration.CreateDefault()));
 
         public static ValidationResult CreateValidationResult<T>(ValidationContext validationContext, string error, params Expression<Func<T, object>>[] expressions)


### PR DESCRIPTION
JavascriptTranslatorConfiguration constructor
initialized the translation collection on every invocation, which caused serious compilation slowdown of staticCommands which need to create new config every time.