### PR TITLE
Fixed string conversion bug with global function

### DIFF
--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslatableMethodCollection.cs
@@ -760,7 +760,7 @@ namespace DotVVM.Framework.Compilation.Javascript
                 }
                 else if (p[0].ParameterType == typeof(string) || p[0].ParameterType == typeof(bool))
                 {
-                    AddMethodTranslator(m, translator: new GenericMethodCompiler(args => wrapInRound(new JsIdentifierExpression("Number").Invoke(args[1]))));
+                    AddMethodTranslator(m, translator: new GenericMethodCompiler(args => wrapInRound(new JsIdentifierExpression("window").Member("Number").Invoke(args[1]))));
                 }
             }
 
@@ -773,7 +773,7 @@ namespace DotVVM.Framework.Compilation.Javascript
                     continue;
                 if (p[0].ParameterType.IsNumericType() && p[0].ParameterType != typeof(char))
                 {
-                    AddMethodTranslator(m, translator: new GenericMethodCompiler(args => new JsIdentifierExpression("Boolean").Invoke(args[1])));
+                    AddMethodTranslator(m, translator: new GenericMethodCompiler(args => new JsIdentifierExpression("window").Member("Boolean").Invoke(args[1])));
                 }
             }
         }

--- a/src/Framework/Framework/Compilation/Javascript/PrimitiveToStringTranslator.cs
+++ b/src/Framework/Framework/Compilation/Javascript/PrimitiveToStringTranslator.cs
@@ -59,7 +59,7 @@ namespace DotVVM.Framework.Compilation.Javascript
             if (isNullable)
                 js = new JsBinaryExpression(js, BinaryOperatorType.NullishCoalescing, new JsLiteral(""));
             if (!isStringAlready)
-                js = new JsIdentifierExpression("String").Invoke(js);
+                js = new JsIdentifierExpression("window").Member("String").Invoke(js);
             return js;
         }
     }

--- a/src/Samples/Common/DotVVM.Samples.Common.csproj
+++ b/src/Samples/Common/DotVVM.Samples.Common.csproj
@@ -98,6 +98,7 @@
     <None Remove="Views\FeatureSamples\CustomPrimitiveTypes\RouteLink.dothtml" />
     <None Remove="Views\FeatureSamples\CustomPrimitiveTypes\TextBox.dothtml" />
     <None Remove="Views\FeatureSamples\CustomPrimitiveTypes\UsedInControls.dothtml" />
+    <None Remove="Views\FeatureSamples\Formatting\ToStringGlobalFunctionBug.dothtml" />
     <None Remove="Views\FeatureSamples\HotReload\ViewChanges.dothtml" />
     <None Remove="Views\FeatureSamples\JavascriptTranslation\ArrayTranslation.dothtml" />
     <None Remove="Views\FeatureSamples\JavascriptTranslation\DateTimeTranslations.dothtml" />

--- a/src/Samples/Common/ViewModels/FeatureSamples/Formatting/ToStringGlobalFunctionBugViewModel.cs
+++ b/src/Samples/Common/ViewModels/FeatureSamples/Formatting/ToStringGlobalFunctionBugViewModel.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+using DotVVM.Framework.Hosting;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.Formatting
+{
+    public class ToStringGlobalFunctionBugViewModel : DotvvmViewModelBase
+    {
+        public bool Boolean { get; set; }
+
+        public string String { get; set; }
+    }
+}
+

--- a/src/Samples/Common/Views/FeatureSamples/Formatting/ToStringGlobalFunctionBug.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/Formatting/ToStringGlobalFunctionBug.dothtml
@@ -1,0 +1,19 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.Formatting.ToStringGlobalFunctionBugViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+    <dot:Button Text="Set to true" Click="{staticCommand: Boolean = true}" />
+
+    <p class="result-boolean">Boolean: {{value: Boolean}}</p>
+    <p class="result-string">String: {{value: String}}</p>
+
+</body>
+</html>
+
+

--- a/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
@@ -249,6 +249,7 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_Directives_ViewModelMissingAssembly = "FeatureSamples/Directives/ViewModelMissingAssembly";
         public const string FeatureSamples_EmbeddedResourceControls_EmbeddedResourceControls = "FeatureSamples/EmbeddedResourceControls/EmbeddedResourceControls";
         public const string FeatureSamples_Formatting_Formatting = "FeatureSamples/Formatting/Formatting";
+        public const string FeatureSamples_Formatting_ToStringGlobalFunctionBug = "FeatureSamples/Formatting/ToStringGlobalFunctionBug";
         public const string FeatureSamples_FormControlsEnabled_FormControlsEnabled = "FeatureSamples/FormControlsEnabled/FormControlsEnabled";
         public const string FeatureSamples_GenericTypes_InCommandBinding = "FeatureSamples/GenericTypes/InCommandBinding";
         public const string FeatureSamples_GenericTypes_InResourceBinding = "FeatureSamples/GenericTypes/InResourceBinding";

--- a/src/Samples/Tests/Tests/Feature/FormattingTests.cs
+++ b/src/Samples/Tests/Tests/Feature/FormattingTests.cs
@@ -55,8 +55,22 @@ namespace DotVVM.Samples.Tests.Feature
             });
         }
 
+        [Fact]
+        public void Feature_Formatting_ToStringGlobalFunctionBug()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_Formatting_ToStringGlobalFunctionBug);
+
+                AssertUI.TextEquals(browser.Single(".result-boolean"), "Boolean: false");
+                AssertUI.TextEquals(browser.Single(".result-string"), "String:");
+                browser.Single("input[type=button]").Click();
+                AssertUI.TextEquals(browser.Single(".result-boolean"), "Boolean: true");
+                AssertUI.TextEquals(browser.Single(".result-string"), "String:");
+            });
+        }
+
         public FormattingTests(ITestOutputHelper output) : base(output)
         {
+            }
         }
     }
-}

--- a/src/Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/Tests/Binding/JavascriptCompilationTests.cs
@@ -999,8 +999,8 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
-        [DataRow("Convert.ToBoolean(IntProp)", "Boolean(IntProp())")]
-        [DataRow("Convert.ToBoolean(DoubleProp)", "Boolean(DoubleProp())")]
+        [DataRow("Convert.ToBoolean(IntProp)", "window.Boolean(IntProp())")]
+        [DataRow("Convert.ToBoolean(DoubleProp)", "window.Boolean(DoubleProp())")]
         [DataRow("Convert.ToDecimal(DoubleProp)", "DoubleProp")]
         [DataRow("Convert.ToInt32(DoubleProp)", "Math.round(DoubleProp())")]
         [DataRow("Convert.ToByte(DoubleProp)", "Math.round(DoubleProp())")]
@@ -1261,6 +1261,7 @@ namespace DotVVM.Framework.Tests.Binding
         [TestMethod]
         public void JavascriptCompilation_MarkupControlProperty()
         {
+            _ = TestMarkupControl.SomePropertyProperty;
             var dataContext = bindingHelper.CreateDataContext(new [] { typeof(object) }, markupControl: typeof(TestMarkupControl));
             var result = bindingHelper.ValueBindingToJs("_control.SomeProperty + 'aa'", dataContext, niceMode: false);
             Assert.AreEqual("($control.SomeProperty()??\"\")+\"aa\"", result);


### PR DESCRIPTION
If we call a global JS function from a binding and there is a viewmodel property with the same name, it takes precedence. In this case, we were converting `bool` to `string` by emitting `String(value)`, but if there was a property called `String` in the viewmodel, it assigned the value in it.

This is a crazy bug, and this PR doesn't by far fix all cases - I am afraid it is almost impossible.

I fixed the `String(...)` and `Number(...)` cases but what if someone has a property called `window` in the viewmodel... ☠️ 
Luckily, most JS global functions start with a lowercase letter while viewmodel properties commonly start with an uppercase letter.  