### PR TITLE
JS: Fix viewmodel freezing

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/metadata/coercer.ts
+++ b/src/Framework/Framework/Resources/Scripts/metadata/coercer.ts
@@ -52,7 +52,8 @@ export function tryCoerce(value: any, type: TypeDefinition | null | undefined, o
     if (result instanceof CoerceError) {
         return result;      // we cannot freeze CoerceError because we modify its path property
     }
-    return Object.freeze(result);
+    Object.freeze(result.value)
+    return result
 }
 
 export function coerce(value: any, type: TypeDefinition, originalValue: any = undefined): any {

--- a/src/Framework/Framework/Resources/Scripts/tests/stateManagement.test.ts
+++ b/src/Framework/Framework/Resources/Scripts/tests/stateManagement.test.ts
@@ -682,3 +682,13 @@ test("changing dynamic type property notifies when dynamic types are different -
     }
     expect(notifyCount).toBe(1);
 });
+
+test("state is frozen", () => {
+    expect(Object.isFrozen(vm.state)).toBe(true);
+    expect(Object.isFrozen(s.state)).toBe(true);
+    expect(Object.isFrozen(vm.Dynamic.state)).toBe(true);
+
+    vm.Dynamic.setState({ x: 1 })
+    s.doUpdateNow()
+    expect(Object.isFrozen(vm.Dynamic.state)).toBe(true);
+})


### PR DESCRIPTION
We have to freeze the viewmodel value, not the CoerceResult object...