### PR TITLE
Updated actions/setup-dotnet to version 4

### DIFF
--- a/.github/setup/action.yml
+++ b/.github/setup/action.yml
@@ -32,7 +32,7 @@ runs:
     shell: bash
 
   # .NET
-  - uses: actions/setup-dotnet@v3
+  - uses: actions/setup-dotnet@v4
     with:
       dotnet-version: |
         8.0.x


### PR DESCRIPTION
This PR solves faulty .net installation on macos-latest 