### PR TITLE
Fix implicit conversion in expressions like `C ? P : null`

### DIFF
--- a/src/Tests/Binding/BindingCompilationTests.cs
+++ b/src/Tests/Binding/BindingCompilationTests.cs
@@ -825,6 +825,26 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        public void BindingCompiler_ImplicitConversion_ConditionalStringAndNull()
+        {
+            var resultNotNull = ExecuteBinding("_this.BoolProp ? _this.StringProp : null", new [] { new TestViewModel { StringProp = "test", BoolProp = true } }, expectedType: typeof(string));
+            Assert.AreEqual("test", resultNotNull);
+            resultNotNull = ExecuteBinding("!_this.BoolProp ? null : _this.StringProp", new [] { new TestViewModel { StringProp = "test", BoolProp = true } }, expectedType: typeof(string));
+            Assert.AreEqual("test", resultNotNull);
+            var resultNull = ExecuteBinding("_this.BoolProp ? _this.StringProp : null", new [] { new TestViewModel { StringProp = "test", BoolProp = false } }, expectedType: typeof(string));
+            Assert.IsNull(resultNull);
+        }
+
+        [TestMethod]
+        public void BindingCompiler_ImplicitConversion_ConditionalEnumAndLiteral()
+        {
+            var result = ExecuteBinding("_this.BoolProp ? _this.EnumProperty : 'A'", new [] { new TestViewModel { EnumProperty = TestEnum.B, BoolProp = false } }, expectedType: typeof(object));
+            Assert.AreEqual(TestEnum.A, result);
+            result = ExecuteBinding("_this.BoolProp ? 'A' : _this.EnumProperty", new [] { new TestViewModel { EnumProperty = TestEnum.B, BoolProp = false } }, expectedType: typeof(object));
+            Assert.AreEqual(TestEnum.B, result);
+        }
+
+        [TestMethod]
         public void BindingCompiler_SimpleBlockExpression()
         {
             var result = ExecuteBinding("SetStringProp2(StringProp + 'kk'); StringProp = StringProp2 + 'll'", new [] { new TestViewModel { StringProp = "a" } });

--- a/src/Tests/Binding/ImplicitConversionTests.cs
+++ b/src/Tests/Binding/ImplicitConversionTests.cs
@@ -29,6 +29,13 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        public void Conversion_NullConversion()
+        {
+            TypeConversion.EnsureImplicitConversion(Expression.Constant(null, typeof(object)), typeof(string));
+            TypeConversion.EnsureImplicitConversion(Expression.Constant(null, typeof(object)), typeof(int?));
+        }
+
+        [TestMethod]
         public void Conversion_ValidToString()
         {
             TypeConversion.EnsureImplicitConversion(Expression.Parameter(typeof(DateTime)), typeof(string), allowToString: true);


### PR DESCRIPTION
Fixes compilation of ternary expressions with ambiguous conversion (in C?A:B A is convertible to B while B is also convertible to A). This is normally disallowed in C#, but I specifically allowed two cases
* one of them is `object` which can be converted to the other type - this occurs if the `object` is null
* one of them is `string` which is convertible to the other type - this occurs for our enum constant literals

should fix part of #1694