### PR TITLE
More reasonable unclosed tag handling

### DIFF
--- a/src/Samples/Common/Views/Samples.dotmaster
+++ b/src/Samples/Common/Views/Samples.dotmaster
@@ -4,7 +4,7 @@
 
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <style>
         ul li {
             padding:2px;


### PR DESCRIPTION
Enabling the warnings in #1659 reveals that our handling of unclosed tags is not ideal. This patch is attempt to improve it, while maintaining reasonable level of backwards compatibility.

The only behavior change is what happens when `</x>` has no opening tag
* previous: close currently open elements, then insert `<x />`
* new: insert `<x />` into the current element

a warning is issued in both cases. The new logic avoids a major problem of one accidental end tag closing the entire hierarchy, including the `<body>` and `<html>` elements. Since we insert script references at the end of body, this puts the scripts and viewmodel wherever the closing tag was. This change has the potential to break something

Other changes only affect the issued warning:
* no warning on an unclosed tags like img, meta, br (which are always self-closing in HTML)
* no warning on automatically closed tags like p, td. In HTML it's perfectly valid let these tags close automatically, so we can also consider this valid.