### PR TITLE
Sort the bindings in invalid command invocation error

### DIFF
--- a/src/Framework/Framework/Runtime/Commands/InvalidCommandInvocationException.cs
+++ b/src/Framework/Framework/Runtime/Commands/InvalidCommandInvocationException.cs
@@ -5,7 +5,7 @@ namespace DotVVM.Framework.Runtime.Commands
 {
     public class InvalidCommandInvocationException : Exception
     {
-        public Dictionary<string, string[]>? AdditionData { get; set; }
+        public KeyValuePair<string, string[]>[]? AdditionData { get; set; }
 
         public InvalidCommandInvocationException(string message)
             : base(message)
@@ -19,24 +19,16 @@ namespace DotVVM.Framework.Runtime.Commands
             
         }
 
-        public InvalidCommandInvocationException(string message, Dictionary<string, CandidateBindings>? data)
+        public InvalidCommandInvocationException(string message, KeyValuePair<string, string[]>[]? data)
             : this(message, (Exception?)null, data)
         {
 
         }
 
-        public InvalidCommandInvocationException(string message, Exception? innerException, Dictionary<string, CandidateBindings>? data)
+        public InvalidCommandInvocationException(string message, Exception? innerException, KeyValuePair<string, string[]>[]? data)
             : base(message, innerException)
         {
-            if(data != null)
-            {
-                AdditionData = new Dictionary<string, string[]>();
-                foreach (var bindings in data)
-                {
-                    AdditionData.Add(bindings.Key, bindings.Value.BindingsToString());
-                }
-            }
-
+            AdditionData = data;
         }
     }
 }


### PR DESCRIPTION
Bindings with matching ID are most prefered,
then bindings from the correct control are prefered, then it's sorted by the number of matching properties.