### PR TITLE
Fixed globalize resource visitor and added the test

### DIFF
--- a/src/Framework/Framework/Compilation/GlobalizeResourceVisitor.cs
+++ b/src/Framework/Framework/Compilation/GlobalizeResourceVisitor.cs
@@ -39,11 +39,6 @@ namespace DotVVM.Framework.Compilation
             base.VisitControl(control);
         }
 
-        public override void VisitPropertyTemplate(ResolvedPropertyTemplate propertyTemplate)
-        {
-            Visit(propertyTemplate, propertyTemplate.Content, base.VisitPropertyTemplate);
-        }
-
         public override void VisitPropertyBinding(ResolvedPropertyBinding propertyBinding)
         {
             var requiredGlobalizeProperty = propertyBinding.Binding.Binding

--- a/src/Samples/Common/DotVVM.Samples.Common.csproj
+++ b/src/Samples/Common/DotVVM.Samples.Common.csproj
@@ -98,6 +98,8 @@
     <None Remove="Views\FeatureSamples\CustomPrimitiveTypes\RouteLink.dothtml" />
     <None Remove="Views\FeatureSamples\CustomPrimitiveTypes\TextBox.dothtml" />
     <None Remove="Views\FeatureSamples\CustomPrimitiveTypes\UsedInControls.dothtml" />
+    <None Remove="Views\FeatureSamples\Formatting\AutoResourceInclusion.dothtml" />
+    <None Remove="Views\FeatureSamples\Formatting\AutoResourceInclusionMaster.dotmaster" />
     <None Remove="Views\FeatureSamples\Formatting\ToStringGlobalFunctionBug.dothtml" />
     <None Remove="Views\FeatureSamples\HotReload\ViewChanges.dothtml" />
     <None Remove="Views\FeatureSamples\JavascriptTranslation\ArrayTranslation.dothtml" />

--- a/src/Samples/Common/ViewModels/FeatureSamples/Formatting/AutoResourceInclusionMasterViewModel.cs
+++ b/src/Samples/Common/ViewModels/FeatureSamples/Formatting/AutoResourceInclusionMasterViewModel.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+using DotVVM.Framework.Hosting;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.Formatting
+{
+    public class AutoResourceInclusionMasterViewModel : DotvvmViewModelBase
+    {
+        
+    }
+}
+

--- a/src/Samples/Common/ViewModels/FeatureSamples/Formatting/AutoResourceInclusionViewModel.cs
+++ b/src/Samples/Common/ViewModels/FeatureSamples/Formatting/AutoResourceInclusionViewModel.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+using DotVVM.Framework.Hosting;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.Formatting
+{
+    public class AutoResourceInclusionViewModel : AutoResourceInclusionMasterViewModel
+    {
+        public List<Item> Items { get; set; }
+
+        public int Number { get; set; } = 15;
+
+        public override Task PreRender()
+        {
+            if (!Context.IsPostBack)
+            {
+                Items = new List<Item>()
+                {
+                    new Item() { Id = 1, DateCreated = new DateTime(2020, 1, 2, 20, 3, 45) },
+                    new Item() { Id = 2, DateCreated = new DateTime(2020, 1, 2, 21, 4, 46) },
+                    new Item() { Id = 3, DateCreated = new DateTime(2020, 1, 2, 22, 5, 47) },
+                };
+            }
+            return base.PreRender();
+        }
+
+        public class Item
+        {
+            public int Id { get; set; }
+
+            public DateTime DateCreated { get; set; }
+        }
+
+    }
+}
+

--- a/src/Samples/Common/Views/FeatureSamples/Formatting/AutoResourceInclusion.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/Formatting/AutoResourceInclusion.dothtml
@@ -1,0 +1,26 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.Formatting.AutoResourceInclusionViewModel, DotVVM.Samples.Common
+@masterPage Views/FeatureSamples/Formatting/AutoResourceInclusionMaster.dotmaster
+
+<dot:Content ContentPlaceHolderID="MainContent">
+    <h1>Makes sure that Globalize resource is added correctly</h1>
+
+    <dot:AuthenticatedView>
+        <AuthenticatedTemplate>
+            {{value: Number}}
+        </AuthenticatedTemplate>
+    </dot:AuthenticatedView>
+
+    <dot:Repeater DataSource="{value: Items}">
+        <EmptyDataTemplate>
+            test
+        </EmptyDataTemplate>
+        <ItemTemplate>
+            <p>
+                <dot:RouteLink RouteName="RepeaterRouteLink-PageDetail" Param-Id="{value: Id}" Text="{value: Id}" />
+                <br />
+                {{value: DateCreated.ToString("g")}}
+            </p>
+        </ItemTemplate>
+    </dot:Repeater>
+
+</dot:Content>

--- a/src/Samples/Common/Views/FeatureSamples/Formatting/AutoResourceInclusionMaster.dotmaster
+++ b/src/Samples/Common/Views/FeatureSamples/Formatting/AutoResourceInclusionMaster.dotmaster
@@ -1,0 +1,18 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.Formatting.AutoResourceInclusionMasterViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+
+ 
+    <dot:ContentPlaceHolder ID="MainContent" />
+
+</body>
+</html>
+
+

--- a/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
@@ -248,6 +248,7 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_Directives_ImportDirectiveInvalid = "FeatureSamples/Directives/ImportDirectiveInvalid";
         public const string FeatureSamples_Directives_ViewModelMissingAssembly = "FeatureSamples/Directives/ViewModelMissingAssembly";
         public const string FeatureSamples_EmbeddedResourceControls_EmbeddedResourceControls = "FeatureSamples/EmbeddedResourceControls/EmbeddedResourceControls";
+        public const string FeatureSamples_Formatting_AutoResourceInclusion = "FeatureSamples/Formatting/AutoResourceInclusion";
         public const string FeatureSamples_Formatting_Formatting = "FeatureSamples/Formatting/Formatting";
         public const string FeatureSamples_Formatting_ToStringGlobalFunctionBug = "FeatureSamples/Formatting/ToStringGlobalFunctionBug";
         public const string FeatureSamples_FormControlsEnabled_FormControlsEnabled = "FeatureSamples/FormControlsEnabled/FormControlsEnabled";

--- a/src/Samples/Tests/Tests/Feature/FormattingTests.cs
+++ b/src/Samples/Tests/Tests/Feature/FormattingTests.cs
@@ -69,8 +69,18 @@ namespace DotVVM.Samples.Tests.Feature
             });
         }
 
+        [Fact]
+        public void Feature_Formatting_AutoResourceInclusion()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_Formatting_AutoResourceInclusion);
+
+                browser.FindElements("p").ThrowIfDifferentCountThan(3);
+            });
+        }
+
         public FormattingTests(ITestOutputHelper output) : base(output)
         {
-            }
         }
     }
+}

--- a/src/Tests/ControlTests/testoutputs/RepeaterTests.IdGeneration.html
+++ b/src/Tests/ControlTests/testoutputs/RepeaterTests.IdGeneration.html
@@ -29,25 +29,25 @@
 		
 		<!-- client rendering - implicit id -->
 		<div data-bind="foreach: { data: Items }">
-			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number), attr: { id: &quot;c24&quot;+'_'+$index()+'_'+&quot;client-div&quot; }"></div>
+			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number), attr: { id: &quot;c23&quot;+'_'+$index()+'_'+&quot;client-div&quot; }"></div>
 		</div>
 		
 		<!-- server rendering - implicit id -->
 		<div data-bind="dotvvm-SSR-foreach: { data: Items }">
 			<!-- ko dotvvm-SSR-item: 0 -->
-			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c31_0_server-div">1</div>
+			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c30_0_server-div">1</div>
 			
 			<!-- /ko -->
 			<!-- ko dotvvm-SSR-item: 1 -->
-			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c31_1_server-div">2</div>
+			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c30_1_server-div">2</div>
 			
 			<!-- /ko -->
 			<!-- ko dotvvm-SSR-item: 2 -->
-			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c31_2_server-div">3</div>
+			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c30_2_server-div">3</div>
 			
 			<!-- /ko -->
 			<!-- ko dotvvm-SSR-item: 3 -->
-			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c31_3_server-div">4</div>
+			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c30_3_server-div">4</div>
 			
 			<!-- /ko -->
 		</div>

--- a/src/Tests/ControlTests/testoutputs/RepeaterTests.IdGeneration_CreatedAtRuntime.html
+++ b/src/Tests/ControlTests/testoutputs/RepeaterTests.IdGeneration_CreatedAtRuntime.html
@@ -29,25 +29,25 @@
 		
 		<!-- client rendering - implicit id -->
 		<div data-bind="foreach: { data: Items }">
-			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number), attr: { id: &quot;c24a0&quot;+'_'+$index()+'_'+&quot;client-div&quot; }"></div>
+			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number), attr: { id: &quot;c23a0&quot;+'_'+$index()+'_'+&quot;client-div&quot; }"></div>
 		</div>
 		
 		<!-- server rendering - implicit id  -->
 		<div data-bind="dotvvm-SSR-foreach: { data: Items }">
 			<!-- ko dotvvm-SSR-item: 0 -->
-			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c31a0_0_server-div">1</div>
+			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c30a0_0_server-div">1</div>
 			
 			<!-- /ko -->
 			<!-- ko dotvvm-SSR-item: 1 -->
-			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c31a0_1_server-div">2</div>
+			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c30a0_1_server-div">2</div>
 			
 			<!-- /ko -->
 			<!-- ko dotvvm-SSR-item: 2 -->
-			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c31a0_2_server-div">3</div>
+			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c30a0_2_server-div">3</div>
 			
 			<!-- /ko -->
 			<!-- ko dotvvm-SSR-item: 3 -->
-			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c31a0_3_server-div">4</div>
+			<div data-bind="text: dotvvm.globalize.bindingNumberToString(Number)" id="c30a0_3_server-div">4</div>
 			
 			<!-- /ko -->
 		</div>


### PR DESCRIPTION
The `GlobalizeResourceVisitor` had a bug that sometimes did not correctly detect the need to add `globalize` JS resource.

When the first binding that requires `globalize` resource was detected, a boolean flag was set, but the `RequiredResource` control was being added when the visitor reached the end of a template property, or the end of a `Content` control, or the end of the entire view. 

```html
{{value: BindingWithGlobalizeRequirement}}
<dot:SomeControl>
  <SomeTemplate>
     <!-- the resource is added here -->
  </SomeTemplate>
</dot:SomeControl>
```

This was leading to a behavior when the resource was added into a random template which may not get into the page control tree eventually (e. g. when it is in `AuthenticatedView` or something like that).

I am not sure if the fix is good - I removed adding the resource in the templates, so it is added at the end of the `Content` or the view itself. Maybe it would be better to add it before or after the control which required the particular binding.