### PR TITLE
null propagation: Fix Throw expression bug

### DIFF
--- a/src/Tests/Binding/NullPropagationTests.cs
+++ b/src/Tests/Binding/NullPropagationTests.cs
@@ -155,7 +155,7 @@ namespace DotVVM.Framework.Tests.Binding
             Func<TestViewModel[], object> compile(Expression e) =>
                 Expression.Lambda<Func<TestViewModel[], object>>(Expression.Convert(e, typeof(object)), parameter)
                     // .CompileFast();
-                    .Compile(preferInterpretation: true);
+                    .Compile(preferInterpretation: false);
 
             var withNullChecks = compile(exprWithChecks);
             var withoutNullChecks = compile(expr);
@@ -224,7 +224,7 @@ namespace DotVVM.Framework.Tests.Binding
         private object EvalExpression<T>(Expression<Func<T, object>> a, T val)
         {
             var nullChecked = ExpressionNullPropagationVisitor.PropagateNulls(a.Body, _ => true);
-            var d = a.Update(body: nullChecked, a.Parameters).Compile(preferInterpretation: true);
+            var d = a.Update(body: nullChecked, a.Parameters).Compile(preferInterpretation: false);
             return d(val);
         }
 


### PR DESCRIPTION
Throw expression is not allowed for technical
reasons inside more complex expression, such as
`TimeSpan.FromHours(1 + (throw ...)).Milliseconds`. However, calling a method which throws is fine
(CIL stack doesn't need to be spilled).

this is minimal demo of the Linq.Expression issue: https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEUCuA7AHwAEAmARgFgAoIgBgAIiyA6AGQEs8BHZgUQQAOsAM7D2EPMIDc1OozJJ5bTj35CYo8ZL6CRYiTKrUAbgEMo9cwHN6AXnoAFc6YC2MDDCgAKDAE8BMBAAZl7AEBAANgCUUYYA9HFmFgAWEDhQwnb0AMISACbsGFpe1mg5EsIYpngYXiy0UWUAKslQEADuXgByMJ1+AcFeAIJQVjhuNQDyOBiTQQBK1VYw/GAwAkUSMWX9gSF5acARMDGxJub0qemZ9i1tnT19/nvDo+MwUzNzi3jLq+ubPDbei7QYHHBHE5nKhJEHsNzCATVLLZUwRCJeaj0bEg56DJrwmAAZSRQOYAHF3ABZdypPJeABEADE2i4ABJpDIMsp4XoAbQAuvQAN64gb7Q7HKL0AC+jSxOKGeXpuUkVRqdWYDTKVwyMUMsIQWQcbQCUD8PkJiOqZQZTQgVQiVPY6PYwhgkDweWEDOh5wsESyrFcwDypgAPEQAKzhsKRMrgyEAPiTXgQZWsUWYuRcAhdMC86iCngAkjVPOoqoCQPQgmj3dCMXWIg3DNRqAl6AS3CTqswWRB2ZzhHV6ABqeg+VodejMOcxZjO13uz3eoA==