### PR TITLE
Fix global resource registration in master pages

### DIFF
--- a/src/Framework/Testing/ControlTestHelper.cs
+++ b/src/Framework/Testing/ControlTestHelper.cs
@@ -134,7 +134,7 @@ namespace DotVVM.Framework.Testing
             ClaimsPrincipal? user = null,
             CultureInfo? culture = null)
         {
-            if (!markup.Contains("<body"))
+            if (!markup.Contains("<body") && !markup.Contains("<dot:Content"))
             {
                 markup = $"<body Validation.Enabled=false >\n{markup}\n{(renderResources ? "" : "<tc:FakeBodyResourceLink />")}\n</body>";
             }
@@ -142,7 +142,7 @@ namespace DotVVM.Framework.Testing
             {
                 markup = "<tc:FakeBodyResourceLink />" + markup;
             }
-            if (!markup.Contains("<head"))
+            if (!markup.Contains("<head") && !markup.Contains("<dot:Content"))
             {
                 markup = $"<head></head>\n{markup}";
             }

--- a/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.AddResourceWithMasterPage.html
+++ b/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.AddResourceWithMasterPage.html
@@ -1,0 +1,53 @@
+    
+    <head>
+        
+        
+    
+    
+    <!-- Resource knockout of type ScriptResource. Pointing to EmbeddedResourceLocation. -->
+    <script src=/dotvvmResource/knockout/knockout defer></script>
+    <!-- Resource dotvvm.internal of type ScriptModuleResource. Pointing to EmbeddedResourceLocation. -->
+    <script src=/dotvvmResource/dotvvm--internal/dotvvm--internal type=module defer></script>
+    <!-- Resource dotvvm of type InlineScriptResource. -->
+    
+    <!-- Resource dotvvm.debug of type ScriptResource. Pointing to EmbeddedResourceLocation. -->
+    <script src=/dotvvmResource/dotvvm--debug/dotvvm--debug defer></script>
+</head>
+    <body>
+        
+        <div class=master1>
+            
+        real body
+    
+        </div>
+    
+    
+    <!-- Resource test-resource4 of type InlineScriptResource. -->
+    <script>alert(4)</script>
+    <!-- Resource test-resource3 of type InlineScriptResource. -->
+    <script>alert(3)</script>
+    <!-- Resource test-resource2 of type InlineScriptResource. -->
+    <script>alert(2)</script>
+    <!-- Resource test-resource5 of type InlineScriptResource. -->
+    <script>alert(5)</script>
+    <!-- Resource test-resource1 of type InlineScriptResource. -->
+    <script>alert(1)</script>
+<input type=hidden id=__dot_viewmodel_root value='{
+  "viewModel": {
+    "$csrfToken": "Not a CSRF token."
+  },
+  "url": "/testpage",
+  "virtualDirectory": "",
+  "renderedResources": [
+    "knockout",
+    "dotvvm.internal",
+    "dotvvm",
+    "dotvvm.debug",
+    "test-resource4",
+    "test-resource3",
+    "test-resource2",
+    "test-resource5",
+    "test-resource1"
+  ],
+  "typeMetadata": {}
+}' /><script defer src="data:text/javascript;base64,ZG90dnZtLm9wdGlvbnMuY29tcHJlc3NQT1NUPWZhbHNlOwp3aW5kb3cuZG90dnZtLmluaXQoImVuLVVTIik7"></script></body>


### PR DESCRIPTION
When the RequiredResource controls are added at the end of the page, the DefaultDotvvmViewBuilder would crash.
This patch specialcases the RequiredResource - since it doesn't render anything, it's safe to include anywhere