### PR TITLE
Added support for localizable routes

### DIFF
--- a/.github/setup/action.yml
+++ b/.github/setup/action.yml
@@ -37,7 +37,6 @@ runs:
       dotnet-version: |
         8.0.x
         6.0.x
-        3.1.x
   - if: ${{ runner.os == 'Windows' }}
     uses: microsoft/setup-msbuild@v1.1
 

--- a/src/Framework/Framework/Controls/RouteLink.cs
+++ b/src/Framework/Framework/Controls/RouteLink.cs
@@ -69,13 +69,13 @@ namespace DotVVM.Framework.Controls
         /// Gets or sets the required culture of the page. This property is supported only when using localizable routes.
         /// </summary>
         [MarkupOptions(AllowBinding = false)]
-        public string Culture
+        public string? Culture
         {
-            get { return (string)GetValue(CultureProperty); }
+            get { return (string?)GetValue(CultureProperty); }
             set { SetValue(CultureProperty, value); }
         }
         public static readonly DotvvmProperty CultureProperty
-            = DotvvmProperty.Register<string, RouteLink>(c => c.Culture, null);
+            = DotvvmProperty.Register<string?, RouteLink>(c => c.Culture, null);
 
         /// <summary>
         /// Gets or sets a collection of parameters to be substituted in the route URL. If the current route contains a parameter with the same name, its value will be reused unless another value is specified here.
@@ -219,7 +219,7 @@ namespace DotVVM.Framework.Controls
                 }
             }
 
-            var parameterDefinitions = route.ParameterNames;
+            var parameterDefinitions = route!.ParameterNames;
             var parameterReferences = control.Properties.Where(i => i.Key is GroupedDotvvmProperty p && p.PropertyGroup == ParamsGroupDescriptor);
 
             var undefinedReferences =

--- a/src/Framework/Framework/Controls/RouteLinkCapability.cs
+++ b/src/Framework/Framework/Controls/RouteLinkCapability.cs
@@ -19,5 +19,7 @@ namespace DotVVM.Framework.Controls
 
         [DefaultValue(null)]
         public ValueOrBinding<string>? UrlSuffix { get; init; }
+
+        public string? Culture { get; init; }
     }
 }

--- a/src/Framework/Framework/Controls/RouteLinkHelpers.cs
+++ b/src/Framework/Framework/Controls/RouteLinkHelpers.cs
@@ -12,7 +12,6 @@ using DotVVM.Framework.ViewModel.Serialization;
 using DotVVM.Framework.Utils;
 using DotVVM.Framework.Configuration;
 using System.Collections.Immutable;
-using System.ComponentModel.DataAnnotations;
 
 namespace DotVVM.Framework.Controls
 {

--- a/src/Framework/Framework/Controls/RouteLinkHelpers.cs
+++ b/src/Framework/Framework/Controls/RouteLinkHelpers.cs
@@ -12,6 +12,7 @@ using DotVVM.Framework.ViewModel.Serialization;
 using DotVVM.Framework.Utils;
 using DotVVM.Framework.Configuration;
 using System.Collections.Immutable;
+using System.ComponentModel.DataAnnotations;
 
 namespace DotVVM.Framework.Controls
 {
@@ -87,7 +88,7 @@ namespace DotVVM.Framework.Controls
 
         private static string GenerateRouteUrlCore(string routeName, RouteLink control, IDotvvmRequestContext context)
         {
-            var route = GetRoute(context, routeName);
+            var route = GetRoute(context, routeName, control.Culture);
             var parameters = ComposeNewRouteParameters(control, context, route);
 
             // evaluate bindings on server
@@ -114,9 +115,18 @@ namespace DotVVM.Framework.Controls
             return UrlHelper.BuildUrlSuffix(urlSuffix, queryParams);
         }
 
-        private static RouteBase GetRoute(IDotvvmRequestContext context, string routeName)
+        private static RouteBase GetRoute(IDotvvmRequestContext context, string routeName, string? cultureIdentifier)
         {
-            return context.Configuration.RouteTable[routeName];
+            var route = context.Configuration.RouteTable[routeName];
+            if (!string.IsNullOrEmpty(cultureIdentifier))
+            {
+                if (route is not LocalizedDotvvmRoute localizedRoute)
+                {
+                    throw new DotvvmControlException($"The route {routeName} is not localizable, the Culture property cannot be used!");
+                }
+                route = localizedRoute.GetRouteForCulture(cultureIdentifier!);
+            }
+            return route;
         }
 
         public static string GenerateKnockoutHrefExpression(string routeName, RouteLink control, IDotvvmRequestContext context)
@@ -146,7 +156,7 @@ namespace DotVVM.Framework.Controls
 
         private static string GenerateRouteLinkCore(string routeName, RouteLink control, IDotvvmRequestContext context)
         {
-            var route = GetRoute(context, routeName);
+            var route = GetRoute(context, routeName, control.Culture);
             var parameters = ComposeNewRouteParameters(control, context, route);
 
             var parametersExpression = parameters.Select(p => TranslateRouteParameter(control, p)).StringJoin(",");

--- a/src/Framework/Framework/Hosting/DotvvmRequestContextExtensions.cs
+++ b/src/Framework/Framework/Hosting/DotvvmRequestContextExtensions.cs
@@ -52,22 +52,13 @@ public static class DotvvmRequestContextExtensions
     [Obsolete("This method only assigns CultureInfo.CurrentCulture, which is not preserved in async methods. You should assign it manually, or use RequestLocalization middleware or LocalizablePresenter.")]
     public static void ChangeCurrentCulture(this IDotvvmRequestContext context, string cultureName, string uiCultureName)
     {
-        if (!string.IsNullOrEmpty(cultureName))
-        {
 #if DotNetCore
-            CultureInfo.CurrentCulture = new CultureInfo(cultureName);
+        CultureInfo.CurrentCulture = new CultureInfo(cultureName);
+        CultureInfo.CurrentUICulture = new CultureInfo(uiCultureName);
 #else
-            Thread.CurrentThread.CurrentCulture = new CultureInfo(cultureName);
+        Thread.CurrentThread.CurrentCulture = new CultureInfo(cultureName);
+        Thread.CurrentThread.CurrentUICulture = new CultureInfo(uiCultureName);
 #endif
-        }
-        if (!string.IsNullOrEmpty(uiCultureName))
-        {
-#if DotNetCore
-            CultureInfo.CurrentUICulture = new CultureInfo(uiCultureName);
-#else
-            Thread.CurrentThread.CurrentUICulture = new CultureInfo(uiCultureName);
-#endif
-        }
     }
 
     /// <summary>

--- a/src/Framework/Framework/Hosting/DotvvmRequestContextExtensions.cs
+++ b/src/Framework/Framework/Hosting/DotvvmRequestContextExtensions.cs
@@ -52,13 +52,22 @@ public static class DotvvmRequestContextExtensions
     [Obsolete("This method only assigns CultureInfo.CurrentCulture, which is not preserved in async methods. You should assign it manually, or use RequestLocalization middleware or LocalizablePresenter.")]
     public static void ChangeCurrentCulture(this IDotvvmRequestContext context, string cultureName, string uiCultureName)
     {
+        if (!string.IsNullOrEmpty(cultureName))
+        {
 #if DotNetCore
-        CultureInfo.CurrentCulture = new CultureInfo(cultureName);
-        CultureInfo.CurrentUICulture = new CultureInfo(uiCultureName);
+            CultureInfo.CurrentCulture = new CultureInfo(cultureName);
 #else
-        Thread.CurrentThread.CurrentCulture = new CultureInfo(cultureName);
-        Thread.CurrentThread.CurrentUICulture = new CultureInfo(uiCultureName);
+            Thread.CurrentThread.CurrentCulture = new CultureInfo(cultureName);
 #endif
+        }
+        if (!string.IsNullOrEmpty(uiCultureName))
+        {
+#if DotNetCore
+            CultureInfo.CurrentUICulture = new CultureInfo(uiCultureName);
+#else
+            Thread.CurrentThread.CurrentUICulture = new CultureInfo(uiCultureName);
+#endif
+        }
     }
 
     /// <summary>

--- a/src/Framework/Framework/Hosting/HostingConstants.cs
+++ b/src/Framework/Framework/Hosting/HostingConstants.cs
@@ -28,5 +28,7 @@ namespace DotVVM.Framework.Hosting
         public const string DotvvmFileUploadAsyncHeaderName = "X-DotVVM-AsyncUpload";
 
         public const string HostAppModeKey = "host.AppMode";
+
+        public const string OwinDoNotSetRequestCulture = "OwinDoNotSetRequestCulture";
     }
 }

--- a/src/Framework/Framework/Hosting/HostingConstants.cs
+++ b/src/Framework/Framework/Hosting/HostingConstants.cs
@@ -29,6 +29,11 @@ namespace DotVVM.Framework.Hosting
 
         public const string HostAppModeKey = "host.AppMode";
 
+        /// <summary>
+        /// When this key is set to true in the OWIN environment, the request culture will not be set by DotVVM to config.DefaultCulture.
+        /// Use this key when the request culture is set by the host or the middleware preceding DotVVM.
+        /// See https://github.com/riganti/dotvvm/blob/93107dd07127ff2bd29c2934f3aa2a26ec2ca79c/src/Samples/Owin/Startup.cs#L34
+        /// </summary>
         public const string OwinDoNotSetRequestCulture = "OwinDoNotSetRequestCulture";
     }
 }

--- a/src/Framework/Framework/ResourceManagement/LocalResourceUrlManager.cs
+++ b/src/Framework/Framework/ResourceManagement/LocalResourceUrlManager.cs
@@ -65,7 +65,7 @@ namespace DotVVM.Framework.ResourceManagement
         public ILocalResourceLocation? FindResource(string url, IDotvvmRequestContext context, out string? mimeType)
         {
             mimeType = null;
-            if (DotvvmRoutingMiddleware.FindMatchingRoute(new[] { resourceRoute }, context, out var parameters) == null)
+            if (DotvvmRoutingMiddleware.FindMatchingRoute(new[] { resourceRoute }, context, out var parameters, out _) == null)
             {
                 return null;
             }

--- a/src/Framework/Framework/ResourceManagement/LocalResourceUrlManager.cs
+++ b/src/Framework/Framework/ResourceManagement/LocalResourceUrlManager.cs
@@ -65,7 +65,9 @@ namespace DotVVM.Framework.ResourceManagement
         public ILocalResourceLocation? FindResource(string url, IDotvvmRequestContext context, out string? mimeType)
         {
             mimeType = null;
-            if (DotvvmRoutingMiddleware.FindMatchingRoute(new[] { resourceRoute }, context, out var parameters, out _) == null)
+
+            var routeMatchUrl = DotvvmRoutingMiddleware.GetRouteMatchUrl(context);
+            if (DotvvmRoutingMiddleware.FindExactMatchRoute(new[] { resourceRoute }, routeMatchUrl, out var parameters) == null)
             {
                 return null;
             }

--- a/src/Framework/Framework/Routing/CanonicalRedirectPartialMatchRouteHandler.cs
+++ b/src/Framework/Framework/Routing/CanonicalRedirectPartialMatchRouteHandler.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+using DotVVM.Framework.Hosting;
+
+namespace DotVVM.Framework.Routing;
+
+public class CanonicalRedirectPartialMatchRouteHandler : IPartialMatchRouteHandler
+{
+    /// <summary>
+    /// Indicates whether a permanent redirect shall be used.
+    /// </summary>
+    public bool IsPermanentRedirect { get; set; }
+
+    public Task<bool> TryHandlePartialMatch(IDotvvmRequestContext context)
+    {
+        context.RedirectToRoute(context.Route!.RouteName, context.Parameters);
+        return Task.FromResult(true);
+    }
+}

--- a/src/Framework/Framework/Routing/DotvvmRoute.cs
+++ b/src/Framework/Framework/Routing/DotvvmRoute.cs
@@ -123,7 +123,7 @@ namespace DotVVM.Framework.Routing
         /// <summary>
         /// Builds the URL core from the parameters.
         /// </summary>
-        protected override string BuildUrlCore(Dictionary<string, object?> values)
+        protected internal override string BuildUrlCore(Dictionary<string, object?> values)
         {
             var convertedValues =
                 values.ToDictionary(

--- a/src/Framework/Framework/Routing/DotvvmRoute.cs
+++ b/src/Framework/Framework/Routing/DotvvmRoute.cs
@@ -20,11 +20,14 @@ namespace DotVVM.Framework.Routing
         private List<Func<Dictionary<string, string?>, string>> urlBuilders;
         private List<KeyValuePair<string, Func<string, ParameterParseResult>?>> parameters;
         private string urlWithoutTypes;
+        private List<KeyValuePair<string, DotvvmRouteParameterMetadata>> parameterMetadata;
 
         /// <summary>
         /// Gets the names of the route parameters in the order in which they appear in the URL.
         /// </summary>
         public override IEnumerable<string> ParameterNames => parameters.Select(p => p.Key);
+
+        public override IEnumerable<KeyValuePair<string, DotvvmRouteParameterMetadata>> ParameterMetadata => parameterMetadata;
 
         public override string UrlWithoutTypes => urlWithoutTypes;
 
@@ -77,6 +80,7 @@ namespace DotVVM.Framework.Routing
             routeRegex = result.RouteRegex;
             urlBuilders = result.UrlBuilders;
             parameters = result.Parameters;
+            parameterMetadata = result.ParameterMetadata;
             urlWithoutTypes = result.UrlWithoutTypes;
         }
 

--- a/src/Framework/Framework/Routing/DotvvmRouteTable.cs
+++ b/src/Framework/Framework/Routing/DotvvmRouteTable.cs
@@ -109,10 +109,21 @@ namespace DotVVM.Framework.Routing
         /// <param name="virtualPath">The virtual path of the Dothtml file.</param>
         /// <param name="defaultValues">The default values.</param>
         /// <param name="presenterFactory">Delegate creating the presenter handling this route</param>
-        public void Add(string routeName, string? url, string virtualPath, object? defaultValues = null, Func<IServiceProvider, IDotvvmPresenter>? presenterFactory = null)
+        public void Add(string routeName, string? url, string virtualPath, object? defaultValues = null, Func<IServiceProvider, IDotvvmPresenter>? presenterFactory = null, LocalizedRouteUrl[]? localizedUrls = null)
         {
             ThrowIfFrozen();
-            Add(group?.RouteNamePrefix + routeName, new DotvvmRoute(CombinePath(group?.UrlPrefix, url), CombinePath(group?.VirtualPathPrefix, virtualPath), defaultValues, presenterFactory ?? GetDefaultPresenter, configuration));
+
+            url = CombinePath(group?.UrlPrefix, url);
+            virtualPath = CombinePath(group?.VirtualPathPrefix, virtualPath);
+            presenterFactory ??= GetDefaultPresenter;
+            routeName = group?.RouteNamePrefix + routeName;
+
+            RouteBase route = localizedUrls == null
+                ? new DotvvmRoute(url, virtualPath, defaultValues, presenterFactory, configuration)
+                : new LocalizedDotvvmRoute(url,
+                    localizedUrls.Select(l => new LocalizedRouteUrl(l.CultureIdentifier, CombinePath(group?.UrlPrefix, l.RouteUrl))).ToArray(),
+                    virtualPath, defaultValues, presenterFactory, configuration);
+            Add(routeName, route);
         }
 
         /// <summary>
@@ -122,10 +133,21 @@ namespace DotVVM.Framework.Routing
         /// <param name="url">The URL.</param>
         /// <param name="defaultValues">The default values.</param>
         /// <param name="presenterFactory">The presenter factory.</param>
-        public void Add(string routeName, string? url, Func<IServiceProvider, IDotvvmPresenter>? presenterFactory = null, object? defaultValues = null)
+        public void Add(string routeName, string? url, Func<IServiceProvider, IDotvvmPresenter>? presenterFactory = null, object? defaultValues = null, LocalizedRouteUrl[]? localizedUrls = null)
         {
             ThrowIfFrozen();
-            Add(group?.RouteNamePrefix + routeName, new DotvvmRoute(CombinePath(group?.UrlPrefix, url), group?.VirtualPathPrefix ?? "", defaultValues, presenterFactory ?? GetDefaultPresenter, configuration));
+
+            url = CombinePath(group?.UrlPrefix, url);
+            presenterFactory ??= GetDefaultPresenter;
+            routeName = group?.RouteNamePrefix + routeName;
+            var virtualPath = group?.VirtualPathPrefix ?? "";
+
+            RouteBase route = localizedUrls == null
+                ? new DotvvmRoute(url, virtualPath, defaultValues, presenterFactory, configuration)
+                : new LocalizedDotvvmRoute(url,
+                    localizedUrls.Select(l => new LocalizedRouteUrl(l.CultureIdentifier, CombinePath(group?.UrlPrefix, l.RouteUrl))).ToArray(),
+                    virtualPath, defaultValues, presenterFactory, configuration);
+            Add(routeName, route);
         }
 
         /// <summary>
@@ -203,7 +225,7 @@ namespace DotVVM.Framework.Routing
         /// <param name="url">The URL.</param>
         /// <param name="presenterType">The presenter factory.</param>
         /// <param name="defaultValues">The default values.</param>
-        public void Add(string routeName, string? url, Type presenterType, object? defaultValues = null)
+        public void Add(string routeName, string? url, Type presenterType, object? defaultValues = null, LocalizedRouteUrl[] localizedUrls = null)
         {
             ThrowIfFrozen();
             if (!typeof(IDotvvmPresenter).IsAssignableFrom(presenterType))
@@ -211,7 +233,7 @@ namespace DotVVM.Framework.Routing
                 throw new ArgumentException($@"{nameof(presenterType)} has to inherit from DotVVM.Framework.Hosting.IDotvvmPresenter.", nameof(presenterType));
             }
             Func<IServiceProvider, IDotvvmPresenter> presenterFactory = provider => (IDotvvmPresenter)provider.GetRequiredService(presenterType);
-            Add(routeName, url, presenterFactory, defaultValues);
+            Add(routeName, url, presenterFactory, defaultValues, localizedUrls);
         }
 
         /// <summary>
@@ -237,6 +259,11 @@ namespace DotVVM.Framework.Routing
         public bool Contains(string routeName)
         {
             return dictionary.ContainsKey(routeName);
+        }
+
+        public bool TryGetValue(string routeName, out RouteBase? route)
+        {
+            return dictionary.TryGetValue(routeName, out route);
         }
 
         public RouteBase this[string routeName]

--- a/src/Framework/Framework/Routing/DotvvmRouteTable.cs
+++ b/src/Framework/Framework/Routing/DotvvmRouteTable.cs
@@ -225,7 +225,7 @@ namespace DotVVM.Framework.Routing
         /// <param name="url">The URL.</param>
         /// <param name="presenterType">The presenter factory.</param>
         /// <param name="defaultValues">The default values.</param>
-        public void Add(string routeName, string? url, Type presenterType, object? defaultValues = null, LocalizedRouteUrl[] localizedUrls = null)
+        public void Add(string routeName, string? url, Type presenterType, object? defaultValues = null, LocalizedRouteUrl[]? localizedUrls = null)
         {
             ThrowIfFrozen();
             if (!typeof(IDotvvmPresenter).IsAssignableFrom(presenterType))

--- a/src/Framework/Framework/Routing/IPartialMatchRoute.cs
+++ b/src/Framework/Framework/Routing/IPartialMatchRoute.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace DotVVM.Framework.Routing;
+
+public interface IPartialMatchRoute
+{
+    bool IsPartialMatch(string url, [MaybeNullWhen(false)] out RouteBase matchedRoute, [MaybeNullWhen(false)] out IDictionary<string, object?> values);
+}

--- a/src/Framework/Framework/Routing/IPartialMatchRouteHandler.cs
+++ b/src/Framework/Framework/Routing/IPartialMatchRouteHandler.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DotVVM.Framework.Hosting;
+
+namespace DotVVM.Framework.Routing;
+
+public interface IPartialMatchRouteHandler
+{
+    /// <summary>
+    /// Handles the partial route match and returns whether the request was handled to prevent other handlers to take place.
+    /// </summary>
+    /// <returns>If true, the next partial match handlers will not be executed.</returns>
+    Task<bool> TryHandlePartialMatch(IDotvvmRequestContext context);
+}

--- a/src/Framework/Framework/Routing/LocalizedDotvvmRoute.cs
+++ b/src/Framework/Framework/Routing/LocalizedDotvvmRoute.cs
@@ -34,6 +34,8 @@ namespace DotVVM.Framework.Routing
         /// </summary>
         public override IEnumerable<string> ParameterNames => GetRouteForCulture(CultureInfo.CurrentUICulture).ParameterNames;
 
+        public override IEnumerable<KeyValuePair<string, DotvvmRouteParameterMetadata>> ParameterMetadata => GetRouteForCulture(CultureInfo.CurrentUICulture).ParameterMetadata;
+
         public override string RouteName
         {
             get
@@ -61,13 +63,24 @@ namespace DotVVM.Framework.Routing
                 throw new ArgumentException("There must be at least one localized route URL!", nameof(localizedUrls));
             }
 
+            var defaultRoute = new DotvvmRoute(defaultLanguageUrl, virtualPath, defaultValues, presenterFactory, configuration);
+
+            var sortedParameters = defaultRoute.ParameterMetadata
+                .OrderBy(n => n.Key)
+                .ToArray();
+
             foreach (var localizedUrl in localizedUrls)
             {
                 var localizedRoute = new DotvvmRoute(localizedUrl.RouteUrl, virtualPath, defaultValues, presenterFactory, configuration);
+                if (!localizedRoute.ParameterMetadata.OrderBy(n => n.Key)
+                        .SequenceEqual(sortedParameters))
+                {
+                    throw new ArgumentException($"Localized route URL '{localizedUrl.RouteUrl}' must contain the same parameters with equal constraints as the default route URL!", nameof(localizedUrls));
+                }
+
                 localizedRoutes.Add(localizedUrl.CultureIdentifier, localizedRoute);
             }
 
-            var defaultRoute = new DotvvmRoute(defaultLanguageUrl, virtualPath, defaultValues, presenterFactory, configuration);
             localizedRoutes.Add("", defaultRoute);
         }
 

--- a/src/Framework/Framework/Routing/LocalizedDotvvmRoute.cs
+++ b/src/Framework/Framework/Routing/LocalizedDotvvmRoute.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using DotVVM.Framework.Configuration;
+using DotVVM.Framework.Hosting;
+
+namespace DotVVM.Framework.Routing
+{
+    /// <summary>
+    /// Represents a localizable route with different matching pattern for each culture.
+    /// Please note that the extraction of the culture from the URL and setting the culture must be done at the beginning of the request pipeline.
+    /// Therefore, the route only matches the URL for the current culture.
+    /// </summary>
+    public sealed class LocalizedDotvvmRoute : RouteBase
+    {
+        private static readonly HashSet<string> AvailableCultureNames = CultureInfo.GetCultures(CultureTypes.AllCultures)
+            .Where(c => c != CultureInfo.InvariantCulture)
+            .Select(c => c.Name)
+            .ToHashSet();
+
+        private readonly SortedDictionary<string, DotvvmRoute> localizedRoutes = new();
+
+        public override string UrlWithoutTypes => GetRouteForCulture(CultureInfo.CurrentUICulture).UrlWithoutTypes;
+
+        /// <summary>
+        /// Gets the names of the route parameters in the order in which they appear in the URL.
+        /// </summary>
+        public override IEnumerable<string> ParameterNames => GetRouteForCulture(CultureInfo.CurrentUICulture).ParameterNames;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotvvmRoute"/> class.
+        /// </summary>
+        public LocalizedDotvvmRoute(string defaultLanguageUrl, LocalizedRouteUrl[] localizedUrls, string virtualPath, object? defaultValues, Func<IServiceProvider, IDotvvmPresenter> presenterFactory, DotvvmConfiguration configuration)
+            : base(defaultLanguageUrl, virtualPath, defaultValues)
+        {
+            if (!localizedUrls.Any())
+            {
+                throw new ArgumentException("There must be at least one localized route URL!", nameof(localizedUrls));
+            }
+
+            foreach (var localizedUrl in localizedUrls)
+            {
+                var localizedRoute = new DotvvmRoute(localizedUrl.RouteUrl, virtualPath, defaultValues, presenterFactory, configuration);
+                localizedRoutes.Add(localizedUrl.CultureIdentifier, localizedRoute);
+            }
+
+            var defaultRoute = new DotvvmRoute(defaultLanguageUrl, virtualPath, defaultValues, presenterFactory, configuration);
+            localizedRoutes.Add("", defaultRoute);
+        }
+
+        public DotvvmRoute GetRouteForCulture(string cultureIdentifier)
+        {
+            ValidateCultureName(cultureIdentifier);
+            return GetRouteForCulture(CultureInfo.GetCultureInfo(cultureIdentifier));
+        }
+
+        public DotvvmRoute GetRouteForCulture(CultureInfo culture)
+        {
+            return localizedRoutes.TryGetValue(culture.Name, out var exactMatchRoute) ? exactMatchRoute
+                : localizedRoutes.TryGetValue(culture.TwoLetterISOLanguageName, out var languageMatchRoute) ? languageMatchRoute
+                : localizedRoutes.TryGetValue("", out var defaultRoute) ? defaultRoute
+                : throw new NotSupportedException("Invalid localized route - no default route found!");
+        }
+
+        public static void ValidateCultureName(string cultureIdentifier)
+        {
+            if (!AvailableCultureNames.Contains(cultureIdentifier))
+            {
+                throw new ArgumentException($"Culture {cultureIdentifier} was not found!", nameof(cultureIdentifier));
+            }
+        }
+
+        /// <summary>
+        /// Processes the request.
+        /// </summary>
+        public override IDotvvmPresenter GetPresenter(IServiceProvider provider) => GetRouteForCulture(CultureInfo.CurrentCulture).GetPresenter(provider);
+
+        /// <summary>
+        /// Determines whether the route matches to the specified URL and extracts the parameter values.
+        /// </summary>
+        public override bool IsMatch(string url, [MaybeNullWhen(false)] out IDictionary<string, object?> values) => GetRouteForCulture(CultureInfo.CurrentCulture).IsMatch(url, out values);
+
+        protected internal override string BuildUrlCore(Dictionary<string, object?> values) => GetRouteForCulture(CultureInfo.CurrentCulture).BuildUrlCore(values);
+
+        protected override void Freeze2()
+        {
+            foreach (var route in localizedRoutes)
+            {
+                route.Value.Freeze();
+            }
+        }
+    }
+}

--- a/src/Framework/Framework/Routing/LocalizedDotvvmRoute.cs
+++ b/src/Framework/Framework/Routing/LocalizedDotvvmRoute.cs
@@ -119,7 +119,7 @@ namespace DotVVM.Framework.Routing
         public bool IsPartialMatch(string url, [MaybeNullWhen(false)] out RouteBase matchedRoute, [MaybeNullWhen(false)] out IDictionary<string, object?> values)
         {
             RouteBase? twoLetterCultureMatch = null;
-            IDictionary<string, object?> twoLetterCultureMatchValues = null;
+            IDictionary<string, object?>? twoLetterCultureMatchValues = null;
 
             foreach (var route in localizedRoutes)
             {

--- a/src/Framework/Framework/Routing/LocalizedRouteUrl.cs
+++ b/src/Framework/Framework/Routing/LocalizedRouteUrl.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+
+namespace DotVVM.Framework.Routing
+{
+    public record LocalizedRouteUrl
+    {
+        /// <summary>
+        /// Gets or sets the culture identifier. Allowed formats are language-REGION (e.g. en-US) or language (e.g. en).
+        /// </summary>
+        public string CultureIdentifier { get; }
+
+        /// <summary>
+        /// Get or sets the corresponding route URL.
+        /// </summary>
+        public string RouteUrl { get; }
+
+        /// <summary>
+        /// Represents a localized route URL.
+        /// </summary>
+        /// <param name="cultureIdentifier">Culture identifier. Allowed formats are language-REGION (e.g. en-US) or language (e.g. en)</param>
+        /// <param name="routeUrl">Corresponding route URL for the culture.</param>
+        public LocalizedRouteUrl(string cultureIdentifier, string routeUrl)
+        {
+            LocalizedDotvvmRoute.ValidateCultureName(cultureIdentifier);
+
+            CultureIdentifier = cultureIdentifier;
+            RouteUrl = routeUrl;
+        }
+
+    }
+}

--- a/src/Framework/Framework/Routing/RouteBase.cs
+++ b/src/Framework/Framework/Routing/RouteBase.cs
@@ -157,7 +157,7 @@ namespace DotVVM.Framework.Routing
         /// Builds the URL core from the parameters.
         /// </summary>
         /// <remarks>The default values are already included in the <paramref name="values"/> collection.</remarks>
-        protected abstract string BuildUrlCore(Dictionary<string, object?> values);
+        protected internal abstract string BuildUrlCore(Dictionary<string, object?> values);
 
         /// <summary>
         /// Adds or updates the parameter collection with the specified values from the anonymous object.

--- a/src/Framework/Framework/Routing/RouteBase.cs
+++ b/src/Framework/Framework/Routing/RouteBase.cs
@@ -26,7 +26,7 @@ namespace DotVVM.Framework.Routing
         /// <summary>
         /// Gets key of route.
         /// </summary>
-        public string RouteName { get; internal set; }
+        public virtual string RouteName { get; internal set; }
 
         /// <summary>
         /// Gets the default values of the optional parameters.

--- a/src/Framework/Framework/Routing/RouteBase.cs
+++ b/src/Framework/Framework/Routing/RouteBase.cs
@@ -90,6 +90,11 @@ namespace DotVVM.Framework.Routing
         public abstract IEnumerable<string> ParameterNames { get; }
 
         /// <summary>
+        /// Gets the metadata of the route parameters.
+        /// </summary>
+        public abstract IEnumerable<KeyValuePair<string, DotvvmRouteParameterMetadata>> ParameterMetadata { get; }
+
+        /// <summary>
         /// Determines whether the route matches to the specified URL and extracts the parameter values.
         /// </summary>
         public abstract bool IsMatch(string url, [MaybeNullWhen(false)] out IDictionary<string, object?> values);

--- a/src/Framework/Framework/Routing/RouteTableJsonConverter.cs
+++ b/src/Framework/Framework/Routing/RouteTableJsonConverter.cs
@@ -75,7 +75,8 @@ namespace DotVVM.Framework.Routing
 
             public override bool IsMatch(string url, [MaybeNullWhen(false)] out IDictionary<string, object?> values) => throw new InvalidOperationException($"Could not create route {RouteName}", error);
 
-            protected override string BuildUrlCore(Dictionary<string, object?> values) => throw new InvalidOperationException($"Could not create route {RouteName}", error);
+            protected internal override string BuildUrlCore(Dictionary<string, object?> values) => throw new InvalidOperationException($"Could not create route {RouteName}", error);
+
             protected override void Freeze2()
             {
                 // no mutable properties in this class

--- a/src/Framework/Framework/Routing/RouteTableJsonConverter.cs
+++ b/src/Framework/Framework/Routing/RouteTableJsonConverter.cs
@@ -67,7 +67,9 @@ namespace DotVVM.Framework.Routing
                 this.error = error;
             }
 
-            public override IEnumerable<string> ParameterNames => new string[0];
+            public override IEnumerable<string> ParameterNames { get; } = new string[0];
+
+            public override IEnumerable<KeyValuePair<string, DotvvmRouteParameterMetadata>> ParameterMetadata { get; } = new KeyValuePair<string, DotvvmRouteParameterMetadata>[0];
 
             public override string UrlWithoutTypes => base.Url;
 

--- a/src/Framework/Hosting.Owin/Hosting/Middlewares/DotvvmMiddleware.cs
+++ b/src/Framework/Hosting.Owin/Hosting/Middlewares/DotvvmMiddleware.cs
@@ -49,7 +49,10 @@ namespace DotVVM.Framework.Hosting
                 var dotvvmContext = CreateDotvvmContext(context, scope);
                 dotvvmContext.Services.GetRequiredService<DotvvmRequestContextStorage>().Context = dotvvmContext;
                 context.Set(HostingConstants.DotvvmRequestContextKey, dotvvmContext);
-                dotvvmContext.ChangeCurrentCulture(Configuration.DefaultCulture);
+                if (context.Get<bool?>("OwinDoNotSetRequestCulture") != true)
+                {
+                    dotvvmContext.ChangeCurrentCulture(Configuration.DefaultCulture);
+                }
 
                 try
                 {

--- a/src/Samples/ApplicationInsights.Owin/Web.config
+++ b/src/Samples/ApplicationInsights.Owin/Web.config
@@ -31,72 +31,50 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Security" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" culture="neutral" publicKeyToken="adb9793829ddae60" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Options" culture="neutral" publicKeyToken="adb9793829ddae60" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" culture="neutral" publicKeyToken="adb9793829ddae60" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31BF3856AD364E35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.11.0.0" newVersion="3.11.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.CodeAnalysis" culture="neutral" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.ApplicationInsights" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.20.0.103" newVersion="2.20.0.103" />
       </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Ben.Demystifier" publicKeyToken="A6D206E05440431A" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-0.4.0.0" newVersion="0.4.0.0" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -107,14 +85,14 @@
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Samples/ApplicationInsights.Owin/Web.config
+++ b/src/Samples/ApplicationInsights.Owin/Web.config
@@ -31,50 +31,72 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" culture="neutral" publicKeyToken="adb9793829ddae60" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Options" culture="neutral" publicKeyToken="adb9793829ddae60" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" culture="neutral" publicKeyToken="adb9793829ddae60" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.11.0.0" newVersion="3.11.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.ApplicationInsights" culture="neutral" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="0.0.0.0-2.20.0.103" newVersion="2.20.0.103" />
       </dependentAssembly>
-    </assemblyBinding>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+        <assemblyIdentity name="Ben.Demystifier" publicKeyToken="A6D206E05440431A" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.4.0.0" newVersion="0.4.0.0" />
       </dependentAssembly>
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -85,14 +107,14 @@
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Samples/AspNetCore/PrefixRequestCultureProvider.cs
+++ b/src/Samples/AspNetCore/PrefixRequestCultureProvider.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Localization;
+
+namespace DotVVM.Samples.BasicSamples
+{
+    public class PrefixRequestCultureProvider : RequestCultureProvider
+    {
+        public override Task<ProviderCultureResult> DetermineProviderCultureResult(HttpContext httpContext)
+        {
+            if (httpContext.Request.Path.StartsWithSegments("/cs"))
+            {
+                return Task.FromResult(new ProviderCultureResult("cs-CZ"));
+            }
+            else if (httpContext.Request.Path.StartsWithSegments("/de"))
+            {
+                return Task.FromResult(new ProviderCultureResult("de"));
+            }
+            else
+            {
+                return Task.FromResult(new ProviderCultureResult("en-US"));
+            }
+        }
+    }
+}

--- a/src/Samples/AspNetCore/Startup.cs
+++ b/src/Samples/AspNetCore/Startup.cs
@@ -68,10 +68,21 @@ namespace DotVVM.Samples.BasicSamples
 
             services.AddScoped<ViewModelScopedDependency>();
             services.AddTransient<ChildViewModel>();
+
+            services.Configure<RequestLocalizationOptions>(options => {
+                var supportedCultures = new[] { "en-US", "cs-CZ", "de" };
+                options
+                    .SetDefaultCulture(supportedCultures[0])
+                    .AddSupportedCultures(supportedCultures)
+                    .AddSupportedUICultures(supportedCultures)
+                    .AddInitialRequestCultureProvider(new PrefixRequestCultureProvider());
+            });
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
         {
+            app.UseRequestLocalization();
+
             app.UseRouting();
             app.UseAuthentication();
 

--- a/src/Samples/AspNetCore/Startup.cs
+++ b/src/Samples/AspNetCore/Startup.cs
@@ -75,7 +75,8 @@ namespace DotVVM.Samples.BasicSamples
                     .SetDefaultCulture(supportedCultures[0])
                     .AddSupportedCultures(supportedCultures)
                     .AddSupportedUICultures(supportedCultures)
-                    .AddInitialRequestCultureProvider(new PrefixRequestCultureProvider());
+                    .AddInitialRequestCultureProvider(new PrefixRequestCultureProvider())
+                    .AddInitialRequestCultureProvider(new QueryStringRequestCultureProvider() { UIQueryStringKey = "lang", QueryStringKey = "lang" }); ;
             });
         }
 

--- a/src/Samples/AspNetCoreLatest/PrefixRequestCultureProvider.cs
+++ b/src/Samples/AspNetCoreLatest/PrefixRequestCultureProvider.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
+
+namespace DotVVM.Samples.BasicSamples
+{
+    public class PrefixRequestCultureProvider : RequestCultureProvider
+    {
+        public override Task<ProviderCultureResult> DetermineProviderCultureResult(HttpContext httpContext)
+        {
+            if (httpContext.Request.Path.StartsWithSegments("/cs"))
+            {
+                return Task.FromResult(new ProviderCultureResult("cs-CZ"));
+            }
+            else if (httpContext.Request.Path.StartsWithSegments("/de"))
+            {
+                return Task.FromResult(new ProviderCultureResult("de"));
+            }
+            else
+            {
+                return Task.FromResult(new ProviderCultureResult("en-US"));
+            }
+        }
+    }
+}

--- a/src/Samples/AspNetCoreLatest/Startup.cs
+++ b/src/Samples/AspNetCoreLatest/Startup.cs
@@ -59,7 +59,7 @@ namespace DotVVM.Samples.BasicSamples
                 .AddCookie("Scheme3");
 
             services.AddHealthChecks();
-
+            
             services.AddLocalization(o => o.ResourcesPath = "Resources");
 
             services.AddDotVVM<DotvvmServiceConfigurator>();
@@ -71,10 +71,22 @@ namespace DotVVM.Samples.BasicSamples
             services.AddSingleton<IGreetingComputationService, HelloGreetingComputationService>();
 
             services.AddScoped<ViewModelScopedDependency>();
+
+            services.Configure<RequestLocalizationOptions>(options =>
+            {
+                var supportedCultures = new[] { "en-US", "cs-CZ", "de" };
+                options
+                    .SetDefaultCulture(supportedCultures[0])
+                    .AddSupportedCultures(supportedCultures)
+                    .AddSupportedUICultures(supportedCultures)
+                    .AddInitialRequestCultureProvider(new PrefixRequestCultureProvider());
+            });
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
         {
+            app.UseRequestLocalization();
+
             app.UseRouting();
             app.UseAuthentication();
 

--- a/src/Samples/AspNetCoreLatest/Startup.cs
+++ b/src/Samples/AspNetCoreLatest/Startup.cs
@@ -79,7 +79,8 @@ namespace DotVVM.Samples.BasicSamples
                     .SetDefaultCulture(supportedCultures[0])
                     .AddSupportedCultures(supportedCultures)
                     .AddSupportedUICultures(supportedCultures)
-                    .AddInitialRequestCultureProvider(new PrefixRequestCultureProvider());
+                    .AddInitialRequestCultureProvider(new PrefixRequestCultureProvider())
+                    .AddInitialRequestCultureProvider(new QueryStringRequestCultureProvider() { UIQueryStringKey = "lang", QueryStringKey = "lang" });
             });
         }
 

--- a/src/Samples/AspNetCoreLatest/Startup.cs
+++ b/src/Samples/AspNetCoreLatest/Startup.cs
@@ -59,7 +59,7 @@ namespace DotVVM.Samples.BasicSamples
                 .AddCookie("Scheme3");
 
             services.AddHealthChecks();
-            
+
             services.AddLocalization(o => o.ResourcesPath = "Resources");
 
             services.AddDotVVM<DotvvmServiceConfigurator>();

--- a/src/Samples/Common/DotvvmStartup.cs
+++ b/src/Samples/Common/DotvvmStartup.cs
@@ -239,6 +239,7 @@ namespace DotVVM.Samples.BasicSamples
                         new("cs-CZ", "cs/FeatureSamples/Localization/lokalizovana-routa"),
                         new("de", "de/FeatureSamples/Localization/lokalisierte-route"),
                 });
+            config.RouteTable.AddPartialMatchHandler(new CanonicalRedirectPartialMatchRouteHandler());
 
             config.RouteTable.AutoDiscoverRoutes(new DefaultRouteStrategy(config));
 

--- a/src/Samples/Common/DotvvmStartup.cs
+++ b/src/Samples/Common/DotvvmStartup.cs
@@ -234,6 +234,12 @@ namespace DotVVM.Samples.BasicSamples
             config.RouteTable.Add("FeatureSamples_Localization_Globalize", "FeatureSamples/Localization/Globalize", "Views/FeatureSamples/Localization/Globalize.dothtml", presenterFactory: LocalizablePresenter.BasedOnQuery("lang"));
             config.RouteTable.Add("FeatureSamples_CustomPrimitiveTypes_Basic", "FeatureSamples/CustomPrimitiveTypes/Basic/{Id?}", "Views/FeatureSamples/CustomPrimitiveTypes/Basic.dothtml");
 
+            config.RouteTable.Add("FeatureSamples_Localization_LocalizableRoute", "FeatureSamples/Localization/LocalizableRoute/{lang?}", "Views/FeatureSamples/Localization/LocalizableRoute.dothtml",
+                localizedUrls: new LocalizedRouteUrl[] {
+                        new("cs-CZ", "cs/FeatureSamples/Localization/lokalizovana-routa"),
+                        new("de", "de/FeatureSamples/Localization/lokalisierte-route"),
+                });
+
             config.RouteTable.AutoDiscoverRoutes(new DefaultRouteStrategy(config));
 
             config.RouteTable.Add("ControlSamples_Repeater_RouteLinkQuery-PageDetail", "ControlSamples/Repeater/RouteLinkQuery/{Id}", "Views/ControlSamples/Repeater/RouteLinkQuery.dothtml", new { Id = 0 });

--- a/src/Samples/Common/DotvvmStartup.cs
+++ b/src/Samples/Common/DotvvmStartup.cs
@@ -234,7 +234,7 @@ namespace DotVVM.Samples.BasicSamples
             config.RouteTable.Add("FeatureSamples_Localization_Globalize", "FeatureSamples/Localization/Globalize", "Views/FeatureSamples/Localization/Globalize.dothtml", presenterFactory: LocalizablePresenter.BasedOnQuery("lang"));
             config.RouteTable.Add("FeatureSamples_CustomPrimitiveTypes_Basic", "FeatureSamples/CustomPrimitiveTypes/Basic/{Id?}", "Views/FeatureSamples/CustomPrimitiveTypes/Basic.dothtml");
 
-            config.RouteTable.Add("FeatureSamples_Localization_LocalizableRoute", "FeatureSamples/Localization/LocalizableRoute/{lang?}", "Views/FeatureSamples/Localization/LocalizableRoute.dothtml",
+            config.RouteTable.Add("FeatureSamples_Localization_LocalizableRoute", "FeatureSamples/Localization/LocalizableRoute", "Views/FeatureSamples/Localization/LocalizableRoute.dothtml",
                 localizedUrls: new LocalizedRouteUrl[] {
                         new("cs-CZ", "cs/FeatureSamples/Localization/lokalizovana-routa"),
                         new("de", "de/FeatureSamples/Localization/lokalisierte-route"),

--- a/src/Samples/Common/ViewModels/FeatureSamples/Localization/LocalizableRouteViewModel.cs
+++ b/src/Samples/Common/ViewModels/FeatureSamples/Localization/LocalizableRouteViewModel.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+using DotVVM.Framework.Hosting;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.Localization
+{
+    public class LocalizableRouteViewModel : DotvvmViewModelBase
+    {
+        
+    }
+}
+

--- a/src/Samples/Common/Views/FeatureSamples/Localization/LocalizableRoute.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/Localization/LocalizableRoute.dothtml
@@ -1,0 +1,33 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.Localization.LocalizableRouteViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+
+    <h1>Localizable route test</h1>
+
+    <p>Current culture: <span data-ui="culture">{{resource: System.Globalization.CultureInfo.CurrentUICulture.Name}}</span></p>
+
+    <dot:RouteLink RouteName="FeatureSamples_Localization_LocalizableRoute"
+                   Culture="cs-CZ"
+                   Text="cs-CZ" />
+
+    <dot:RouteLink RouteName="FeatureSamples_Localization_LocalizableRoute"
+                   Culture="de"
+                   Text="de" />
+
+    <dot:RouteLink RouteName="FeatureSamples_Localization_LocalizableRoute"
+                   Culture="en-US"
+                   Text="en-US" />
+
+    <dot:RouteLink RouteName="FeatureSamples_Localization_LocalizableRoute"
+                   Text="current language" />
+</body>
+</html>
+
+

--- a/src/Samples/Owin/Startup.cs
+++ b/src/Samples/Owin/Startup.cs
@@ -4,6 +4,7 @@ using System.Web.Hosting;
 using DotVVM.Framework.Hosting;
 using DotVVM.Samples.BasicSamples;
 using DotVVM.Samples.BasicSamples.ViewModels.ComplexSamples.Auth;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Owin;
 using Microsoft.Owin.Security.Cookies;
 using Owin;
@@ -16,9 +17,7 @@ using System;
 using System.Configuration;
 using DotVVM.Framework.Utils;
 using System.Linq;
-using System.Threading;
 using System.Globalization;
-using System.Runtime.Remoting.Contexts;
 
 [assembly: OwinStartup(typeof(Startup))]
 

--- a/src/Samples/Owin/Startup.cs
+++ b/src/Samples/Owin/Startup.cs
@@ -4,7 +4,6 @@ using System.Web.Hosting;
 using DotVVM.Framework.Hosting;
 using DotVVM.Samples.BasicSamples;
 using DotVVM.Samples.BasicSamples.ViewModels.ComplexSamples.Auth;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Owin;
 using Microsoft.Owin.Security.Cookies;
 using Owin;
@@ -17,6 +16,9 @@ using System;
 using System.Configuration;
 using DotVVM.Framework.Utils;
 using System.Linq;
+using System.Threading;
+using System.Globalization;
+using System.Runtime.Remoting.Contexts;
 
 [assembly: OwinStartup(typeof(Startup))]
 
@@ -26,6 +28,21 @@ namespace DotVVM.Samples.BasicSamples
     {
         public void Configuration(IAppBuilder app)
         {
+            app.Use((context, next) => {
+                if (context.Request.Path.StartsWithSegments(new PathString("/cs")))
+                {
+                    CultureInfo.CurrentCulture = CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("cs-CZ");
+                    context.Set(HostingConstants.OwinDoNotSetRequestCulture, true);
+                }
+                else if (context.Request.Path.StartsWithSegments(new PathString("/de")))
+                {
+                    CultureInfo.CurrentCulture = CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("de");
+                    context.Set(HostingConstants.OwinDoNotSetRequestCulture, true);
+                }
+
+                return next();
+            });
+
             app.Use<SwitchMiddleware>(
                 new List<SwitchMiddlewareCase> {
                     new SwitchMiddlewareCase(

--- a/src/Samples/Owin/Startup.cs
+++ b/src/Samples/Owin/Startup.cs
@@ -28,7 +28,17 @@ namespace DotVVM.Samples.BasicSamples
         public void Configuration(IAppBuilder app)
         {
             app.Use((context, next) => {
-                if (context.Request.Path.StartsWithSegments(new PathString("/cs")))
+                if (context.Request.Query["lang"] == "cs")
+                {
+                    CultureInfo.CurrentCulture = CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("cs-CZ");
+                    context.Set(HostingConstants.OwinDoNotSetRequestCulture, true);
+                }
+                else if (context.Request.Query["lang"] == "de")
+                {
+                    CultureInfo.CurrentCulture = CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("de");
+                    context.Set(HostingConstants.OwinDoNotSetRequestCulture, true);
+                }
+                else if (context.Request.Path.StartsWithSegments(new PathString("/cs")))
                 {
                     CultureInfo.CurrentCulture = CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("cs-CZ");
                     context.Set(HostingConstants.OwinDoNotSetRequestCulture, true);

--- a/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
@@ -283,6 +283,7 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_LambdaExpressions_StaticCommands = "FeatureSamples/LambdaExpressions/StaticCommands";
         public const string FeatureSamples_LiteralBinding_LiteralBinding_Zero = "FeatureSamples/LiteralBinding/LiteralBinding_Zero";
         public const string FeatureSamples_Localization_Globalize = "FeatureSamples/Localization/Globalize";
+        public const string FeatureSamples_Localization_LocalizableRoute = "FeatureSamples/Localization/LocalizableRoute";
         public const string FeatureSamples_Localization_Localization = "FeatureSamples/Localization/Localization";
         public const string FeatureSamples_Localization_Localization_Control_Page = "FeatureSamples/Localization/Localization_Control_Page";
         public const string FeatureSamples_Localization_Localization_FormatString = "FeatureSamples/Localization/Localization_FormatString";

--- a/src/Samples/Tests/Tests/Feature/LocalizationTests.cs
+++ b/src/Samples/Tests/Tests/Feature/LocalizationTests.cs
@@ -133,6 +133,49 @@ namespace DotVVM.Samples.Tests.Feature
             });
         }
 
+        [Fact]
+        public void Feature_Localization_LocalizableRoute()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_Localization_LocalizableRoute);
+
+                var culture = browser.Single("span[data-ui=culture]");
+                var links = browser.FindElements("a");
+                AssertUI.TextEquals(culture, "en-US");
+                AssertUI.Attribute(links[0], "href", v => v.EndsWith("/cs/FeatureSamples/Localization/lokalizovana-routa"));
+                AssertUI.Attribute(links[1], "href", v => v.EndsWith("/de/FeatureSamples/Localization/lokalisierte-route"));
+                AssertUI.Attribute(links[2], "href", v => v.EndsWith("/FeatureSamples/Localization/LocalizableRoute"));
+                AssertUI.Attribute(links[3], "href", links[2].GetAttribute("href"));
+
+                links[0].Click().Wait(500);
+                culture = browser.Single("span[data-ui=culture]");
+                links = browser.FindElements("a");
+                AssertUI.TextEquals(culture, "cs-CZ");
+                AssertUI.Attribute(links[0], "href", v => v.EndsWith("/cs/FeatureSamples/Localization/lokalizovana-routa"));
+                AssertUI.Attribute(links[1], "href", v => v.EndsWith("/de/FeatureSamples/Localization/lokalisierte-route"));
+                AssertUI.Attribute(links[2], "href", v => v.EndsWith("/FeatureSamples/Localization/LocalizableRoute"));
+                AssertUI.Attribute(links[3], "href", links[0].GetAttribute("href"));
+
+                links[1].Click().Wait(500);
+                culture = browser.Single("span[data-ui=culture]");
+                links = browser.FindElements("a");
+                AssertUI.TextEquals(culture, "de");
+                AssertUI.Attribute(links[0], "href", v => v.EndsWith("/cs/FeatureSamples/Localization/lokalizovana-routa"));
+                AssertUI.Attribute(links[1], "href", v => v.EndsWith("/de/FeatureSamples/Localization/lokalisierte-route"));
+                AssertUI.Attribute(links[2], "href", v => v.EndsWith("/FeatureSamples/Localization/LocalizableRoute"));
+                AssertUI.Attribute(links[3], "href", links[1].GetAttribute("href"));
+
+                links[2].Click().Wait(500);
+                culture = browser.Single("span[data-ui=culture]");
+                links = browser.FindElements("a");
+                AssertUI.TextEquals(culture, "en-US");
+                AssertUI.Attribute(links[0], "href", v => v.EndsWith("/cs/FeatureSamples/Localization/lokalizovana-routa"));
+                AssertUI.Attribute(links[1], "href", v => v.EndsWith("/de/FeatureSamples/Localization/lokalisierte-route"));
+                AssertUI.Attribute(links[2], "href", v => v.EndsWith("/FeatureSamples/Localization/LocalizableRoute"));
+                AssertUI.Attribute(links[3], "href", links[2].GetAttribute("href"));
+            });
+        }
+
         public LocalizationTests(ITestOutputHelper output) : base(output)
         {
         }

--- a/src/Samples/Tests/Tests/Feature/LocalizationTests.cs
+++ b/src/Samples/Tests/Tests/Feature/LocalizationTests.cs
@@ -176,6 +176,19 @@ namespace DotVVM.Samples.Tests.Feature
             });
         }
 
+        [Fact]
+        public void Feature_Localization_LocalizableRoute_PartialMatchHandlers()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl("/cs/FeatureSamples/Localization/lokalizovana-routa?lang=de");
+
+                var culture = browser.Single("span[data-ui=culture]");
+                AssertUI.TextEquals(culture, "de");
+
+                AssertUI.Url(browser, p => p.EndsWith("/de/FeatureSamples/Localization/lokalisierte-route"));
+            });
+        }
+
         public LocalizationTests(ITestOutputHelper output) : base(output)
         {
         }

--- a/src/Tests/Routing/DotvvmRouteTests.cs
+++ b/src/Tests/Routing/DotvvmRouteTests.cs
@@ -325,6 +325,21 @@ namespace DotVVM.Framework.Tests.Routing
             });
         }
 
+        [DataTestMethod]
+        [DataRow("product/{id?}/{name:maxLength(5)}", "en/products/{id?}/{name:maxLength(10)}")]
+        [DataRow("product/{id?}/{name:maxLength(5)}", "en/products/{id?}/{name}")]
+        [DataRow("product/{id?}/{name:maxLength(5)}", "en/products/{Id:int?}/{name}")]
+        [DataRow("product/{id?}/{name:maxLength(5)}", "en/products/{abc}")]
+        [DataRow("product/{id?}/{name:maxLength(5)}", "en/products/{Id?}/{name:maxLength(5)}")]
+        public void LocalizedDotvvmRoute_RouteConstraintChecks(string defaultRoute, string localizedRoute)
+        {
+            Assert.ThrowsException<ArgumentException>(() => {
+                var route = new LocalizedDotvvmRoute(defaultRoute, new[] {
+                    new LocalizedRouteUrl("en", localizedRoute)
+                }, "", null, _ => null, configuration);
+            });
+        }
+
         [TestMethod]
         public void DotvvmRoute_BuildUrl_UrlTwoParameters()
         {

--- a/src/Tests/Routing/DotvvmRouteTests.cs
+++ b/src/Tests/Routing/DotvvmRouteTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using System.Globalization;
+using System.Threading;
 using DotVVM.Framework.Tests.Binding;
 
 namespace DotVVM.Framework.Tests.Routing
@@ -260,6 +261,68 @@ namespace DotVVM.Framework.Tests.Routing
 
             Assert.IsTrue(result);
             Assert.AreEqual(1, parameters.Count);
+        }
+
+        [TestMethod]
+        public void LocalizedDotvvmRoute_IsMatch_ExactCultureMatch()
+        {
+            CultureUtils.RunWithCulture("cs-CZ", () =>
+            {
+                var route = new LocalizedDotvvmRoute("cs-CZ", new [] {
+                    new LocalizedRouteUrl("cs", "cs"),
+                    new LocalizedRouteUrl("cs-CZ", "cs-CZ"),
+                    new LocalizedRouteUrl("en", "en")
+                }, "", null, _ => null, configuration);
+
+                var result = route.IsMatch("cs-CZ", out var parameters);
+                Assert.IsTrue(result);
+            });
+        }
+
+        [TestMethod]
+        public void LocalizedDotvvmRoute_IsMatch_TwoLetterCultureMatch()
+        {
+            CultureUtils.RunWithCulture("en-US", () => {
+                var route = new LocalizedDotvvmRoute("en", new[] {
+                    new LocalizedRouteUrl("cs", "cs"),
+                    new LocalizedRouteUrl("cs-CZ", "cs-CZ"),
+                    new LocalizedRouteUrl("en", "en")
+                }, "", null, _ => null, configuration);
+
+                var result = route.IsMatch("en", out var parameters);
+                Assert.IsTrue(result);
+            });
+        }
+
+        [TestMethod]
+        public void LocalizedDotvvmRoute_IsMatch_InvalidCultureMatch()
+        {
+            CultureUtils.RunWithCulture("en-US", () => {
+                var route = new LocalizedDotvvmRoute("", new[] {
+                    new LocalizedRouteUrl("cs", "cs"),
+                    new LocalizedRouteUrl("cs-CZ", "cs-CZ"),
+                    new LocalizedRouteUrl("en", "en")
+                }, "", null, _ => null, configuration);
+
+                var result = route.IsMatch("cs", out var parameters);
+                Assert.IsFalse(result);
+            });
+        }
+
+        [TestMethod]
+        public void LocalizedDotvvmRoute_IsPartialMatch()
+        {
+            CultureUtils.RunWithCulture("en-US", () => {
+                var route = new LocalizedDotvvmRoute("", new[] {
+                    new LocalizedRouteUrl("cs", "cs"),
+                    new LocalizedRouteUrl("cs-CZ", "cs-CZ"),
+                    new LocalizedRouteUrl("en", "en")
+                }, "", null, _ => null, configuration);
+
+                var result = route.IsPartialMatch("cs", out var matchedRoute, out var parameters);
+                Assert.IsTrue(result);
+                Assert.AreEqual("cs", matchedRoute.Url);
+            });
         }
 
         [TestMethod]

--- a/src/Tests/Routing/RouteTableGroupTests.cs
+++ b/src/Tests/Routing/RouteTableGroupTests.cs
@@ -40,7 +40,7 @@ namespace DotVVM.Framework.Tests.Routing
         {
             var table = new DotvvmRouteTable(configuration);
             table.AddGroup("Group", "UrlPrefix/{Id}", null, opt => {
-                opt.Add("Default", "", null, null, null);
+                opt.Add("Default", "", null, null, null, null);
             });
 
             var group = table.GetGroup("Group");
@@ -56,7 +56,7 @@ namespace DotVVM.Framework.Tests.Routing
         {
             var table = new DotvvmRouteTable(configuration);
             table.AddGroup("Group", "UrlPrefix/{Id}", null, opt => {
-                opt.Add("Route", "Article/{Title}", null, new { Title = "test" }, null);
+                opt.Add("Route", "Article/{Title}", null, new { Title = "test" }, null, null);
             });
 
             var group = table.GetGroup("Group");
@@ -74,8 +74,8 @@ namespace DotVVM.Framework.Tests.Routing
         {
             var table = new DotvvmRouteTable(configuration);
             table.AddGroup("Group", "UrlPrefix/{Id}", null, opt => {
-                opt.Add("Route0", "Article0/{Title}", null, null, null);
-                opt.Add("Route1", "Article1/{Title}", null, null, null);
+                opt.Add("Route0", "Article0/{Title}", null, null, null, null);
+                opt.Add("Route1", "Article1/{Title}", null, null, null, null);
             });
 
             var group = table.GetGroup("Group");
@@ -90,8 +90,8 @@ namespace DotVVM.Framework.Tests.Routing
         {
             var table = new DotvvmRouteTable(configuration);
             table.AddGroup("Group", "UrlPrefix/{Id}", null, opt => {
-                opt.Add("Route0", "Article0/{Title}", null, null, null);
-                opt.Add("Route1", "Article1/{Title}", null, null, null);
+                opt.Add("Route0", "Article0/{Title}", null, null, null, null);
+                opt.Add("Route1", "Article1/{Title}", null, null, null, null);
             });
 
             var group = table.GetGroup("Group");
@@ -110,11 +110,11 @@ namespace DotVVM.Framework.Tests.Routing
             table.AddGroup("Group1", "UrlPrefix1", null, opt1 => {
                 opt1.AddGroup("Group2", "UrlPrefix2", null, opt2 => {
                     opt2.AddGroup("Group3", "UrlPrefix3", null, opt3 => {
-                        opt3.Add("Route3", "Article3", null, null, null);
+                        opt3.Add("Route3", "Article3", null, null, null, null);
                     });
-                    opt2.Add("Route2", "Article2", null, null, null);
+                    opt2.Add("Route2", "Article2", null, null, null, null);
                 });
-                opt1.Add("Route1", "Article1", null, null, null);
+                opt1.Add("Route1", "Article1", null, null, null, null);
             });
 
             var group = table.GetGroup("Group1");

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -1410,6 +1410,10 @@
       }
     },
     "DotVVM.Framework.Controls.RouteLink": {
+      "Culture": {
+        "type": "System.String",
+        "onlyHardcoded": true
+      },
       "Enabled": {
         "type": "System.Boolean",
         "defaultValue": true


### PR DESCRIPTION
This PR adds support to define multiple route URLs for the same route that will apply in different request cultures.
A default route URL, which is applied for any unmatched language, is required. 
The primary motivation for this is using the same route name for all language versions of the same page. Without that, the route name for each language would have to be different and thus dynamically computed for all `RouteLink` controls in the application).

```
config.RouteTable.Add("FeatureSamples_Localization_LocalizableRoute", "FeatureSamples/Localization/LocalizableRoute/{lang?}", "Views/FeatureSamples/Localization/LocalizableRoute.dothtml",
    localizedUrls: new LocalizedRouteUrl[] {
            new("cs-CZ", "cs/FeatureSamples/Localization/lokalizovana-routa"),
            new("de", "de/FeatureSamples/Localization/lokalisierte-route"),
    });
```

The `RouteLink` control was extended with the `Culture` property to generate a link to the specified route for a different culture (to allow easy language switching).

The route matching assumes that the request culture is already set. 
Detection of the language must be done at the beginning of the request pipeline:
* In ASP.NET Core, the easiest way is to use the standard Request Localization middleware.
* In OWIN, there is no built-in mechanism. It is sufficient to write a middleware, which sets `CultureInfo.CurrentCulture` and `CultureInfo.CurrentUICulture`, but you must also call `context.Set(HostingConstants.OwinDoNotSetRequestCulture, true);` to prevent DotVVM from overwriting the current culture to `configuration.DefaultCulture`.

`LocalizablePresenter` is not supported for this feature as it detects the request culture too late.

Also, the localization is currently unavailable for URL segments defined in route groups.