### PR TITLE
Properties with the same name defined by `@property` directive

### DIFF
--- a/src/Framework/Framework/Compilation/Directives/PropertyDeclarationDirectiveCompiler.cs
+++ b/src/Framework/Framework/Compilation/Directives/PropertyDeclarationDirectiveCompiler.cs
@@ -112,6 +112,19 @@ namespace DotVVM.Framework.Compilation.Directives
 
             return directives
             .Where(HasPropertyType)
+            .GroupBy(
+                directive => directive.NameSyntax.Name,
+                directive => directive,
+                (name, directiveOfSameName) => {
+                    if (directiveOfSameName.Count() > 1)
+                    {
+                        foreach (var sameNameDirective in directiveOfSameName.Skip(1))
+                        {
+                            sameNameDirective.DothtmlNode?.AddError("Property with the same name is already defined.");
+                        };
+                    }
+                    return directiveOfSameName.First();
+                })
             .Select(TryCreateDotvvmPropertyFromDirective)
             .ToImmutableList();
         }

--- a/src/Samples/Common/DotVVM.Samples.Common.csproj
+++ b/src/Samples/Common/DotVVM.Samples.Common.csproj
@@ -74,6 +74,10 @@
     <None Remove="Views\Errors\ExceptionInRender.dothtml" />
     <None Remove="Views\Errors\InvalidServiceDirective.dothtml" />
     <None Remove="Views\Errors\InvalidLocationFallback.dothtml" />
+    <None Remove="Views\Errors\MarkupControlInvalidViewModel.dothtml" />
+    <None Remove="Views\Errors\MarkupControlPropertiesSameName.dotcontrol" />
+    <None Remove="Views\Errors\MarkupControlPropertiesSameNameWithBase.dotcontrol" />
+    <None Remove="Views\Errors\MarkupControlPropertiesSameNameWithBase.dothtml" />
     <None Remove="Views\Errors\ResourceCircularDependency.dothtml" />
     <None Remove="Views\FeatureSamples\Api\ApiInSpa_Master.dotmaster" />
     <None Remove="Views\FeatureSamples\Api\ApiInSpa_PageA.dothtml" />

--- a/src/Samples/Common/ViewModels/Errors/MarkupControlPropertiesSameNameWithBase.cs
+++ b/src/Samples/Common/ViewModels/Errors/MarkupControlPropertiesSameNameWithBase.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Controls;
+
+namespace DotVVM.Samples.Common.ViewModels.Errors
+{
+    public class MarkupControlPropertiesSameNameWithBase : DotvvmMarkupControl
+    {
+        public string MyProperty
+        {
+            get { return (string)GetValue(MyPropertyProperty); }
+            set { SetValue(MyPropertyProperty, value); }
+        }
+        public static readonly DotvvmProperty MyPropertyProperty
+            = DotvvmProperty.Register<string, MarkupControlPropertiesSameNameWithBase>(c => c.MyProperty, null);
+
+    }
+}

--- a/src/Samples/Common/Views/Errors/MarkupControlPropertiesSameName.dotcontrol
+++ b/src/Samples/Common/Views/Errors/MarkupControlPropertiesSameName.dotcontrol
@@ -1,0 +1,6 @@
+﻿@viewModel object
+
+@property int MyProperty
+@property bool MyProperty
+
+{{value: _control.MyProperty}}

--- a/src/Samples/Common/Views/Errors/MarkupControlPropertiesSameName.dothtml
+++ b/src/Samples/Common/Views/Errors/MarkupControlPropertiesSameName.dothtml
@@ -1,0 +1,15 @@
+﻿@viewModel object
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+    <sample:MarkupControlPropertiesSameName MyProperty="1" />
+</body>
+</html>
+
+

--- a/src/Samples/Common/Views/Errors/MarkupControlPropertiesSameNameWithBase.dotcontrol
+++ b/src/Samples/Common/Views/Errors/MarkupControlPropertiesSameNameWithBase.dotcontrol
@@ -1,0 +1,6 @@
+﻿@viewModel object
+@baseType DotVVM.Samples.Common.ViewModels.Errors.MarkupControlPropertiesSameNameWithBase
+
+@property bool MyProperty
+
+{{value: _control.MyProperty}}

--- a/src/Samples/Common/Views/Errors/MarkupControlPropertiesSameNameWithBase.dothtml
+++ b/src/Samples/Common/Views/Errors/MarkupControlPropertiesSameNameWithBase.dothtml
@@ -1,0 +1,15 @@
+﻿@viewModel object
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+    <sample:MarkupControlPropertiesSameNameWithBase MyProperty="1" />
+</body>
+</html>
+
+

--- a/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
@@ -179,6 +179,8 @@ namespace DotVVM.Testing.Abstractions
         public const string Errors_InvalidViewModel = "Errors/InvalidViewModel";
         public const string Errors_MalformedBinding = "Errors/MalformedBinding";
         public const string Errors_MarkupControlInvalidViewModel = "Errors/MarkupControlInvalidViewModel";
+        public const string Errors_MarkupControlPropertiesSameName = "Errors/MarkupControlPropertiesSameName";
+        public const string Errors_MarkupControlPropertiesSameNameWithBase = "Errors/MarkupControlPropertiesSameNameWithBase";
         public const string Errors_MasterPageRequiresDifferentViewModel = "Errors/MasterPageRequiresDifferentViewModel";
         public const string Errors_MissingRequiredProperty = "Errors/MissingRequiredProperty";
         public const string Errors_MissingRequiredProperty2 = "Errors/MissingRequiredProperty2";

--- a/src/Samples/Tests/Tests/ErrorsTests.cs
+++ b/src/Samples/Tests/Tests/ErrorsTests.cs
@@ -487,6 +487,17 @@ namespace DotVVM.Samples.Tests
             });
         }
 
+        [Fact]
+        public void Error_MarkupControlPropertiesSameName()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.Errors_MarkupControlPropertiesSameName);
+
+                AssertUI.InnerText(browser.First(".exceptionMessage"), s => s.Contains("already defined"));
+                AssertUI.InnerText(browser.First(".errorUnderline"), s => s.Contains("@property bool MyProperty"));
+            });
+        }
+
         public ErrorsTests(ITestOutputHelper output) : base(output)
         {
         }

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/PropertyDirectiveTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/PropertyDirectiveTests.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using DotVVM.Framework.Tests.Runtime.ControlTree.DefaultControlTreeResolver;
 using System.Linq;
 using DotVVM.Framework.Compilation.ControlTree;
-using DotVVM.Framework.Controls;
 
 namespace DotVVM.Framework.Tests.Runtime.ControlTree
 {
@@ -81,6 +79,34 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
             Assert.AreEqual(2, property.Attributes.Count);
             AssertEx.BindingNode(property.Attributes[0].Initializer, "True", 62, 5);
             AssertEx.BindingNode(property.Attributes[1].Initializer, "False", 106, 6);
+        }
+
+        [TestMethod]
+        public void ResolvedTree_PropertyDirectiveSameName_ErrorReported()
+        {
+            var root = ParseSource("""
+                @viewModel object
+                @property int MyProperty
+                @property bool MyProperty
+                @property string MyProperty
+
+                {{value: _control.MyProperty}}
+""", "control.dotcontrol");
+
+            var firstProperty = root.Directives["property"][0] as IAbstractPropertyDeclarationDirective;
+            var secondProperty = root.Directives["property"][1] as IAbstractPropertyDeclarationDirective;
+            var thirdProperty = root.Directives["property"][2] as IAbstractPropertyDeclarationDirective;
+
+            var property = root.Metadata.FindProperty("MyProperty");
+
+            //First property wins
+            Assert.AreEqual(property.PropertyType, typeof(int));
+
+            Assert.IsFalse(firstProperty.DothtmlNode.HasNodeErrors);
+            Assert.IsTrue(secondProperty.DothtmlNode.HasNodeErrors);
+            Assert.IsTrue(thirdProperty.DothtmlNode.HasNodeErrors);
+
+
         }
     }
 }


### PR DESCRIPTION
If user defines two properties of the same name in the same markup file, there should be an error.