### PR TITLE
Fix tokenizer error when empty directive is used

### DIFF
--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Tokenizer/DothtmlTokenizer.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Tokenizer/DothtmlTokenizer.cs
@@ -145,6 +145,14 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
             }
             SkipWhitespace(false);
 
+            if (Peek() is '\r' or '\n' or NullChar)
+            {
+                // empty value
+                CreateToken(DothtmlTokenType.DirectiveValue);
+                SkipWhitespace();
+                return;
+            }
+
             // whitespace
             if (LastToken!.Type != DothtmlTokenType.WhiteSpace)
             {
@@ -152,15 +160,7 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer
             }
 
             // directive value
-            if (Peek() == '\r' || Peek() == '\n' || Peek() == NullChar)
-            {
-                CreateToken(DothtmlTokenType.DirectiveValue, errorProvider: t => CreateTokenError(t, DothtmlTokenType.DirectiveStart, DothtmlTokenizerErrors.DirectiveValueExpected));
-                SkipWhitespace();
-            }
-            else
-            {
-                ReadTextUntilNewLine(DothtmlTokenType.DirectiveValue);
-            }
+            ReadTextUntilNewLine(DothtmlTokenType.DirectiveValue);
         }
 
         /// <summary>

--- a/src/Tests/Parser/Dothtml/DothtmlTokenizerDirectivesTests.cs
+++ b/src/Tests/Parser/Dothtml/DothtmlTokenizerDirectivesTests.cs
@@ -95,19 +95,15 @@ this is a test content";
             Assert.AreEqual(0, tokenizer.Tokens[i].Length);
             Assert.AreEqual(DothtmlTokenType.DirectiveName, tokenizer.Tokens[i++].Type);
 
-            Assert.IsTrue(tokenizer.Tokens[i].HasError);
-            Assert.AreEqual(0, tokenizer.Tokens[i].Length);
-            Assert.AreEqual(DothtmlTokenType.WhiteSpace, tokenizer.Tokens[i++].Type);
-
-            Assert.IsTrue(tokenizer.Tokens[i].HasError);
+            Assert.IsFalse(tokenizer.Tokens[i].HasError);
             Assert.AreEqual(0, tokenizer.Tokens[i].Length);
             Assert.AreEqual(DothtmlTokenType.DirectiveValue, tokenizer.Tokens[i++].Type);
         }
 
         [TestMethod]
-        public void DothtmlTokenizer_DirectiveParsing_Invalid_AtSymbol_DirectiveName()
+        public void DothtmlTokenizer_DirectiveParsing_Invalid_ValueWithoutSpace()
         {
-            var input = @"@viewmodel";
+            var input = @"@viewmodel=something";
 
             // parse
             var tokenizer = new DothtmlTokenizer();
@@ -124,7 +120,28 @@ this is a test content";
             Assert.AreEqual(0, tokenizer.Tokens[i].Length);
             Assert.AreEqual(DothtmlTokenType.WhiteSpace, tokenizer.Tokens[i++].Type);
 
-            Assert.IsTrue(tokenizer.Tokens[i].HasError);
+            Assert.AreEqual("=something", tokenizer.Tokens[i].Text);
+            Assert.IsFalse(tokenizer.Tokens[i].HasError);
+            Assert.AreEqual(DothtmlTokenType.DirectiveValue, tokenizer.Tokens[i++].Type);
+        }
+
+        [TestMethod]
+        public void DothtmlTokenizer_DirectiveParsing_Valid_EmptyDirective()
+        {
+            var input = @"@viewmodel";
+
+            // parse
+            var tokenizer = new DothtmlTokenizer();
+            tokenizer.Tokenize(input);
+            CheckForErrors(tokenizer, input.Length);
+
+            var i = 0;
+            Assert.AreEqual(DothtmlTokenType.DirectiveStart, tokenizer.Tokens[i++].Type);
+
+            Assert.AreEqual("viewmodel", tokenizer.Tokens[i].Text);
+            Assert.AreEqual(DothtmlTokenType.DirectiveName, tokenizer.Tokens[i++].Type);
+
+            Assert.IsFalse(tokenizer.Tokens[i].HasError);
             Assert.AreEqual(0, tokenizer.Tokens[i].Length);
             Assert.AreEqual(DothtmlTokenType.DirectiveValue, tokenizer.Tokens[i++].Type);
         }
@@ -170,11 +187,7 @@ test";
             Assert.AreEqual(0, tokenizer.Tokens[i].Length);
             Assert.AreEqual(DothtmlTokenType.DirectiveName, tokenizer.Tokens[i++].Type);
 
-            Assert.IsTrue(tokenizer.Tokens[i].HasError);
-            Assert.AreEqual(0, tokenizer.Tokens[i].Length);
-            Assert.AreEqual(DothtmlTokenType.WhiteSpace, tokenizer.Tokens[i++].Type);
-
-            Assert.IsTrue(tokenizer.Tokens[i].HasError);
+            Assert.IsFalse(tokenizer.Tokens[i].HasError);
             Assert.AreEqual(0, tokenizer.Tokens[i].Length);
             Assert.AreEqual(DothtmlTokenType.DirectiveValue, tokenizer.Tokens[i++].Type);
 
@@ -184,7 +197,7 @@ test";
         }
 
         [TestMethod]
-        public void DothtmlTokenizer_DirectiveParsing_Invalid_AtSymbol_DirectiveName_NewLine_Content()
+        public void DothtmlTokenizer_DirectiveParsing_DirectiveName_EmptyValue_NewLine_Content()
         {
             var input = "@viewmodel\ntest";
 
@@ -199,11 +212,7 @@ test";
             Assert.AreEqual("viewmodel", tokenizer.Tokens[i].Text);
             Assert.AreEqual(DothtmlTokenType.DirectiveName, tokenizer.Tokens[i++].Type);
 
-            Assert.IsTrue(tokenizer.Tokens[i].HasError);
-            Assert.AreEqual(0, tokenizer.Tokens[i].Length);
-            Assert.AreEqual(DothtmlTokenType.WhiteSpace, tokenizer.Tokens[i++].Type);
-
-            Assert.IsTrue(tokenizer.Tokens[i].HasError);
+            Assert.IsFalse(tokenizer.Tokens[i].HasError);
             Assert.AreEqual(0, tokenizer.Tokens[i].Length);
             Assert.AreEqual(DothtmlTokenType.DirectiveValue, tokenizer.Tokens[i++].Type);
 
@@ -233,7 +242,7 @@ test";
             Assert.AreEqual(2, tokenizer.Tokens[i].Length);
             Assert.AreEqual(DothtmlTokenType.WhiteSpace, tokenizer.Tokens[i++].Type);
 
-            Assert.IsTrue(tokenizer.Tokens[i].HasError);
+            Assert.IsFalse(tokenizer.Tokens[i].HasError);
             Assert.AreEqual(0, tokenizer.Tokens[i].Length);
             Assert.AreEqual(DothtmlTokenType.DirectiveValue, tokenizer.Tokens[i++].Type);
 
@@ -265,7 +274,7 @@ test";
             Assert.AreEqual(2, tokenizer.Tokens[i].Length);
             Assert.AreEqual(DothtmlTokenType.WhiteSpace, tokenizer.Tokens[i++].Type);
 
-            Assert.IsTrue(tokenizer.Tokens[i].HasError);
+            Assert.IsFalse(tokenizer.Tokens[i].HasError);
             Assert.AreEqual(0, tokenizer.Tokens[i].Length);
             Assert.AreEqual(DothtmlTokenType.DirectiveValue, tokenizer.Tokens[i++].Type);
 

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/ViewModelDirectiveTest.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/ViewModelDirectiveTest.cs
@@ -32,6 +32,16 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
         }
 
         [TestMethod]
+        public void ResolvedTree_EmptyViewModelType()
+        {
+            var root = ParseSource(@"@viewModel
+");
+
+            var directiveNode = ((DothtmlRootNode)root.DothtmlNode).Directives.First();
+            Assert.IsTrue(directiveNode.HasNodeErrors);
+        }
+
+        [TestMethod]
         public void ResolvedTree_ViewModel_GenericType()
         {
             var root = ParseSource(@"@viewModel System.Collections.Generic.List<System.Collections.Generic.Dictionary<System.String, System.Int32>>");


### PR DESCRIPTION
Fixes the problem reported in https://forum.dotvvm.com/t/nowrappertag-syntax/101/2

The bug currently only affects VS extension, not framework - we don't currently report tokenizer "errors" -> no need for 4.2 patch