### PR TITLE
Fixed bug in ExtractGenericArgumentDataContextChangeAttribute

### DIFF
--- a/src/Framework/Framework/Binding/ExtractGenericArgumentDataContextChangeAttribute.cs
+++ b/src/Framework/Framework/Binding/ExtractGenericArgumentDataContextChangeAttribute.cs
@@ -45,7 +45,9 @@ public class ExtractGenericArgumentDataContextChangeAttribute : DataContextChang
 
     public override Type? GetChildDataContextType(Type dataContext, DataContextStack controlContextStack, DotvvmBindableObject control, DotvvmProperty? property = null)
     {
-        var implementations = ReflectionUtils.GetBaseTypesAndInterfaces(dataContext).ToList();
+        var implementations = ReflectionUtils.GetBaseTypesAndInterfaces(dataContext)
+            .Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == GenericType)
+            .ToList();
         if (implementations.Count == 0)
         {
             throw new Exception($"The data context {dataContext} doesn't implement {GenericType}!");

--- a/src/Framework/Framework/Utils/ReflectionUtils.cs
+++ b/src/Framework/Framework/Utils/ReflectionUtils.cs
@@ -647,6 +647,7 @@ namespace DotVVM.Framework.Utils
                 yield return i;
             }
 
+            yield return type;
             while (type.BaseType is { } baseType)
             {
                 yield return baseType;

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/ControlWithOverriddenRules.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/ControlWithOverriddenRules.cs
@@ -36,6 +36,20 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree.DefaultControlTreeResolver
         }
         public static readonly DotvvmProperty TextProperty
             = DotvvmProperty.Register<string, ControlWithExtractGenericArgument>(c => c.Text, null);
+
+        [ExtractGenericArgumentDataContextChange(typeof(List<>), 0)]
+        public string Text2
+        {
+            get { return (string)GetValue(Text2Property); }
+            set { SetValue(Text2Property, value); }
+        }
+        public static readonly DotvvmProperty Text2Property
+            = DotvvmProperty.Register<string, ControlWithExtractGenericArgument>(c => c.Text2, null);
+
+    }
+
+    public class ListOfString : List<string>
+    {
     }
 }
 

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/DefaultControlTreeResolverTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/DefaultControlTreeResolverTests.cs
@@ -668,7 +668,7 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
         }
 
         [TestMethod]
-        public void ResolvedTree_DataContextChange_ExtractGenericArgument()
+        public void ResolvedTree_DataContextChange_ExtractGenericArgument_Interface()
         {
             var prop = ControlWithExtractGenericArgument.TextProperty;
 
@@ -680,6 +680,36 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
 
             Assert.AreEqual(typeof(string), binding.Binding.DataContextTypeStack.DataContextType);
             Assert.AreEqual(typeof(List<string>), binding.Binding.DataContextTypeStack.Parent!.DataContextType);
+        }
+
+        [TestMethod]
+        public void ResolvedTree_DataContextChange_ExtractGenericArgument_Self()
+        {
+            var prop = ControlWithExtractGenericArgument.Text2Property;
+
+            var root = ParseSource(@"@viewModel System.Collections.Generic.List<System.String>
+<cc:ControlWithExtractGenericArgument Text2={value: _this} />");
+
+            var binding = root.Content.Single().Properties[prop] as ResolvedPropertyBinding;
+            Assert.IsNotNull(binding);
+
+            Assert.AreEqual(typeof(string), binding.Binding.DataContextTypeStack.DataContextType);
+            Assert.AreEqual(typeof(List<string>), binding.Binding.DataContextTypeStack.Parent!.DataContextType);
+        }
+
+        [TestMethod]
+        public void ResolvedTree_DataContextChange_ExtractGenericArgument_BaseType()
+        {
+            var prop = ControlWithExtractGenericArgument.Text2Property;
+
+            var root = ParseSource(@"@viewModel DotVVM.Framework.Tests.Runtime.ControlTree.DefaultControlTreeResolver.ListOfString
+<cc:ControlWithExtractGenericArgument Text2={value: _this} />");
+
+            var binding = root.Content.Single().Properties[prop] as ResolvedPropertyBinding;
+            Assert.IsNotNull(binding);
+
+            Assert.AreEqual(typeof(string), binding.Binding.DataContextTypeStack.DataContextType);
+            Assert.AreEqual(typeof(ListOfString), binding.Binding.DataContextTypeStack.Parent!.DataContextType);
         }
 
         [TestMethod]


### PR DESCRIPTION
There was a bug in `ExtractGenericArgumentDataContextChange` attribute - the method overload with `Type` wasn't comparing the generic arguments correctly.
Also, when the DataContext was directly the requested type, it didn't match because we inspected only implemented interfaces and base types, but not self.