### PR TITLE
Validate that properties on custom primitive types are not used in JS

### DIFF
--- a/src/Framework/Framework/Compilation/Javascript/JsViewModelPropertyAdjuster.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JsViewModelPropertyAdjuster.cs
@@ -10,7 +10,9 @@ using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Compilation.Javascript.Ast;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.Utils;
+using DotVVM.Framework.ViewModel;
 using DotVVM.Framework.ViewModel.Serialization;
+using FastExpressionCompiler;
 
 namespace DotVVM.Framework.Compilation.Javascript
 {
@@ -90,6 +92,11 @@ namespace DotVVM.Framework.Compilation.Javascript
                 {
                     // Plain .NET is used on _control, this property is not serialized, so it will not work client-side
                     throw new NotSupportedException($"Control property {member.Name} is not a registered DotvvmProperty and cannot be used client-side. Either use a resource binding to use the server-side value, or see https://www.dotvvm.com/docs/latest/pages/concepts/control-development/control-properties how to register a DotvvmProperty.");
+                }
+
+                if (member is {} && typeof(IDotvvmPrimitiveType).IsAssignableFrom(member.DeclaringType))
+                {
+                    throw new NotSupportedException($"Cannot translate property {member.Name} on custom primitive type {member.DeclaringType.ToCode()} to Javascript. Use the ToString() method to get the underlying value.");
                 }
 
                 annotation.ContainsObservables ??= !this.preferUsingState; // we don't know -> guess what is the current preference

--- a/src/Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/Tests/Binding/JavascriptCompilationTests.cs
@@ -1309,6 +1309,16 @@ namespace DotVVM.Framework.Tests.Binding
         {
             var result = CompileBinding("VehicleNumber.ToString()", typeof(TestViewModel));
             Assert.AreEqual("VehicleNumber", result);
+            // nullable .Value unwrap
+            result = CompileBinding("VehicleNumber.Value.ToString()", typeof(TestViewModel));
+            Assert.AreEqual("VehicleNumber", result);
+        }
+
+        [TestMethod]
+        public void JavascriptCompilation_CustomPrimitiveProperty_Disallowed()
+        {
+            var e = Assert.ThrowsException<NotSupportedException>(() => CompileBinding("VehicleNumber.Value.Value", typeof(TestViewModel)));
+            XAssert.Contains("Cannot translate property Value on custom primitive type DotVVM.Framework.Tests.Binding.VehicleNumber", e.Message);
         }
 
         [TestMethod]


### PR DESCRIPTION
The primitive will be a string client-side, and the property will thus always be `undefined`.