### PR TITLE
control usage validators can produce warning + validate attached properties

### DIFF
--- a/src/Framework/Framework/Compilation/Validation/ControlUsageError.cs
+++ b/src/Framework/Framework/Compilation/Validation/ControlUsageError.cs
@@ -1,18 +1,37 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using DotVVM.Framework.Binding.Properties;
 using DotVVM.Framework.Compilation.Parser.Dothtml.Parser;
 
 namespace DotVVM.Framework.Compilation.Validation
 {
+    /// <summary> Represents an error or a warning reported by a control usage validation method. </summary>
+    /// <seealso cref="ControlUsageValidatorAttribute"/>
     public class ControlUsageError
     {
         public string ErrorMessage { get; }
+        /// <summary> The error will be shown on the these syntax nodes. When empty, the start tag is underlined. </summary>
         public DothtmlNode[] Nodes { get; }
-        public ControlUsageError(string message, IEnumerable<DothtmlNode?> nodes)
+        /// <summary> Error - the page compilation will fail. Warning - the user will only be notified about the reported problem (in the log, for example). Other severities are currently not shown at all. </summary>
+        public DiagnosticSeverity Severity { get; } = DiagnosticSeverity.Error;
+        public ControlUsageError(string message, DiagnosticSeverity severity, IEnumerable<DothtmlNode?> nodes)
         {
             ErrorMessage = message;
             Nodes = nodes.Where(n => n != null).ToArray()!;
+            Severity = severity;
         }
-        public ControlUsageError(string message, params DothtmlNode?[] nodes) : this(message, nodes.AsEnumerable()) { }
+        public ControlUsageError(string message, IEnumerable<DothtmlNode?> nodes) : this(message, DiagnosticSeverity.Error, nodes) { }
+        public ControlUsageError(string message, params DothtmlNode?[] nodes) : this(message, DiagnosticSeverity.Error, nodes.AsEnumerable()) { }
+        public ControlUsageError(string message, DiagnosticSeverity severity, params DothtmlNode?[] nodes) : this(message, severity, nodes.AsEnumerable()) { }
+
+        public override string ToString()
+        {
+            var core = $"{Severity} {ErrorMessage}";
+            var someToken = Nodes.SelectMany(n => n.Tokens).FirstOrDefault();
+            if (someToken == null)
+                return core;
+            else
+                return $"{core} (at {someToken.LineNumber}:{someToken.ColumnNumber})";
+        }
     }
 }

--- a/src/Framework/Framework/Compilation/Validation/ControlUsageValidationVisitor.cs
+++ b/src/Framework/Framework/Compilation/Validation/ControlUsageValidationVisitor.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using DotVVM.Framework.Binding.Properties;
 using DotVVM.Framework.Compilation.ControlTree.Resolved;
-using DotVVM.Framework.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace DotVVM.Framework.Compilation.Validation
 {
@@ -23,7 +22,19 @@ namespace DotVVM.Framework.Compilation.Validation
             {
                 Errors.Add((control, e));
                 foreach (var node in e.Nodes)
-                    node.AddError(e.ErrorMessage);
+                {
+                    switch (e.Severity)
+                    {
+                        case DiagnosticSeverity.Error:
+                            node.AddError(e.ErrorMessage);
+                            break;
+                        case DiagnosticSeverity.Warning:
+                            node.AddWarning(e.ErrorMessage);
+                            break;
+                        default:
+                            break;
+                    }
+                }
             }
             base.VisitControl(control);
         }
@@ -33,9 +44,8 @@ namespace DotVVM.Framework.Compilation.Validation
         {
             if (this.Errors.Any()) throw new Exception("The ControlUsageValidationVisitor has already collected some errors.");
             VisitView(view);
-            if (this.Errors.Any())
+            if (this.Errors.FirstOrDefault(e => e.err.Severity == DiagnosticSeverity.Error) is { err: {} } controlUsageError)
             {
-                var controlUsageError = this.Errors.First();
                 var lineNumber =
                     controlUsageError.control.GetAncestors()
                         .Select(c => c.DothtmlNode)

--- a/src/Framework/Framework/Compilation/Validation/ControlUsageValidatorAttribute.cs
+++ b/src/Framework/Framework/Compilation/Validation/ControlUsageValidatorAttribute.cs
@@ -2,9 +2,24 @@
 
 namespace DotVVM.Framework.Compilation.Validation
 {
+    /// <summary>
+    /// Call this static method for each compiled control of a matching type.
+    /// The method should have the signature:
+    /// <code> <![CDATA[
+    /// public static IEnumerable< ControlUsageError> Validator(ResolvedControl control)
+    /// ]]></code>.
+    /// Optionally, an DotvvmConfiguration parameter may be present on the method.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     public class ControlUsageValidatorAttribute: Attribute
     {
+        /// <summary> Ignore all validators from the base controls. </summary>
         public bool Override { get; set; }
+        /// <summary>
+        /// Call this method even on other controls when a property from the declaring class is used.
+        /// The method will be called once per control.
+        /// Properties on derived nor base classes do not trigger the validator.
+        /// </summary>
+        public bool IncludeAttachedProperties { get; set; }
     }
 }

--- a/src/Framework/Framework/Controls/Validation.cs
+++ b/src/Framework/Framework/Controls/Validation.cs
@@ -1,4 +1,13 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq.Expressions;
 using DotVVM.Framework.Binding;
+using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Binding.Properties;
+using DotVVM.Framework.Compilation.ControlTree;
+using DotVVM.Framework.Compilation.ControlTree.Resolved;
+using DotVVM.Framework.Compilation.Parser.Dothtml.Parser;
+using DotVVM.Framework.Compilation.Validation;
 
 namespace DotVVM.Framework.Controls
 {
@@ -12,5 +21,24 @@ namespace DotVVM.Framework.Controls
         [AttachedProperty(typeof(object))]
         [MarkupOptions(AllowHardCodedValue = false)]
         public static DotvvmProperty TargetProperty = DotvvmProperty.Register<object?, Validation>(() => TargetProperty, null, true);
+
+
+        [ControlUsageValidator(IncludeAttachedProperties = true)]
+        public static IEnumerable<ControlUsageError> ValidateUsage(ResolvedControl control)
+        {
+            if (control.GetValue(Validation.TargetProperty) is ResolvedPropertyBinding { Binding: {} targetBinding })
+            {
+                if (targetBinding.ResultType.IsPrimitiveTypeDescriptor() &&
+                    targetBinding.Expression is not ConstantExpression // Allow Target={value: 0}, it's an OK hack to supress automatic validation 
+                )
+                {
+                    yield return new ControlUsageError(
+                        $"Validation.Target should be bound to a complex object instead of '{targetBinding.ResultType!.CSharpName}'. Validation attributes on the specified property are ignored, only the rules inside the target object are validated.",
+                        DiagnosticSeverity.Warning,
+                        (targetBinding.DothtmlNode as DothtmlBindingNode)?.ValueNode ?? targetBinding.DothtmlNode
+                    );
+                }
+            }
+        }
     }
 }

--- a/src/Samples/Common/ViewModels/FeatureSamples/Validation/ValidationTargetIsCollectionViewModel.cs
+++ b/src/Samples/Common/ViewModels/FeatureSamples/Validation/ValidationTargetIsCollectionViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using DotVVM.Framework.ViewModel;
 
@@ -7,6 +8,8 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.Validation
     public class ValidationTargetIsCollectionViewModel : DotvvmViewModelBase
     {
         public List<Customer> Customers { get; set; }
+
+        public DateTime Something { get; set; } = DateTime.Now;
 
         public ValidationTargetIsCollectionViewModel()
         {

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/CompilationWarningsTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/CompilationWarningsTests.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DotVVM.Framework.Utils;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Compilation.Parser.Dothtml.Parser;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+
+namespace DotVVM.Framework.Tests.Runtime.ControlTree
+{
+    [TestClass]
+    public class CompilationWarningsTests : DefaultControlTreeResolverTestsBase
+    {
+        public (string warning, string tokens)[] GetWarnings(string dothtml)
+        {
+            var tree = ParseSource(dothtml, checkErrors: false);
+            return tree.DothtmlNode
+                       .EnumerateNodes()
+                       .SelectMany(n => n.NodeWarnings.Select(w => (w, string.Join(" ", n.Tokens.Select(t => t.Text)))))
+                       .ToArray();
+        }
+
+        [TestMethod]
+        public void CompilationWarning_ValidationTargetPrimitiveType()
+        {
+            var warnings = GetWarnings($$"""
+                @viewModel {{typeof(TestViewModel)}}
+                <div Validation.Target={value: BoolProp}></div>
+            """);
+            Assert.AreEqual(1, warnings.Length);
+            StringAssert.Contains(warnings[0].warning, "Validation.Target should be bound to a complex object instead of 'bool'");
+            Assert.AreEqual("BoolProp", warnings[0].tokens.Trim());
+        }
+
+        [DataTestMethod]
+        [DataRow("TestViewModel2")]
+        [DataRow("VMArray")]
+        [DataRow("0")]
+        public void CompilationWarning_ValidationTargetPrimitiveType_Negative(string property)
+        {
+            var warnings = GetWarnings($$"""
+                @viewModel {{typeof(TestViewModel)}}
+                <div Validation.Target={value: {{property}}}></div>
+            """);
+            XAssert.Empty(warnings);
+        }
+
+        [TestMethod]
+        public void DefaultViewCompiler_NonExistenPropertyWarning()
+        {
+           var markup = $@"
+@viewModel System.Boolean
+<dot:Button TestProperty=AA Visble={{value: false}} normal-attribute=AA Click={{command: 0}} />
+";
+            var button = ParseSource(markup)
+                .Content.SelectRecursively(c => c.Content)
+                .Single(c => c.Metadata.Type == typeof(Button));
+
+            var elementNode = (DothtmlElementNode)button.DothtmlNode;
+            var attribute1 = elementNode.Attributes.Single(a => a.AttributeName == "TestProperty");
+            var attribute2 = elementNode.Attributes.Single(a => a.AttributeName == "normal-attribute");
+            var attribute3 = elementNode.Attributes.Single(a => a.AttributeName == "Visble");
+
+            Assert.AreEqual(0, attribute2.AttributeNameNode.NodeWarnings.Count(), attribute2.AttributeNameNode.NodeWarnings.StringJoin(", "));
+            Assert.AreEqual("HTML attribute name 'TestProperty' should not contain uppercase letters. Did you intent to use a DotVVM property instead?", attribute1.AttributeNameNode.NodeWarnings.Single());
+            Assert.AreEqual("HTML attribute name 'Visble' should not contain uppercase letters. Did you mean Visible, or another DotVVM property?", attribute3.AttributeNameNode.NodeWarnings.Single());
+        }
+
+        [TestMethod]
+        public void DefaultViewCompiler_NonExistenPropertyWarning_PrefixedGroup()
+        {
+           var markup = $@"
+@viewModel System.Boolean
+<dot:HierarchyRepeater ItemClass=AA ItemIncludeInPage=false />
+";
+            var repeater = ParseSource(markup)
+                .Content.SelectRecursively(c => c.Content)
+                .Single(c => c.Metadata.Type == typeof(HierarchyRepeater));
+
+            var elementNode = (DothtmlElementNode)repeater.DothtmlNode;
+            var attribute1 = elementNode.Attributes.Single(a => a.AttributeName == "ItemClass");
+            var attribute2 = elementNode.Attributes.Single(a => a.AttributeName == "ItemIncludeInPage");
+
+            Assert.AreEqual(0, attribute1.AttributeNameNode.NodeWarnings.Count(), attribute1.AttributeNameNode.NodeWarnings.StringJoin(", "));
+            Assert.AreEqual("HTML attribute name 'IncludeInPage' should not contain uppercase letters. Did you intent to use a DotVVM property instead?", XAssert.Single(attribute2.AttributeNameNode.NodeWarnings));
+        }
+
+        [TestMethod]
+        public void DefaultViewCompiler_UnsupportedCallSite_ResourceBinding_Warning()
+        {
+            var markup = @"
+@viewModel System.DateTime
+{{resource: _this.ToBrowserLocalTime()}}
+";
+            var literal = ParseSource(markup)
+                .Content.SelectRecursively(c => c.Content)
+                .Single(c => c.Metadata.Type == typeof(Literal));
+
+            Assert.AreEqual(1, literal.DothtmlNode.NodeWarnings.Count());
+            Assert.AreEqual("Evaluation of method \"ToBrowserLocalTime\" on server-side may yield unexpected results.", literal.DothtmlNode.NodeWarnings.First());
+        }
+    }
+
+}

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/DefaultControlTreeResolverTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/DefaultControlTreeResolverTests.cs
@@ -747,61 +747,6 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
         }
 
         [TestMethod]
-        public void DefaultViewCompiler_NonExistenPropertyWarning()
-        {
-           var markup = $@"
-@viewModel System.Boolean
-<dot:Button TestProperty=AA Visble={{value: false}} normal-attribute=AA Click={{command: 0}} />
-";
-            var button = ParseSource(markup)
-                .Content.SelectRecursively(c => c.Content)
-                .Single(c => c.Metadata.Type == typeof(Button));
-
-            var elementNode = (DothtmlElementNode)button.DothtmlNode;
-            var attribute1 = elementNode.Attributes.Single(a => a.AttributeName == "TestProperty");
-            var attribute2 = elementNode.Attributes.Single(a => a.AttributeName == "normal-attribute");
-            var attribute3 = elementNode.Attributes.Single(a => a.AttributeName == "Visble");
-
-            Assert.AreEqual(0, attribute2.AttributeNameNode.NodeWarnings.Count(), attribute2.AttributeNameNode.NodeWarnings.StringJoin(", "));
-            Assert.AreEqual("HTML attribute name 'TestProperty' should not contain uppercase letters. Did you intent to use a DotVVM property instead?", attribute1.AttributeNameNode.NodeWarnings.Single());
-            Assert.AreEqual("HTML attribute name 'Visble' should not contain uppercase letters. Did you mean Visible, or another DotVVM property?", attribute3.AttributeNameNode.NodeWarnings.Single());
-        }
-
-        [TestMethod]
-        public void DefaultViewCompiler_NonExistenPropertyWarning_PrefixedGroup()
-        {
-           var markup = $@"
-@viewModel System.Boolean
-<dot:HierarchyRepeater ItemClass=AA ItemIncludeInPage=false />
-";
-            var repeater = ParseSource(markup)
-                .Content.SelectRecursively(c => c.Content)
-                .Single(c => c.Metadata.Type == typeof(HierarchyRepeater));
-
-            var elementNode = (DothtmlElementNode)repeater.DothtmlNode;
-            var attribute1 = elementNode.Attributes.Single(a => a.AttributeName == "ItemClass");
-            var attribute2 = elementNode.Attributes.Single(a => a.AttributeName == "ItemIncludeInPage");
-
-            Assert.AreEqual(0, attribute1.AttributeNameNode.NodeWarnings.Count(), attribute1.AttributeNameNode.NodeWarnings.StringJoin(", "));
-            Assert.AreEqual("HTML attribute name 'IncludeInPage' should not contain uppercase letters. Did you intent to use a DotVVM property instead?", XAssert.Single(attribute2.AttributeNameNode.NodeWarnings));
-        }
-
-        [TestMethod]
-        public void DefaultViewCompiler_UnsupportedCallSite_ResourceBinding_Warning()
-        {
-            var markup = @"
-@viewModel System.DateTime
-{{resource: _this.ToBrowserLocalTime()}}
-";
-            var literal = ParseSource(markup)
-                .Content.SelectRecursively(c => c.Content)
-                .Single(c => c.Metadata.Type == typeof(Literal));
-
-            Assert.AreEqual(1, literal.DothtmlNode.NodeWarnings.Count());
-            Assert.AreEqual("Evaluation of method \"ToBrowserLocalTime\" on server-side may yield unexpected results.", literal.DothtmlNode.NodeWarnings.First());
-        }
-
-        [TestMethod]
         public void DefaultViewCompiler_DifferentControlPrimaryName()
         {
             var root = ParseSource(@"@viewModel System.String


### PR DESCRIPTION
It's not possible to add compilation warnings using control usage validators. It is also possible to validate attached properties on foreign controls.

```csharp
        [ControlUsageValidator(IncludeAttachedProperties = true)]
        public static IEnumerable<ControlUsageError> ValidateUsage(ResolvedControl control)
        {
               if (control.TryGetProperty(MyAttachedProperty, out var prop))
                    yield return new ControlUsageError("Test warning", DiagnosticSeverity.Warning, prop.DothtmlNode);
        }
```

Used to implemented check that Validation.Target is not a primitive type (see #1583)