### PR TITLE
Incorrect child nodes for array initializer fixed

### DIFF
--- a/src/Framework/Framework/Compilation/Parser/Binding/Parser/ArrayInitializerExpression.cs
+++ b/src/Framework/Framework/Compilation/Parser/Binding/Parser/ArrayInitializerExpression.cs
@@ -14,7 +14,7 @@ namespace DotVVM.Framework.Compilation.Parser.Binding.Parser
             ElementInitializers = elementInitializers;
         }
 
-        public override IEnumerable<BindingParserNode> EnumerateChildNodes() => base.EnumerateNodes().Concat(ElementInitializers);
+        public override IEnumerable<BindingParserNode> EnumerateChildNodes() => ElementInitializers;
 
         public override string ToDisplayString() => $"[ {(string.Join(", ", ElementInitializers.Select(arg => arg.ToDisplayString())))} ]";
     }

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/PropertyDirectiveTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/PropertyDirectiveTests.cs
@@ -43,5 +43,21 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
 
             Assert.IsTrue(error.Contains("Cannot assign"), "Expected error about failed assignment into the attribute property.");
         }
+
+        [TestMethod]
+        public void ResolvedTree_PropertyDirectiveArrayInicializer_ResolvedCorrectly()
+        {
+            var root = ParseSource(@$"
+@viewModel object
+@property string a=[, MarkupOptionsAttribute.Required = true");
+
+            var property = root.Directives["property"].SingleOrDefault() as IAbstractPropertyDeclarationDirective;
+
+            var nodes = property.InitializerSyntax.EnumerateChildNodes();
+
+            Assert.IsFalse(nodes.Any(n => n == property.InitializerSyntax));
+
+            Assert.AreEqual(2,nodes.Count());
+        }
     }
 }


### PR DESCRIPTION
- `EnumerateChildNodes` method incorectly returned the node itself leading to overflow in visitors.