### PR TITLE
runtime warnings: include markup line number of nearest ancestor

### DIFF
--- a/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
+++ b/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
@@ -548,7 +548,7 @@ namespace DotVVM.Framework.Controls
             if (useHtml)
             {
                 var tagName = cname.prefix is null ?
-                    $"<span class='tag-name'>{cname.tagName}</span>" :
+                    $"<span class='tag-name'>{WebUtility.HtmlEncode(cname.tagName)}</span>" :
                     $"<span class='tag-prefix'>{WebUtility.HtmlEncode(cname.prefix)}</span>:<span class='control-name'>{WebUtility.HtmlEncode(cname.tagName)}</span>";
                 dothtmlString = $"&lt;<span class='tag' title='{WebUtility.HtmlEncode(type.ToCode())}'>{tagName}</span> ";
                 var prefixLength = dothtmlString.Length;

--- a/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
+++ b/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
@@ -593,7 +593,7 @@ namespace DotVVM.Framework.Controls
             
             var fileLocation = (location.file)
                      + (location.line >= 0 ? ":" + location.line : "")
-                     + (location.nearestControlInMarkup is null && multiline ? "" : $" (nearest dothtml control is <{location.nearestControlInMarkup}>)");
+                     + (location.nearestControlInMarkup is null || !multiline ? "" : $" (nearest dothtml control is <{location.nearestControlInMarkup}>)");
 
             if (useHtml)
             {


### PR DESCRIPTION
Useful when warnings are produced on control created from a CompositeControl. We still only show details of the nested control, but at least the line number now identifies where it comes from.

![image](https://github.com/riganti/dotvvm/assets/7894687/93d8fbac-bd16-4aaa-82cb-40ec508e6991)
