### PR TITLE
Fixed too early initialization of view compilation service

### DIFF
--- a/src/Framework/Hosting.AspNetCore/Hosting/DotvvmHealthCheck.cs
+++ b/src/Framework/Hosting.AspNetCore/Hosting/DotvvmHealthCheck.cs
@@ -47,14 +47,14 @@ namespace DotVVM.Framework.Hosting
 
         public static void RegisterHealthCheck(IServiceCollection services)
         {
-            services.ConfigureWithServices<HealthCheckServiceOptions>((options, s) => {
+            services.Configure<HealthCheckServiceOptions>(options => {
                 if (options.Registrations.Any(c => c.Name == "DotVVM"))
                     return;
 
                 options.Registrations.Add(
                     new HealthCheckRegistration(
                         "DotVVM",
-                        ActivatorUtilities.CreateInstance<DotvvmHealthCheck>(s),
+                        s => ActivatorUtilities.CreateInstance<DotvvmHealthCheck>(s),
                         null,
                         new [] { "dotvvm" }
                     )


### PR DESCRIPTION
Adding HealthChecks this way caused `IDotvvmViewCompilationService` and `DotvvmConfiguration` to resolve too early on the startup. 
Because of that, `configuration.Debug` was not set yet to `true` and even in the development mode, DotVVM was not reloading modified markup files until the application got restarted.

This PR goes to `4.2`, but we should cherry-pick it to `main` also. 