### PR TITLE
Use grouped operation name in application insights telemetry

### DIFF
--- a/src/Tracing/ApplicationInsights.AspNetCore/OperationNameTelemetryInitializer.cs
+++ b/src/Tracing/ApplicationInsights.AspNetCore/OperationNameTelemetryInitializer.cs
@@ -1,0 +1,31 @@
+﻿using DotVVM.Framework.Hosting;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.AspNetCore.Http;
+
+namespace DotVVM.Tracing.ApplicationInsights.AspNetCore;
+
+public class OperationNameTelemetryInitializer : ITelemetryInitializer
+{
+    private readonly IHttpContextAccessor _accessor;
+
+    public OperationNameTelemetryInitializer(IHttpContextAccessor accessor)
+    {
+        _accessor = accessor;
+    }
+
+    public void Initialize(ITelemetry telemetry)
+    {
+        var url = _accessor.HttpContext?.GetDotvvmContext()?.Route?.Url;
+        if (string.IsNullOrWhiteSpace(url) == false && telemetry is RequestTelemetry)
+        {
+            var method = _accessor.HttpContext.Request.Method;
+            var operationName = $"{method} /{url}";
+
+            var requestTelemetry = telemetry as RequestTelemetry;
+            requestTelemetry.Name = operationName;
+            requestTelemetry.Context.Operation.Name = operationName;
+        }
+    }
+}

--- a/src/Tracing/ApplicationInsights.AspNetCore/OperationNameTelemetryInitializer.cs
+++ b/src/Tracing/ApplicationInsights.AspNetCore/OperationNameTelemetryInitializer.cs
@@ -17,10 +17,11 @@ public class OperationNameTelemetryInitializer : ITelemetryInitializer
 
     public void Initialize(ITelemetry telemetry)
     {
-        var url = _accessor.HttpContext?.GetDotvvmContext()?.Route?.Url;
-        if (string.IsNullOrWhiteSpace(url) == false && telemetry is RequestTelemetry)
+        var context = _accessor.HttpContext;
+        var url = context?.GetDotvvmContext()?.Route?.Url;
+        if (url != null && telemetry is RequestTelemetry)
         {
-            var method = _accessor.HttpContext.Request.Method;
+            var method = context.Request.Method;
             var operationName = $"{method} /{url}";
 
             var requestTelemetry = telemetry as RequestTelemetry;

--- a/src/Tracing/ApplicationInsights.AspNetCore/TracingBuilderExtensions.cs
+++ b/src/Tracing/ApplicationInsights.AspNetCore/TracingBuilderExtensions.cs
@@ -30,6 +30,7 @@ namespace DotVVM.Framework.Configuration
             services.AddDotvvmApplicationInsights();
 
             services.Services.AddApplicationInsightsTelemetryProcessor<RequestTelemetryFilter>();
+            services.Services.AddSingleton<ITelemetryInitializer, OperationNameTelemetryInitializer>();
 
             services.Services.TryAddSingleton<JavaScriptSnippet>();
             services.Services.AddTransient<IConfigureOptions<DotvvmConfiguration>, ApplicationInsightSetup>();

--- a/src/Tracing/ApplicationInsights.Owin/DotVVM.Tracing.ApplicationInsights.Owin.csproj
+++ b/src/Tracing/ApplicationInsights.Owin/DotVVM.Tracing.ApplicationInsights.Owin.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Owin.Host.SystemWeb" Version="4.2.2" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Tracing/ApplicationInsights.Owin/OperationNameTelemetryInitializer.cs
+++ b/src/Tracing/ApplicationInsights.Owin/OperationNameTelemetryInitializer.cs
@@ -1,0 +1,24 @@
+﻿using System.Web;
+using DotVVM.Framework.Hosting;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.Channel;
+
+namespace DotVVM.Tracing.ApplicationInsights.Owin;
+
+public class OperationNameTelemetryInitializer : ITelemetryInitializer
+{
+    public void Initialize(ITelemetry telemetry)
+    {
+        var url = HttpContext.Current?.GetOwinContext()?.GetDotvvmContext()?.Route?.Url;
+        if (string.IsNullOrWhiteSpace(url) == false && telemetry is RequestTelemetry)
+        {
+            var method = HttpContext.Current.Request.HttpMethod;
+            var operationName = $"{method} /{url}";
+
+            var requestTelemetry = telemetry as RequestTelemetry;
+            requestTelemetry.Name = operationName;
+            requestTelemetry.Context.Operation.Name = operationName;
+        }
+    }
+}

--- a/src/Tracing/ApplicationInsights.Owin/OperationNameTelemetryInitializer.cs
+++ b/src/Tracing/ApplicationInsights.Owin/OperationNameTelemetryInitializer.cs
@@ -10,10 +10,11 @@ public class OperationNameTelemetryInitializer : ITelemetryInitializer
 {
     public void Initialize(ITelemetry telemetry)
     {
-        var url = HttpContext.Current?.GetOwinContext()?.GetDotvvmContext()?.Route?.Url;
-        if (string.IsNullOrWhiteSpace(url) == false && telemetry is RequestTelemetry)
+        var context = HttpContext.Current;
+        var url = context?.GetOwinContext()?.GetDotvvmContext()?.Route?.Url;
+        if (url != null && telemetry is RequestTelemetry)
         {
-            var method = HttpContext.Current.Request.HttpMethod;
+            var method = context.Request.HttpMethod;
             var operationName = $"{method} /{url}";
 
             var requestTelemetry = telemetry as RequestTelemetry;

--- a/src/Tracing/ApplicationInsights.Owin/TracingBuilderExtensions.cs
+++ b/src/Tracing/ApplicationInsights.Owin/TracingBuilderExtensions.cs
@@ -18,6 +18,7 @@ namespace DotVVM.Framework.Configuration
         public static IDotvvmServiceCollection AddApplicationInsightsTracing(this IDotvvmServiceCollection services)
         {
             TelemetryConfiguration.Active.TelemetryProcessorChainBuilder.Use(next => new RequestTelemetryFilter(next)).Build();
+            TelemetryConfiguration.Active.TelemetryInitializers.Add(new OperationNameTelemetryInitializer());
 
             services.Services.TryAddSingleton<TelemetryClient>();
             services.AddDotvvmApplicationInsights();


### PR DESCRIPTION
Application insights request telemetry on DOTVVM pages is identified by request URL. If there are path variables app insights considers them as different operations and does not apply grouping. Results are hard to read with tables consisted of many rows pointing to the same route.

![image](https://github.com/riganti/dotvvm/assets/13980038/6deac8bc-a399-4b4b-b0da-da11030081e0)

I was inspired by Web API where operation name ignores variables and used DOTVVM route URL as new name. I was also considering DOTVVM route name, but from my experience URL is always provided by problem reporter (imagine non IT users as reporters) but route name can be more problematic to guess at first look. 

![image](https://github.com/riganti/dotvvm/assets/13980038/f822ce67-0ec1-4da3-bc5c-8e4489ed65e0)

As you can see on second screenshot "vyuctovanie" was grouped and I can see overal behavior of this page.