### PR TITLE
Improve error reporting on tag names

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Building">
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <!-- Disable warning for missing XML doc comments. -->
     <NoWarn>$(NoWarn);CS1591;CS1573</NoWarn>
     <Deterministic>true</Deterministic>

--- a/src/Framework/Framework/Compilation/ControlTree/ControlResolverBase.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ControlResolverBase.cs
@@ -200,6 +200,10 @@ namespace DotVVM.Framework.Compilation.ControlTree
 		/// </summary>
 		protected abstract IControlType FindMarkupControl(string file);
 
+		/// <summary> Returns a list of possible DotVVM controls. </summary>
+		/// <remark>Used only for smart error handling, the list isn't necessarily complete, but doesn't contain false positives.</remark>
+		public abstract IEnumerable<(string tagPrefix, IControlType type)> EnumerateControlTypes();
+
 		/// <summary>
 		/// Gets the control metadata.
 		/// </summary>

--- a/src/Framework/Framework/Compilation/ControlTree/ControlResolverBase.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ControlResolverBase.cs
@@ -202,7 +202,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
 
 		/// <summary> Returns a list of possible DotVVM controls. </summary>
 		/// <remark>Used only for smart error handling, the list isn't necessarily complete, but doesn't contain false positives.</remark>
-		public abstract IEnumerable<(string tagPrefix, IControlType type)> EnumerateControlTypes();
+		public abstract IEnumerable<(string tagPrefix, string? tagName, IControlType type)> EnumerateControlTypes();
 
 		/// <summary>
 		/// Gets the control metadata.

--- a/src/Framework/Framework/Compilation/ControlTree/ControlTreeHelper.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ControlTreeHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using DotVVM.Framework.Compilation.Parser.Dothtml.Parser;
 
@@ -7,7 +7,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
     public static class ControlTreeHelper
     {
         public static bool HasEmptyContent(this IAbstractControl control)
-            => control.Content.All(c => !DothtmlNodeHelper.IsNotEmpty(c.DothtmlNode)); // allow only whitespace literals
+            => control.Content.All(c => DothtmlNodeHelper.IsEmpty(c.DothtmlNode)); // allow only whitespace literals
 
         public static bool HasProperty(this IAbstractControl control, IPropertyDescriptor property)
         {

--- a/src/Framework/Framework/Compilation/ControlTree/DefaultControlTreeResolver.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/DefaultControlTreeResolver.cs
@@ -5,6 +5,7 @@ using DotVVM.Framework.Compilation.ControlTree.Resolved;
 using DotVVM.Framework.Compilation.Directives;
 using DotVVM.Framework.Compilation.Parser.Dothtml.Parser;
 using DotVVM.Framework.Compilation.ViewCompiler;
+using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Compilation.ControlTree
@@ -23,8 +24,9 @@ namespace DotVVM.Framework.Compilation.ControlTree
             IControlResolver controlResolver,
             IAbstractTreeBuilder treeBuilder,
             IControlBuilderFactory controlBuilderFactory,
-            IMarkupDirectiveCompilerPipeline direrectiveCompilerPipeline)
-            : base(controlResolver, treeBuilder, direrectiveCompilerPipeline)
+            IMarkupDirectiveCompilerPipeline direrectiveCompilerPipeline,
+            DotvvmConfiguration configuration)
+            : base(controlResolver, treeBuilder, direrectiveCompilerPipeline, configuration)
         {
             this.controlBuilderFactory = controlBuilderFactory;
         }

--- a/src/Framework/Framework/Compilation/ControlTree/IControlResolver.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/IControlResolver.cs
@@ -29,7 +29,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
 
         /// <summary> Returns a list of possible DotVVM controls. </summary>
         /// <remark>Used only for smart error handling, the list isn't necessarily complete, but doesn't contain false positives.</remark>
-        IEnumerable<(string tagPrefix, IControlType type)> EnumerateControlTypes();
+        IEnumerable<(string tagPrefix, string? tagName, IControlType type)> EnumerateControlTypes();
 
         /// <summary>
         /// Resolves the binding type.

--- a/src/Framework/Framework/Compilation/ControlTree/IControlResolver.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/IControlResolver.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.Runtime;
 
@@ -25,6 +26,10 @@ namespace DotVVM.Framework.Compilation.ControlTree
         /// Resolves the control metadata for specified type.
         /// </summary>
         IControlResolverMetadata ResolveControl(ITypeDescriptor controlType);
+
+        /// <summary> Returns a list of possible DotVVM controls. </summary>
+        /// <remark>Used only for smart error handling, the list isn't necessarily complete, but doesn't contain false positives.</remark>
+        IEnumerable<(string tagPrefix, IControlType type)> EnumerateControlTypes();
 
         /// <summary>
         /// Resolves the binding type.

--- a/src/Framework/Framework/Compilation/ControlTree/ResolvedTreeHelpers.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ResolvedTreeHelpers.cs
@@ -55,7 +55,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
 
         
         public static bool IsOnlyWhitespace(this IAbstractControl control) =>
-            control.Metadata.Type.IsEqualTo(ResolvedTypeDescriptor.Create(typeof(RawLiteral))) && control.DothtmlNode?.IsNotEmpty() == false;
+            control.Metadata.Type.IsEqualTo(ResolvedTypeDescriptor.Create(typeof(RawLiteral))) && control.DothtmlNode?.IsEmpty() == true;
 
         public static bool HasOnlyWhiteSpaceContent(this IAbstractContentNode control) =>
             control.Content.All(IsOnlyWhitespace);

--- a/src/Framework/Framework/Compilation/ControlType.cs
+++ b/src/Framework/Framework/Compilation/ControlType.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Diagnostics;
+using System.Reflection;
 using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Compilation.ControlTree.Resolved;
+using DotVVM.Framework.Controls;
 
 namespace DotVVM.Framework.Compilation
 {
@@ -16,6 +18,10 @@ namespace DotVVM.Framework.Compilation
         ITypeDescriptor IControlType.Type => new ResolvedTypeDescriptor(Type);
 
         ITypeDescriptor? IControlType.DataContextRequirement => ResolvedTypeDescriptor.Create(DataContextRequirement);
+
+        public string PrimaryName => GetControlNames(Type).primary;
+
+        public string[] AlternativeNames => GetControlNames(Type).alternative;
 
         static void ValidateControlClass(Type control)
         {
@@ -33,6 +39,19 @@ namespace DotVVM.Framework.Compilation
             VirtualPath = virtualPath;
             if (dataContextRequirement != typeof(Binding.UnknownTypeSentinel))
                 DataContextRequirement = dataContextRequirement;
+        }
+
+        public static (string primary, string[] alternative) GetControlNames(Type controlType)
+        {
+            var attr = controlType.GetCustomAttribute<ControlMarkupOptionsAttribute>();
+            if (attr is null)
+            {
+                return (controlType.Name, Array.Empty<string>());
+            }
+            else
+            {
+                return (attr.PrimaryName ?? controlType.Name, attr.AlternativeNames ?? Array.Empty<string>());
+            }
         }
 
 

--- a/src/Framework/Framework/Compilation/IControlType.cs
+++ b/src/Framework/Framework/Compilation/IControlType.cs
@@ -11,5 +11,9 @@ namespace DotVVM.Framework.Compilation
 
         ITypeDescriptor? DataContextRequirement { get; }
 
+        string PrimaryName { get; }
+
+        string[] AlternativeNames { get; }
+
     }
 }

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DotHtmlCommentNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DotHtmlCommentNode.cs
@@ -39,5 +39,8 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
         {
             return base.EnumerateNodes().Concat(EnumerateChildNodes().SelectMany(node => node.EnumerateNodes()));
         }
+
+        public override string ToString() =>
+            IsServerSide ? $"<%-- {Value} --%>" : $"<!-- {Value} -->";
     }
 }

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlAttributeNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlAttributeNode.cs
@@ -5,14 +5,14 @@ using DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer;
 
 namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
 {
-    [DebuggerDisplay("{debuggerDisplay,nq}{ValueNode}")]
     public sealed class DothtmlAttributeNode : DothtmlNode
     {
-        #region debugger display
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private string debuggerDisplay =>
-            AttributeFullName + (ValueNode == null ? "" : "=");
-        #endregion
+        public override string ToString() =>
+            AttributeFullName + ValueNode switch {
+                null => "",
+                DothtmlValueBindingNode => $"={ValueNode}",
+                _ => $"=\"{ValueNode}\""
+            };
         public string? AttributePrefix => AttributePrefixNode?.Text;
 
         public string AttributeName => AttributeNameNode.Text;

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlBindingNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlBindingNode.cs
@@ -5,21 +5,12 @@ using DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer;
 
 namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
 {
-    [DebuggerDisplay("{debuggerDisplay,nq}")]
     public class DothtmlBindingNode : DothtmlNode
     {
-
-        #region debugger display
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private string debuggerDisplay
+        public override string ToString()
         {
-            get
-            {
-                return "{" + Name + ": " + Value + "}";
-            }
+            return "{" + Name + ": " + Value + "}";
         }
-        #endregion
-
 
         public DothtmlBindingNode(DothtmlToken startToken, DothtmlToken endToken, DothtmlToken separatorToken, DothtmlNameNode nameNode, DothtmlValueTextNode valueNode)
         {

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlDirectiveNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlDirectiveNode.cs
@@ -39,5 +39,7 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
         {
             return base.EnumerateNodes().Concat( EnumerateChildNodes().SelectMany(node => node.EnumerateNodes() ) );
         }
+
+        public override string ToString() => $"@{Name} {Value}";
     }
 }

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlElementNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlElementNode.cs
@@ -5,19 +5,12 @@ using DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer;
 
 namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
 {
-    [DebuggerDisplay("{debuggerDisplay,nq}")]
     public sealed class DothtmlElementNode : DothtmlNodeWithContent
     {
-        #region debugger display
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private string debuggerDisplay
+        public override string ToString()
         {
-            get
-            {
-                return "<" + (IsClosingTag ? "/" : "") + FullTagName + (Attributes.Any() ? " ..." : "") + (IsSelfClosingTag ? " /" : "") + ">";
-            }
+            return "<" + (IsClosingTag ? "/" : "") + FullTagName + (Attributes.Any() ? " ..." : "") + (IsSelfClosingTag ? " /" : "") + ">";
         }
-        #endregion
 
         public string TagName => TagNameNode.Text;
         public string? TagPrefix => TagPrefixNode?.Text;

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlLiteralNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlLiteralNode.cs
@@ -5,7 +5,6 @@ using DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer;
 
 namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
 {
-    [DebuggerDisplay("{Value}")]
     public sealed class DothtmlLiteralNode : DothtmlNode
     {
         public DothtmlToken? MainValueToken { get; set; }
@@ -20,5 +19,7 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
         {
             visitor.Visit(this);
         }
+
+        public override string ToString() => Value;
     }
 }

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlNodeHelper.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlNodeHelper.cs
@@ -5,11 +5,13 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
 {
     public static class DothtmlNodeHelper
     {
-        public static bool IsNotEmpty([NotNullWhen(true)] this DothtmlNode? node)
+        public static bool IsNotEmpty([NotNullWhen(true)] this DothtmlNode? node) =>
+            !IsEmpty(node);
+
+        public static bool IsEmpty([NotNullWhen(false)] this DothtmlNode? node)
         {
-            return node is object &&
-                   !(node is DotHtmlCommentNode) &&
-                   !(node is DothtmlLiteralNode literalNode && string.IsNullOrWhiteSpace(literalNode.Value));
+            return node is null or DotHtmlCommentNode ||
+                   (node is DothtmlLiteralNode literalNode && string.IsNullOrWhiteSpace(literalNode.Value));
         }
 
         public static int GetContentStartPosition(this DothtmlElementNode node)

--- a/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlValueBindingNode.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/Parser/DothtmlValueBindingNode.cs
@@ -39,5 +39,7 @@ namespace DotVVM.Framework.Compilation.Parser.Dothtml.Parser
         {
             return base.EnumerateNodes().Concat(EnumerateChildNodes().SelectMany(n=> n.EnumerateNodes()));
         }
+
+        public override string ToString() => BindingNode.ToString();
     }
 }

--- a/src/Framework/Framework/Utils/StringSimilarity.cs
+++ b/src/Framework/Framework/Utils/StringSimilarity.cs
@@ -4,7 +4,7 @@ namespace DotVVM.Framework.Utils
 {
     internal static class StringSimilarity
     {
-        /// <summary> Edit distance with deletion (Visble), insertion (Visivble), substitution (Visine) and transposition (Visilbe) </summary>
+        /// <summary> Edit distance with deletion (Visble), insertion (Visivble), substitution (Visinle) and transposition (Visilbe) </summary>
         public static int DamerauLevenshteinDistance(string a, string b)
         {
             // https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance

--- a/src/Samples/Tests/Tests/ErrorsTests.cs
+++ b/src/Samples/Tests/Tests/ErrorsTests.cs
@@ -57,7 +57,7 @@ namespace DotVVM.Samples.Tests
                             s.Contains("could not be resolved")
                             );
                 AssertUI.InnerTextEquals(browser.First("[class='errorUnderline']")
-                    , "<dot:NonExistingControl />", false);
+                    , "NonExistingControl", false);
             });
         }
 

--- a/src/Tests/ControlTests/CompositeControlTests.cs
+++ b/src/Tests/ControlTests/CompositeControlTests.cs
@@ -282,7 +282,7 @@ namespace DotVVM.Framework.Tests.ControlTests
                     <cc:ControlWithCollectionProperty> <Repeaters> <bazmek /> </Repeaters> </cc:ControlWithCollectionProperty>
                 "));
 
-            Assert.AreEqual("Control type DotVVM.Framework.Controls.HtmlGenericControl can't be used in collection of type DotVVM.Framework.Controls.Repeater.", e.Message);
+            Assert.AreEqual("Control type DotVVM.Framework.Controls.HtmlGenericControl can't be used in a property of type DotVVM.Framework.Controls.Repeater.", e.Message);
         }
 
         [TestMethod]

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/DefaultControlTreeResolverTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/DefaultControlTreeResolverTests.cs
@@ -218,6 +218,22 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
             Assert.AreEqual("The control <bp:Button> could not be resolved! Did you mean dot:Button, or other DotVVM control? Otherwise, make sure that the tagPrefix 'bp' is registered in DotvvmConfiguration.Markup.Controls collection!", XAssert.Single(node.NodeErrors));
         }
 
+
+        [TestMethod]
+        public void ResolvedTree_SimilarToMarkupControl()
+        {
+            var root = ParseSource(@"@viewModel string
+<cmc:ControlWithPropertyDirectives />
+<cmc:ControlWithGazeType />
+");
+
+            var controls = root.Content.Where(c => !c.IsOnlyWhitespace()).ToArray();
+            var node = (controls[0].DothtmlNode as DothtmlElementNode).TagNameNode;
+            Assert.AreEqual("The control <cmc:ControlWithPropertyDirectives> could not be resolved! Did you mean cmc:ControlWithPropertyDirective, or other DotVVM control?", XAssert.Single(node.NodeErrors));
+            node = (controls[1].DothtmlNode as DothtmlElementNode).TagNameNode;
+            Assert.AreEqual("The control <cmc:ControlWithGazeType> could not be resolved! Did you mean cmc:ControlWithBaseType, or other DotVVM control?", XAssert.Single(node.NodeErrors));
+        }
+
         [TestMethod]
         public void ResolvedTree_ElementProperty()
         {

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/DefaultControlTreeResolverTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/DefaultControlTreeResolverTests.cs
@@ -201,10 +201,21 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
             Assert.AreEqual(typeof(HtmlGenericControl), control.Metadata.Type);
             Assert.AreEqual(1, control.ConstructorParameters.Length);
             Assert.AreEqual("dot:xxxButton", control.ConstructorParameters[0]);
-            Assert.IsTrue(control.DothtmlNode.HasNodeErrors);
-            Assert.IsTrue(control.DothtmlNode.NodeErrors.First().Contains("could not be resolved"));
+            var node = (control.DothtmlNode as DothtmlElementNode).TagNameNode;
+            Assert.AreEqual("The control <dot:xxxButton> could not be resolved! Did you mean dot:LinkButton, dot:Button, or other DotVVM control?", XAssert.Single(node.NodeErrors));
 
             Assert.AreEqual(root, control.Parent);
+        }
+
+        [TestMethod]
+        public void ResolvedTree_UnknownPrefix()
+        {
+            var root = ParseSource(@"@viewModel string
+<bp:Button />");
+
+            var control = root.Content.First();
+            var node = (control.DothtmlNode as DothtmlElementNode).TagNameNode;
+            Assert.AreEqual("The control <bp:Button> could not be resolved! Did you mean dot:Button, or other DotVVM control? Otherwise, make sure that the tagPrefix 'bp' is registered in DotvvmConfiguration.Markup.Controls collection!", XAssert.Single(node.NodeErrors));
         }
 
         [TestMethod]

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/DefaultControlTreeResolverTestsBase.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/DefaultControlTreeResolverTestsBase.cs
@@ -1,7 +1,11 @@
-﻿using DotVVM.Framework.Compilation.ControlTree.Resolved;
+﻿using DotVVM.Framework.Binding;
+using DotVVM.Framework.Compilation.ControlTree.Resolved;
 using DotVVM.Framework.Configuration;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Hosting;
 using DotVVM.Framework.Testing;
 using DotVVM.Framework.Tests.Runtime.ControlTree.DefaultControlTreeResolver;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DotVVM.Framework.Tests.Runtime.ControlTree
 {
@@ -11,13 +15,43 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
 
         static DefaultControlTreeResolverTestsBase()
         {
-            configuration = DotvvmTestHelper.CreateConfiguration();
+            var fakeMarkupFileLoader = new FakeMarkupFileLoader() {
+                MarkupFiles = {
+                    ["ControlWithBaseType.dotcontrol"] = """
+                        @viewModel object
+                        @baseType DotVVM.Framework.Tests.Runtime.ControlTree.DefaultControlTreeResolverTestsBase.TestMarkupControl1
+
+                        {{value: Text}}
+                        """,
+                    ["ControlWithPropertyDirective.dotcontrol"] = """
+                        @viewModel object
+                        @property string Text
+
+                        {{value: Text}}
+                        """
+                }
+            };
+            configuration = DotvvmTestHelper.CreateConfiguration(s => {
+                s.AddSingleton<IMarkupFileLoader>(fakeMarkupFileLoader);
+            });
             configuration.Markup.AddCodeControls("cc", typeof(ClassWithInnerElementProperty));
+            configuration.Markup.AddMarkupControl("cmc", "ControlWithBaseType", "ControlWithBaseType.dotcontrol");
+            configuration.Markup.AddMarkupControl("cmc", "ControlWithPropertyDirective", "ControlWithPropertyDirective.dotcontrol");
             configuration.Freeze();
         }
 
         protected ResolvedTreeRoot ParseSource(string markup, string fileName = "default.dothtml", bool checkErrors = false) =>
            DotvvmTestHelper.ParseResolvedTree(markup, fileName, configuration, checkErrors);
 
+        public class TestMarkupControl1: DotvvmMarkupControl
+        {
+            public string Text 
+            {
+                get { return (string)GetValue(TextProperty); }
+                set { SetValue(TextProperty, value); }
+            }
+            public static readonly DotvvmProperty TextProperty =
+                DotvvmProperty.Register<string, TestMarkupControl1>(nameof(Text));
+        }
     }
 }

--- a/src/Tests/Runtime/ViewCompilationServiceTests.cs
+++ b/src/Tests/Runtime/ViewCompilationServiceTests.cs
@@ -88,7 +88,7 @@ namespace DotVVM.Framework.Tests.Runtime
             service.BuildView(route, out _);
             Assert.AreEqual(CompilationState.CompilationFailed, route.Status);
             Assert.IsNotNull(route.Exception);
-            Assert.AreEqual("The control <test:ThisControlDoesNotExist> could not be resolved! Make sure that the tagPrefix is registered in DotvvmConfiguration.Markup.Controls collection!", route.Exception);
+            Assert.AreEqual("The control <test:ThisControlDoesNotExist> could not be resolved!", route.Exception);
         }
 
         [TestMethod]


### PR DESCRIPTION
Mainly adds warnings and more detailed errors to cover some rough edges of inner element properties.
Also includes similarity matching of control types.