### PR TITLE
support Linq methods on ImmutableArray + added Errors tab to Compilation Page

### DIFF
--- a/src/Framework/Framework/Diagnostics/CompilationPage.dothtml
+++ b/src/Framework/Framework/Diagnostics/CompilationPage.dothtml
@@ -1,4 +1,4 @@
-@viewModel DotVVM.Framework.Diagnostics.CompilationPageViewModel
+﻿@viewModel DotVVM.Framework.Diagnostics.CompilationPageViewModel
 
 <!DOCTYPE html>
 <html lang="en">
@@ -34,10 +34,14 @@
                     Text="Master pages"
                     class="nav"
                     Class-active="{value: ActiveTab == 2}" />
+        <dot:Button Click="{staticCommand: ActiveTab = 3}"
+                    Text="Errors"
+                    class="nav"
+                    Class-active="{value: ActiveTab == 3}" />
     </nav>
     <hr />
     <main>
-        <section Visible="{value: ActiveTab == 0}">
+        <section IncludeInPage="{value: ActiveTab == 0}">
             <h2>Routes</h2>
             <dot:GridView DataSource="{value: Routes}" class="nowrap">
                 <RowDecorators>
@@ -80,7 +84,7 @@
             </dot:GridView>
         </section>
 
-        <section Visible="{value: ActiveTab == 1}">
+        <section IncludeInPage="{value: ActiveTab == 1}" Visible={value: _page.EvaluatingOnClient}>
             <h2>Controls</h2>
             <dot:GridView DataSource="{value: Controls}" class="nowrap">
                 <RowDecorators>
@@ -111,7 +115,7 @@
             </dot:GridView>
         </section>
 
-        <section Visible="{value: ActiveTab == 2}">
+        <section IncludeInPage="{value: ActiveTab == 2}" Visible={value: _page.EvaluatingOnClient}>
             <h2>Master pages</h2>
             <dot:GridView DataSource="{value: MasterPages}" class="nowrap">
 
@@ -138,6 +142,67 @@
                     </dot:GridViewTemplateColumn>
                 </Columns>
             </dot:GridView>
+        </section>
+        <section IncludeInPage={value: ActiveTab == 3} Visible={value: _page.EvaluatingOnClient} >
+            <h2>Errors</h2>
+
+            <p IncludeInPage={value: MasterPages.AsEnumerable().Any(m => m.Status == 'None') || Controls.AsEnumerable().Any(m => m.Status == 'None') || Routes.AsEnumerable().Any(m => m.Status == 'None')}
+                style="color: var(--error-dark-color)">
+                Some files have not been compiled yet. Please press the "Compile all" button to make the list of errors complete.
+            </p>
+            <table>
+                <thead>
+                    <th>Type</th>
+                    <th>Name</th>
+                    <th>File path</th>
+                    <th>Status</th>
+                    <th>Actions</th>
+                </thead>
+                <dot:Repeater DataSource={value: Routes.Where(r => r.Status == 'CompilationFailed')} WrapperTagName=tbody >
+                    <tr class="failure">
+                        <td>Route</td>
+                        <td title={value: $"{Url} -> {RouteName}"}>
+                            <span IncludeInPage={value: !HasParameters}>
+                                <a href="{value: _root.PathBase + Url}">{{value: RouteName}}</a>
+                            </span>
+                            <span IncludeInPage={value: HasParameters}>
+                                {{value: RouteName}}
+                            </span>
+                        </td>
+                        <td title={value: VirtualPath}>{{value: VirtualPath}}</td>
+                        <td>{{value: Status}}</td>
+                        <td>
+                            <dot:LinkButton Click="{command: _root.BuildView(_this)}" Text="Recompile" class="execute" />
+                        </td>
+                    </tr>
+                </dot:Repeater>
+                <dot:Repeater DataSource={value: Controls.Where(r => r.Status == 'CompilationFailed')} WrapperTagName=tbody >
+                    <tr class="failure">
+                        <td>Control</td>
+                        <td>
+                            {{value: $"{TagPrefix}:{TagName}"}}
+                        </td>
+                        <td title={value: VirtualPath}>{{value: VirtualPath}}</td>
+                        <td>{{value: Status}}</td>
+                        <td>
+                            <dot:LinkButton Click="{command: _root.BuildView(_this)}" Text="Recompile" class="execute" />
+                        </td>
+                    </tr>
+                </dot:Repeater>
+                <dot:Repeater DataSource={value: MasterPages.Where(r => r.Status == 'CompilationFailed')} WrapperTagName=tbody >
+                    <tr class="failure">
+                        <td>Master page</td>
+                        <td></td>
+                        <td title={value: VirtualPath}>{{value: VirtualPath}}</td>
+                        <td>{{value: Status}}</td>
+                        <td>
+                            <dot:LinkButton Click="{command: _root.BuildView(_this)}" Text="Recompile" class="execute" />
+                        </td>
+                    </tr>
+                </dot:Repeater>
+
+
+            </table>
         </section>
     </main>
     <hr />

--- a/src/Framework/Framework/Diagnostics/CompilationPage.dothtml
+++ b/src/Framework/Framework/Diagnostics/CompilationPage.dothtml
@@ -1,4 +1,4 @@
-﻿@viewModel DotVVM.Framework.Diagnostics.CompilationPageViewModel
+@viewModel DotVVM.Framework.Diagnostics.CompilationPageViewModel
 
 <!DOCTYPE html>
 <html lang="en">
@@ -52,15 +52,19 @@
                     <dot:GridViewTemplateColumn HeaderText="Url">
                         <ContentTemplate>
                             <span IncludeInPage={value: !HasParameters}>
-                                <a href="{value: "/" +  Url}">{{value: Url}}</a>
+                                <a href="{value: _root.PathBase + Url}">{{value: Url == "" ? "<Empty>" : Url}}</a>
                             </span>
-                            <span IncludeInPage={value: HasParameters}>
+                            <span IncludeInPage={value: HasParameters} title={value: Url}>
                                 {{value: Url}}
                             </span>
                         </ContentTemplate>
                     </dot:GridViewTemplateColumn>
                     <dot:GridViewTextColumn ValueBinding="{value: VirtualPath}"
-                                            HeaderText="Virtual Path" />
+                                            HeaderText="Virtual Path">
+                        <CellDecorators>
+                            <dot:Decorator title={value: VirtualPath} />
+                        </CellDecorators>
+                    </dot:GridViewTextColumn>
                     <dot:GridViewTextColumn ValueBinding="{value: Status}"
                                             HeaderText="Status"
                                             HeaderCssClass="fit"
@@ -89,7 +93,11 @@
                                             HeaderCssClass="fit"
                                             CssClass="fit" />
                     <dot:GridViewTextColumn ValueBinding="{value: TagName}" HeaderText="Tag" />
-                    <dot:GridViewTextColumn ValueBinding="{value: VirtualPath}" HeaderText="Virtual Path" />
+                    <dot:GridViewTextColumn ValueBinding="{value: VirtualPath}" HeaderText="Virtual Path">
+                        <CellDecorators>
+                            <dot:Decorator title={value: VirtualPath} />
+                        </CellDecorators>
+                    </dot:GridViewTextColumn>
                     <dot:GridViewTextColumn ValueBinding="{value: Status}"
                                             HeaderText="Status"
                                             HeaderCssClass="fit"
@@ -112,11 +120,15 @@
                                    Class-success="{value: Status == 'CompletedSuccessfully'}" />
                 </RowDecorators>
                 <Columns>
-                    <dot:GridViewTextColumn ValueBinding="{value: VirtualPath}" HeaderText="Virtual Path" />
+                    <dot:GridViewTextColumn ValueBinding="{value: VirtualPath}" HeaderText="Virtual Path">
+                        <CellDecorators>
+                            <dot:Decorator title={value: VirtualPath} />
+                        </CellDecorators>
+                    </dot:GridViewTextColumn>
                     <dot:GridViewTextColumn ValueBinding="{value: Status}"
                                             HeaderText="Status"
                                             HeaderCssClass="fit"
-                                            CssClass="fit status" />
+                                            CssClass="fit status"/>
                     <dot:GridViewTemplateColumn HeaderText="Actions" HeaderCssClass="fit" CssClass="fit">
                         <ContentTemplate>
                             <span Visible="{value: Status != CompilationState.NonCompilable}">

--- a/src/Framework/Framework/Diagnostics/CompilationPageViewModel.cs
+++ b/src/Framework/Framework/Diagnostics/CompilationPageViewModel.cs
@@ -15,6 +15,7 @@ namespace DotVVM.Framework.Diagnostics
         public ImmutableArray<DotHtmlFileInfo> MasterPages => viewCompilationService.GetMasterPages();
         public ImmutableArray<DotHtmlFileInfo> Controls => viewCompilationService.GetControls();
         public int ActiveTab { get; set; } = 0;
+        public string PathBase => Context.TranslateVirtualPath("~/");
 
         public CompilationPageViewModel(IDotvvmViewCompilationService viewCompilationService)
         {

--- a/src/Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/Tests/Binding/JavascriptCompilationTests.cs
@@ -562,9 +562,10 @@ namespace DotVVM.Framework.Tests.Binding
         [TestMethod]
         [DataRow("Enumerable.Where(LongArray, (long item) => item % 2 == 0)", DisplayName = "Regular call of Enumerable.Where")]
         [DataRow("LongArray.Where((long item) => item % 2 == 0)", DisplayName = "Syntax sugar - extension method")]
+        [DataRow("LongArray.ToImmutableArray().Where((long item) => item % 2 == 0)", DisplayName = "Immutable array - extension method")]
         public void JsTranslator_EnumerableWhere(string binding)
         {
-            var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
+            var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq"), new NamespaceImport("System.Collections.Immutable") }, new[] { typeof(TestViewModel) });
             Assert.AreEqual("LongArray().filter((item)=>ko.unwrap(item)%2==0)", result);
         }
 
@@ -579,18 +580,21 @@ namespace DotVVM.Framework.Tests.Binding
         [TestMethod]
         [DataRow("Enumerable.Select(LongArray, (long item) => -item)", DisplayName = "Regular call of Enumerable.Select")]
         [DataRow("LongArray.Select((long item) => -item)", DisplayName = "Syntax sugar - extension method")]
+        [DataRow("LongArray.ToImmutableArray().Select((long item) => -item)", DisplayName = "Immutable array - extension method")]
+        [DataRow("LongArray.ToImmutableList().Select((long item) => -item)", DisplayName = "Immutable list - extension method")]
         public void JsTranslator_EnumerableSelect(string binding)
         {
-            var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
+            var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq"), new NamespaceImport("System.Collections.Immutable") }, new[] { typeof(TestViewModel) });
             Assert.AreEqual("LongArray().map((item)=>-ko.unwrap(item))", result);
         }
 
         [TestMethod]
         [DataRow("Enumerable.Concat(LongArray, LongArray)", DisplayName = "Regular call of Enumerable.Concat")]
         [DataRow("LongArray.Concat(LongArray)", DisplayName = "Syntax sugar - extension method")]
+        [DataRow("LongArray.ToImmutableArray().Concat(LongArray.ToImmutableArray())", DisplayName = "Immutable arrays")]
         public void JsTranslator_EnumerableConcat(string binding)
         {
-            var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
+            var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq"), new NamespaceImport("System.Collections.Immutable") }, new[] { typeof(TestViewModel) });
             Assert.AreEqual("LongArray().concat(LongArray())", result);
         }
 
@@ -636,18 +640,20 @@ namespace DotVVM.Framework.Tests.Binding
         [TestMethod]
         [DataRow("Enumerable.All(LongArray, (long item) => item > 0)", DisplayName = "Regular call of Enumerable.All")]
         [DataRow("LongArray.All((long item) => item > 0)", DisplayName = "Syntax sugar - extension method")]
+        [DataRow("LongArray.ToImmutableArray().All((long item) => item > 0)", DisplayName = "Immutable array - extension method")]
         public void JsTranslator_EnumerableAll(string binding)
         {
-            var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
+            var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq"), new NamespaceImport("System.Collections.Immutable") }, new[] { typeof(TestViewModel) });
             Assert.AreEqual("LongArray().every((item)=>ko.unwrap(item)>0)", result);
         }
 
         [TestMethod]
         [DataRow("Enumerable.Any(LongArray, (long item) => item > 0)", DisplayName = "Regular call of Enumerable.Any")]
         [DataRow("LongArray.Any((long item) => item > 0)", DisplayName = "Syntax sugar - extension method")]
+        [DataRow("LongArray.ToImmutableArray().Any((long item) => item > 0)", DisplayName = "Immutable array - extension method")]
         public void JsTranslator_EnumerableAny(string binding)
         {
-            var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
+            var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq"), new NamespaceImport("System.Collections.Immutable") }, new[] { typeof(TestViewModel) });
             Assert.AreEqual("LongArray().some((item)=>ko.unwrap(item)>0)", result);
         }
 
@@ -666,20 +672,34 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        [DataRow("Enumerable.Empty<int>()")]
+        [DataRow("Array.Empty<int>()")]
+        [DataRow("ImmutableArray<int>.Empty")]
+        [DataRow("ImmutableList<int>.Empty")]
+        public void JsTranslator_EnumerableEmpty(string binding)
+        {
+            var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq"), new NamespaceImport("System.Collections.Immutable") }, new[] { typeof(TestViewModel) });
+            Assert.AreEqual("[]", result);
+        }
+
+
+        [TestMethod]
         [DataRow("Enumerable.FirstOrDefault(LongArray)", DisplayName = "Regular call of Enumerable.FirstOrDefault")]
         [DataRow("LongArray.FirstOrDefault()", DisplayName = "Syntax sugar - extension method")]
+        [DataRow("LongArray.ToImmutableArray().FirstOrDefault()", DisplayName = "Immutable array - extension method")]
         public void JsTranslator_EnumerableFirstOrDefault(string binding)
         {
-            var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
+            var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq"), new NamespaceImport("System.Collections.Immutable") }, new[] { typeof(TestViewModel) });
             Assert.AreEqual("LongArray()[0]", result);
         }
 
         [TestMethod]
         [DataRow("Enumerable.FirstOrDefault(LongArray, (long item) => item > 0)", DisplayName = "Regular call of Enumerable.FirstOrDefault")]
         [DataRow("LongArray.FirstOrDefault((long item) => item > 0)", DisplayName = "Syntax sugar - extension method")]
+        [DataRow("LongArray.ToImmutableArray().FirstOrDefault((long item) => item > 0)", DisplayName = "Immutable array - extension method")]
         public void JsTranslator_EnumerableFirstOrDefaultParametrized(string binding)
         {
-            var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
+            var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq"), new NamespaceImport("System.Collections.Immutable") }, new[] { typeof(TestViewModel) });
             Assert.AreEqual("dotvvm.translations.array.firstOrDefault(LongArray(),(item)=>ko.unwrap(item)>0)", result);
         }
 
@@ -718,10 +738,11 @@ namespace DotVVM.Framework.Tests.Binding
         [TestMethod]
         [DataRow("Enumerable.LastOrDefault(LongArray)", DisplayName = "Regular call of Enumerable.LastOrDefault")]
         [DataRow("LongArray.LastOrDefault()", DisplayName = "Syntax sugar - extension method")]
+        [DataRow("LongArray.ToImmutableArray().LastOrDefault()", DisplayName = "Immutable array - extension method")]
         public void JsTranslator_EnumerableLastOrDefault(string binding)
         {
-            var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
-            Assert.AreEqual("dotvvm.translations.array.lastOrDefault(LongArray(),()=>true)", result);
+            var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq"), new NamespaceImport("System.Collections.Immutable") }, new[] { typeof(TestViewModel) });
+            Assert.AreEqual("LongArray().at(-1)", result);
         }
 
         [TestMethod]
@@ -729,7 +750,7 @@ namespace DotVVM.Framework.Tests.Binding
         [DataRow("LongArray.LastOrDefault((long item) => item > 0)", DisplayName = "Syntax sugar - extension method")]
         public void JsTranslator_EnumerableLastOrDefaultParametrized(string binding)
         {
-            var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
+            var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq"), new NamespaceImport("System.Collections.Immutable") }, new[] { typeof(TestViewModel) });
             Assert.AreEqual("dotvvm.translations.array.lastOrDefault(LongArray(),(item)=>ko.unwrap(item)>0)", result);
         }
 


### PR DESCRIPTION
Original goal was to add an "Errors" tab to the compilation which lists all failed pages, controls and master pages. Saves few clicks and scrolling when checking the compilation page.

![image](https://github.com/riganti/dotvvm/assets/7894687/4b49fa43-ff22-4b71-850a-33352568f50d)

However, I had to fix Linq translations on `ImmutableArray`. ImmutableArray is a struct so it has custom Linq method overloads to avoid allocations. These are preferred by the compiler over the `IEnumerable<T>` methods.

I also added .AsEnumerable and few other conversion methods to help users work around similar issues.