### PR TITLE
feature flag to reenable dothtml reloading in Production environment

### DIFF
--- a/src/Framework/Framework/Compilation/ControlTree/DefaultControlResolver.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/DefaultControlResolver.cs
@@ -22,13 +22,13 @@ namespace DotVVM.Framework.Compilation.ControlTree
         private readonly DotvvmConfiguration configuration;
         private readonly IControlBuilderFactory controlBuilderFactory;
         private readonly CompiledAssemblyCache compiledAssemblyCache;
+        private readonly Dictionary<string, Type>? controlNameMappings;
 
         private static object locker = new object();
         private static bool isInitialized = false;
         private static object dotvvmLocker = new object();
         private static bool isDotvvmInitialized = false;
 
-        private static Dictionary<string, Type>? controlNameMappings;
 
         public DefaultControlResolver(DotvvmConfiguration configuration, IControlBuilderFactory controlBuilderFactory, CompiledAssemblyCache compiledAssemblyCache) : base(configuration.Markup)
         {

--- a/src/Framework/Framework/Compilation/DefaultControlBuilderFactory.cs
+++ b/src/Framework/Framework/Compilation/DefaultControlBuilderFactory.cs
@@ -31,7 +31,7 @@ namespace DotVVM.Framework.Compilation
         public DefaultControlBuilderFactory(DotvvmConfiguration configuration, IMarkupFileLoader markupFileLoader, CompiledAssemblyCache compiledAssemblyCache)
         {
             this.configuration = configuration;
-            this.allowReload = configuration.Debug;
+            this.allowReload = configuration.Runtime.ReloadMarkupFiles.Enabled ?? configuration.Debug;
 
             // WORKAROUND: there is a circular dependency
             // TODO: get rid of that

--- a/src/Framework/Framework/Configuration/Dotvvm3StateFeatureFlag.cs
+++ b/src/Framework/Framework/Configuration/Dotvvm3StateFeatureFlag.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Newtonsoft.Json;
+
+namespace DotVVM.Framework.Configuration
+{
+    /// <summary> Overrides an automatically enabled feature by always enabling or disabling it for the entire application or only for certain routes. </summary>
+    public class Dotvvm3StateFeatureFlag: IDotvvmFeatureFlagAdditiveConfiguration
+    {
+        [JsonIgnore]
+        public string FlagName { get; }
+
+        public Dotvvm3StateFeatureFlag(string flagName)
+        {
+            FlagName = flagName;
+        }
+
+        /// <summary> Default state of this feature flag. true = enabled, false = disabled, null = enabled automatically based on other conditions (usually running in Development/Production environment) </summary>
+        [JsonProperty("enabled")]
+        public bool? Enabled
+        {
+            get => _enabled;
+            set
+            {
+                ThrowIfFrozen();
+                _enabled = value;
+            }
+        }
+        private bool? _enabled = null;
+
+        /// <summary> List of routes where the feature flag is always enabled. </summary>
+        [JsonProperty("includedRoutes")]
+        public ISet<string> IncludedRoutes
+        {
+            get => _includedRoutes;
+            set
+            {
+                ThrowIfFrozen();
+                _includedRoutes = value;
+            }
+        }
+        private ISet<string> _includedRoutes = new FreezableSet<string>(comparer: StringComparer.OrdinalIgnoreCase);
+
+        /// <summary> List of routes where the feature flag is always disabled. </summary>
+        [JsonProperty("excludedRoutes")]
+        public ISet<string> ExcludedRoutes
+        {
+            get => _excludedRoutes;
+            set
+            {
+                ThrowIfFrozen();
+                _excludedRoutes = value;
+            }
+        }
+        private ISet<string> _excludedRoutes = new FreezableSet<string>(comparer: StringComparer.OrdinalIgnoreCase);
+
+        /// <summary> Resets the feature flag to its default state. </summary>
+        public IDotvvmFeatureFlagAdditiveConfiguration Reset()
+        {
+            ThrowIfFrozen();
+            IncludedRoutes.Clear();
+            ExcludedRoutes.Clear();
+            Enabled = null;
+            return this;
+        }
+
+        /// <summary> Enables the feature flag for all routes, even if it has been previously disabled. </summary>
+        public IDotvvmFeatureFlagAdditiveConfiguration EnableForAllRoutes()
+        {
+            ThrowIfFrozen();
+            IncludedRoutes.Clear();
+            ExcludedRoutes.Clear();
+            Enabled = true;
+            return this;
+        }
+
+        /// <summary> Disables the feature flag for all routes, even if it has been previously enabled. </summary>
+        public IDotvvmFeatureFlagAdditiveConfiguration DisableForAllRoutes()
+        {
+            ThrowIfFrozen();
+            IncludedRoutes.Clear();
+            ExcludedRoutes.Clear();
+            Enabled = false;
+            return this;
+        }
+
+        /// <summary> Enables the feature flag only for the specified routes, and disables for all other (Clears any previous rules). </summary>
+        public void EnableForRoutes(params string[] routes)
+        {
+            ThrowIfFrozen();
+            Enabled = false;
+            ExcludedRoutes.Clear();
+
+            IncludedRoutes.Clear();
+            foreach (var route in routes)
+            {
+                IncludedRoutes.Add(route);
+            }
+        }
+
+        /// <summary> Enables the feature flag for all routes except the specified ones (Clears any previous rules). </summary>
+        public void EnableForAllRoutesExcept(params string[] routes)
+        {
+            ThrowIfFrozen();
+            Enabled = true;
+            IncludedRoutes.Clear();
+
+            ExcludedRoutes.Clear();
+            foreach (var route in routes)
+            {
+                ExcludedRoutes.Add(route);
+            }
+        }
+
+        /// <summary> Include the specified route in this feature flag. Enables the feature for the route. </summary>
+        public IDotvvmFeatureFlagAdditiveConfiguration IncludeRoute(string routeName)
+        {
+            ThrowIfFrozen();
+            if (Enabled == true)
+                throw new InvalidOperationException($"Cannot include route '{routeName}' because the feature flag {this.FlagName} is enabled by default.");
+            if (ExcludedRoutes.Contains(routeName))
+                throw new InvalidOperationException($"Cannot include route '{routeName}' because it is already in the list of excluded routes.");
+            IncludedRoutes.Add(routeName);
+            return this;
+        }
+        /// <summary> Include the specified routes in this feature flag. Enables the feature for the routes. </summary>
+        public IDotvvmFeatureFlagAdditiveConfiguration IncludeRoutes(params string[] routeNames)
+        {
+            foreach (var routeName in routeNames)
+            {
+                IncludeRoute(routeName);
+            }
+            return this;
+        }
+        /// <summary> Exclude the specified route from this feature flag. Disables the feature for the route. </summary>
+        public IDotvvmFeatureFlagAdditiveConfiguration ExcludeRoute(string routeName)
+        {
+            ThrowIfFrozen();
+            if (Enabled == false)
+                throw new InvalidOperationException($"Cannot exclude route '{routeName}' because the feature flag {this.FlagName} is disabled by default.");
+            if (IncludedRoutes.Contains(routeName))
+                throw new InvalidOperationException($"Cannot exclude route '{routeName}' because it is already in the list of included routes.");
+            ExcludedRoutes.Add(routeName);
+            return this;
+        }
+        /// <summary> Exclude the specified routes from this feature flag. Disables the feature for the routes. </summary>
+        public IDotvvmFeatureFlagAdditiveConfiguration ExcludeRoutes(params string[] routeNames)
+        {
+            foreach (var routeName in routeNames)
+            {
+                ExcludeRoute(routeName);
+            }
+            return this;
+        }
+
+        /// <summary> Return true if there exists a route where this feature flag is enabled. </summary>
+        public bool IsEnabledForAnyRoute(bool defaultValue)
+        {
+            if (Enabled == false && IncludedRoutes.Count == 0)
+                return false;
+            return defaultValue || Enabled == true || IncludedRoutes.Count > 0;
+        }
+
+        /// <summary> Returns true/false if this feature flag has been explicitly enabled/disabled for the specified route. </summary>
+        public bool? IsEnabledForRoute(string? routeName)
+        {
+            if (IncludedRoutes.Contains(routeName!))
+                return true;
+            if (ExcludedRoutes.Contains(routeName!))
+                return false;
+            return Enabled;
+        }
+
+        /// <summary> Returns if this feature flag has been explicitly for the specified route. </summary>
+        public bool IsEnabledForRoute(string? routeName, bool defaultValue)
+        {
+            defaultValue = Enabled ?? defaultValue;
+            if (defaultValue)
+                return !ExcludedRoutes.Contains(routeName!);
+            else
+                return IncludedRoutes.Contains(routeName!);
+        }
+
+        private bool isFrozen = false;
+        private void ThrowIfFrozen()
+        {
+            if (isFrozen)
+                throw FreezableUtils.Error($"{nameof(DotvvmFeatureFlag)} {this.FlagName}");
+        }
+        public void Freeze()
+        {
+            this.isFrozen = true;
+            FreezableSet.Freeze(ref this._excludedRoutes);
+            FreezableSet.Freeze(ref this._includedRoutes);
+        }
+
+        public override string ToString()
+        {
+            var defaultStr = Enabled switch { null => "Default state", true => "Enabled by default", false => "Disabled by default" };
+            var enabledStr = IncludedRoutes.Count > 0 ? $", enabled for routes: [{string.Join(", ", IncludedRoutes)}]" : null;
+            var disabledStr = ExcludedRoutes.Count > 0 ? $", disabled for routes: [{string.Join(", ", ExcludedRoutes)}]" : null;
+            return $"Feature flag {this.FlagName}: {defaultStr}{enabledStr}{disabledStr}";
+        }
+    }
+}

--- a/src/Framework/Framework/Configuration/DotvvmConfiguration.cs
+++ b/src/Framework/Framework/Configuration/DotvvmConfiguration.cs
@@ -158,6 +158,7 @@ namespace DotVVM.Framework.Configuration
         public void Freeze()
         {
             isFrozen = true;
+            Diagnostics.Freeze();
             Markup.Freeze();
             RouteTable.Freeze();
             Resources.Freeze();

--- a/src/Framework/Framework/Configuration/DotvvmControlConfiguration.cs
+++ b/src/Framework/Framework/Configuration/DotvvmControlConfiguration.cs
@@ -93,7 +93,7 @@ namespace DotVVM.Framework.Configuration
         private void ThrowIfFrozen()
         {
             if (isFrozen)
-                FreezableUtils.Error(nameof(DotvvmControlConfiguration));
+                throw FreezableUtils.Error(nameof(DotvvmControlConfiguration));
         }
         public void Freeze()
         {

--- a/src/Framework/Framework/Configuration/DotvvmFeatureFlag.cs
+++ b/src/Framework/Framework/Configuration/DotvvmFeatureFlag.cs
@@ -166,7 +166,7 @@ namespace DotVVM.Framework.Configuration
         private void ThrowIfFrozen()
         {
             if (isFrozen)
-                FreezableUtils.Error($"{nameof(DotvvmFeatureFlag)} {this.FlagName}");
+                throw FreezableUtils.Error($"{nameof(DotvvmFeatureFlag)} {this.FlagName}");
         }
         public void Freeze()
         {

--- a/src/Framework/Framework/Configuration/DotvvmGlobal3StateFeatureFlag.cs
+++ b/src/Framework/Framework/Configuration/DotvvmGlobal3StateFeatureFlag.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace DotVVM.Framework.Configuration
+{
+    /// <summary> Overrides an automatically enabled feature by always enabling or disabling it for the entire application. </summary>
+    public class DotvvmGlobal3StateFeatureFlag
+    {
+        [JsonIgnore]
+        public string FlagName { get; }
+
+        public DotvvmGlobal3StateFeatureFlag(string flagName)
+        {
+            FlagName = flagName;
+        }
+
+        /// <summary> Gets or sets whether the feature is enabled or disabled. </summary>
+        [JsonProperty("enabled")]
+        public bool? Enabled
+        {
+            get => _enabled;
+            set
+            {
+                ThrowIfFrozen();
+                _enabled = value;
+            }
+        }
+        private bool? _enabled = null;
+
+        /// <summary> Resets the feature flag to its default state. </summary>
+        public void Reset()
+        {
+            ThrowIfFrozen();
+            Enabled = null;
+        }
+
+        /// <summary> Enables the feature for this application. </summary>
+        public void Enable()
+        {
+            ThrowIfFrozen();
+            Enabled = true;
+        }
+        /// <summary> Disables the feature for this application </summary>
+        public void Disable()
+        {
+            ThrowIfFrozen();
+            Enabled = false;
+        }
+
+        private bool isFrozen = false;
+        private void ThrowIfFrozen()
+        {
+            if (isFrozen)
+                throw FreezableUtils.Error($"{nameof(DotvvmGlobalFeatureFlag)} {this.FlagName}");
+        }
+
+        public void Freeze()
+        {
+            this.isFrozen = true;
+        }
+
+        public override string ToString() => $"Feature flag {FlagName}: {Enabled switch { null => "Default", true => "Enabled", false => "Disabled"}}";
+    }
+}

--- a/src/Framework/Framework/Configuration/DotvvmGlobalFeatureFlag.cs
+++ b/src/Framework/Framework/Configuration/DotvvmGlobalFeatureFlag.cs
@@ -47,7 +47,7 @@ namespace DotVVM.Framework.Configuration
         private void ThrowIfFrozen()
         {
             if (isFrozen)
-                FreezableUtils.Error($"{nameof(DotvvmGlobalFeatureFlag)} {this.FlagName}");
+                throw FreezableUtils.Error($"{nameof(DotvvmGlobalFeatureFlag)} {this.FlagName}");
         }
 
         public void Freeze()

--- a/src/Framework/Framework/Configuration/DotvvmMarkupConfiguration.cs
+++ b/src/Framework/Framework/Configuration/DotvvmMarkupConfiguration.cs
@@ -196,8 +196,9 @@ namespace DotVVM.Framework.Configuration
             foreach (var t in this.HtmlAttributeTransforms)
                 t.Value.Freeze();
             _defaultDirectives.Freeze();
-
+            FreezableList.Freeze(ref _importedNamespaces);
             JavascriptTranslator.Freeze();
+            FreezableList.Freeze(ref _defaultExtensionParameters);
         }
     }
 }

--- a/src/Framework/Framework/Configuration/DotvvmRuntimeConfiguration.cs
+++ b/src/Framework/Framework/Configuration/DotvvmRuntimeConfiguration.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 using DotVVM.Framework.Runtime.Filters;
-using DotVVM.Framework.Runtime.Tracing;
 
 namespace DotVVM.Framework.Configuration
 {
@@ -15,6 +14,13 @@ namespace DotVVM.Framework.Configuration
         [JsonIgnore()]
         public IList<IActionFilter> GlobalFilters => _globalFilters;
         private IList<IActionFilter> _globalFilters;
+
+        /// <summary>
+        /// When enabled, dothtml files are reloaded and recompiled after a change. Note that resources (CSS, JS) are not controlled by this option.
+        /// By default, reloading is only enabled in debug mode.
+        /// </summary>
+        [JsonProperty("reloadMarkupFiles")]
+        public DotvvmGlobal3StateFeatureFlag ReloadMarkupFiles { get; } = new("Dotvvm3StateFeatureFlag.ReloadMarkupFiles");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DotvvmRuntimeConfiguration"/> class.
@@ -35,6 +41,7 @@ namespace DotVVM.Framework.Configuration
         {
             this.isFrozen = true;
             FreezableList.Freeze(ref _globalFilters);
+            ReloadMarkupFiles.Freeze();
         }
     }
 }

--- a/src/Tests/Runtime/ConfigurationValidationTests.cs
+++ b/src/Tests/Runtime/ConfigurationValidationTests.cs
@@ -6,6 +6,10 @@ using DotVVM.Framework.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using DotVVM.Framework.Testing;
 using DotVVM.Framework.Routing;
+using DotVVM.Framework.ResourceManagement;
+using System.Threading.Tasks;
+using DotVVM.Framework.Compilation;
+using DotVVM.Framework.Compilation.Styles;
 
 namespace DotVVM.Framework.Tests.Runtime
 {
@@ -60,6 +64,112 @@ namespace DotVVM.Framework.Tests.Runtime
             var flag = new DotvvmFeatureFlag("myFlag");
             var e = XAssert.ThrowsAny<Exception>(() => flag.DisableForAllRoutes().ExcludeRoute("a"));
             XAssert.Equal("Cannot exclude route 'a' because the feature flag myFlag is disabled by default.", e.Message);
+        }
+
+        [TestMethod]
+        public void FeatureFlag3State_InvalidExclude()
+        {
+            var flag = new Dotvvm3StateFeatureFlag("myFlag");
+            flag.Enabled = false;
+            var e = XAssert.ThrowsAny<Exception>(() => flag.ExcludeRoute("a"));
+            XAssert.Equal("Cannot exclude route 'a' because the feature flag myFlag is disabled by default.", e.Message);
+        }
+
+        [TestMethod]
+        public void FeatureFlag3State_ValidOperations()
+        {
+            var flag = new Dotvvm3StateFeatureFlag("myFlag");
+
+            Assert.IsNull(flag.Enabled);
+            Assert.IsNull(flag.IsEnabledForRoute("a"));
+            Assert.IsTrue(flag.IsEnabledForRoute("a", true));
+
+            flag.EnableForAllRoutes();
+            Assert.IsTrue(flag.Enabled);
+            Assert.IsTrue(flag.IsEnabledForRoute("a", false));
+            XAssert.Empty(flag.IncludedRoutes);
+            XAssert.Empty(flag.ExcludedRoutes);
+
+            flag.ExcludeRoute("a");
+            Assert.IsTrue(flag.Enabled);
+            XAssert.Contains("a", flag.ExcludedRoutes);
+            Assert.IsFalse(flag.IsEnabledForRoute("a"));
+            Assert.IsTrue(flag.IsEnabledForRoute("b"));
+
+            flag.DisableForAllRoutes()
+                .IncludeRoute("a")
+                .IncludeRoute("b");
+            Assert.IsFalse(flag.Enabled);
+            XAssert.Contains("a", flag.IncludedRoutes);
+            XAssert.Contains("b", flag.IncludedRoutes);
+            XAssert.Empty(flag.ExcludedRoutes);
+
+            flag.EnableForRoutes("x", "y");
+            Assert.IsFalse(flag.Enabled);
+            XAssert.Equal(new [] { "x", "y" }, flag.IncludedRoutes);
+            XAssert.Empty(flag.ExcludedRoutes);
+
+            flag.Reset().IncludeRoute("always-enabled").ExcludeRoute("always-disabled");
+            Assert.IsNull(flag.IsEnabledForRoute("a"));
+            Assert.IsTrue(flag.IsEnabledForRoute("always-enabled"));
+            Assert.IsFalse(flag.IsEnabledForRoute("always-disabled"));
+        }
+
+        [TestMethod]
+        public void FeatureFlagGlobal3State_ValidOperations()
+        {
+            var flag = new DotvvmGlobal3StateFeatureFlag("myFlag");
+            Assert.IsNull(flag.Enabled);
+            flag.Enable();
+            Assert.IsTrue(flag.Enabled);
+            flag.Disable();
+            Assert.IsFalse(flag.Enabled);
+            flag.Reset();
+            Assert.IsNull(flag.Enabled);
+            flag.Freeze();
+            XAssert.ThrowsAny<Exception>(() => flag.Enabled = true);
+        }
+
+        [TestMethod]
+        public void Freezing()
+        {
+            var config = DotvvmTestHelper.CreateConfiguration();
+            config.Freeze();
+            XAssert.ThrowsAny<Exception>(() => config.RouteTable.Add("a", "a", null, null, presenterFactory: _ => throw new NotImplementedException()));
+            XAssert.ThrowsAny<Exception>(() => config.RouteTable.AddRouteRedirection("b", "url", "a"));
+            XAssert.ThrowsAny<Exception>(() => config.ApplicationPhysicalPath = "a");
+            XAssert.ThrowsAny<Exception>(() => config.Debug = true);
+            XAssert.ThrowsAny<Exception>(() => config.DefaultCulture = "a");
+            XAssert.ThrowsAny<Exception>(() => config.Diagnostics.PerfWarnings.BigViewModelBytes = 1);
+            XAssert.ThrowsAny<Exception>(() => config.Diagnostics.PerfWarnings.IsEnabled = false);
+            XAssert.ThrowsAny<Exception>(() => config.Diagnostics.CompilationPage.AuthorizationPredicate = _ => Task.FromResult(true));
+            XAssert.ThrowsAny<Exception>(() => config.Diagnostics.CompilationPage.RouteName = "a");
+            XAssert.ThrowsAny<Exception>(() => config.Resources.DefaultResourceProcessors.Add(new SpaModeResourceProcessor(config)));
+            // adding resources is actually explicitly allowed as they are stored in a ConcurrentDictionary
+            config.Resources.Register("my-test-resource", new InlineScriptResource("alert(1)"));
+            XAssert.ThrowsAny<Exception>(() => config.RouteConstraints.Add("a", new GenericRouteParameterType(_ => "..", (_, _) => new ParameterParseResult(true, "yes"))));
+            XAssert.ThrowsAny<Exception>(() => config.Markup.Assemblies.Add("aa"));
+            XAssert.ThrowsAny<Exception>(() => config.Markup.ViewCompilation.CompileInParallel = false);
+            XAssert.ThrowsAny<Exception>(() => config.Markup.ImportedNamespaces.Add(new("ns1")));
+            XAssert.ThrowsAny<Exception>(() => config.Markup.DefaultDirectives.Add(new("import", "ABC")));
+            XAssert.ThrowsAny<Exception>(() => config.Markup.HtmlAttributeTransforms.Remove(new HtmlTagAttributePair { TagName = "a", AttributeName = "href" }));
+            XAssert.ThrowsAny<Exception>(() => config.Runtime.ReloadMarkupFiles.Enable());
+            XAssert.ThrowsAny<Exception>(() => config.Runtime.GlobalFilters.Add(null));
+            XAssert.ThrowsAny<Exception>(() => config.Security.ContentTypeOptionsHeader.IncludedRoutes.Add("abc"));
+            XAssert.ThrowsAny<Exception>(() => config.Security.ContentTypeOptionsHeader.ExcludedRoutes.Add("abc"));
+            XAssert.ThrowsAny<Exception>(() => config.Security.FrameOptionsCrossOrigin.Enabled = true);
+            XAssert.ThrowsAny<Exception>(() => config.Security.FrameOptionsSameOrigin.Enabled = true);
+            XAssert.ThrowsAny<Exception>(() => config.Security.FrameOptionsSameOrigin.Enabled = true);
+            XAssert.ThrowsAny<Exception>(() => config.Security.RequireSecFetchHeaders.Enabled = true);
+            XAssert.ThrowsAny<Exception>(() => config.Security.VerifySecFetchForCommands.Enabled = true);
+            XAssert.ThrowsAny<Exception>(() => config.Security.XssProtectionHeader.Enabled = true);
+            XAssert.ThrowsAny<Exception>(() => config.Security.ReferrerPolicyValue = "aa");
+            XAssert.ThrowsAny<Exception>(() => config.Security.SessionIdCookieName = "aa");
+            XAssert.ThrowsAny<Exception>(() => config.Styles.RegisterForTag("div").SetAttribute("data-a", "b"));
+            XAssert.ThrowsAny<Exception>(() => config.Styles.Styles = new List<IStyle>());
+            XAssert.ThrowsAny<Exception>(() => config.Styles.Styles.RemoveAt(0));
+            XAssert.ThrowsAny<Exception>(() => config.Styles.Styles.Add(null));
+
         }
 
         [TestMethod]

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/BaseTypeDirectiveTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/BaseTypeDirectiveTests.cs
@@ -7,6 +7,7 @@ using DotVVM.Framework.Binding;
 using DotVVM.Framework.Binding.Expressions;
 using System.Threading.Tasks;
 using DotVVM.Framework.Compilation;
+using DotVVM.Framework.Testing;
 
 namespace DotVVM.Framework.Tests.Runtime.ControlTree
 {
@@ -57,29 +58,31 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
         [TestMethod]
         public void ResolvedTree_BaseTypeDirective_CorrectBindings_UsingGlobalAliasedType()
         {
-            configuration.Markup.ImportedNamespaces.Add(new NamespaceImport($"DotVVM.Framework.Tests.Runtime.ControlTree.{nameof(TestControl)}", "controlAlias"));
-            var root = ParseSource(@$"
+            var config = DotvvmTestHelper.CreateConfiguration();
+            config.Markup.ImportedNamespaces.Add(new NamespaceImport($"DotVVM.Framework.Tests.Runtime.ControlTree.{nameof(TestControl)}", "controlAlias"));
+            var root = DotvvmTestHelper.ParseResolvedTree(@$"
 @viewModel object
 @baseType controlAlias
 
 <dot:TextBox Text={{value: _control.MyProperty }} />
 <dot:Button Click={{staticCommand: _control.MyCommand()}} Text=""Test"" />
-");
+", configuration: config);
             CheckServiceAndBinding(root);
         }
 
         [TestMethod]
         public void ResolvedTree_BaseTypeDirective_CorrectBindings_UsingGlobalImportedNamespace()
         {
-            configuration.Markup.ImportedNamespaces.Add(new NamespaceImport("DotVVM.Framework.Tests.Runtime.ControlTree"));
+            var config = DotvvmTestHelper.CreateConfiguration();
+            config.Markup.ImportedNamespaces.Add(new NamespaceImport("DotVVM.Framework.Tests.Runtime.ControlTree"));
 
-            var root = ParseSource(@$"
+            var root = DotvvmTestHelper.ParseResolvedTree(@$"
 @viewModel object
 @baseType {nameof(TestControl)}
 
 <dot:TextBox Text={{value: _control.MyProperty }} />
 <dot:Button Click={{staticCommand: _control.MyCommand()}} Text=""Test"" />
-");
+", configuration: config);
             CheckServiceAndBinding(root);
         }
 

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/MarkupDeclaredPropertyTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/MarkupDeclaredPropertyTests.cs
@@ -3,6 +3,7 @@ using DotVVM.Framework.Compilation.ControlTree.Resolved;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using DotVVM.Framework.Utils;
 using System;
+using DotVVM.Framework.Testing;
 using System.Collections.Generic;
 using DotVVM.Framework.Compilation;
 
@@ -103,10 +104,11 @@ fileName: "control.dotcontrol");
         [TestMethod]
         public void ResolvedTree_MarkupDeclaredProperty_GlobalImportUsed()
         {
-            configuration.Markup.ImportedNamespaces.Add(new NamespaceImport("System.Collections.Generic"));
-            configuration.Markup.ImportedNamespaces.Add(new NamespaceImport("System"));
+            var config = DotvvmTestHelper.CreateConfiguration();
+            config.Markup.ImportedNamespaces.Add(new NamespaceImport("System.Collections.Generic"));
+            config.Markup.ImportedNamespaces.Add(new NamespaceImport("System"));
 
-            var root = ParseSource(@$"
+            var root = DotvvmTestHelper.ParseResolvedTree(@$"
 @viewModel object
 @property List<Guid> Items
 
@@ -114,7 +116,7 @@ fileName: "control.dotcontrol");
    <li>{{{{value: _this}}}}</li>
 </dot:Repeater>
 ",
-fileName: "control.dotcontrol");
+fileName: "control.dotcontrol", configuration: config);
 
             CheckPropertyAndBinding(root, typeof(List<Guid>), "Items");
         }

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/ServiceDirectiveTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/ServiceDirectiveTests.cs
@@ -5,6 +5,7 @@ using DotVVM.Framework.Utils;
 using DotVVM.Framework.Tests.Runtime.ControlTree.DefaultControlTreeResolver;
 using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Compilation;
+using DotVVM.Framework.Testing;
 
 namespace DotVVM.Framework.Tests.Runtime.ControlTree
 {
@@ -52,30 +53,32 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
         [TestMethod]
         public void ResolvedTree_ServiceDirective_CorrectBindingFromInjectedService_UsingGlobalImportedAliasedNamespace()
         {
-            configuration.Markup.ImportedNamespaces.Add(new NamespaceImport(
+            var config = DotvvmTestHelper.CreateConfiguration();
+            config.Markup.ImportedNamespaces.Add(new NamespaceImport(
                 $"DotVVM.Framework.Tests.Runtime.ControlTree.DefaultControlTreeResolver.{nameof(TestService)}",
                 "testServiceAlias"));
 
-            var root = ParseSource(@$"
+            var root = DotvvmTestHelper.ParseResolvedTree(@$"
 @viewModel object
 @service testService = testServiceAlias
 
 <dot:Button Click={{staticCommand: testService.TestCall()}} Text=""Test"" />
-");
+", configuration: config);
             CheckServiceAndBinding(root);
         }
 
         [TestMethod]
         public void ResolvedTree_ServiceDirective_CorrectBindingFromInjectedService_UsingGlobalImportedNamespace()
         {
-            configuration.Markup.ImportedNamespaces.Add(new NamespaceImport($"DotVVM.Framework.Tests.Runtime.ControlTree.DefaultControlTreeResolver"));
+            var config = DotvvmTestHelper.CreateConfiguration();
+            config.Markup.ImportedNamespaces.Add(new NamespaceImport($"DotVVM.Framework.Tests.Runtime.ControlTree.DefaultControlTreeResolver"));
 
-            var root = ParseSource(@$"
+            var root = DotvvmTestHelper.ParseResolvedTree(@$"
 @viewModel object
 @service testService = {nameof(TestService)}
 
 <dot:Button Click={{staticCommand: testService.TestCall()}} Text=""Test"" />
-");
+", configuration: config);
             CheckServiceAndBinding(root);
         }
 

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/ViewModelDirectiveTest.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/ViewModelDirectiveTest.cs
@@ -4,6 +4,7 @@ using DotVVM.Framework.Compilation.Parser.Dothtml.Parser;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using DotVVM.Framework.Compilation.Binding;
 using DotVVM.Framework.Compilation;
+using DotVVM.Framework.Testing;
 
 namespace DotVVM.Framework.Tests.Runtime.ControlTree
 {
@@ -70,9 +71,10 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
         [TestMethod]
         public void ResolvedTree_ViewModel_TypeFromGlobalImportedAliasedType()
         {
-            configuration.Markup.ImportedNamespaces.Add(new NamespaceImport("DotVVM.Framework.Tests.Runtime.ControlTree.TestViewModel", "viewModelAlias"));
+            var config = DotvvmTestHelper.CreateConfiguration();
+            config.Markup.ImportedNamespaces.Add(new NamespaceImport("DotVVM.Framework.Tests.Runtime.ControlTree.TestViewModel", "viewModelAlias"));
 
-            var root = ParseSource(@"@viewModel viewModelAlias");
+            var root = DotvvmTestHelper.ParseResolvedTree(@"@viewModel viewModelAlias", configuration: config);
 
             Assert.IsFalse(root.Directives.Any(d => d.Value.Any(dd => dd.DothtmlNode.HasNodeErrors)));
             Assert.AreEqual(typeof(TestViewModel), root.DataContextTypeStack.DataContextType);
@@ -81,9 +83,10 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
         [TestMethod]
         public void ResolvedTree_ViewModel_TypeFromGlobalImportedNamespace()
         {
-            configuration.Markup.ImportedNamespaces.Add(new NamespaceImport("DotVVM.Framework.Tests.Runtime.ControlTree"));
+            var config = DotvvmTestHelper.CreateConfiguration();
+            config.Markup.ImportedNamespaces.Add(new NamespaceImport("DotVVM.Framework.Tests.Runtime.ControlTree"));
 
-            var root = ParseSource(@"@viewModel TestViewModel");
+            var root = DotvvmTestHelper.ParseResolvedTree(@"@viewModel TestViewModel", configuration: config);
 
             Assert.IsFalse(root.Directives.Any(d => d.Value.Any(dd => dd.DothtmlNode.HasNodeErrors)));
             Assert.AreEqual(typeof(TestViewModel), root.DataContextTypeStack.DataContextType);

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.AuxOptions.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.AuxOptions.json
@@ -33,7 +33,9 @@
         "enabled": true
       }
     },
-    "runtime": {},
+    "runtime": {
+      "reloadMarkupFiles": {}
+    },
     "defaultCulture": "cs-CZ",
     "clientSideValidation": false,
     "experimentalFeatures": {},

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.ExperimentalFeatures.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.ExperimentalFeatures.json
@@ -32,7 +32,9 @@
         "enabled": true
       }
     },
-    "runtime": {},
+    "runtime": {
+      "reloadMarkupFiles": {}
+    },
     "defaultCulture": "en-US",
     "experimentalFeatures": {
       "lazyCsrfToken": {

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.Markup.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.Markup.json
@@ -74,7 +74,9 @@
         "enabled": true
       }
     },
-    "runtime": {},
+    "runtime": {
+      "reloadMarkupFiles": {}
+    },
     "defaultCulture": "en-US",
     "experimentalFeatures": {},
     "debug": false,

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.RestAPI.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.RestAPI.json
@@ -64,7 +64,9 @@
         "enabled": true
       }
     },
-    "runtime": {},
+    "runtime": {
+      "reloadMarkupFiles": {}
+    },
     "defaultCulture": "en-US",
     "experimentalFeatures": {},
     "debug": false,

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -147,7 +147,9 @@
         "enabled": true
       }
     },
-    "runtime": {},
+    "runtime": {
+      "reloadMarkupFiles": {}
+    },
     "defaultCulture": "en-US",
     "experimentalFeatures": {
       "explicitAssemblyLoading": {

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeEmptyConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeEmptyConfig.json
@@ -32,7 +32,9 @@
         "enabled": true
       }
     },
-    "runtime": {},
+    "runtime": {
+      "reloadMarkupFiles": {}
+    },
     "defaultCulture": "en-US",
     "experimentalFeatures": {},
     "debug": false,

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeResources.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeResources.json
@@ -115,7 +115,9 @@
         "enabled": true
       }
     },
-    "runtime": {},
+    "runtime": {
+      "reloadMarkupFiles": {}
+    },
     "defaultCulture": "en-US",
     "experimentalFeatures": {},
     "debug": false,

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeRoutes.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeRoutes.json
@@ -63,7 +63,9 @@
         "enabled": true
       }
     },
-    "runtime": {},
+    "runtime": {
+      "reloadMarkupFiles": {}
+    },
     "defaultCulture": "en-US",
     "experimentalFeatures": {},
     "debug": false,


### PR DESCRIPTION
Adds a feature flag which enables markup file reloading even in Production environment. We always reloaded the files before v4.2, so this at least adds the "feature" back as opt-in. Just for symmetry, it can also be disabled even in Development mode.

I also made a number of fixes to the DotvvmConfiguration freezing, it is in separate commits.