### PR TITLE
Remove defer attribute from `<script type=module` elements

### DIFF
--- a/src/Framework/Framework/ResourceManagement/ResourceRepositoryExtensions.cs
+++ b/src/Framework/Framework/ResourceManagement/ResourceRepositoryExtensions.cs
@@ -53,7 +53,9 @@ namespace DotVVM.Framework.ResourceManagement
             string[]? dependencies = null,
             string? integrityHash = null)
         {
-            LinkResourceBase r = module ? new ScriptModuleResource(location, defer) : new ScriptResource(location, defer);
+            if (!defer && module)   
+                throw new ArgumentException("<script type='module'> always deferred, please do not specify defer: false", nameof(defer));
+            LinkResourceBase r = module ? new ScriptModuleResource(location) : new ScriptResource(location, defer);
             r.Dependencies = dependencies ?? Array.Empty<string>();
             r.IntegrityHash = integrityHash;
             repo.Register(name, r);
@@ -75,13 +77,25 @@ namespace DotVVM.Framework.ResourceManagement
         /// <summary> Registers a <see cref="ScriptModuleResource" /> from the specified file.
         /// The file can be anywhere in the filesystem, it does not have to be in the wwwroot folder.
         /// DotVVM will handle its serving, caching, ... automatically </summary>
+        [Obsolete("<script type='module'> is always deferred, the attribute does nothing")]
         public static LinkResourceBase RegisterScriptModuleFile(
             this DotvvmResourceRepository repo,
             string name,
             string filePath,
-            bool defer = true,
             string[]? dependencies = null) =>
-            repo.RegisterScript(name, new FileResourceLocation(filePath), defer, module: true, dependencies);
+            repo.RegisterScript(name, new FileResourceLocation(filePath), defer: true, module: true, dependencies);
+
+        /// <summary> Registers a <see cref="ScriptModuleResource" /> from the specified file.
+        /// The file can be anywhere in the filesystem, it does not have to be in the wwwroot folder.
+        /// DotVVM will handle its serving, caching, ... automatically </summary>
+        [Obsolete("<script type='module'> is always deferred, the attribute does nothing")]
+        public static LinkResourceBase RegisterScriptModuleFile(
+            this DotvvmResourceRepository repo,
+            string name,
+            string filePath,
+            bool defer,
+            string[]? dependencies = null) =>
+            repo.RegisterScript(name, new FileResourceLocation(filePath), defer: true, module: true, dependencies);
 
         /// <summary> Registers a <see cref="ScriptResource" /> with the specified URL.
         /// If the URL is local, consider using the <see cref="RegisterScriptFile(DotvvmResourceRepository, string, string, bool, bool, string[])" /> method. </summary>

--- a/src/Framework/Framework/ResourceManagement/ScriptModuleResource.cs
+++ b/src/Framework/Framework/ResourceManagement/ScriptModuleResource.cs
@@ -14,10 +14,19 @@ namespace DotVVM.Framework.ResourceManagement
     {
         [Obsolete("We don't support IE anymore", error: true)]
         public IResourceLocation? NomoduleLocation { get; }
-        /// <summary> If `defer` attribute should be used. </summary>
-        public bool Defer { get; }
 
-        public ScriptModuleResource(IResourceLocation location, bool defer = true)
+
+        [Obsolete("<script type='module'> is always deferred, the attribute does nothing")]
+        public bool Defer { get; }
+        bool IDeferrableResource.Defer => true;
+
+        public ScriptModuleResource(IResourceLocation location)
+            : base(ResourceRenderPosition.Anywhere, "text/javascript", location)
+        {
+        }
+
+        [Obsolete("<script type='module'> is always deferred, the attribute does nothing")]
+        public ScriptModuleResource(IResourceLocation location, bool defer)
             : base(defer ? ResourceRenderPosition.Anywhere : ResourceRenderPosition.Body, "text/javascript", location)
         {
             this.Defer = defer;
@@ -27,8 +36,6 @@ namespace DotVVM.Framework.ResourceManagement
         {
             AddSrcAndIntegrity(writer, context, location.GetUrl(context, resourceName), "src");
             writer.AddAttribute("type", "module");
-            if (Defer)
-                writer.AddAttribute("defer", null);
             writer.RenderBeginTag("script");
             writer.RenderEndTag();
         }

--- a/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.AddResourceWithMasterPage.html
+++ b/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.AddResourceWithMasterPage.html
@@ -7,7 +7,7 @@
     <!-- Resource knockout of type ScriptResource. Pointing to EmbeddedResourceLocation. -->
     <script src=/dotvvmResource/knockout/knockout defer></script>
     <!-- Resource dotvvm.internal of type ScriptModuleResource. Pointing to EmbeddedResourceLocation. -->
-    <script src=/dotvvmResource/dotvvm--internal/dotvvm--internal type=module defer></script>
+    <script src=/dotvvmResource/dotvvm--internal/dotvvm--internal type=module></script>
     <!-- Resource dotvvm of type InlineScriptResource. -->
     
     <!-- Resource dotvvm.debug of type ScriptResource. Pointing to EmbeddedResourceLocation. -->

--- a/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModule.html
+++ b/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModule.html
@@ -5,7 +5,7 @@
 		<script defer="" src="/dotvvmResource/knockout/knockout"></script>
 		
 		<!-- Resource dotvvm.internal of type ScriptModuleResource. Pointing to EmbeddedResourceLocation. -->
-		<script defer="" src="/dotvvmResource/dotvvm--internal/dotvvm--internal" type="module"></script>
+		<script src="/dotvvmResource/dotvvm--internal/dotvvm--internal" type="module"></script>
 		
 		<!-- Resource dotvvm of type InlineScriptResource. -->          
 		<!-- Resource dotvvm.debug of type ScriptResource. Pointing to EmbeddedResourceLocation. -->

--- a/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModuleInControl.html
+++ b/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModuleInControl.html
@@ -5,7 +5,7 @@
 		<script defer="" src="/dotvvmResource/knockout/knockout"></script>
 		
 		<!-- Resource dotvvm.internal of type ScriptModuleResource. Pointing to EmbeddedResourceLocation. -->
-		<script defer="" src="/dotvvmResource/dotvvm--internal/dotvvm--internal" type="module"></script>
+		<script src="/dotvvmResource/dotvvm--internal/dotvvm--internal" type="module"></script>
 		
 		<!-- Resource dotvvm of type InlineScriptResource. -->          
 		<!-- Resource viewModule.import.lIquTPFe3a42GboPePTmYZ4Xc1S4ok-JXmZud9HUybE of type ViewModuleImportResource. -->

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -43,7 +43,6 @@
       },
       "DotVVM.Framework.ResourceManagement.ScriptModuleResource": {
         "dotvvm.internal": {
-          "Defer": true,
           "Location": {
             "$type": "DotVVM.Framework.ResourceManagement.EmbeddedResourceLocation, DotVVM.Framework",
             "Assembly": "DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da",
@@ -57,7 +56,6 @@
           "RenderPosition": "Anywhere"
         },
         "dotvvm.internal-spa": {
-          "Defer": true,
           "Location": {
             "$type": "DotVVM.Framework.ResourceManagement.EmbeddedResourceLocation, DotVVM.Framework",
             "Assembly": "DotVVM.Framework, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da",


### PR DESCRIPTION
The module scripts are always deferred and the defer attribute is actually invalid on the element