### PR TITLE
Fix whitespace padding width with tabs and Unicode combining characters

### DIFF
--- a/src/Framework/Framework/Compilation/ViewCompiler/DefaultViewCompiler.cs
+++ b/src/Framework/Framework/Compilation/ViewCompiler/DefaultViewCompiler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Compilation.ControlTree.Resolved;
@@ -148,10 +149,19 @@ namespace DotVVM.Framework.Compilation.ViewCompiler
                     ""
                 );
                 string error;
-                if (ContextLine is {})
+                if (ContextLine is {} contextLine)
                 {
-                    var errorHighlight = new string(' ', CharPosition ?? 1) + new string('^', HighlightLength);
-                    error = $"{fileLocation}: Dotvvm Compilation Warning\n{ContextLine}\n{errorHighlight} {Message}";
+                    var graphemeIndices = StringInfo.ParseCombiningCharacters(contextLine.Substring(0, Math.Min(contextLine.Length, CharPosition ?? 0)));
+                    var padding = string.Concat(
+                        graphemeIndices.Select(
+                            startIndex => contextLine[startIndex] switch {
+                                '\t' => "\t",
+                                _ => " "
+                            }
+                        )
+                    );
+                    var errorHighlight = padding + new string('^', HighlightLength);
+                    error = $"{fileLocation}: Dotvvm Compilation Warning\n{contextLine}\n{errorHighlight} {Message}";
                 }
                 else
                 {


### PR DESCRIPTION
Tabs are replaced by tabs to preserve the string width, all other characters are replaced by a single space. Moreover we now count the unicode graphemes instead of UTF16 units. It still has the problem that some characters (Emoji, CJK) are wider even in monospace fonts, but that's not that easy to determine.

Before:
![image](https://github.com/riganti/dotvvm/assets/7894687/7b02480f-8b2e-4ead-8851-5d701e67c55b)

Now:
![image](https://github.com/riganti/dotvvm/assets/7894687/e9ddd9ea-0754-4ae5-9414-3809ecf62b23)

The 2 spaces after the emoji is actually a bug in the terminal emulator I use.


