### PR TITLE
Fix config.ClientSideValidation switch, remove redundant vm.validationRules property

### DIFF
--- a/src/Framework/Framework/Runtime/HotReloadMetadataUpdateHandler.cs
+++ b/src/Framework/Framework/Runtime/HotReloadMetadataUpdateHandler.cs
@@ -19,6 +19,7 @@ namespace DotVVM.Framework.Runtime
     public static class HotReloadMetadataUpdateHandler
     {
         internal static readonly ConcurrentBag<WeakReference<ViewModelSerializationMapper>> SerializationMappers = new();
+        internal static readonly ConcurrentBag<WeakReference<ViewModelTypeMetadataSerializer>> TypeMetadataSerializer = new();
         internal static readonly ConcurrentBag<WeakReference<UserColumnMappingCache>> UserColumnMappingCaches = new();
         internal static readonly ConcurrentBag<WeakReference<ExtensionMethodsCache>> ExtensionMethodsCaches = new();
         public static void ClearCache(Type[]? updatedTypes)
@@ -36,6 +37,11 @@ namespace DotVVM.Framework.Runtime
                             problematicTypes.Add(u);
                     }
             }
+            foreach (var tRef in TypeMetadataSerializer)
+            {
+                if (tRef.TryGetTarget(out var t))
+                    t.ClearCaches(updatedTypes);
+            }
             foreach (var cRef in UserColumnMappingCaches)
             {
                 if (cRef.TryGetTarget(out var c))
@@ -47,7 +53,6 @@ namespace DotVVM.Framework.Runtime
                     e.ClearCaches(updatedTypes);
             }
 
-            ViewModelTypeMetadataSerializer.ClearCaches(updatedTypes);
             DefaultViewModelLoader.ClearCaches(updatedTypes);
             AttributeViewModelParameterBinder.ClearCaches(updatedTypes);
             ChildViewModelsCache.ClearCaches(updatedTypes);


### PR DESCRIPTION
We moved validation rules to the type metadata, but we didn't remove the old validation rules from the view model. The new code also didn't respect the config.ClientSideValidation (which disables client-side validation rules).
This patchs removes the old duplicated validationRules and adds config.ClientSideValidation to the type mapper.