### PR TITLE
BindingParser: Fixing missing tokens and ranges

### DIFF
--- a/src/Framework/Framework/Compilation/ControlTree/IAbstractTreeBuilder.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/IAbstractTreeBuilder.cs
@@ -29,7 +29,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
 
         IAbstractViewModuleDirective BuildViewModuleDirective(DothtmlDirectiveNode directiveNode, string modulePath, string resourceName);
         IAbstractPropertyDeclarationDirective BuildPropertyDeclarationDirective(DothtmlDirectiveNode directive, TypeReferenceBindingParserNode typeSyntax, SimpleNameBindingParserNode nameSyntax, BindingParserNode? initializer, IList<IAbstractDirectiveAttributeReference> resolvedAttributes, BindingParserNode valueSyntaxRoot, ImmutableList<NamespaceImport> imports);
-        IAbstractDirectiveAttributeReference BuildPropertyDeclarationAttributeReference(DothtmlDirectiveNode directiveNode, IdentifierNameBindingParserNode propertyNameSyntax, ActualTypeReferenceBindingParserNode typeSyntax, LiteralExpressionBindingParserNode initializer, ImmutableList<NamespaceImport> imports);
+        IAbstractDirectiveAttributeReference BuildPropertyDeclarationAttributeReference(DothtmlDirectiveNode directiveNode, IdentifierNameBindingParserNode propertyNameSyntax, TypeReferenceBindingParserNode typeSyntax, LiteralExpressionBindingParserNode initializer, ImmutableList<NamespaceImport> imports);
         IAbstractPropertyBinding BuildPropertyBinding(IPropertyDescriptor property, IAbstractBinding binding, DothtmlAttributeNode? sourceAttributeNode);
 
         IAbstractPropertyControl BuildPropertyControl(IPropertyDescriptor property, IAbstractControl? control, DothtmlElementNode? wrapperElementNode);

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedTreeBuilder.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedTreeBuilder.cs
@@ -113,7 +113,7 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
         public IAbstractDirectiveAttributeReference BuildPropertyDeclarationAttributeReference(
             DothtmlDirectiveNode directiveNode,
             IdentifierNameBindingParserNode propertyNameSyntax,
-            ActualTypeReferenceBindingParserNode typeSyntax,
+            TypeReferenceBindingParserNode typeSyntax,
             LiteralExpressionBindingParserNode initializer,
             ImmutableList<NamespaceImport> imports)
         {

--- a/src/Framework/Framework/Compilation/Directives/PropertyDeclarationDirectiveCompiler.cs
+++ b/src/Framework/Framework/Compilation/Directives/PropertyDeclarationDirectiveCompiler.cs
@@ -59,9 +59,9 @@ namespace DotVVM.Framework.Compilation.Directives
             return TreeBuilder.BuildPropertyDeclarationDirective(directiveNode, type, name, declaration?.Initializer, resolvedAttributes, valueSyntaxRoot, imports);
         }
 
-        private List<(ActualTypeReferenceBindingParserNode type, IdentifierNameBindingParserNode name, LiteralExpressionBindingParserNode initializer)> ProcessPropertyDirectiveAttributeReference(DothtmlDirectiveNode directiveNode, List<BindingParserNode> attributeReferences)
+        private List<(TypeReferenceBindingParserNode type, IdentifierNameBindingParserNode name, LiteralExpressionBindingParserNode initializer)> ProcessPropertyDirectiveAttributeReference(DothtmlDirectiveNode directiveNode, List<BindingParserNode> attributeReferences)
         {
-            var result = new List<(ActualTypeReferenceBindingParserNode, IdentifierNameBindingParserNode, LiteralExpressionBindingParserNode)>();
+            var result = new List<(TypeReferenceBindingParserNode, IdentifierNameBindingParserNode, LiteralExpressionBindingParserNode)>();
             foreach (var attributeReference in attributeReferences)
             {
                 if (attributeReference is not BinaryOperatorBindingParserNode { Operator: BindingTokenType.AssignOperator } assignment)
@@ -75,7 +75,7 @@ namespace DotVVM.Framework.Compilation.Directives
                 var attributePropertyNameReference = attributePropertyReference?.MemberNameExpression;
                 var initializer = assignment.SecondExpression as LiteralExpressionBindingParserNode;
 
-                if (attributeTypeReference == null || attributePropertyNameReference == null)
+                if (attributeTypeReference is not TypeReferenceBindingParserNode attributeType || attributePropertyNameReference == null)
                 {
                     directiveNode.AddError("Property attributes must be in the form Attribute.Property = value.");
                     continue;
@@ -85,7 +85,7 @@ namespace DotVVM.Framework.Compilation.Directives
                     directiveNode.AddError($"Value for property {attributeTypeReference.ToDisplayString()} of attribute {attributePropertyNameReference.ToDisplayString()} is missing or not a constant.");
                     continue;
                 }
-                result.Add((new ActualTypeReferenceBindingParserNode(attributeTypeReference), attributePropertyNameReference, initializer));
+                result.Add(new (attributeType, attributePropertyNameReference, initializer));
             }
             return result;
         }

--- a/src/Framework/Framework/Compilation/Directives/PropertyDeclarationDirectiveCompiler.cs
+++ b/src/Framework/Framework/Compilation/Directives/PropertyDeclarationDirectiveCompiler.cs
@@ -75,7 +75,7 @@ namespace DotVVM.Framework.Compilation.Directives
                 var attributePropertyNameReference = attributePropertyReference?.MemberNameExpression;
                 var initializer = assignment.SecondExpression as LiteralExpressionBindingParserNode;
 
-                if (attributeTypeReference is not TypeReferenceBindingParserNode attributeType || attributePropertyNameReference == null)
+                if (attributeTypeReference is null || attributePropertyNameReference is null)
                 {
                     directiveNode.AddError("Property attributes must be in the form Attribute.Property = value.");
                     continue;
@@ -85,7 +85,10 @@ namespace DotVVM.Framework.Compilation.Directives
                     directiveNode.AddError($"Value for property {attributeTypeReference.ToDisplayString()} of attribute {attributePropertyNameReference.ToDisplayString()} is missing or not a constant.");
                     continue;
                 }
-                result.Add(new (attributeType, attributePropertyNameReference, initializer));
+
+                var type = new ActualTypeReferenceBindingParserNode(attributeTypeReference);
+                type.TransferTokens(attributeTypeReference);
+                result.Add(new (type, attributePropertyNameReference, initializer));
             }
             return result;
         }

--- a/src/Framework/Framework/Compilation/Parser/Binding/Parser/BindingParser.cs
+++ b/src/Framework/Framework/Compilation/Parser/Binding/Parser/BindingParser.cs
@@ -642,7 +642,7 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
                     Read();
                     var member = ReadIdentifierNameExpression();
                     if (expression is TypeOrFunctionReferenceBindingParserNode typeOrFunction)
-                        expression = typeOrFunction.ToTypeReference();
+                        expression = CreateNode(typeOrFunction.ToTypeReference(), startIndex);
 
                     expression = CreateNode(new MemberAccessBindingParserNode(expression, member), startIndex);
                 }
@@ -657,7 +657,7 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
                 else if (!onlyTypeName && next.Type == BindingTokenType.OpenParenthesis)
                 {
                     if (expression is TypeOrFunctionReferenceBindingParserNode typeOrFunction)
-                        expression = typeOrFunction.ToFunctionReference();
+                        expression = CreateNode(typeOrFunction.ToFunctionReference(), startIndex);
 
                     expression = ReadFunctionCall(startIndex, expression);
                 }

--- a/src/Framework/Framework/Compilation/Parser/Binding/Parser/BindingParserNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Binding/Parser/BindingParserNode.cs
@@ -47,14 +47,24 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
 
         public abstract string ToDisplayString();
 
-        internal void TransferTokens(BindingParserNode sourceNode)
+        internal void TransferTokens(BindingParserNode sourceNode, int? startPosition = null)
         {
-            Length = sourceNode.Length;
-            StartPosition = sourceNode.StartPosition;
+            
+            StartPosition = startPosition ?? sourceNode.StartPosition;
+            Length = 0;
+
             Tokens.Clear();
             Tokens.Capacity = sourceNode.Tokens.Capacity;
+
             for (int i = 0; i < sourceNode.Tokens.Count; i++)
-                Tokens.Add(sourceNode.Tokens[i]);
+            {
+                var token = sourceNode.Tokens[i];
+                if ((startPosition ?? 0) <= token.StartPosition)
+                {
+                    Length += token.Length;
+                    Tokens.Add(token);
+                }
+            }
         }
     }
 }

--- a/src/Framework/Framework/Compilation/Parser/Binding/Parser/BindingParserNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Binding/Parser/BindingParserNode.cs
@@ -47,5 +47,14 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
 
         public abstract string ToDisplayString();
 
+        internal void TransferTokens(BindingParserNode sourceNode)
+        {
+            Length = sourceNode.Length;
+            StartPosition = sourceNode.StartPosition;
+            Tokens.Clear();
+            Tokens.Capacity = sourceNode.Tokens.Capacity;
+            for (int i = 0; i < sourceNode.Tokens.Count; i++)
+                Tokens.Add(sourceNode.Tokens[i]);
+        }
     }
 }

--- a/src/Framework/Framework/Compilation/Parser/Binding/Parser/TypeOrFunctionReferenceBindingParserNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Binding/Parser/TypeOrFunctionReferenceBindingParserNode.cs
@@ -54,7 +54,10 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
                 if (TypeArguments.Count == 0)
                     return memberAccess;
 
-                var genericName = new GenericNameBindingParserNode(memberAccess.MemberNameExpression.NameToken, TypeArguments);
+                var name = memberAccess.MemberNameExpression.NameToken;
+                var genericName = new GenericNameBindingParserNode(name, TypeArguments);
+                genericName.TransferTokens(this, name.StartPosition);
+
                 memberAccess.MemberNameExpression = genericName;
                 return memberAccess;
             }

--- a/src/Framework/Framework/Compilation/Parser/Binding/Parser/TypeOrFunctionReferenceBindingParserNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Binding/Parser/TypeOrFunctionReferenceBindingParserNode.cs
@@ -32,6 +32,8 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
         public TypeReferenceBindingParserNode ToTypeReference()
         {
             var type = new ActualTypeReferenceBindingParserNode(TypeOrFunction);
+            type.TransferTokens(TypeOrFunction);
+
             if (TypeArguments.Count == 0)
                 return type;
 

--- a/src/Tests/Parser/Binding/BindingParserTests.cs
+++ b/src/Tests/Parser/Binding/BindingParserTests.cs
@@ -882,7 +882,7 @@ namespace DotVVM.Framework.Tests.Parser.Binding
 
         [TestMethod]
         [DataRow("(arg) => Method(arg)", DisplayName = "Simple implicit single-parameter lambda expression with parentheses.")]
-        [DataRow("arg => Method(arg)", DisplayName = "Simple implicit single-parameter lambda expression without parentheses.")]           
+        [DataRow("arg => Method(arg)", DisplayName = "Simple implicit single-parameter lambda expression without parentheses.")]
         [DataRow("  arg    =>   Method   (   arg  )", DisplayName = "Simple lambda with various whitespaces.")]
         [DataRow("arg =>Method(arg)", DisplayName = "Simple lambda with various whitespaces.")]
         [DataRow("arg=>Method(arg)", DisplayName = "Simple lambda with various whitespaces.")]
@@ -1158,7 +1158,7 @@ namespace DotVVM.Framework.Tests.Parser.Binding
 
             Assert.AreEqual(SkipWhitespaces(bindingExpression), SkipWhitespaces(node.ToDisplayString()));
         }
-        
+
         [TestMethod]
         public void BindingParser_VariableExpression_3Vars()
         {
@@ -1191,9 +1191,9 @@ namespace DotVVM.Framework.Tests.Parser.Binding
             var type = root.PropertyType.CastTo<TypeReferenceBindingParserNode>();
             var name = root.Name.CastTo<SimpleNameBindingParserNode>();
 
-            Assert.AreEqual("System.String MyProperty", root.ToDisplayString());
-            Assert.AreEqual("System.String", type.ToDisplayString());
-            Assert.AreEqual("MyProperty", name.ToDisplayString());
+            AssertNode(root, "System.String MyProperty = \"Test\"", 0, 33);
+            AssertNode(type, "System.String", 0, 13);
+            AssertNode(name, "MyProperty", 14, 11);
         }
 
         [TestMethod]
@@ -1207,10 +1207,10 @@ namespace DotVVM.Framework.Tests.Parser.Binding
             var name = root.Name.CastTo<SimpleNameBindingParserNode>();
             var init = root.Initializer.CastTo<LiteralExpressionBindingParserNode>();
 
-            Assert.AreEqual("System.String MyProperty = \"Test\"", root.ToDisplayString());
-            Assert.AreEqual("System.String", type.ToDisplayString());
-            Assert.AreEqual("MyProperty", name.ToDisplayString());
-            Assert.AreEqual("\"Test\"", init.ToDisplayString());
+            AssertNode(root, "System.String MyProperty = \"Test\"", 0, 33);
+            AssertNode(type, "System.String", 0, 13);
+            AssertNode(name, "MyProperty", 14, 11);
+            AssertNode(init, "\"Test\"", 27, 6);
         }
 
         [TestMethod]
@@ -1229,12 +1229,12 @@ namespace DotVVM.Framework.Tests.Parser.Binding
             var att1 = root.Attributes[0].CastTo<BinaryOperatorBindingParserNode>();
             var att2 = root.Attributes[1].CastTo<BinaryOperatorBindingParserNode>();
 
-            Assert.AreEqual("System.String MyProperty = \"Test\", MarkupOptions.AllowHardCodedValue = False, MarkupOptions.Required = True", root.ToDisplayString());
-            Assert.AreEqual("System.String", type.ToDisplayString());
-            Assert.AreEqual("MyProperty", name.ToDisplayString());
-            Assert.AreEqual("\"Test\"", init.ToDisplayString());
-            Assert.AreEqual("MarkupOptions.AllowHardCodedValue = False", att1.ToDisplayString());
-            Assert.AreEqual("MarkupOptions.Required = True", att2.ToDisplayString());
+            AssertNode(root, "System.String MyProperty = \"Test\", MarkupOptions.AllowHardCodedValue = False, MarkupOptions.Required = True", 0, 107);
+            AssertNode(type, "System.String", 0, 13);
+            AssertNode(name, "MyProperty", 14, 11);
+            AssertNode(init, "\"Test\"", 27, 6);
+            AssertNode(att1, "MarkupOptions.AllowHardCodedValue = False", 35, 41);
+            AssertNode(att2, "MarkupOptions.Required = True", 77, 30);
         }
 
         [TestMethod]
@@ -1244,7 +1244,8 @@ namespace DotVVM.Framework.Tests.Parser.Binding
             var declaration = parser.ReadPropertyDirectiveValue();
 
             var root = declaration.CastTo<PropertyDeclarationBindingParserNode>();
-            var type = root.PropertyType.CastTo<TypeReferenceBindingParserNode>();
+            var type = root.PropertyType.CastTo<ArrayTypeReferenceBindingParserNode>();
+            var elementType = type.ElementType.CastTo<TypeReferenceBindingParserNode>();
             var name = root.Name.CastTo<SimpleNameBindingParserNode>();
             var attributes = root.Attributes;
 
@@ -1282,16 +1283,45 @@ namespace DotVVM.Framework.Tests.Parser.Binding
             var element2Initializer = root.Initializer.CastTo<ArrayInitializerExpression>().ElementInitializers[1].CastTo<MemberAccessBindingParserNode>();
             var element3Initializer = root.Initializer.CastTo<ArrayInitializerExpression>().ElementInitializers[2].CastTo<MemberAccessBindingParserNode>();
 
-            Assert.AreEqual("Namespace.Enum[] MyProperty = [ Namespace.Enum.Value1, Namespace.Enum.Value2, Namespace.Enum.Value3 ], MarkupOptions.AllowHardCodedValue = False, MarkupOptions.Required = True", root.ToDisplayString());
-            Assert.AreEqual("Namespace.Enum[]", type.ToDisplayString());
-            Assert.AreEqual("MyProperty", name.ToDisplayString());
+            AssertNode(root, "Namespace.Enum[] MyProperty = [ Namespace.Enum.Value1, Namespace.Enum.Value2, Namespace.Enum.Value3 ], MarkupOptions.AllowHardCodedValue = False, MarkupOptions.Required = True", 0, 175);
+            AssertNode(type, "Namespace.Enum[]", 0, 16);
+            AssertNode(elementType, "Namespace.Enum", 0, 14);
+            AssertNode(name, "MyProperty", 16, 12);
 
-            Assert.AreEqual("Namespace.Enum.Value1", element1Initializer.ToDisplayString());
-            Assert.AreEqual("Namespace.Enum.Value2", element2Initializer.ToDisplayString());
-            Assert.AreEqual("Namespace.Enum.Value3", element3Initializer.ToDisplayString());
+            AssertNode(element1Initializer, "Namespace.Enum.Value1", 32, 21);
+            AssertNode(element2Initializer, "Namespace.Enum.Value2", 55, 21);
+            AssertNode(element3Initializer, "Namespace.Enum.Value3", 78, 22);
 
-            Assert.AreEqual("MarkupOptions.AllowHardCodedValue = False", att1.ToDisplayString());
-            Assert.AreEqual("MarkupOptions.Required = True", att2.ToDisplayString());
+            AssertNode(att1, "MarkupOptions.AllowHardCodedValue = False", 103, 41);
+            AssertNode(att2, "MarkupOptions.Required = True", 145, 30);
+        }
+
+        [TestMethod]
+        public void BindingParser_GenericTypePropertyDeclaration()
+        {
+            var parser = bindingParserNodeFactory.SetupParser("IDictionary<int, System.String> MyProperty");
+            var declaration = parser.ReadPropertyDirectiveValue();
+
+            var root = declaration.CastTo<PropertyDeclarationBindingParserNode>();
+            var genericType = root.PropertyType.CastTo<GenericTypeReferenceBindingParserNode>();
+            var name = root.Name.CastTo<SimpleNameBindingParserNode>();
+
+            var type = genericType.Type.CastTo<TypeReferenceBindingParserNode>();
+            var arg1 = genericType.Arguments[0].CastTo<TypeReferenceBindingParserNode>();
+            var arg2 = genericType.Arguments[1].CastTo<TypeReferenceBindingParserNode>();
+
+            AssertNode(root, "IDictionary<int, System.String> MyProperty", 0, 42);
+            AssertNode(name, "MyProperty", 31, 11);
+            AssertNode(type, "IDictionary", 0, 11);
+            AssertNode(arg1, "int", 12, 3);
+            AssertNode(arg2, "System.String", 17, 13);
+        }
+
+        private static void AssertNode(BindingParserNode elementType, string expectedDisplayString, int start, int length)
+        {
+            Assert.AreEqual(expectedDisplayString, elementType.ToDisplayString(), $"Node {elementType.GetType().Name}: display string incorrect.");
+            Assert.AreEqual(start, elementType.StartPosition, $"Node {elementType.GetType().Name}: Start position incorrect.");
+            Assert.AreEqual(length, elementType.Length, $"Node {elementType.GetType().Name}: Length incorrect.");
         }
 
         private static string SkipWhitespaces(string str) => string.Join("", str.Where(c => !char.IsWhiteSpace(c)));

--- a/src/Tests/Parser/Binding/BindingParserTests.cs
+++ b/src/Tests/Parser/Binding/BindingParserTests.cs
@@ -1302,8 +1302,7 @@ namespace DotVVM.Framework.Tests.Parser.Binding
             var declaration = parser.ReadPropertyDirectiveValue();
 
             var root = declaration.CastTo<PropertyDeclarationBindingParserNode>();
-            var type = root.PropertyType.CastTo<ArrayTypeReferenceBindingParserNode>();
-            var elementType = type.ElementType.CastTo<TypeReferenceBindingParserNode>();
+            var type = root.PropertyType.CastTo<ActualTypeReferenceBindingParserNode>();
             var name = root.Name.CastTo<SimpleNameBindingParserNode>();
             var attributes = root.Attributes;
 
@@ -1327,7 +1326,8 @@ namespace DotVVM.Framework.Tests.Parser.Binding
             var declaration = parser.ReadPropertyDirectiveValue();
 
             var root = declaration.CastTo<PropertyDeclarationBindingParserNode>();
-            var type = root.PropertyType.CastTo<TypeReferenceBindingParserNode>();
+            var type = root.PropertyType.CastTo<ArrayTypeReferenceBindingParserNode>();
+            var elementType = type.ElementType.CastTo<ActualTypeReferenceBindingParserNode>();
             var name = root.Name.CastTo<SimpleNameBindingParserNode>();
             var attributes = root.Attributes;
 

--- a/src/Tests/Parser/Binding/BindingParserTests.cs
+++ b/src/Tests/Parser/Binding/BindingParserTests.cs
@@ -1191,9 +1191,66 @@ namespace DotVVM.Framework.Tests.Parser.Binding
             var type = root.PropertyType.CastTo<TypeReferenceBindingParserNode>();
             var name = root.Name.CastTo<SimpleNameBindingParserNode>();
 
-            AssertNode(root, "System.String MyProperty = \"Test\"", 0, 33);
+            AssertNode(root, "System.String MyProperty", 0, 24);
+            AssertNode(type, "System.String", 0, 14);
+            AssertNode(name, "MyProperty", 14, 10);
+        }
+
+        [TestMethod]
+        public void BindingParser_NullablePropertyDeclaration()
+        {
+            var parser = bindingParserNodeFactory.SetupParser("System.String? MyProperty");
+            var declaration = parser.ReadPropertyDirectiveValue();
+
+            var root = declaration.CastTo<PropertyDeclarationBindingParserNode>();
+            var nullable = root.PropertyType.CastTo<NullableTypeReferenceBindingParserNode>();
+            var type = nullable.InnerType.CastTo<ActualTypeReferenceBindingParserNode>();
+            var name = root.Name.CastTo<SimpleNameBindingParserNode>();
+
+            AssertNode(root, "System.String? MyProperty", 0, 25);
+            AssertNode(nullable, "System.String?", 0, 14);
             AssertNode(type, "System.String", 0, 13);
             AssertNode(name, "MyProperty", 14, 11);
+        }
+
+        [TestMethod]
+        public void BindingParser_ComplexTypePropertyDeclaration()
+        {
+            var parser = bindingParserNodeFactory.SetupParser("System.Func<System.String?, int?, string, IdentifierNameBindingParserNode?[]>? MyProperty");
+            var declaration = parser.ReadPropertyDirectiveValue();
+
+            var root = declaration.CastTo<PropertyDeclarationBindingParserNode>();
+            var nullableFunc = root.PropertyType.CastTo<NullableTypeReferenceBindingParserNode>();
+            var funcGeneric = nullableFunc.InnerType.CastTo<GenericTypeReferenceBindingParserNode>();
+            var func = funcGeneric.Type.CastTo<ActualTypeReferenceBindingParserNode>();
+
+            var arg1Nullable = funcGeneric.Arguments[0].CastTo<NullableTypeReferenceBindingParserNode>();
+            var arg2Nullable = funcGeneric.Arguments[1].CastTo<NullableTypeReferenceBindingParserNode>();
+            var arg4Array = funcGeneric.Arguments[3].CastTo<ArrayTypeReferenceBindingParserNode>();
+
+            var arg1 = arg1Nullable.InnerType.CastTo<ActualTypeReferenceBindingParserNode>();
+            var arg2 = arg2Nullable.InnerType.CastTo<ActualTypeReferenceBindingParserNode>();
+            var arg3 = funcGeneric.Arguments[2].CastTo<ActualTypeReferenceBindingParserNode>();
+            var arg4Nullable = arg4Array.ElementType.CastTo<NullableTypeReferenceBindingParserNode>();
+
+            var arg4 = arg4Nullable.InnerType.CastTo<ActualTypeReferenceBindingParserNode>();
+
+            AssertNode(root, "System.Func<System.String?, int?, string, IdentifierNameBindingParserNode?[]>? MyProperty", 0, 89);
+            AssertNode(nullableFunc, "System.Func<System.String?, int?, string, IdentifierNameBindingParserNode?[]>?", 0, 78);
+            AssertNode(funcGeneric, "System.Func<System.String?, int?, string, IdentifierNameBindingParserNode?[]>", 0, 77);
+            AssertNode(func, "System.Func", 0, 11);
+            AssertNode(root.Name, "MyProperty", 78, 11);
+
+            AssertNode(arg1Nullable, "System.String?", 12, 14);
+            AssertNode(arg2Nullable, "int?", 28, 4);
+            AssertNode(arg3, "string", 34, 6);
+            AssertNode(arg4Array, "IdentifierNameBindingParserNode?[]", 42, 34);
+
+            AssertNode(arg1, "System.String", 12, 13);
+            AssertNode(arg2, "int", 28, 3);
+            AssertNode(arg4Nullable, "IdentifierNameBindingParserNode?", 42, 32);
+
+            AssertNode(arg4, "IdentifierNameBindingParserNode", 42, 31);
         }
 
         [TestMethod]
@@ -1208,7 +1265,7 @@ namespace DotVVM.Framework.Tests.Parser.Binding
             var init = root.Initializer.CastTo<LiteralExpressionBindingParserNode>();
 
             AssertNode(root, "System.String MyProperty = \"Test\"", 0, 33);
-            AssertNode(type, "System.String", 0, 13);
+            AssertNode(type, "System.String", 0, 14);
             AssertNode(name, "MyProperty", 14, 11);
             AssertNode(init, "\"Test\"", 27, 6);
         }
@@ -1230,7 +1287,7 @@ namespace DotVVM.Framework.Tests.Parser.Binding
             var att2 = root.Attributes[1].CastTo<BinaryOperatorBindingParserNode>();
 
             AssertNode(root, "System.String MyProperty = \"Test\", MarkupOptions.AllowHardCodedValue = False, MarkupOptions.Required = True", 0, 107);
-            AssertNode(type, "System.String", 0, 13);
+            AssertNode(type, "System.String", 0, 14);
             AssertNode(name, "MyProperty", 14, 11);
             AssertNode(init, "\"Test\"", 27, 6);
             AssertNode(att1, "MarkupOptions.AllowHardCodedValue = False", 35, 41);
@@ -1255,11 +1312,11 @@ namespace DotVVM.Framework.Tests.Parser.Binding
             var att1 = root.Attributes[0].CastTo<BinaryOperatorBindingParserNode>();
             var att2 = root.Attributes[1].CastTo<BinaryOperatorBindingParserNode>();
 
-            Assert.AreEqual("System.String MyProperty, MarkupOptions.AllowHardCodedValue = False, MarkupOptions.Required = True", root.ToDisplayString());
-            Assert.AreEqual("System.String", type.ToDisplayString());
-            Assert.AreEqual("MyProperty", name.ToDisplayString());
-            Assert.AreEqual("MarkupOptions.AllowHardCodedValue = False", att1.ToDisplayString());
-            Assert.AreEqual("MarkupOptions.Required = True", att2.ToDisplayString());
+            AssertNode(root, "System.String MyProperty, MarkupOptions.AllowHardCodedValue = False, MarkupOptions.Required = True", 0, 98);
+            AssertNode(type, "System.String", 0, 14);
+            AssertNode(name, "MyProperty", 14, 10);
+            AssertNode(att1, "MarkupOptions.AllowHardCodedValue = False", 26, 41);
+            AssertNode(att2, "MarkupOptions.Required = True", 68, 30);
         }
 
         [TestMethod]
@@ -1312,6 +1369,7 @@ namespace DotVVM.Framework.Tests.Parser.Binding
 
             AssertNode(root, "IDictionary<int, System.String> MyProperty", 0, 42);
             AssertNode(name, "MyProperty", 31, 11);
+            AssertNode(genericType, "IDictionary<int, System.String>", 0, 31);
             AssertNode(type, "IDictionary", 0, 11);
             AssertNode(arg1, "int", 12, 3);
             AssertNode(arg2, "System.String", 17, 13);

--- a/src/Tests/Parser/Binding/BindingParserTests.cs
+++ b/src/Tests/Parser/Binding/BindingParserTests.cs
@@ -955,7 +955,7 @@ namespace DotVVM.Framework.Tests.Parser.Binding
         [DataRow("(string arg) => Method(arg)", "string")]
         [DataRow("(float arg) => Method(arg)", "float")]
         [DataRow("(decimal arg) => Method(arg)", "decimal")]
-        [DataRow("(System.Collections.Generic.List<int> arg) => Method(arg)", "System.Collections.Generic.List<int>")]
+        [DataRow("(System.Collections.Generic.List<int>.Subtype arg) => Method(arg)", "System.Collections.Generic.List<int>.Subtype")]
         public void BindingParser_Lambda_WithTypeInfo_SingleParameter(string expr, string type)
         {
             var parser = bindingParserNodeFactory.SetupParser(expr);


### PR DESCRIPTION
With introduction of type reference nodes a bug appeared, where the type references had incorrect ranges and tokens.