### PR TITLE
Added repro for a bug with passing commands in markup controls

### DIFF
--- a/src/Framework/Framework/Compilation/Javascript/ParametrizedCode.cs
+++ b/src/Framework/Framework/Compilation/Javascript/ParametrizedCode.cs
@@ -50,9 +50,14 @@ namespace DotVVM.Framework.Compilation.Javascript
 
         // TODO(exyi): add WriteTo(StringBuilder)
         /// <summary>
-        /// Converts this to string and assigns all parameters using `parameterAssignment`. If there is any missing, exception is thrown.
+        /// Converts this to string and assigns all parameters using `parameterAssignment`.
         /// </summary>
+        /// <exception cref="MissingAssignmentException">Thrown when some parameter is not assigned and has no default value.</exception>
         public string ToString(Func<CodeSymbolicParameter, CodeParameterAssignment> parameterAssignment) => ToString(parameterAssignment, out var _);
+        /// <summary>
+        /// Converts this to string and assigns all parameters using `parameterAssignment`.
+        /// </summary>
+        /// <exception cref="MissingAssignmentException">Thrown when some parameter is not assigned and has no default value.</exception>
         public string ToString(Func<CodeSymbolicParameter, CodeParameterAssignment> parameterAssignment, out bool allIsDefault)
         {
             allIsDefault = true;
@@ -285,6 +290,11 @@ namespace DotVVM.Framework.Compilation.Javascript
                         yield return inner;
                 }
             }
+        }
+
+        public record MissingAssignmentException(CodeParameterInfo Parameter, ParametrizedCode FullCode): RecordExceptions.RecordException
+        {
+            public override string Message => $"Assignment of parameter '{Parameter.Parameter}' was not found.";
         }
 
         /// <summary>

--- a/src/Framework/Framework/Controls/KnockoutHelper.cs
+++ b/src/Framework/Framework/Controls/KnockoutHelper.cs
@@ -12,6 +12,7 @@ using DotVVM.Framework.Compilation.Javascript;
 using DotVVM.Framework.Compilation.Javascript.Ast;
 using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Utils;
+using FastExpressionCompiler;
 
 namespace DotVVM.Framework.Controls
 {
@@ -271,19 +272,27 @@ namespace DotVVM.Framework.Controls
 
             string SubstituteArguments(ParametrizedCode parametrizedCode)
             {
-                return parametrizedCode.ToString(p =>
-                    p == JavascriptTranslator.CurrentElementParameter ? elementAccessor :
-                    p == CommandBindingExpression.CurrentPathParameter ? CodeParameterAssignment.FromIdentifier(getContextPath(control)) :
-                    p == CommandBindingExpression.ControlUniqueIdParameter ? uniqueControlId?.GetParametrizedJsExpression(control) ?? CodeParameterAssignment.FromLiteral("") :
-                    p == JavascriptTranslator.KnockoutContextParameter ? knockoutContext :
-                    p == JavascriptTranslator.KnockoutViewModelParameter ? viewModel :
-                    p == CommandBindingExpression.OptionalKnockoutContextParameter ? optionalKnockoutContext :
-                    p == CommandBindingExpression.CommandArgumentsParameter ? options.CommandArgs ?? default :
-                    p == CommandBindingExpression.PostbackHandlersParameter ? CodeParameterAssignment.FromIdentifier(getHandlerScript()) :
-                    p == CommandBindingExpression.AbortSignalParameter ? abortSignal :
-                    p is JavascriptTranslator.ResourceSymbolicParameter resource ? resource.Evaluate(dataContextTarget.target, parametrizedCode, expression) :
-                    default
-                );
+                try
+                {
+                    return parametrizedCode.ToString(p =>
+                        p == JavascriptTranslator.CurrentElementParameter ? elementAccessor :
+                        p == CommandBindingExpression.CurrentPathParameter ? CodeParameterAssignment.FromIdentifier(getContextPath(control)) :
+                        p == CommandBindingExpression.ControlUniqueIdParameter ? uniqueControlId?.GetParametrizedJsExpression(control) ?? CodeParameterAssignment.FromLiteral("") :
+                        p == JavascriptTranslator.KnockoutContextParameter ? knockoutContext :
+                        p == JavascriptTranslator.KnockoutViewModelParameter ? viewModel :
+                        p == CommandBindingExpression.OptionalKnockoutContextParameter ? optionalKnockoutContext :
+                        p == CommandBindingExpression.CommandArgumentsParameter ? options.CommandArgs ?? default :
+                        p == CommandBindingExpression.PostbackHandlersParameter ? CodeParameterAssignment.FromIdentifier(getHandlerScript()) :
+                        p == CommandBindingExpression.AbortSignalParameter ? abortSignal :
+                        p is JavascriptTranslator.ResourceSymbolicParameter resource ? resource.Evaluate(dataContextTarget.target, parametrizedCode, expression) :
+                        default
+                    );
+                }
+                catch (ParametrizedCode.MissingAssignmentException e) when (e.Parameter.Parameter == CommandBindingExpression.CommandArgumentsParameter)
+                {
+                    var returnType = expression.GetProperty<ResultTypeBindingProperty>(ErrorHandlingMode.ReturnNull)?.Type;
+                    throw new DotvvmControlException(control, $"The binding {expression} of type {returnType?.ToCode(stripNamespace: true) ?? "?"} requires arguments, but none were provided to the KnockoutHelper.GenerateClientPostback method.", innerException: e) { RelatedBinding = expression };
+                }
             }
         }
 

--- a/src/Samples/Common/DotVVM.Samples.Common.csproj
+++ b/src/Samples/Common/DotVVM.Samples.Common.csproj
@@ -90,12 +90,12 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <!-- the wildcard would not work in Target.Inputs, it only works in Include -->
     <TypescriptFile Include="Scripts/**/*.tsx;Scripts/**/*.ts" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>

--- a/src/Samples/Common/DotvvmStartup.cs
+++ b/src/Samples/Common/DotvvmStartup.cs
@@ -211,7 +211,7 @@ namespace DotVVM.Samples.BasicSamples
                     newDict["Id"] = 1221;
                     return newDict;
                 });
-            
+
             config.RouteTable.AddRouteRedirection("ComplexSamples_SPA_redirect", "ComplexSamples/SPA/redirect", "ComplexSamples_SPA_test");
         }
 
@@ -286,6 +286,9 @@ namespace DotVVM.Samples.BasicSamples
             config.Markup.AddMarkupControl("sample", "EmbeddedResourceControls_Button", "embedded://EmbeddedResourceControls/Button.dotcontrol");
             config.Markup.AddMarkupControl("cc", "NodeControl", "Views/ControlSamples/HierarchyRepeater/NodeControl.dotcontrol");
             config.Markup.AddMarkupControl("cc", "CommandInsideWhereControl", "Views/FeatureSamples/JavascriptTranslation/CommandInsideWhereControl.dotcontrol");
+            config.Markup.AddMarkupControl("cc", "CommandAsProperty", "Views/FeatureSamples/MarkupControl/CommandAsProperty.dotcontrol");
+            config.Markup.AddMarkupControl("cc", "CommandAsPropertyWrapper", "Views/FeatureSamples/MarkupControl/CommandAsPropertyWrapper.dotcontrol");
+
             config.Markup.AutoDiscoverControls(new DefaultControlRegistrationStrategy(config, "sample", "Views/"));
 
             if (config.Markup.Controls.FirstOrDefault(c => c.Src is not null && Path.IsPathRooted(c.Src)) is {} invalidControl)

--- a/src/Samples/Common/ViewModels/FeatureSamples/MarkupControl/CommandAsPropertyPageViewModel.cs
+++ b/src/Samples/Common/ViewModels/FeatureSamples/MarkupControl/CommandAsPropertyPageViewModel.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+using DotVVM.Framework.Hosting;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.MarkupControl
+{
+    public class CommandAsPropertyPageViewModel : DotvvmViewModelBase
+    {
+
+        public List<ItemModel> Items { get; set; } = new() {
+            new ItemModel() { Name = "One", IsTrue = true },
+            new ItemModel() { Name = "Two", IsTrue = false },
+            new ItemModel() { Name = "Three", IsTrue = true }
+        };
+
+        public ItemModel SelectedItem { get; set; }
+
+        public Task MyFunction(string name, bool isTrue)
+        {
+            SelectedItem = new ItemModel() { Name = name, IsTrue = isTrue };
+            return Task.CompletedTask;
+        }
+
+
+        public class ItemModel
+        {
+            public string Name { get; set; }
+            public bool IsTrue { get; set; }
+
+        }
+    }
+}
+

--- a/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsProperty.cs
+++ b/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsProperty.cs
@@ -11,13 +11,13 @@ namespace DotVVM.Samples.Common.Views.FeatureSamples.MarkupControl
     public class CommandAsProperty : DotvvmMarkupControl
     {
 
-        public Func<string, bool, Task> Click
+        public Func<Task> Click
         {
-            get => (Func<string, bool, Task>)GetValue(ClickProperty)!;
+            get => (Func<Task>)GetValue(ClickProperty)!;
             set => SetValue(ClickProperty, value);
         }
         public static readonly DotvvmProperty ClickProperty
-                = DotvvmProperty.Register<Func<string, bool, Task>, CommandAsProperty>(c => c.Click, null);
+                = DotvvmProperty.Register<Func<Task>, CommandAsProperty>(c => c.Click, null);
 
     }
 }

--- a/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsProperty.cs
+++ b/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsProperty.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Controls;
+
+namespace DotVVM.Samples.Common.Views.FeatureSamples.MarkupControl
+{
+    public class CommandAsProperty : DotvvmMarkupControl
+    {
+
+        public Func<string, bool, Task> Click
+        {
+            get => (Func<string, bool, Task>)GetValue(ClickProperty)!;
+            set => SetValue(ClickProperty, value);
+        }
+        public static readonly DotvvmProperty ClickProperty
+                = DotvvmProperty.Register<Func<string, bool, Task>, CommandAsProperty>(c => c.Click, null);
+
+    }
+}
+

--- a/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsProperty.dotcontrol
+++ b/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsProperty.dotcontrol
@@ -1,0 +1,10 @@
+﻿@viewModel System.String, mscorlib
+@baseType DotVVM.Samples.Common.Views.FeatureSamples.MarkupControl.CommandAsProperty, DotVVM.Samples.Common
+
+<%-- When uncommented, it produces an error --%>
+<%-- In Release mode, the error that is really hard to debug (maybe it was caused because the control was loaded from embedded resource). --%>
+<%--<dot:Button Text="{value: _this}" Click="{command: _control.Click}" />--%>
+
+
+<%--The following with ToString works somehow and I am not sure by what magic--%>
+<dot:Button Text="{value: _this}" Click="{command: _control.Click.ToString()}" />

--- a/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsProperty.dotcontrol
+++ b/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsProperty.dotcontrol
@@ -7,4 +7,4 @@
 
 
 <%--The following with ToString works somehow and I am not sure by what magic--%>
-<dot:Button Text="{value: _this}" Click="{command: _control.Click.ToString()}" />
+<dot:Button Text="{value: _this}" Click="{command: _control.Click}" />

--- a/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsProperty.dotcontrol
+++ b/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsProperty.dotcontrol
@@ -1,10 +1,6 @@
 ﻿@viewModel System.String, mscorlib
 @baseType DotVVM.Samples.Common.Views.FeatureSamples.MarkupControl.CommandAsProperty, DotVVM.Samples.Common
 
-<%-- When uncommented, it produces an error --%>
-<%-- In Release mode, the error that is really hard to debug (maybe it was caused because the control was loaded from embedded resource). --%>
-<%--<dot:Button Text="{value: _this}" Click="{command: _control.Click}" />--%>
-
-
-<%--The following with ToString works somehow and I am not sure by what magic--%>
+<%-- both options are legit --%>
 <dot:Button Text="{value: _this}" Click="{command: _control.Click}" />
+<dot:Button Text="{value: _this}" Click="{staticCommand: _control.Click}" />

--- a/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsPropertyPage.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsPropertyPage.dothtml
@@ -13,9 +13,9 @@
     <cc:CommandAsPropertyWrapper Click="{command: (string name, bool isTrue) => _root.MyFunction(name, isTrue)}" />
     <hr />
 
-    <%--<h1>Pass as static command</h1>
-    <cc:CommandAsPropertyWrapper Click="{staticCommand: (string name, bool isTrue) => (_root.Name = name; _root.IsTrue = isTrue)}" />
-    <hr />--%>
+    <h1>Pass as static command</h1>
+    <cc:CommandAsPropertyWrapper Click="{staticCommand: (string name, bool isTrue) => (_root.SelectedItem.Name = name; _root.SelectedItem.IsTrue = isTrue)}" />
+    <hr />
 
     <%--<h1>Pass as value</h1>
     <cc:CommandAsPropertyWrapper Click="{value: (string name, bool isTrue) => _root.MyFunction(name, isTrue)}" />

--- a/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsPropertyPage.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsPropertyPage.dothtml
@@ -9,9 +9,23 @@
 </head>
 <body>
 
+    <h1>Pass as command</h1>
     <cc:CommandAsPropertyWrapper Click="{command: (string name, bool isTrue) => _root.MyFunction(name, isTrue)}" />
+    <hr />
 
-    <p DataContext="{value: SelectedItem}">Selected item: {{value: Name}}, {{value: IsTrue}}</p>
+    <%--<h1>Pass as static command</h1>
+    <cc:CommandAsPropertyWrapper Click="{staticCommand: (string name, bool isTrue) => (_root.Name = name; _root.IsTrue = isTrue)}" />
+    <hr />--%>
+
+    <%--<h1>Pass as value</h1>
+    <cc:CommandAsPropertyWrapper Click="{value: (string name, bool isTrue) => _root.MyFunction(name, isTrue)}" />
+    <hr />--%>
+
+    <%--<h1>Pass as resource</h1>
+    <cc:CommandAsPropertyWrapper Click="{resource: (string name, bool isTrue) => _root.MyFunction(name, isTrue)}" />
+    <hr />--%>
+
+    <p DataContext="{value: SelectedItem}" data-ui="result">Selected item: {{value: Name}}, {{value: IsTrue}}</p>
 
 </body>
 </html>

--- a/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsPropertyPage.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsPropertyPage.dothtml
@@ -1,0 +1,19 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.MarkupControl.CommandAsPropertyPageViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+
+    <cc:CommandAsPropertyWrapper Click="{command: (string name, bool isTrue) => _root.MyFunction(name, isTrue)}" />
+
+    <p DataContext="{value: SelectedItem}">Selected item: {{value: Name}}, {{value: IsTrue}}</p>
+
+</body>
+</html>
+
+

--- a/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsPropertyWrapper.cs
+++ b/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsPropertyWrapper.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Controls;
+
+namespace DotVVM.Samples.Common.Views.FeatureSamples.MarkupControl
+{
+    public class CommandAsPropertyWrapper : DotvvmMarkupControl
+    {
+
+        public Func<string, bool, Task> Click
+        {
+            get { return (Func<string, bool, Task>)GetValue(ClickProperty); }
+            set { SetValue(ClickProperty, value); }
+        }
+        public static readonly DotvvmProperty ClickProperty
+            = DotvvmProperty.Register<Func<string, bool, Task>, CommandAsPropertyWrapper>(c => c.Click, null);
+
+    }
+}
+

--- a/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsPropertyWrapper.dotcontrol
+++ b/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsPropertyWrapper.dotcontrol
@@ -2,9 +2,22 @@
 @baseType DotVVM.Samples.Common.Views.FeatureSamples.MarkupControl.CommandAsPropertyWrapper, DotVVM.Samples.Common
 
 <dot:Repeater DataSource="{value: Items}">
-    <%--
-    The correct syntax would be Click="{value: _control.Click(_parent.Name, _parent.IsTrue)}"
-    Btw is value binding the right thing, or shall we use resource binding here?
-    --%>
-    <cc:CommandAsProperty Click="{value: _control.Click(_parent.Name, _parent.IsTrue)}" DataContext="{value: Name}" />
+    <div style="display: flex; flex-direction: row; gap: 4em" data-ui="button-list">
+        <div>
+            <h2>Passed as command</h2>
+            <cc:CommandAsProperty Click="{command: _control.Click(_parent.Name, _parent.IsTrue)}" DataContext="{value: Name}" />
+        </div>
+        <div>
+            <h2>Passed as static command</h2>
+            <cc:CommandAsProperty Click="{staticCommand: _control.Click(_parent.Name, _parent.IsTrue)}" DataContext="{value: Name}" />
+        </div>
+        <div>
+            <h2>Passed as value</h2>
+            <cc:CommandAsProperty Click="{value: _control.Click(_parent.Name, _parent.IsTrue)}" DataContext="{value: Name}" />
+        </div>
+        <div>
+            <h2>Passed as resource</h2>
+            <cc:CommandAsProperty Click="{resource: _control.Click(_parent.Name, _parent.IsTrue)}" DataContext="{value: Name}" />
+        </div>
+    </div>
 </dot:Repeater>

--- a/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsPropertyWrapper.dotcontrol
+++ b/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsPropertyWrapper.dotcontrol
@@ -11,6 +11,8 @@
             <h2>Passed as static command</h2>
             <cc:CommandAsProperty Click="{staticCommand: _control.Click(_parent.Name, _parent.IsTrue)}" DataContext="{value: Name}" />
         </div>
+
+        <%-- remove after we fix the lambda conversion --%>
         <div>
             <h2>Passed as value</h2>
             <cc:CommandAsProperty Click="{value: _control.Click(_parent.Name, _parent.IsTrue)}" DataContext="{value: Name}" />

--- a/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsPropertyWrapper.dotcontrol
+++ b/src/Samples/Common/Views/FeatureSamples/MarkupControl/CommandAsPropertyWrapper.dotcontrol
@@ -1,0 +1,10 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.MarkupControl.CommandAsPropertyPageViewModel, DotVVM.Samples.Common
+@baseType DotVVM.Samples.Common.Views.FeatureSamples.MarkupControl.CommandAsPropertyWrapper, DotVVM.Samples.Common
+
+<dot:Repeater DataSource="{value: Items}">
+    <%--
+    The correct syntax would be Click="{value: _control.Click(_parent.Name, _parent.IsTrue)}"
+    Btw is value binding the right thing, or shall we use resource binding here?
+    --%>
+    <cc:CommandAsProperty Click="{value: _control.Click(_parent.Name, _parent.IsTrue)}" DataContext="{value: Name}" />
+</dot:Repeater>

--- a/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
@@ -300,6 +300,7 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_Localization_Localization_FormatString = "FeatureSamples/Localization/Localization_FormatString";
         public const string FeatureSamples_Localization_Localization_NestedPage_Type = "FeatureSamples/Localization/Localization_NestedPage_Type";
         public const string FeatureSamples_MarkupControl_ComboBoxDataSourceBoundToStaticCollection = "FeatureSamples/MarkupControl/ComboBoxDataSourceBoundToStaticCollection";
+        public const string FeatureSamples_MarkupControl_CommandAsPropertyPage = "FeatureSamples/MarkupControl/CommandAsPropertyPage";
         public const string FeatureSamples_MarkupControl_CommandBindingInDataContextWithControlProperty = "FeatureSamples/MarkupControl/CommandBindingInDataContextWithControlProperty";
         public const string FeatureSamples_MarkupControl_CommandBindingInRepeater = "FeatureSamples/MarkupControl/CommandBindingInRepeater";
         public const string FeatureSamples_MarkupControl_CommandPropertiesInMarkupControl = "FeatureSamples/MarkupControl/CommandPropertiesInMarkupControl";

--- a/src/Samples/Tests/Tests/Feature/MarkupControlTests.cs
+++ b/src/Samples/Tests/Tests/Feature/MarkupControlTests.cs
@@ -408,5 +408,29 @@ namespace DotVVM.Samples.Tests.Feature
                 browser.WaitFor(() => AssertUI.InnerTextEquals(browser.First("[data-ui=counter]"), "2"), 2000);
             });
         }
+
+        [Fact]
+        public void Feature_MarkupControl_CommandAsPropertyPage()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_MarkupControl_CommandAsPropertyPage);
+
+                var lists = browser.FindElements("div[data-ui=button-list]");
+                for (var j = 0; j < 4; j++)
+                {
+                    for (var i = 0; i < lists.Count; i++)
+                    {
+                        lists[i].ElementAt("input[type=button]", j).Click();
+                        AssertUI.InnerTextEquals(browser.Single("p[data-ui=result]"), (i % 3) switch {
+                            0 => "Selected item: One, true",
+                            1 => "Selected item: Two, false",
+                            _ => "Selected item: Three, true"
+                        });
+
+                        i++;
+                    }
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
We found a strange bug - probably caused by missing validation of delegates passed to DotVVM properties.

I've added a repro `/FeatureSamples/MarkupControl/CommandAsPropertyPage` but I cannot find the place where to fix it.