### PR TITLE
Changed type casting of ChromeDriver to ChromiumDriver - MS Edge fix

### DIFF
--- a/src/Samples/Tests/Tests/Complex/SPAErrorReportingTests.cs
+++ b/src/Samples/Tests/Tests/Complex/SPAErrorReportingTests.cs
@@ -32,7 +32,7 @@ namespace DotVVM.Samples.Tests.Complex
 
                 void SetOfflineMode(bool offline)
                 {
-                    ((ChromeDriver)browser.Driver).NetworkConditions = new ChromiumNetworkConditions() {
+                    ((ChromiumDriver)browser.Driver).NetworkConditions = new ChromiumNetworkConditions() {
                         IsOffline = offline,
                         Latency = TimeSpan.FromMilliseconds(5),
                         DownloadThroughput = 500 * 1024,


### PR DESCRIPTION
Test Complex_SPAErrorReporting_NavigationAndPostbacks is failing when run on MS Edge due to wrong type casting.