### PR TITLE
DataPager styling & templating

### DIFF
--- a/src/Framework/Framework/Controls/DataPager.cs
+++ b/src/Framework/Framework/Controls/DataPager.cs
@@ -21,7 +21,6 @@ namespace DotVVM.Framework.Controls
     public class DataPager : HtmlGenericControl
     {
         private readonly GridViewDataSetBindingProvider gridViewDataSetBindingProvider;
-        private readonly BindingCompilationService bindingCompilationService;
 
         private DataPagerBindings? pagerBindings;
 
@@ -30,7 +29,6 @@ namespace DotVVM.Framework.Controls
             : base("ul", false)
         {
             this.gridViewDataSetBindingProvider = gridViewDataSetBindingProvider;
-            this.bindingCompilationService = bindingCompilationService;
         }
 
         /// <summary>
@@ -179,7 +177,7 @@ namespace DotVVM.Framework.Controls
         [MarkupOptions(AllowBinding = false)]
         public string ActiveItemCssClass
         {
-            get { return (string)GetValue(ActiveItemCssClassProperty); }
+            get { return (string)GetValue(ActiveItemCssClassProperty)!; }
             set { SetValue(ActiveItemCssClassProperty, value); }
         }
         public static readonly DotvvmProperty ActiveItemCssClassProperty
@@ -191,7 +189,7 @@ namespace DotVVM.Framework.Controls
         [MarkupOptions(AllowBinding = false)]
         public string DisabledItemCssClass
         {
-            get { return (string)GetValue(DisabledItemCssClassProperty); }
+            get { return (string)GetValue(DisabledItemCssClassProperty)!; }
             set { SetValue(DisabledItemCssClassProperty, value); }
         }
         public static readonly DotvvmProperty DisabledItemCssClassProperty
@@ -363,7 +361,7 @@ namespace DotVVM.Framework.Controls
             }
             else
             {
-                span.SetBinding(Literal.TextProperty, pagerBindings.PageNumberText.NotNull());
+                span.SetBinding(HtmlGenericControl.InnerTextProperty, pagerBindings.PageNumberText.NotNull());
             }
         }
 

--- a/src/Samples/Common/ViewModels/ControlSamples/DataPager/DataPagerTemplatesViewModel.cs
+++ b/src/Samples/Common/ViewModels/ControlSamples/DataPager/DataPagerTemplatesViewModel.cs
@@ -6,15 +6,11 @@ using System.Threading.Tasks;
 
 namespace DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.DataPager
 {
-    public class DataPagerViewModel : DotvvmViewModelBase
+    public class DataPagerTemplatesViewModel : DotvvmViewModelBase
     {
         public GridViewDataSet<Data> DataSet { get; set; }
 
-        public string[] RomanNumerals { get; set; } = new[] { "", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X", "XI", "XII", "XIII", "XIV", "XV", "XVI", "XVII", "XVIII", "XIX", "XX" };
-
-        public bool Enabled { get; set; } = true;
-
-        public int ItemsInDatabaseCount { get; set; } = 2;
+        public string[] RomanNumerals { get; set; } = new[] { "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X", "XI", "XII", "XIII", "XIV", "XV", "XVI", "XVII", "XVIII", "XIX", "XX" };
 
         public override Task Init()
         {
@@ -32,16 +28,10 @@ namespace DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.DataPager
         {
             if (DataSet.IsRefreshRequired)
             {
-                DataSet.LoadFromQueryable(FakeDB(ItemsInDatabaseCount));
+                DataSet.LoadFromQueryable(FakeDB(50));
             }
 
             return base.PreRender();
-        }
-
-        public void Populate()
-        {
-            ItemsInDatabaseCount = 50;
-            DataSet.RequestRefresh();
         }
 
         private IQueryable<Data> FakeDB(int itemsCreatorCounter)

--- a/src/Samples/Common/Views/ControlSamples/DataPager/DataPagerTemplates.dothtml
+++ b/src/Samples/Common/Views/ControlSamples/DataPager/DataPagerTemplates.dothtml
@@ -1,0 +1,52 @@
+﻿@viewModel DotVVM.Samples.BasicSamples.ViewModels.ControlSamples.DataPager.DataPagerTemplatesViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+    <style>
+        .pagination {
+            list-style-type: none;
+            display: flex;
+            align-items: center;
+        }
+        .page-item {
+            margin: 0 1em;
+        }
+        .page-link {
+            text-decoration: none;
+        }
+        .disabled {
+            opacity: 0.3;
+        }
+    </style>
+</head>
+<body>
+
+    <h1>Templates in DataPager</h1>
+
+    <dot:Repeater DataSource="{value: DataSet}" WrapperTagName="ul">
+        <ItemTemplate>
+            <li>{{value: Text}}</li>
+        </ItemTemplate>
+    </dot:Repeater>
+
+    <dot:DataPager DataSet="{value: DataSet}"
+                   class="pagination"
+                   ListItemclass="page-item"
+                   Linkclass="page-link">
+        <FirstPageTemplate>◀️◀️</FirstPageTemplate>
+        <PreviousPageTemplate>◀️</PreviousPageTemplate>
+        <NextPageTemplate>▶️</NextPageTemplate>
+        <LastPageTemplate>▶️▶️</LastPageTemplate>
+        <PageNumberTemplate>
+            {{value: _root.RomanNumerals[_this]}}
+        </PageNumberTemplate>
+    </dot:DataPager>
+
+</body>
+</html>
+
+

--- a/src/Samples/Common/Views/ControlSamples/DataPager/DataPagerTemplates.dothtml
+++ b/src/Samples/Common/Views/ControlSamples/DataPager/DataPagerTemplates.dothtml
@@ -14,6 +14,8 @@
         }
         .page-item {
             margin: 0 1em;
+            padding: 1em;
+            border: solid 1px black;
         }
         .page-link {
             text-decoration: none;
@@ -35,7 +37,7 @@
 
     <dot:DataPager DataSet="{value: DataSet}"
                    class="pagination"
-                   ListItemclass="page-item"
+                   ListItemClass="page-item"
                    Linkclass="page-link">
         <FirstPageTemplate>◀️◀️</FirstPageTemplate>
         <PreviousPageTemplate>◀️</PreviousPageTemplate>

--- a/src/Samples/Common/Views/ControlSamples/DataPager/DataPagerTemplates.dothtml
+++ b/src/Samples/Common/Views/ControlSamples/DataPager/DataPagerTemplates.dothtml
@@ -37,7 +37,7 @@
 
     <dot:DataPager DataSet="{value: DataSet}"
                    class="pagination"
-                   ListItemClass="page-item"
+                   ListItemclass="page-item"
                    Linkclass="page-link">
         <FirstPageTemplate>◀️◀️</FirstPageTemplate>
         <PreviousPageTemplate>◀️</PreviousPageTemplate>

--- a/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
@@ -76,6 +76,7 @@ namespace DotVVM.Testing.Abstractions
         public const string ControlSamples_ContentPlaceHolder_ContentPlaceHolderPage_ContentTest = "ControlSamples/ContentPlaceHolder/ContentPlaceHolderPage_ContentTest";
         public const string ControlSamples_ContentPlaceHolder_DoubleContentPlaceHolderPage_ContentTest = "ControlSamples/ContentPlaceHolder/DoubleContentPlaceHolderPage_ContentTest";
         public const string ControlSamples_DataPager_DataPager = "ControlSamples/DataPager/DataPager";
+        public const string ControlSamples_DataPager_DataPagerTemplates = "ControlSamples/DataPager/DataPagerTemplates";
         public const string ControlSamples_EnabledProperty_EnabledProperty = "ControlSamples/EnabledProperty/EnabledProperty";
         public const string ControlSamples_EnvironmentView_EnvironmentViewTest = "ControlSamples/EnvironmentView/EnvironmentViewTest";
         public const string ControlSamples_FileUpload_FileSize = "ControlSamples/FileUpload/FileSize";

--- a/src/Samples/Tests/Tests/Control/DataPagerTests.cs
+++ b/src/Samples/Tests/Tests/Control/DataPagerTests.cs
@@ -295,5 +295,27 @@ namespace DotVVM.Samples.Tests.Control
                 CheckNearPageIndexes(Enumerable.Range(11, 7));
             });
         }
+
+        [Fact]
+        public void Control_DataPager_DataPagerTemplates()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.ControlSamples_DataPager_DataPagerTemplates);
+
+                var pager = browser.Single(".pagination");
+
+                var items = pager.FindElements(".page-item");
+                items.ThrowIfDifferentCountThan(10);
+
+                var content = new[] { "◀️◀️", "◀️", "I", "II", "III", "IV", "V", "VI", "▶️", "▶️▶️" };
+                for (var i = 0; i < items.Count; i++)
+                {
+                    var item = items[i];
+
+                    var link = item.Single(".page-link");
+                    AssertUI.TextEquals(link, content[i]);
+                }
+            });
+        }
     }
 }

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -550,10 +550,20 @@
       }
     },
     "DotVVM.Framework.Controls.DataPager": {
+      "ActiveItemCssClass": {
+        "type": "System.String",
+        "defaultValue": "active",
+        "onlyHardcoded": true
+      },
       "DataSet": {
         "type": "DotVVM.Framework.Controls.IPageableGridViewDataSet`1[[DotVVM.Framework.Controls.IPagingOptions, DotVVM.Core, Version=***, Culture=neutral, PublicKeyToken=23f3607db32275da]], DotVVM.Core",
         "required": true,
         "onlyBindings": true
+      },
+      "DisabledItemCssClass": {
+        "type": "System.String",
+        "defaultValue": "disabled",
+        "onlyHardcoded": true
       },
       "Enabled": {
         "type": "System.Boolean",
@@ -574,12 +584,51 @@
         "mappingMode": "InnerElement",
         "onlyHardcoded": true
       },
+      "LinkID": {
+        "type": "System.String",
+        "fromCapability": "LinkHtmlCapability"
+      },
+      "LinkVisible": {
+        "type": "System.Boolean",
+        "defaultValue": true,
+        "fromCapability": "LinkHtmlCapability"
+      },
+      "ListItemID": {
+        "type": "System.String",
+        "fromCapability": "ListItemHtmlCapability"
+      },
+      "ListItemVisible": {
+        "type": "System.Boolean",
+        "defaultValue": true,
+        "fromCapability": "ListItemHtmlCapability"
+      },
       "LoadData": {
         "type": "DotVVM.Framework.Binding.Expressions.ICommandBinding, DotVVM.Framework",
         "onlyBindings": true
       },
       "NextPageTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
+        "mappingMode": "InnerElement",
+        "onlyHardcoded": true
+      },
+      "PageNumberTemplate": {
+        "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
+        "dataContextChange": [
+          {
+            "$type": "DotVVM.Framework.Binding.ConstantDataContextChangeAttribute",
+            "Type": "System.Int32[]",
+            "Order": 0,
+            "ServerSideOnly": null,
+            "NestDataContext": true,
+            "PropertyDependsOn": []
+          },
+          {
+            "$type": "DotVVM.Framework.Binding.CollectionElementDataContextChangeAttribute",
+            "Order": 1,
+            "NestDataContext": true,
+            "PropertyDependsOn": []
+          }
+        ],
         "mappingMode": "InnerElement",
         "onlyHardcoded": true
       },
@@ -1823,6 +1872,16 @@
         "type": "DotVVM.Framework.Controls.TextOrContentCapability, DotVVM.Framework"
       }
     },
+    "DotVVM.Framework.Controls.DataPager": {
+      "LinkHtmlCapability": {
+        "type": "DotVVM.Framework.Controls.HtmlCapability, DotVVM.Framework",
+        "capabilityPrefix": "Link"
+      },
+      "ListItemHtmlCapability": {
+        "type": "DotVVM.Framework.Controls.HtmlCapability, DotVVM.Framework",
+        "capabilityPrefix": "ListItem"
+      }
+    },
     "DotVVM.Framework.Controls.HierarchyRepeater": {
       "ItemHtmlCapability": {
         "type": "DotVVM.Framework.Controls.HtmlCapability, DotVVM.Framework",
@@ -1955,6 +2014,44 @@
         "prefix": "Property-",
         "type": "DotVVM.Framework.Binding.Expressions.IValueBinding, DotVVM.Framework",
         "fromCapability": "FieldSelectorProps"
+      }
+    },
+    "DotVVM.Framework.Controls.DataPager": {
+      "LinkAttributes": {
+        "prefixes": [
+          "Link",
+          "Linkhtml:"
+        ],
+        "type": "System.Object",
+        "fromCapability": "LinkHtmlCapability"
+      },
+      "LinkCssClasses": {
+        "prefix": "LinkClass-",
+        "type": "System.Boolean",
+        "fromCapability": "LinkHtmlCapability"
+      },
+      "LinkCssStyles": {
+        "prefix": "LinkStyle-",
+        "type": "System.Object",
+        "fromCapability": "LinkHtmlCapability"
+      },
+      "ListItemAttributes": {
+        "prefixes": [
+          "ListItem",
+          "ListItemhtml:"
+        ],
+        "type": "System.Object",
+        "fromCapability": "ListItemHtmlCapability"
+      },
+      "ListItemCssClasses": {
+        "prefix": "ListItemClass-",
+        "type": "System.Boolean",
+        "fromCapability": "ListItemHtmlCapability"
+      },
+      "ListItemCssStyles": {
+        "prefix": "ListItemStyle-",
+        "type": "System.Object",
+        "fromCapability": "ListItemHtmlCapability"
       }
     },
     "DotVVM.Framework.Controls.HierarchyRepeater": {


### PR DESCRIPTION
`DataPager` did not have a way to provide custom templates for page numbers, and there was no way to apply CSS classes or other attributes on inner `<li>` and `<a>` / `<span>` elements.

> However, there is a bug here - when I use `ListItemClass` instead of `ListItemclass`, the attribute is rendered as `Class` and is not combined with Knockout JS binding `css: { "class": something }`. 
> 
> It can be reproduced in `ControlSamples/DataPager/DataPagerTemplates` sample by changing the casing.