### PR TITLE
Fix SelectorItem with boolean value

### DIFF
--- a/src/Framework/Framework/Binding/ValueOrBinding.cs
+++ b/src/Framework/Framework/Binding/ValueOrBinding.cs
@@ -160,6 +160,15 @@ namespace DotVVM.Framework.Binding
                 return processValue(this.Evaluate(control)!);
         }
 
+        /// <summary> If this contains a `resource` binding, it is evaluated and its value placed in <see cref="Value" /> property. `value`, and all other bindings are untouched and remain in the <see cref="Binding"/> property. </summary>
+        public ValueOrBinding<T?> EvaluateResourceBinding(DotvvmBindableObject control)
+        {
+            if (binding is null or IValueBinding or not IStaticValueBinding) return this;
+
+            var value = this.Evaluate(control);
+            return new ValueOrBinding<T?>(value);
+        }
+
         public static explicit operator ValueOrBinding<T>(T val) => new ValueOrBinding<T>(val);
 
         public const string EqualsDisabledReason = "Equals is disabled on ValueOrBinding<T> as it may lead to unexpected behavior. Please use object.ReferenceEquals for reference comparison or evaluate the ValueOrBinding<T> and compare the value. Or use IsNull/NotNull for nullchecks on bindings.";

--- a/src/Framework/Framework/Controls/SelectorItem.cs
+++ b/src/Framework/Framework/Controls/SelectorItem.cs
@@ -51,7 +51,16 @@ namespace DotVVM.Framework.Controls
 
         protected override void AddAttributesToRender(IHtmlWriter writer, IDotvvmRequestContext context)
         {
-            writer.AddAttribute("value", Value + "");
+            var value = this.GetValueOrBinding<object>(ValueProperty).EvaluateResourceBinding(this);
+            if (value.ValueOrDefault is string s)
+            {
+                writer.AddAttribute("value", s);
+            }
+            else
+            {
+                // anything else than string is better to pass as knockout value binding to avoid issues with `false != 'false'`, ...
+                writer.AddKnockoutDataBind("value", value.GetJsExpression(this));
+            }
             base.AddAttributesToRender(writer, context);
         }
 

--- a/src/Framework/Framework/Resources/Scripts/metadata/primitiveTypes.ts
+++ b/src/Framework/Framework/Resources/Scripts/metadata/primitiveTypes.ts
@@ -26,7 +26,7 @@ export const primitiveTypes: PrimitiveTypes = {
             } else if (value === "true" || value === "True") {
                 return { value: true, wasCoerced: true };
             } else if (value === "false" || value === "False") {
-                return { value: true, wasCoerced: true };
+                return { value: false, wasCoerced: true };
             } else if (typeof value === "number") {
                 return { value: !!value, wasCoerced: true };
             }

--- a/src/Framework/Framework/Resources/Scripts/tests/coercer.test.ts
+++ b/src/Framework/Framework/Resources/Scripts/tests/coercer.test.ts
@@ -449,10 +449,30 @@ test("boolean - valid, converted from number", () => {
     expect(result.value).toEqual(true);
 })
 
-test("boolean - valid, converted from string", () => {
+test("boolean - valid, true converted from string", () => {
     const result = tryCoerce("true", "Boolean");
     expect(result.wasCoerced).toBeTruthy();
     expect(result.value).toEqual(true);
+})
+
+test("boolean - valid, false converted from string", () => {
+    const result = tryCoerce("false", "Boolean");
+    expect(result.wasCoerced).toBeTruthy();
+    expect(result.value).toEqual(false);
+})
+test("boolean - valid, False converted from string", () => {
+    const result = tryCoerce("False", "Boolean");
+    expect(result.wasCoerced).toBeTruthy();
+    expect(result.value).toEqual(false);
+})
+
+test("boolean - invalid, invalid string", () => {
+    const result = tryCoerce("", "Boolean");
+    expect(result.isError).toBeTruthy();
+})
+test("boolean - invalid, invalid string", () => {
+    const result = tryCoerce("bazmek", "Boolean");
+    expect(result.isError).toBeTruthy();
 })
 
 test("boolean - invalid, null", () => {

--- a/src/Samples/Common/ViewModels/ControlSamples/ComboBox/ComboBoxBooleanViewModel.cs
+++ b/src/Samples/Common/ViewModels/ControlSamples/ComboBox/ComboBoxBooleanViewModel.cs
@@ -1,0 +1,11 @@
+namespace DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.ComboBox
+{
+    public class ComboBoxBooleanViewModel
+    {
+        public bool? NullableSelectedValue { get; set; }
+        public bool NonNullableSelectedValue { get; set; }
+
+        public bool[] Items { get; } = new bool[] { true, false };
+        public bool?[] NullableItems { get; } = new bool?[] { true, false, null };
+    }
+}

--- a/src/Samples/Common/Views/ControlSamples/ComboBox/BooleanProperty.dothtml
+++ b/src/Samples/Common/Views/ControlSamples/ComboBox/BooleanProperty.dothtml
@@ -1,0 +1,60 @@
+@viewModel DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.ComboBox.ComboBoxBooleanViewModel
+
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>Hello from DotVVM!</title>
+    <style>
+        .invalid {
+            color: red;
+        }
+    </style>
+    <dot:RequiredResource Name="globalize:cs-CZ" />
+</head>
+<body>
+    <p>
+        Demonstrates ComboBox working when bound to <code>bool</code> or <code>bool?</code>. Each table column should display the same value.
+    </p>
+    <table>
+        <tr>
+            <th></th>
+            <th>Nullable boolean</th>
+            <th>Non-nullable boolean</th>
+        </tr>
+        <tr>
+            <th>Current values</th>
+            <td data-ui='value-n'>
+                {{value: NullableSelectedValue == null ? "null" : NullableSelectedValue}}
+            </td>
+            <td data-ui='value-nn'>
+                {{value: NonNullableSelectedValue.ToString()}}
+            </td>
+        </tr>
+        <tr>
+            <th>DataSource</th>
+            <td>
+                <dot:ComboBox DataSource="{value: NullableItems}" SelectedValue="{value: NullableSelectedValue}" data-ui="cb1-n" />
+            </td>
+            <td>
+                <dot:ComboBox DataSource="{value: Items}" SelectedValue="{value: NonNullableSelectedValue}" data-ui="cb1-nn" />
+            </td>
+        </tr>
+        <tr>
+            <th>Hardcoded items</th>
+            <td>
+                <dot:ComboBox SelectedValue="{value: NullableSelectedValue}" data-ui="cb2-n">
+                    <dot:SelectorItem Text="TRUE" Value={value: true} />
+                    <dot:SelectorItem Text="FALSE" Value={value: false} />
+                    <dot:SelectorItem Text="NULL" Value={value: null} />
+                </dot:ComboBox>
+            </td>
+            <td>
+                <dot:ComboBox SelectedValue="{value: NonNullableSelectedValue}" data-ui="cb2-nn">
+                    <dot:SelectorItem Text="TRUE" Value={value: true} />
+                    <dot:SelectorItem Text="FALSE" Value={value: false} />
+                </dot:ComboBox>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
@@ -56,6 +56,7 @@ namespace DotVVM.Testing.Abstractions
         public const string ControlSamples_CheckBox_InRepeater = "ControlSamples/CheckBox/InRepeater";
         public const string ControlSamples_ClaimView_ClaimViewTest = "ControlSamples/ClaimView/ClaimViewTest";
         public const string ControlSamples_ComboBox_BindingCTValidation_StringToEnum = "ControlSamples/ComboBox/BindingCTValidation_StringToEnum";
+        public const string ControlSamples_ComboBox_BooleanProperty = "ControlSamples/ComboBox/BooleanProperty";
         public const string ControlSamples_ComboBox_Default = "ControlSamples/ComboBox/Default";
         public const string ControlSamples_ComboBox_DelaySync = "ControlSamples/ComboBox/DelaySync";
         public const string ControlSamples_ComboBox_DelaySync2 = "ControlSamples/ComboBox/DelaySync2";

--- a/src/Samples/Tests/Tests/Control/ComboBoxTests.cs
+++ b/src/Samples/Tests/Tests/Control/ComboBoxTests.cs
@@ -1,9 +1,11 @@
 ﻿using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
+using OpenQA.Selenium.Support.UI;
 using Riganti.Selenium.Core;
 using Riganti.Selenium.DotVVM;
 using Xunit;
 using Xunit.Abstractions;
+using Xunit.Sdk;
 
 namespace DotVVM.Samples.Tests.Control
 {
@@ -295,6 +297,31 @@ namespace DotVVM.Samples.Tests.Control
                 }
             });
         }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Control_ComboBox_BooleanProperty(bool nullable)
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.ControlSamples_ComboBox_BooleanProperty);
+                var suffix = nullable ? "-n" : "-nn";
+                var values = nullable ? new bool?[] {true, false, null, false, true} : new bool?[] { true, false, false, true };
+
+                foreach (var selectedBox in new [] { "cb1", "cb2" })
+                {
+                    foreach (var v in values)
+                    {
+                        var index = v switch { true => 0, false => 1, null => 2 };
+                        browser.Single(selectedBox + suffix, SelectByDataUi).Select(index);
+                        AssertUI.InnerTextEquals(browser.Single("value" + suffix, SelectByDataUi), v?.ToString() ?? "null");
+                        Assert.Equal(new SelectElement(browser.Single("cb1" + suffix, SelectByDataUi).WebElement).SelectedOption.Text, v?.ToString().ToLowerInvariant() ?? "");
+                        Assert.Equal(new SelectElement(browser.Single("cb2" + suffix, SelectByDataUi).WebElement).SelectedOption.Text, v?.ToString().ToUpperInvariant() ?? "NULL");
+                    }
+                }
+            });
+        }
+
 
     }
 }


### PR DESCRIPTION
* broken JS coercion from 'false' to boolean fixed
* SelectorItems renders all non-string values as `data-bind='value: value'`. Knockout.js then reads the value binding instead of the value attribute, so we avoid the roundtrip through strings

resolves  #1812