### PR TITLE
Fix culture in literal tests

### DIFF
--- a/src/Framework/Testing/ControlTestHelper.cs
+++ b/src/Framework/Testing/ControlTestHelper.cs
@@ -115,13 +115,13 @@ namespace DotVVM.Framework.Testing
             CultureInfo? culture = null
         )
         {
-            CultureInfo.CurrentCulture = culture ?? new CultureInfo("en-US");
-            CultureInfo.CurrentUICulture = culture ?? new CultureInfo("en-US");
+            CultureInfo.CurrentCulture = CultureInfo.CurrentUICulture =
+                culture ?? new CultureInfo("en-US");
 
             Configuration.Freeze();
             fileName = (fileName ?? "testpage") + ".dothtml";
             var (_, controlBuilder) = CompilePage(markup, fileName, markupFiles);
-            return PrepareRequest(fileName, user: user);
+            return PrepareRequest(fileName, user: user, culture: culture);
         }
 
         public async Task<PageRunResult> RunPage(

--- a/src/Framework/Testing/DotvvmTestHelper.cs
+++ b/src/Framework/Testing/DotvvmTestHelper.cs
@@ -4,7 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Security;
 using System.Text;
-using System.Threading;
+using System.Threading.Tasks;
 using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Compilation.ControlTree.Resolved;
 using DotVVM.Framework.Compilation.Parser.Dothtml.Parser;
@@ -190,19 +190,35 @@ namespace DotVVM.Framework.Testing
 
         public static void RunInCulture(CultureInfo cultureInfo, Action action)
         {
-            var originalCulture = Thread.CurrentThread.CurrentCulture;
-            var originalUICulture = Thread.CurrentThread.CurrentUICulture;
+            var originalCulture = CultureInfo.CurrentCulture;
+            var originalUICulture = CultureInfo.CurrentUICulture;
 
-            Thread.CurrentThread.CurrentCulture = cultureInfo;
-            Thread.CurrentThread.CurrentUICulture = cultureInfo;
+            CultureInfo.CurrentCulture = cultureInfo;
+            CultureInfo.CurrentUICulture = cultureInfo;
             try
             {
                 action();
             }
             finally
             {
-                Thread.CurrentThread.CurrentCulture = originalCulture;
-                Thread.CurrentThread.CurrentUICulture = originalUICulture;
+                CultureInfo.CurrentCulture = originalCulture;
+                CultureInfo.CurrentUICulture = originalUICulture;
+            }
+        }
+        public static async Task RunInCultureAsync(CultureInfo cultureInfo, Func<Task> action)
+        {
+            var originalCulture = CultureInfo.CurrentCulture;
+            var originalUICulture = CultureInfo.CurrentUICulture;
+
+            CultureInfo.CurrentCulture = CultureInfo.CurrentUICulture = cultureInfo;
+            try
+            {
+                await action();
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+                CultureInfo.CurrentUICulture = originalUICulture;
             }
         }
 

--- a/src/Tests/ControlTests/SimpleControlTests.cs
+++ b/src/Tests/ControlTests/SimpleControlTests.cs
@@ -70,49 +70,55 @@ namespace DotVVM.Framework.Tests.ControlTests
         [TestMethod]
         public async Task Literal_ClientServerRendering()
         {
-            var r = await cth.RunPage(typeof(BasicTestViewModel), @"
-                <!-- literal syntax, client rendering -->
-                <span>
-                    {{value: Integer}}
-                    {{value: Float}}
-                    {{value: DateTime}}
-                    {{value: NullableString}}
-                </span>
-                <!-- literal syntax, server rendering -->
-                <span RenderSettings.Mode=Server>
-                    {{value: Integer}}
-                    {{value: Float}}
-                    {{value: DateTime}}
-                    {{value: NullableString}}
-                </span>
-                <!-- control syntax, client rendering -->
-                <span RenderSettings.Mode=Client>
-                    <dot:Literal Text={value: Integer} />
-                    <dot:Literal Text={value: Float} />
-                    <dot:Literal Text={value: DateTime} />
-                </span>
-                <!-- control syntax, server rendering -->
-                <span RenderSettings.Mode=Server>
-                    <dot:Literal Text={value: Integer} />
-                    <dot:Literal Text={value: Float} />
-                    <dot:Literal Text={value: DateTime} />
-                </span>
-                <!-- control syntax, client rendering, format string -->
-                <span RenderSettings.Mode=Client>
-                    <dot:Literal Text={value: Integer} FormatString=X />
-                    <dot:Literal Text={value: Float} FormatString=P2 />
-                    <dot:Literal Text={value: DateTime} FormatString=dddd />
-                </span>
-                <!-- control syntax, server rendering, format string -->
-                <span RenderSettings.Mode=Server>
-                    <dot:Literal Text={value: Integer} FormatString=X />
-                    <dot:Literal Text={value: Float} FormatString=P2 />
-                    <dot:Literal Text={value: DateTime} FormatString=dddd />
-                </span>
-                "
-            );
-
-            check.CheckString(r.FormattedHtml, fileExtension: "html");
+            await DotvvmTestHelper.RunInCultureAsync(new CultureInfo("sv"), async () => {
+                await Task.Delay(1);
+                Assert.AreEqual("sv", CultureInfo.CurrentCulture.Name);
+                var r = await cth.RunPage(typeof(BasicTestViewModel), """
+                    <!-- literal syntax, client rendering -->
+                    {{resource: System.Globalization.CultureInfo.CurrentCulture.Name}}
+                    <span>
+                        {{value: Integer}}
+                        {{value: Float}}
+                        {{value: DateTime}}
+                        {{value: NullableString}}
+                    </span>
+                    <!-- literal syntax, server rendering -->
+                    <span RenderSettings.Mode=Server>
+                        {{value: Integer}}
+                        {{value: Float}}
+                        {{value: DateTime}}
+                        {{value: NullableString}}
+                    </span>
+                    <!-- control syntax, client rendering -->
+                    <span RenderSettings.Mode=Client>
+                        <dot:Literal Text={value: Integer} />
+                        <dot:Literal Text={value: Float} />
+                        <dot:Literal Text={value: DateTime} />
+                    </span>
+                    <!-- control syntax, server rendering -->
+                    <span RenderSettings.Mode=Server>
+                        <dot:Literal Text={value: Integer} />
+                        <dot:Literal Text={value: Float} />
+                        <dot:Literal Text={value: DateTime} />
+                    </span>
+                    <!-- control syntax, client rendering, format string -->
+                    <span RenderSettings.Mode=Client>
+                        <dot:Literal Text={value: Integer} FormatString=X />
+                        <dot:Literal Text={value: Float} FormatString=P2 />
+                        <dot:Literal Text={value: DateTime} FormatString=dddd />
+                    </span>
+                    <!-- control syntax, server rendering, format string -->
+                    <span RenderSettings.Mode=Server>
+                        <dot:Literal Text={value: Integer} FormatString=X />
+                        <dot:Literal Text={value: Float} FormatString=P2 />
+                        <dot:Literal Text={value: DateTime} FormatString=dddd />
+                    </span>
+                    """,
+                    culture: new CultureInfo("sv")
+                );
+                Assert.AreEqual("sv", CultureInfo.CurrentCulture.Name);
+                check.CheckString(r.FormattedHtml, fileExtension: "html");
+            });
         }
 
         [TestMethod]

--- a/src/Tests/ControlTests/testoutputs/SimpleControlTests.Literal_ClientServerRendering.html
+++ b/src/Tests/ControlTests/testoutputs/SimpleControlTests.Literal_ClientServerRendering.html
@@ -2,11 +2,11 @@
 	<head></head>
 	<body>
 		
-		<!-- literal syntax, client rendering -->
-		<span data-bind="text: dotvvm.globalize.bindingNumberToString(int)() + &quot;\n                    &quot; + dotvvm.globalize.bindingNumberToString(float)() + &quot;\n                    &quot; + (dotvvm.globalize.bindingDateToString(date)() ?? &quot;&quot;) + &quot;\n                    &quot; + (NullableString() ?? &quot;&quot;)"></span>
+		<!-- literal syntax, client rendering --> sv
+		<span data-bind="text: dotvvm.globalize.bindingNumberToString(int)() + &quot;\n    &quot; + dotvvm.globalize.bindingNumberToString(float)() + &quot;\n    &quot; + (dotvvm.globalize.bindingDateToString(date)() ?? &quot;&quot;) + &quot;\n    &quot; + (NullableString() ?? &quot;&quot;)"></span>
 		
 		<!-- literal syntax, server rendering -->
-		<span data-bind="text: dotvvm.globalize.bindingNumberToString(int)() + &quot;\n                    &quot; + dotvvm.globalize.bindingNumberToString(float)() + &quot;\n                    &quot; + (dotvvm.globalize.bindingDateToString(date)() ?? &quot;&quot;) + &quot;\n                    &quot; + (NullableString() ?? &quot;&quot;)">10000000                     0.11111                     8/11/2020 4:01:44 PM
+		<span data-bind="text: dotvvm.globalize.bindingNumberToString(int)() + &quot;\n    &quot; + dotvvm.globalize.bindingNumberToString(float)() + &quot;\n    &quot; + (dotvvm.globalize.bindingDateToString(date)() ?? &quot;&quot;) + &quot;\n    &quot; + (NullableString() ?? &quot;&quot;)">10000000     0,11111     2020-08-11 16:01:44
 		</span>
 		
 		<!-- control syntax, client rendering -->
@@ -19,8 +19,8 @@
 		<!-- control syntax, server rendering -->
 		<span>
 			<span data-bind="text: int">10000000</span>
-			<span data-bind="text: dotvvm.globalize.formatString(&quot;&quot;, float, &quot;double&quot;)">0.11111</span>
-			<span data-bind="text: dotvvm.globalize.formatString(&quot;&quot;, date, &quot;datetime&quot;)">8/11/2020 4:01:44 PM</span>
+			<span data-bind="text: dotvvm.globalize.formatString(&quot;&quot;, float, &quot;double&quot;)">0,11111</span>
+			<span data-bind="text: dotvvm.globalize.formatString(&quot;&quot;, date, &quot;datetime&quot;)">2020-08-11 16:01:44</span>
 		</span>
 		
 		<!-- control syntax, client rendering, format string -->
@@ -33,8 +33,8 @@
 		<!-- control syntax, server rendering, format string -->
 		<span>
 			<span data-bind="text: dotvvm.globalize.formatString(&quot;X&quot;, int, &quot;int32&quot;)">989680</span>
-			<span data-bind="text: dotvvm.globalize.formatString(&quot;P2&quot;, float, &quot;double&quot;)">11.11%</span>
-			<span data-bind="text: dotvvm.globalize.formatString(&quot;dddd&quot;, date, &quot;datetime&quot;)">Tuesday</span>
+			<span data-bind="text: dotvvm.globalize.formatString(&quot;P2&quot;, float, &quot;double&quot;)">11,11 %</span>
+			<span data-bind="text: dotvvm.globalize.formatString(&quot;dddd&quot;, date, &quot;datetime&quot;)">tisdag</span>
 		</span>
 	</body>
 </html>

--- a/src/Tests/Runtime/DotvvmControlRenderedHtmlTests.cs
+++ b/src/Tests/Runtime/DotvvmControlRenderedHtmlTests.cs
@@ -197,7 +197,7 @@ namespace DotVVM.Framework.Tests.Runtime
         [TestMethod]
         public void Literal_DateTimeToBrowserLocalTime_RenderOnServer()
         {
-            DotvvmTestHelper.RunInCulture(new CultureInfo("en-US"), () =>
+            DotvvmTestHelper.RunInCulture(new CultureInfo("sv"), () =>
             {
                 var vm = new LiteralDateTimeViewModel();
                 var control = $@"@viewModel {vm.GetType().FullName}
@@ -207,7 +207,7 @@ namespace DotVVM.Framework.Tests.Runtime
                 var context = CreateContext(vm);
                 var html = InvokeLifecycleAndRender(dotvvmBuilder.BuildView(context), context);
 
-                Assert.AreEqual(@"<span>1/2/2021 3:04:05 AM</span><span>1/2/2021 3:04:05 AM</span>", html);
+                Assert.AreEqual(@"<span>2021-01-02 03:04:05</span><span>2021-01-02 03:04:05</span>", html);
             });
         }
 


### PR DESCRIPTION
For some reason dotnet prefixes PM/AM  with a different space on different systems. This replaces `en` culture with sv culture in the two problematic and fixes some issues with passing the culture into the DotvvmTestHelper