### PR TITLE
Allow type=module in InlineScriptResource

### DIFF
--- a/src/Framework/Framework/Configuration/RestApiRegistrationHelpers.cs
+++ b/src/Framework/Framework/Configuration/RestApiRegistrationHelpers.cs
@@ -227,7 +227,7 @@ namespace DotVVM.Framework.Configuration
         private static void RegisterApiDependencies(DotvvmConfiguration configuration, string identifier, string jsApiClientFile, JsNode jsinitializer, ApiGroupDescriptor descriptor)
         {
             configuration.Resources.RegisterScript("apiClient" + identifier, new FileResourceLocation(jsApiClientFile));
-            configuration.Resources.Register("apiInit" + identifier, new InlineScriptResource(defer: true, code: jsinitializer.FormatScript(niceMode: configuration.Debug)) { Dependencies = new[] { "dotvvm", "apiClient" + identifier } });
+            configuration.Resources.Register("apiInit" + identifier, new InlineScriptResource(module: true, code: jsinitializer.FormatScript(niceMode: configuration.Debug)) { Dependencies = new[] { "dotvvm", "apiClient" + identifier } });
 
             configuration.Markup.DefaultExtensionParameters.Add(new ApiExtensionParameter(identifier, descriptor));
 

--- a/src/Framework/Framework/Controls/Infrastructure/BodyResourceLinks.cs
+++ b/src/Framework/Framework/Controls/Infrastructure/BodyResourceLinks.cs
@@ -42,8 +42,7 @@ namespace DotVVM.Framework.Controls
             {
                 initCode = $"ko.options.deferUpdates = true;\n{initCode}";
             }
-            new InlineScriptResource(initCode, defer: true)
-                .Render(writer, context, "dotvvm-init-script");
+            InlineScriptResource.RenderScript(writer, initCode, defer: true, module: true);
 
             var warnings = RenderWarnings(context);
             if (warnings.Length > 0)

--- a/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.AddResourceWithMasterPage.html
+++ b/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.AddResourceWithMasterPage.html
@@ -50,4 +50,5 @@
     "test-resource1"
   ],
   "typeMetadata": {}
-}' /><script defer src="data:text/javascript;base64,ZG90dnZtLm9wdGlvbnMuY29tcHJlc3NQT1NUPWZhbHNlOwp3aW5kb3cuZG90dnZtLmluaXQoImVuLVVTIik7"></script></body>
+}' /><script type=module>dotvvm.options.compressPOST=false;
+window.dotvvm.init("en-US");</script></body>

--- a/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModule.html
+++ b/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModule.html
@@ -36,6 +36,7 @@
   ],
   &quot;typeMetadata&quot;: {}
 }">
-		<script defer="" src="data:text/javascript;base64,ZG90dnZtLm9wdGlvbnMuY29tcHJlc3NQT1NUPWZhbHNlOwp3aW5kb3cuZG90dnZtLmluaXQoImVuLVVTIik7"></script>
+		<script type="module">dotvvm.options.compressPOST=false;
+window.dotvvm.init("en-US");</script>
 	</body>
 </html>

--- a/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModuleInControl.html
+++ b/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModuleInControl.html
@@ -70,6 +70,7 @@
     }
   }
 }">
-		<script defer="" src="data:text/javascript;base64,ZG90dnZtLm9wdGlvbnMuY29tcHJlc3NQT1NUPWZhbHNlOwp3aW5kb3cuZG90dnZtLmluaXQoImVuLVVTIik7"></script>
+		<script type="module">dotvvm.options.compressPOST=false;
+window.dotvvm.init("en-US");</script>
 	</body>
 </html>

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.RestAPI.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.RestAPI.json
@@ -27,6 +27,7 @@
         "apiInit_testApi": {
           "Code": "dotvvm.api._testApi=new DotVVM.Framework.Tests.Binding.TestApiClient(\"http://server/api\");",
           "Defer": true,
+          "Module": true,
           "Dependencies": [
             "dotvvm",
             "apiClient_testApi"


### PR DESCRIPTION
1. type=module scripts are deferred and allow inline content, allowing us to bypass the base64 trick
2. it is necessary if someone wants to import other modules from the inline script

Unfortunatelly, we cannot make it the default when defer is requested, as type=module also enabled JS strict mode.