### PR TITLE
Allow weird assembly name

### DIFF
--- a/src/Framework/Framework/Compilation/Parser/Binding/Parser/AssemblyNameBindingParserNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Binding/Parser/AssemblyNameBindingParserNode.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using DotVVM.Framework.Compilation.Parser.Binding.Tokenizer;
+using System.Diagnostics;
+using System.Collections.Immutable;
+
+namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
+{
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class AssemblyNameBindingParserNode : BindingParserNode
+    {
+        public string Name { get; }
+        public AssemblyNameBindingParserNode(List<BindingToken> tokens)
+        {
+            Tokens = tokens;
+            Name = string.Concat(tokens.Select(t => t.Text));
+        }
+
+        public AssemblyNameBindingParserNode(string name)
+            : this(new List<BindingToken>() { new BindingToken(name, BindingTokenType.Identifier, 0, 0, 0, 0)})
+        { }
+
+        public override IEnumerable<BindingParserNode> EnumerateChildNodes()
+            => Enumerable.Empty<BindingParserNode>();
+
+        public override string ToDisplayString() => $"{Name}";
+    }
+}

--- a/src/Framework/Framework/Compilation/Parser/Binding/Parser/AssemblyQualifiedNameBindingParserNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Binding/Parser/AssemblyQualifiedNameBindingParserNode.cs
@@ -8,9 +8,9 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
     public class AssemblyQualifiedNameBindingParserNode: BindingParserNode
     {
         public BindingParserNode TypeName { get; }
-        public BindingParserNode AssemblyName { get; }
+        public AssemblyNameBindingParserNode AssemblyName { get; }
 
-        public AssemblyQualifiedNameBindingParserNode(BindingParserNode typeName, BindingParserNode assemblyName)
+        public AssemblyQualifiedNameBindingParserNode(BindingParserNode typeName, AssemblyNameBindingParserNode assemblyName)
         {
             this.TypeName = typeName;
             this.AssemblyName = assemblyName;

--- a/src/Tests/Parser/Binding/BindingParserTests.cs
+++ b/src/Tests/Parser/Binding/BindingParserTests.cs
@@ -859,20 +859,26 @@ namespace DotVVM.Framework.Tests.Parser.Binding
         }
 
         [TestMethod]
-        [DataRow("Domain.Company.Product.DotVVM.Feature.Type, Domain.Company.Product")]
-        [DataRow("Domain.Company.Product.DotVVM.Feature.Type, Product")]
-        public void BindingParser_AssemblyQualifiedName_ValidAssemblyName(string binding)
+        [DataRow("Domain.Company.Product.DotVVM.Feature.Type, Domain.Company.Product", "Domain.Company.Product")]
+        [DataRow("Domain.Company.Product.DotVVM.Feature.Type, Product", "Product")]
+        [DataRow("Domain.Company.Product.DotVVM.Feature.Type, My-Assembly-Name", "My-Assembly-Name")]
+        [DataRow("Domain.Company.Product.DotVVM.Feature.Type, Domain.Company.Product<int>", "Domain.Company.Product<int>")]
+        [DataRow("Domain.Company.Product.DotVVM.Feature.Type, Domain.Company<int>.Product", "Domain.Company<int>.Product")]
+        [DataRow("Domain.Company.Product.DotVVM.Feature.Type, Domain<int>.Company.Product", "Domain<int>.Company.Product")]
+        [DataRow("Domain.Company.Product.DotVVM.Feature.Type, Product<int>", "Product<int>")]
+
+        public void BindingParser_AssemblyQualifiedName_ValidAssemblyName(string binding, string assemblyName)
         {
             var parser = bindingParserNodeFactory.SetupParser(binding);
             var node = parser.ReadDirectiveTypeName() as AssemblyQualifiedNameBindingParserNode;
             Assert.IsFalse(node.AssemblyName.HasNodeErrors);
+            Assert.AreEqual(assemblyName, node.AssemblyName.ToDisplayString());
         }
 
         [TestMethod]
-        [DataRow("Domain.Company.Product.DotVVM.Feature.Type, Domain.Company.Product<int>")]
-        [DataRow("Domain.Company.Product.DotVVM.Feature.Type, Domain.Company<int>.Product")]
-        [DataRow("Domain.Company.Product.DotVVM.Feature.Type, Domain<int>.Company.Product")]
-        [DataRow("Domain.Company.Product.DotVVM.Feature.Type, Product<int>")]
+        [DataRow("Domain.Company.Product.DotVVM.Feature.Type,  ")]
+        [DataRow("Domain.Company.Product.DotVVM.Feature.Type, ,,,,,,,,,")]
+        [DataRow("Domain.Company.Product.DotVVM.Feature.Type, this/is/apparently/invalid/for/some/reason")]
         public void BindingParser_AssemblyQualifiedName_InvalidAssemblyName(string binding)
         {
             var parser = bindingParserNodeFactory.SetupParser(binding);


### PR DESCRIPTION
I didn't find and documented restrictions on the assembly names. If we take the new AssemblyName(...) function as reference implementation, basically only restrictions are no `,`, `=`, `/`, `\` and nullbytes (invalid UTF-16 is also allowed 🤦 :D)

So this allows whatever we can allow. Assembly name is always at the end, so there is no point in placing restrictions on it.

resolves  #1728