### PR TITLE
Repro for a bug with null assignment

### DIFF
--- a/src/Framework/Framework/Compilation/Binding/TypeConversions.cs
+++ b/src/Framework/Framework/Compilation/Binding/TypeConversions.cs
@@ -130,7 +130,16 @@ namespace DotVVM.Framework.Compilation.Binding
             {
                 result = ToStringConversion(src);
             }
-            if (throwException && result == null) throw new InvalidOperationException($"Could not implicitly convert expression of type { src.Type.ToCode() } to { destType.ToCode() }.");
+            if (throwException && result == null)
+            {
+                if (src is ConstantExpression { Value: null } && destType.IsValueType)
+                    throw new InvalidOperationException($"Cannot convert null to {destType.ToCode()} because it is a non-nullable value type.");
+                else if (src is ConstantExpression { Value: var value })
+                    // constants have quite different conversion rules, so we include the value in the error message
+                    throw new InvalidOperationException($"Cannot convert '{value}' of type {src.Type.ToCode()} to {destType.ToCode()}.");
+
+                throw new InvalidOperationException($"Cannot implicitly convert expression of type { src.Type.ToCode() } to { destType.ToCode() }.");
+            }
             return result;
         }
 

--- a/src/Samples/Common/DotVVM.Samples.Common.csproj
+++ b/src/Samples/Common/DotVVM.Samples.Common.csproj
@@ -127,6 +127,7 @@
     <None Remove="Views\FeatureSamples\Validation\RangeClientSideValidation.dothtml" />
     <None Remove="Views\FeatureSamples\Validation\ValidationTargetIsCollection.dothtml" />
     <None Remove="Views\FeatureSamples\Validation\ValidatorValueComplexExpressions.dothtml" />
+    <None Remove="Views\FeatureSamples\ViewModelDeserialization\PropertyNullAssignment.dothtml" />
     <None Remove="Views\FeatureSamples\ViewModules\Incrementer.dotcontrol" />
     <None Remove="Views\FeatureSamples\ViewModules\IncrementerInRepeater.dothtml" />
     <None Remove="Views\FeatureSamples\ViewModules\InnerModuleControl.dotcontrol" />

--- a/src/Samples/Common/ViewModels/FeatureSamples/ViewModelDeserialization/PropertyNullAssignmentViewModel.cs
+++ b/src/Samples/Common/ViewModels/FeatureSamples/ViewModelDeserialization/PropertyNullAssignmentViewModel.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+using DotVVM.Framework.Hosting;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.ViewModelDeserialization
+{
+    public class PropertyNullAssignmentViewModel : DotvvmViewModelBase
+    {
+
+        public DateTime? NullableDateTime { get; set; }
+
+        public DateTime Value { get; set; } = new DateTime(2023, 1, 2, 3, 4, 5, 678);
+
+        public void SetNullableDateTimeToNull()
+        {
+            NullableDateTime = null;
+        }
+    }
+}
+

--- a/src/Samples/Common/Views/FeatureSamples/ViewModelDeserialization/PropertyNullAssignment.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/ViewModelDeserialization/PropertyNullAssignment.dothtml
@@ -1,0 +1,21 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.ViewModelDeserialization.PropertyNullAssignmentViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+
+    <p class="result">{{value: NullableDateTime}}</p>
+
+    <dot:Button Text="Set value" Click="{command: NullableDateTime = Value}" />
+    <dot:Button Text="Set null" Click="{command: NullableDateTime = null}" />
+    <dot:Button Text="Set null with command" Click="{command: SetNullableDateTimeToNull()}" />
+
+</body>
+</html>
+
+

--- a/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
@@ -381,6 +381,7 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_ViewModelCache_ViewModelCacheMiss = "FeatureSamples/ViewModelCache/ViewModelCacheMiss";
         public const string FeatureSamples_ViewModelDeserialization_DoesNotDropObject = "FeatureSamples/ViewModelDeserialization/DoesNotDropObject";
         public const string FeatureSamples_ViewModelDeserialization_NegativeLongNumber = "FeatureSamples/ViewModelDeserialization/NegativeLongNumber";
+        public const string FeatureSamples_ViewModelDeserialization_PropertyNullAssignment = "FeatureSamples/ViewModelDeserialization/PropertyNullAssignment";
         public const string FeatureSamples_ViewModelNesting_NestedViewModel = "FeatureSamples/ViewModelNesting/NestedViewModel";
         public const string FeatureSamples_ViewModelProtection_ComplexViewModelProtection = "FeatureSamples/ViewModelProtection/ComplexViewModelProtection";
         public const string FeatureSamples_ViewModelProtection_NestedSignatures = "FeatureSamples/ViewModelProtection/NestedSignatures";

--- a/src/Samples/Tests/Tests/ErrorsTests.cs
+++ b/src/Samples/Tests/Tests/ErrorsTests.cs
@@ -99,7 +99,7 @@ namespace DotVVM.Samples.Tests
             RunInAllBrowsers(browser => {
                 browser.NavigateToUrl(SamplesRouteUrls.Errors_WrongPropertyValue);
                 AssertUI.InnerText(browser.First("[class='exceptionMessage']")
-                    , s => s.Contains("Could not implicitly convert expression"));
+                    , s => s.Contains("Cannot convert 'NotAllowedValue' of type string to bool?"));
 
                 AssertUI.InnerText(browser.First("[class='errorUnderline']")
                     , s => s.Contains("NotAllowedValue"));

--- a/src/Samples/Tests/Tests/Feature/ViewModelDeserializationTests.cs
+++ b/src/Samples/Tests/Tests/Feature/ViewModelDeserializationTests.cs
@@ -52,6 +52,31 @@ namespace DotVVM.Samples.Tests.Feature
             });
         }
 
+        [Fact]
+        public void Feature_ViewModelDeserialization_PropertyNullAssignment()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_ViewModelDeserialization_PropertyNullAssignment);
+
+                var value = browser.Single(".result");
+                var buttons = browser.FindElements("input[type=button]");
+
+                AssertUI.InnerTextEquals(value, "");
+
+                buttons[0].Click();
+                AssertUI.InnerTextEquals(value, "1/2/2023 3:04:05 AM");
+
+                buttons[1].Click();
+                AssertUI.InnerTextEquals(value, "");
+
+                buttons[0].Click();
+                AssertUI.InnerTextEquals(value, "1/2/2023 3:04:05 AM");
+
+                buttons[2].Click();
+                AssertUI.InnerTextEquals(value, "");
+            });
+        }
+
         public ViewModelDeserializationTests(ITestOutputHelper output) : base(output)
         {
         }

--- a/src/Tests/Binding/NullPropagationTests.cs
+++ b/src/Tests/Binding/NullPropagationTests.cs
@@ -62,7 +62,14 @@ namespace DotVVM.Framework.Tests.Binding
             Create((DateTime d) => d.ToString()),
             Create((double a) => TimeSpan.FromSeconds(a)),
             Create((TestViewModel vm) => (TimeSpan)vm.Time),
-            Create((TestViewModel vm, TimeSpan time, int integer, double number, DateTime d) => new TestViewModel{ EnumProperty = TestEnum.B, BoolMethodExecuted = vm.BoolMethodExecuted, StringProp = time + ": " + vm.StringProp, StringProp2 = integer + vm.StringProp2 + number, TestViewModel2 = vm.TestViewModel2, DateFrom = d}),
+            Create((TestViewModel vm, TimeSpan time, int integer, double number, DateTime d) => new TestViewModel {
+                EnumProperty = TestEnum.B,
+                BoolMethodExecuted = (bool?)vm.BoolMethodExecuted ?? false,
+                StringProp = time + ": " + vm.StringProp,
+                StringProp2 = integer + vm.StringProp2 + number,
+                TestViewModel2 = vm.TestViewModel2,
+                DateFrom = d
+            }),
         };
 
         private static LambdaExpression Create<T1, T2>(Expression<Func<T1, T2>> e) => e;
@@ -200,6 +207,16 @@ namespace DotVVM.Framework.Tests.Binding
                     Assert.IsTrue(ex.Message.StartsWith("Binding expression"));
                     // and it must only occur for value types
                     Assert.IsTrue(new [] { "System.Int", "System.TimeSpan", "System.Char", "System.Double" }.Any(ex.Message.Contains));
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine($"Original expression: {expr.ToCSharpString()}");
+                    Console.WriteLine($"Null-checked expression {expr.ToCSharpString()}");
+                    Console.WriteLine();
+                    Console.WriteLine(expr.ToExpressionString());
+                    Console.WriteLine(e.ToString());
+                    Assert.Fail($"Exception {e.Message} while executing null-checked {expr.ToCSharpString()}");
+                    return;
                 }
             }
         }


### PR DESCRIPTION
I've found a bug, probably in the binding parser - `NullableProperty = null` doesn't work as expected - instead of assigning `null` to the property, it assigns the default value for its unwrapped type.

Repro sample is here: `/FeatureSamples/ViewModelDeserialization/PropertyNullAssignment`