### PR TITLE
Attribute value initializer of PropertyDirective changes

### DIFF
--- a/src/Framework/Framework/Compilation/ControlTree/IAbstractDirectiveAttributeReference.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/IAbstractDirectiveAttributeReference.cs
@@ -15,7 +15,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
     {
         TypeReferenceBindingParserNode TypeSyntax { get; }
         IdentifierNameBindingParserNode NameSyntax { get; }
-        LiteralExpressionBindingParserNode Initializer { get; }
+        BindingParserNode Initializer { get; }
         ITypeDescriptor? Type { get; }
     }
 }

--- a/src/Framework/Framework/Compilation/ControlTree/IAbstractTreeBuilder.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/IAbstractTreeBuilder.cs
@@ -29,7 +29,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
 
         IAbstractViewModuleDirective BuildViewModuleDirective(DothtmlDirectiveNode directiveNode, string modulePath, string resourceName);
         IAbstractPropertyDeclarationDirective BuildPropertyDeclarationDirective(DothtmlDirectiveNode directive, TypeReferenceBindingParserNode typeSyntax, SimpleNameBindingParserNode nameSyntax, BindingParserNode? initializer, IList<IAbstractDirectiveAttributeReference> resolvedAttributes, BindingParserNode valueSyntaxRoot, ImmutableList<NamespaceImport> imports);
-        IAbstractDirectiveAttributeReference BuildPropertyDeclarationAttributeReference(DothtmlDirectiveNode directiveNode, IdentifierNameBindingParserNode propertyNameSyntax, TypeReferenceBindingParserNode typeSyntax, LiteralExpressionBindingParserNode initializer, ImmutableList<NamespaceImport> imports);
+        IAbstractDirectiveAttributeReference BuildPropertyDeclarationAttributeReference(DothtmlDirectiveNode directiveNode, IdentifierNameBindingParserNode propertyNameSyntax, TypeReferenceBindingParserNode typeSyntax, BindingParserNode initializer, ImmutableList<NamespaceImport> imports);
         IAbstractPropertyBinding BuildPropertyBinding(IPropertyDescriptor property, IAbstractBinding binding, DothtmlAttributeNode? sourceAttributeNode);
 
         IAbstractPropertyControl BuildPropertyControl(IPropertyDescriptor property, IAbstractControl? control, DothtmlElementNode? wrapperElementNode);

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedPropertyDeclarationDirective.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedPropertyDeclarationDirective.cs
@@ -62,7 +62,7 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
                 (name, attributes) => {
 
                     var attributeType = (attributes.First().Type as ResolvedTypeDescriptor)?.Type;
-                    var properties = attributes.Select(a => (name: a.NameSyntax.Name, value: a.Initializer));
+                    var properties = attributes.Select(a => (name: a.NameSyntax.Name, value: (a.Initializer as LiteralExpressionBindingParserNode)?.Value ?? ""));
 
                     return (attributeType, properties);
                 }).ToList();

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedPropertyDeclarationDirective.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedPropertyDeclarationDirective.cs
@@ -62,7 +62,7 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
                 (name, attributes) => {
 
                     var attributeType = (attributes.First().Type as ResolvedTypeDescriptor)?.Type;
-                    var properties = attributes.Select(a => (name: a.NameSyntax.Name, value: a.Initializer.Value));
+                    var properties = attributes.Select(a => (name: a.NameSyntax.Name, value: a.Initializer));
 
                     return (attributeType, properties);
                 }).ToList();

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedPropertyDirectiveAttributeReference.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedPropertyDirectiveAttributeReference.cs
@@ -15,14 +15,14 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
         public TypeReferenceBindingParserNode TypeSyntax { get; }
         public IdentifierNameBindingParserNode NameSyntax { get; }
         public ITypeDescriptor? Type { get; set; }
-        public LiteralExpressionBindingParserNode Initializer { get; }
+        public BindingParserNode Initializer { get; }
 
         public ResolvedPropertyDirectiveAttributeReference(
             DirectiveCompilationService directiveService,
             DothtmlDirectiveNode directiveNode,
             TypeReferenceBindingParserNode typeReferenceBindingParserNode,
             IdentifierNameBindingParserNode attributePropertyNameReference,
-            LiteralExpressionBindingParserNode initializer,
+            BindingParserNode initializer,
             ImmutableList<NamespaceImport> imports)
         {
             DirectiveNode = directiveNode;

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedTreeBuilder.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedTreeBuilder.cs
@@ -114,7 +114,7 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
             DothtmlDirectiveNode directiveNode,
             IdentifierNameBindingParserNode propertyNameSyntax,
             TypeReferenceBindingParserNode typeSyntax,
-            LiteralExpressionBindingParserNode initializer,
+            BindingParserNode initializer,
             ImmutableList<NamespaceImport> imports)
         {
             return new ResolvedPropertyDirectiveAttributeReference(directiveService, directiveNode, typeSyntax, propertyNameSyntax, initializer, imports);

--- a/src/Framework/Framework/Compilation/Directives/PropertyDeclarationDirectiveCompiler.cs
+++ b/src/Framework/Framework/Compilation/Directives/PropertyDeclarationDirectiveCompiler.cs
@@ -77,11 +77,11 @@ namespace DotVVM.Framework.Compilation.Directives
                 return new AttributeInfo(
                     typeRef,
                     new SimpleNameBindingParserNode("") { StartPosition = attributeReference.EndPosition },
-                    new LiteralExpressionBindingParserNode("") { StartPosition = attributeReference.EndPosition });
+                    new SimpleNameBindingParserNode("") { StartPosition = attributeReference.EndPosition });
             }
 
             var attributePropertyReference = assignment.FirstExpression as MemberAccessBindingParserNode;
-            var initializer = assignment.SecondExpression as LiteralExpressionBindingParserNode;
+            var initializer = assignment.SecondExpression; 
             var attributeTypeReference = attributePropertyReference?.TargetExpression;
             var attributePropertyNameReference = attributePropertyReference?.MemberNameExpression;
 
@@ -93,10 +93,9 @@ namespace DotVVM.Framework.Compilation.Directives
                 attributeTypeReference = attributeTypeReference ?? new SimpleNameBindingParserNode("");
                 attributePropertyNameReference = attributePropertyNameReference ?? new SimpleNameBindingParserNode("") { StartPosition = attributeTypeReference.EndPosition };
             }
-            if (initializer == null)
+            if (assignment.SecondExpression is not LiteralExpressionBindingParserNode)
             {
                 directiveNode.AddError($"Value for property {attributeTypeReference.ToDisplayString()} of attribute {attributePropertyNameReference.ToDisplayString()} is missing or not a constant.");
-                initializer = new LiteralExpressionBindingParserNode("") { StartPosition = attributePropertyNameReference.EndPosition };
             }
 
             var type = new ActualTypeReferenceBindingParserNode(attributeTypeReference);
@@ -120,7 +119,7 @@ namespace DotVVM.Framework.Compilation.Directives
         protected abstract bool HasPropertyType(IAbstractPropertyDeclarationDirective directive);
         protected abstract DotvvmProperty TryCreateDotvvmPropertyFromDirective(IAbstractPropertyDeclarationDirective propertyDeclarationDirective);
 
-        private record AttributeInfo(ActualTypeReferenceBindingParserNode Type, IdentifierNameBindingParserNode Name, LiteralExpressionBindingParserNode Initializer);
+        private record AttributeInfo(ActualTypeReferenceBindingParserNode Type, IdentifierNameBindingParserNode Name, BindingParserNode Initializer);
     }
 
     public class ResolvedPropertyDeclarationDirectiveCompiler : PropertyDeclarationDirectiveCompiler

--- a/src/Tests/AssertEx.cs
+++ b/src/Tests/AssertEx.cs
@@ -10,7 +10,7 @@ namespace DotVVM.Framework.Tests
 {
     public static class AssertEx
     {
-        public static void AssertNode(BindingParserNode node, string expectedDisplayString, int start, int length, bool hasErrors = false)
+        public static void BindingNode(BindingParserNode node, string expectedDisplayString, int start, int length, bool hasErrors = false)
         {
             Assert.AreEqual(expectedDisplayString, node.ToDisplayString(), $"Node {node.GetType().Name}: display string incorrect.");
             Assert.AreEqual(start, node.StartPosition, $"Node {node.GetType().Name}: Start position incorrect.");

--- a/src/Tests/AssertEx.cs
+++ b/src/Tests/AssertEx.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.Compilation.Parser.Binding.Parser;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotVVM.Framework.Tests
+{
+    public static class AssertEx
+    {
+        public static void AssertNode(BindingParserNode node, string expectedDisplayString, int start, int length, bool hasErrors = false)
+        {
+            Assert.AreEqual(expectedDisplayString, node.ToDisplayString(), $"Node {node.GetType().Name}: display string incorrect.");
+            Assert.AreEqual(start, node.StartPosition, $"Node {node.GetType().Name}: Start position incorrect.");
+            Assert.AreEqual(length, node.Length, $"Node {node.GetType().Name}: Length incorrect.");
+
+            if (hasErrors)
+            {
+                Assert.IsTrue(node.HasNodeErrors);
+            }
+            else
+            {
+                Assert.IsFalse(node.HasNodeErrors);
+            }
+        }
+    }
+}

--- a/src/Tests/Parser/Binding/BindingParserTests.cs
+++ b/src/Tests/Parser/Binding/BindingParserTests.cs
@@ -1490,7 +1490,7 @@ namespace DotVVM.Framework.Tests.Parser.Binding
         }
 
         private static void AssertNode(BindingParserNode node, string expectedDisplayString, int start, int length, bool hasErrors = false)
-            => AssertEx.AssertNode(node, expectedDisplayString, start, length, hasErrors);
+            => AssertEx.BindingNode(node, expectedDisplayString, start, length, hasErrors);
 
         private static string SkipWhitespaces(string str) => string.Join("", str.Where(c => !char.IsWhiteSpace(c)));
 

--- a/src/Tests/Parser/Binding/BindingParserTests.cs
+++ b/src/Tests/Parser/Binding/BindingParserTests.cs
@@ -1490,20 +1490,7 @@ namespace DotVVM.Framework.Tests.Parser.Binding
         }
 
         private static void AssertNode(BindingParserNode node, string expectedDisplayString, int start, int length, bool hasErrors = false)
-        {
-            Assert.AreEqual(expectedDisplayString, node.ToDisplayString(), $"Node {node.GetType().Name}: display string incorrect.");
-            Assert.AreEqual(start, node.StartPosition, $"Node {node.GetType().Name}: Start position incorrect.");
-            Assert.AreEqual(length, node.Length, $"Node {node.GetType().Name}: Length incorrect.");
-
-            if (hasErrors)
-            {
-                Assert.IsTrue(node.HasNodeErrors);
-            }
-            else
-            {
-                Assert.IsFalse(node.HasNodeErrors);
-            }
-        }
+            => AssertEx.AssertNode(node, expectedDisplayString, start, length, hasErrors);
 
         private static string SkipWhitespaces(string str) => string.Join("", str.Where(c => !char.IsWhiteSpace(c)));
 

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/PropertyDirectiveTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/PropertyDirectiveTests.cs
@@ -68,9 +68,10 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
         [TestMethod]
         public void ResolvedTree_PropertyDirectiveArrayInicializerAndAttributes_ResolvedCorrectly()
         {
-            var root = ParseSource(@$"
+            var root = ParseSource("""
 @viewModel object
-@property string[] MyProperty=["""",""""], MarkupOptionsAttribute.Required = true, MarkupOptionsAttribute.AllowBinding = false");
+@property string[] MyProperty=["",""], MarkupOptionsAttribute.Required = true, MarkupOptionsAttribute.AllowBinding = false
+""");
 
             var property = root.Directives["property"].SingleOrDefault() as IAbstractPropertyDeclarationDirective;
 

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/PropertyDirectiveTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/PropertyDirectiveTests.cs
@@ -50,7 +50,7 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
         }
 
         [TestMethod]
-        public void ResolvedTree_PropertyDirectiveArrayInicializer_ResolvedCorrectly()
+        public void ResolvedTree_PropertyDirectiveInvalidArrayInicializer_ResolvedCorrectly()
         {
             var root = ParseSource(@$"
 @viewModel object
@@ -58,15 +58,28 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
 
             var property = root.Directives["property"].SingleOrDefault() as IAbstractPropertyDeclarationDirective;
 
-            Assert.AreEqual("System.String[]", property.PropertyType.FullName);
-            Assert.AreEqual("MyProperty", property.NameSyntax.Name);
+            Assert.AreEqual("System.String", property.PropertyType.FullName);
+            Assert.AreEqual("a", property.NameSyntax.Name);
 
             var nodes = property.InitializerSyntax.EnumerateChildNodes();
             Assert.IsFalse(nodes.Any(n => n == property.InitializerSyntax));
+        }
+
+        [TestMethod]
+        public void ResolvedTree_PropertyDirectiveArrayInicializerAndAttributes_ResolvedCorrectly()
+        {
+            var root = ParseSource(@$"
+@viewModel object
+@property string[] MyProperty=["""",""""], MarkupOptionsAttribute.Required = true, MarkupOptionsAttribute.AllowBinding = false");
+
+            var property = root.Directives["property"].SingleOrDefault() as IAbstractPropertyDeclarationDirective;
+
+            Assert.AreEqual("System.String[]", property.PropertyType.FullName);
+            Assert.AreEqual("MyProperty", property.NameSyntax.Name);
 
             Assert.AreEqual(2, property.Attributes.Count);
-            AssertEx.AssertNode(property.Attributes[0].Initializer, "True", 66, 5);
-            AssertEx.AssertNode(property.Attributes[1].Initializer, "False", 110, 6);
+            AssertEx.AssertNode(property.Attributes[0].Initializer, "True", 62, 5);
+            AssertEx.AssertNode(property.Attributes[1].Initializer, "False", 106, 6);
         }
     }
 }

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/PropertyDirectiveTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/PropertyDirectiveTests.cs
@@ -25,8 +25,8 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
 
             AssertEx.AssertNode(property.Attributes[0].Initializer, "", 19, 0);
             AssertEx.AssertNode(property.Attributes[1].Initializer, "", 28, 0);
-            AssertEx.AssertNode(property.Attributes[2].Initializer, "", 43, 0);
-            AssertEx.AssertNode(property.Attributes[3].Initializer, "t", 105, 0);
+            AssertEx.AssertNode(property.Attributes[2].Initializer, "", 42, 1, true);
+            AssertEx.AssertNode(property.Attributes[3].Initializer, "t", 104, 2);
         }
 
         [TestMethod]
@@ -58,11 +58,15 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
 
             var property = root.Directives["property"].SingleOrDefault() as IAbstractPropertyDeclarationDirective;
 
-            var nodes = property.InitializerSyntax.EnumerateChildNodes();
+            Assert.AreEqual("System.String[]", property.PropertyType.FullName);
+            Assert.AreEqual("MyProperty", property.NameSyntax.Name);
 
+            var nodes = property.InitializerSyntax.EnumerateChildNodes();
             Assert.IsFalse(nodes.Any(n => n == property.InitializerSyntax));
 
-            Assert.AreEqual(2,nodes.Count());
+            Assert.AreEqual(2, property.Attributes.Count);
+            AssertEx.AssertNode(property.Attributes[0].Initializer, "True", 66, 5);
+            AssertEx.AssertNode(property.Attributes[1].Initializer, "False", 110, 6);
         }
     }
 }

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/PropertyDirectiveTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/PropertyDirectiveTests.cs
@@ -23,10 +23,10 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
 
             Assert.AreEqual(4, property.Attributes.Count);
 
-            AssertEx.AssertNode(property.Attributes[0].Initializer, "", 19, 0);
-            AssertEx.AssertNode(property.Attributes[1].Initializer, "", 28, 0);
-            AssertEx.AssertNode(property.Attributes[2].Initializer, "", 42, 1, true);
-            AssertEx.AssertNode(property.Attributes[3].Initializer, "t", 104, 2);
+            AssertEx.BindingNode(property.Attributes[0].Initializer, "", 19, 0);
+            AssertEx.BindingNode(property.Attributes[1].Initializer, "", 28, 0);
+            AssertEx.BindingNode(property.Attributes[2].Initializer, "", 42, 1, true);
+            AssertEx.BindingNode(property.Attributes[3].Initializer, "t", 104, 2);
         }
 
         [TestMethod]
@@ -78,8 +78,8 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
             Assert.AreEqual("MyProperty", property.NameSyntax.Name);
 
             Assert.AreEqual(2, property.Attributes.Count);
-            AssertEx.AssertNode(property.Attributes[0].Initializer, "True", 62, 5);
-            AssertEx.AssertNode(property.Attributes[1].Initializer, "False", 106, 6);
+            AssertEx.BindingNode(property.Attributes[0].Initializer, "True", 62, 5);
+            AssertEx.BindingNode(property.Attributes[1].Initializer, "False", 106, 6);
         }
     }
 }

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/PropertyDirectiveTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/PropertyDirectiveTests.cs
@@ -22,6 +22,11 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
             Assert.AreEqual("MyProperty", property.NameSyntax.Name);
 
             Assert.AreEqual(4, property.Attributes.Count);
+
+            AssertEx.AssertNode(property.Attributes[0].Initializer, "", 19, 0);
+            AssertEx.AssertNode(property.Attributes[1].Initializer, "", 28, 0);
+            AssertEx.AssertNode(property.Attributes[2].Initializer, "", 43, 0);
+            AssertEx.AssertNode(property.Attributes[3].Initializer, "t", 105, 0);
         }
 
         [TestMethod]


### PR DESCRIPTION
Now the initializer of the attribute supports half written values for the VS extension.
The validation before was way too strict and replaced invalid values with empty literal.
