### PR TITLE
Add back support for manually handling POST requests

### DIFF
--- a/src/Framework/Framework/Hosting/DotvvmPresenter.cs
+++ b/src/Framework/Framework/Hosting/DotvvmPresenter.cs
@@ -478,11 +478,8 @@ namespace DotVVM.Framework.Hosting
         async Task ValidateSecFetchHeaders(IDotvvmRequestContext context)
         {
             var route = context.Route?.RouteName;
-            var isPost = context.HttpContext.Request.Method switch {
-                "POST" => true,
-                "GET" => false,
-                _ => throw new NotSupportedException()
-            };
+            var requestType = DotvvmRequestContext.DetermineRequestType(context.HttpContext);
+            var isPost = requestType is DotvvmRequestType.Command or DotvvmRequestType.StaticCommand;
             var checksAllowed = (isPost ? SecurityConfiguration.VerifySecFetchForCommands : SecurityConfiguration.VerifySecFetchForPages).IsEnabledForRoute(route);
             var dest = context.HttpContext.Request.Headers["Sec-Fetch-Dest"];
             var site = context.HttpContext.Request.Headers["Sec-Fetch-Site"];

--- a/src/Framework/Framework/Hosting/DotvvmRequestContext.cs
+++ b/src/Framework/Framework/Hosting/DotvvmRequestContext.cs
@@ -171,6 +171,9 @@ namespace DotVVM.Framework.Hosting
                 {
                     return DotvvmRequestType.Command;
                 }
+                // Unknown POST request is treated as a Navigate request
+                // it is useful for submitting classic <form method=POST> elements (as a no-JS fallback, login forms, etc.)
+                return DotvvmRequestType.Navigate;
             }
             return DotvvmRequestType.Unknown;
         }

--- a/src/Samples/Common/DotVVM.Samples.Common.csproj
+++ b/src/Samples/Common/DotVVM.Samples.Common.csproj
@@ -188,6 +188,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Views\FeatureSamples\ViewModules\LinkModuleControl.dotcontrol" />

--- a/src/Samples/Common/ViewModels/FeatureSamples/NoJsForm/NoJsFormViewModel.cs
+++ b/src/Samples/Common/ViewModels/FeatureSamples/NoJsForm/NoJsFormViewModel.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.NoJsForm
+{
+    public class NoJsFormViewModel : DotvvmViewModelBase
+    {
+        public string Form1Value { get; set; }
+        public string Form2Value { get; set; }
+
+        public override async Task Load()
+        {
+            var req = Context.HttpContext.Request;
+            if (req.Method == "POST")
+            {
+                using var body = new StreamReader(req.Body);
+                var data = HttpUtility.ParseQueryString(await body.ReadToEndAsync());
+                var submit = data["submit"];
+                if (submit == "form1")
+                {
+                    Form1Value = data["text"];
+                }
+                else if (submit == "form2")
+                {
+                    Form2Value = data["text"];
+                }
+            }
+        }
+    }
+}
+

--- a/src/Samples/Common/Views/FeatureSamples/NoJsForm/NoJsForm.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/NoJsForm/NoJsForm.dothtml
@@ -1,0 +1,35 @@
+@viewModel DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.NoJsForm.NoJsFormViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+</head>
+<body>
+    <div RenderSettings.Mode=Server>
+        <fieldset>
+            <legend>Form 1</legend>
+            <form method="POST">
+                <input id=input1 type="text" name="text" />
+                <button id=submit1 type=submit name=submit value=form1>Submit</button>
+
+                <p Visible={value: Form1Value != null}>
+                    Last submitted value: <span id=result1>{{value: Form1Value}}</span>
+                </p>
+            </form>
+        </fieldset>
+
+        <fieldset>
+            <legend>Form 2</legend>
+            <form method="POST">
+                <input id=input2 type="text" name="text" />
+                <button id=submit2 type=submit name=submit value=form2>Submit</button>
+
+                <p Visible={value: Form2Value != null}>
+                    Last submitted value: <span id=result2>{{value: Form2Value}}</span>
+                </p>
+            </form>
+        </fieldset>
+    </div>
+</body>
+</html>

--- a/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
@@ -294,6 +294,7 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_MarkupControl_StaticCommandInMarkupControl = "FeatureSamples/MarkupControl/StaticCommandInMarkupControl";
         public const string FeatureSamples_MarkupControl_StaticCommandInMarkupControlCallingRegularCommand = "FeatureSamples/MarkupControl/StaticCommandInMarkupControlCallingRegularCommand";
         public const string FeatureSamples_NestedMasterPages_Content = "FeatureSamples/NestedMasterPages/Content";
+        public const string FeatureSamples_NoJsForm_NoJsForm = "FeatureSamples/NoJsForm/NoJsForm";
         public const string FeatureSamples_ParameterBinding_OptionalParameterBinding = "FeatureSamples/ParameterBinding/OptionalParameterBinding";
         public const string FeatureSamples_ParameterBinding_ParameterBinding = "FeatureSamples/ParameterBinding/ParameterBinding";
         public const string FeatureSamples_PostBack_ConfirmPostBackHandler = "FeatureSamples/PostBack/ConfirmPostBackHandler";

--- a/src/Samples/Tests/Tests/Feature/NoJsFormTests.cs
+++ b/src/Samples/Tests/Tests/Feature/NoJsFormTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using DotVVM.Samples.Tests.Base;
+using DotVVM.Testing.Abstractions;
+using Riganti.Selenium.Core;
+using Riganti.Selenium.DotVVM;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DotVVM.Samples.Tests.Feature
+{
+    public class NoJsFormTests : AppSeleniumTest
+    {
+        [Fact]
+        public void Feature_NoJsForm_NoJsForm()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_NoJsForm_NoJsForm);
+
+                browser.SendKeys("#input1", "Q");
+                browser.Click("#submit1");
+                AssertUI.InnerTextEquals(browser.First("#result1"), "Q");
+
+                browser.SendKeys("#input2", "W");
+                browser.Click("#submit2");
+                AssertUI.InnerTextEquals(browser.First("#result2"), "W");
+            });
+        }
+
+        public NoJsFormTests(ITestOutputHelper output) : base(output)
+        {
+        }
+    }
+}


### PR DESCRIPTION
We used to ignore the request method and only decide if we should run a command or a page initial "GET" based on the headers. This got rewritten in 4.2 and thus broke anyone manually doing and handling POST requests. It has been "expoited" by some users to do "API requests", but can also be used to implement classic POST forms,
as a no-JS or shitty network fallback.

To implement a no-JS form in DotVVM with this patch:

    <form method="POST">
        <input type="text" name="something" />
        <button type=submit name=submit value=my-form>Submit</button>
    </form>

and handle it in view model:

    public override async Task Load()
    {
        var req = Context.HttpContext.Request;
        if (req.Method == "POST")
        {
            using var body = new StreamReader(req.Body);
            var data = HttpUtility.ParseQueryString(await body.ReadToEndAsync());
            var submitedForm = data["submit"];
            var something = data["something"];
        }
    }

Thanks [danielajithraja](forum.dotvvm.com/t/post-method-from-ajax-not-working) for reporting the issue