### PR TITLE
Added a failing test for conditional operator nullable conversions

### DIFF
--- a/src/Tests/Binding/BindingCompilationTests.cs
+++ b/src/Tests/Binding/BindingCompilationTests.cs
@@ -836,6 +836,17 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        public void BindingCompiler_ImplicitConversion_ConditionalNullableAndNonNullable()
+        {
+            var resultNotNull = ExecuteBinding("_this.BoolProp ? _this.NullableDoubleProp : _this.DoubleProp", new[] { new TestViewModel { NullableDoubleProp = 11.1, DoubleProp = 22.2, BoolProp = true } }, expectedType: typeof(double?));
+            Assert.AreEqual(11.1, resultNotNull);
+            resultNotNull = ExecuteBinding("!_this.BoolProp ? _this.NullableDoubleProp : _this.DoubleProp", new[] { new TestViewModel { NullableDoubleProp = 11.1, DoubleProp = 22.2, BoolProp = true } }, expectedType: typeof(double?));
+            Assert.AreEqual(22.2, resultNotNull);
+            var resultNull = ExecuteBinding("_this.BoolProp ? null : _this.DoubleProp", new[] { new TestViewModel { NullableDoubleProp = 11.1, DoubleProp = 22.2, BoolProp = true } }, expectedType: typeof(double?));
+            Assert.IsNull(resultNull);
+        }
+
+        [TestMethod]
         public void BindingCompiler_ImplicitConversion_ConditionalEnumAndLiteral()
         {
             var result = ExecuteBinding("_this.BoolProp ? _this.EnumProperty : 'A'", new [] { new TestViewModel { EnumProperty = TestEnum.B, BoolProp = false } }, expectedType: typeof(object));


### PR DESCRIPTION
I have added a test case `BindingCompiler_ImplicitConversion_ConditionalNullableAndNonNullable` for conditional operators that cannot compile:

```
boolValue ? nullableDouble : double
```

It seems to me that the [VisitConditionalExpression](https://github.com/riganti/dotvvm/blob/main/src/Framework/Framework/Compilation/Binding/ExpressionBuildingVisitor.cs#L314) can do both implicit conversions (from nullable double to double and vice versa) and cannot decide on the direction.

Shall we be even able to do an implicit conversion from nullable to non-nullable? 
I am not sure if I can fix it in the logic of implicit conversion, or if it is a special case here.