### PR TITLE
Remove reference to `Microsoft.CodeAnalysis.CSharp` in AspNetCore package

### DIFF
--- a/src/Framework/Hosting.AspNetCore/DotVVM.Framework.Hosting.AspNetCore.csproj
+++ b/src/Framework/Hosting.AspNetCore/DotVVM.Framework.Hosting.AspNetCore.csproj
@@ -21,9 +21,6 @@
     <ProjectReference Include="../Framework/DotVVM.Framework.csproj" />
     <ProjectReference Include="../Core/DotVVM.Core.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.8.0" />
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.2.0" />


### PR DESCRIPTION
This PR removes an unnecessary reference to `Microsoft.CodeAnalysis.CSharp` in the project `DotVVM.Framework.Hosting.AspNetCore`. This reference is unused yet brings a lot of transitive references to legacy `System` packages from .NET Core 1.x.

