### PR TITLE
CompositeControl: ambiguous GetContents error message, test inheritance

### DIFF
--- a/src/Tests/ControlTests/CompositeControlTests.cs
+++ b/src/Tests/ControlTests/CompositeControlTests.cs
@@ -17,6 +17,7 @@ using DotVVM.Framework.Tests.Runtime;
 using DotVVM.Framework.ViewModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using DotVVM.Framework.Hosting;
+using System.ComponentModel;
 
 namespace DotVVM.Framework.Tests.ControlTests
 {
@@ -317,6 +318,18 @@ namespace DotVVM.Framework.Tests.ControlTests
                     {{value: _this}}
                 </cc:MenuRepeater>
                 "
+            );
+
+            check.CheckString(r.FormattedHtml, fileExtension: "html");
+        }
+
+        [TestMethod]
+        public async Task CompositeControlInheritance()
+        {
+            var r = await cth.RunPage(typeof(BasicTestViewModel), """
+                <cc:TestBaseCompositeControl Text="Text" Number=1 />
+                <cc:TestDerivedCompositeControl Text="SecondText" AnotherNumber=1.1 />
+                """
             );
 
             check.CheckString(r.FormattedHtml, fileExtension: "html");
@@ -687,6 +700,37 @@ namespace DotVVM.Framework.Tests.ControlTests
             icon.AddCssClass("fas");
             icon.CssClasses.Add("fa-times", testStatus.Select(t => t == TestStatusEnum.Failed));
             return icon;
+        }
+    }
+
+    public class TestBaseCompositeControl: CompositeControl
+    {
+        public static DotvvmControl GetContents(
+            ValueOrBinding<string> text,
+            [DefaultValue(1)]
+            ValueOrBinding<int> number
+        )
+        {
+            return new HtmlGenericControl("div") {
+                Children = {
+                    new Literal(text), new Literal(number)
+                }
+            };
+        }
+    }
+
+    public class TestDerivedCompositeControl: TestBaseCompositeControl
+    {
+        public static DotvvmControl GetContents(
+            ValueOrBinding<string> text,
+            ValueOrBinding<double> anotherNumber // declare another property, type of existing property cannot be changed
+        )
+        {
+            return new HtmlGenericControl("p") {
+                Children = {
+                    new Literal(text), new Literal(anotherNumber)
+                }
+            };
         }
     }
 }

--- a/src/Tests/ControlTests/testoutputs/CompositeControlTests.CompositeControlInheritance.html
+++ b/src/Tests/ControlTests/testoutputs/CompositeControlTests.CompositeControlInheritance.html
@@ -1,0 +1,7 @@
+<html>
+	<head></head>
+	<body>
+		<div>Text1</div>
+		<p>SecondText1.1</p>
+	</body>
+</html>


### PR DESCRIPTION
According to  #1613 CompositeControl do not work with both base and derived types defining GetContents method. I could not replicate that, the provided example works for me, maybe it was fixed accidentally.

* I added test for that
* In any case, multiple GetContents overloads were handled poorly, I added better error for this case.

In the issue, I mentioned that it would be complex to handle potential redefinition or "removal" of properties in the derived type. That isn't really the case, both cases don't need any special code
* The "removal" - omission of an property in the derived type is simply ignored. I think that it's quite intuitive that properties can't disappear in derived types, if the GetContents doesn't ask for it it won't get it.
* Redefinition is already handled reasonably, since we can already try to redefine IncludeInPage or some capability property.

Resolves #1613