### PR TITLE
Better error message for wrong assembly name in directives

### DIFF
--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/ViewModelDirectiveTest.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/ViewModelDirectiveTest.cs
@@ -99,5 +99,16 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
             Assert.IsFalse(root.Directives.Any(d => d.Value.Any(dd => dd.DothtmlNode.HasNodeErrors)));
             Assert.AreEqual(typeof(string), root.DataContextTypeStack.DataContextType);
         }
+
+        [TestMethod]
+        public void ResolvedTree_ViewModel_AssemblyNotFound_Error()
+        {
+            var root = ParseSource($"@viewModel DotVVM.Framework.Controls.IGridViewDataSet, DotVVM.Framework");
+
+            var directive = root.Directives["viewModel"].Single().DothtmlNode;
+            Assert.IsTrue(directive.HasNodeErrors);
+            StringAssert.Contains(directive.NodeErrors.Single(), "'DotVVM.Core'");
+        }
+
     }
 }


### PR DESCRIPTION
We now try to find the type without the assembly, if it gets resolved we let the user know that a different assembly has the correct type.