### PR TITLE
Add JS test for nested postbacks

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/tests/helper.ts
+++ b/src/Framework/Framework/Resources/Scripts/tests/helper.ts
@@ -18,7 +18,7 @@ export async function waitForEnd<T>(result: Promise<T>[], s: fc_types.Scheduler,
 
     while (!done) {
         // console.log(s.report())
-        expect(s.count()).toBeGreaterThan(0)
+        expect(s.count()).toBeGreaterThan(0) // scheduler is stuck - in reality there would be deadlock
         await s.waitOne()
 
         assert()


### PR DESCRIPTION
resolves #900

Note that it seems to work fine, but the nested postbacks must be in a different concurrency queue (regardless of the concurrency mode)