### PR TITLE
Helper methods to build command binding expressions

### DIFF
--- a/src/Framework/Framework/Binding/DotvvmBindingCacheHelper.cs
+++ b/src/Framework/Framework/Binding/DotvvmBindingCacheHelper.cs
@@ -60,6 +60,28 @@ namespace DotVVM.Framework.Binding
                 }));
         }
 
+        /// <summary> Compiles a new `{command: ...code...}` binding which can be evaluated server-side and also client-side. The result is cached. </summary>
+        public CommandBindingExpression CreateCommand(string code, DataContextStack dataContext, BindingParserOptions? parserOptions = null)
+        {
+            return CreateCachedBinding($"Command:{code}", new object?[] { dataContext, parserOptions }, () =>
+                new CommandBindingExpression(compilationService, new object?[] {
+                    dataContext,
+                    new OriginalStringBindingProperty(code),
+                    parserOptions
+                }));
+        }
+
+        /// <summary> Compiles a new `{command: ...code...}` binding which can be evaluated server-side and also client-side. The result is implicitly converted to <typeparamref name="TResult" />. The result is cached. </summary>
+        public CommandBindingExpression<TResult> CreateCommand<TResult>(string code, DataContextStack dataContext, BindingParserOptions? parserOptions = null)
+        {
+            return CreateCachedBinding($"Command<{typeof(TResult).ToCode()}>:{code}", new object?[] { dataContext, parserOptions }, () =>
+                new CommandBindingExpression<TResult>(compilationService, new object?[] {
+                    dataContext,
+                    new OriginalStringBindingProperty(code),
+                    parserOptions
+                }));
+        }
+
         /// <summary> Compiles a new `{staticCommand: ...code...}` binding which can be evaluated server-side and also client-side. The result is cached. </summary>
         public StaticCommandBindingExpression CreateStaticCommand(string code, DataContextStack dataContext, BindingParserOptions? parserOptions = null)
         {

--- a/src/Framework/Framework/Binding/DotvvmBindingCacheHelper.cs
+++ b/src/Framework/Framework/Binding/DotvvmBindingCacheHelper.cs
@@ -60,7 +60,7 @@ namespace DotVVM.Framework.Binding
                 }));
         }
 
-        /// <summary> Compiles a new `{resource: ...code...}` binding which can be evaluated server-side. The result is cached. </summary>
+        /// <summary> Compiles a new `{resource: ...code...}` binding which can be evaluated server-side. The result is cached. <see cref="ResourceBindingExpression.ResourceBindingExpression(BindingCompilationService, IEnumerable{object})" /> </summary>
         public ResourceBindingExpression CreateResourceBinding(string code, DataContextStack dataContext, BindingParserOptions? parserOptions = null)
         {
             return CreateCachedBinding("ResourceBinding:" + code, new object?[] { dataContext, parserOptions }, () =>
@@ -82,7 +82,7 @@ namespace DotVVM.Framework.Binding
                 }));
         }
 
-        /// <summary> Compiles a new `{command: ...code...}` binding which can be evaluated server-side and also client-side. The result is cached. </summary>
+        /// <summary> Compiles a new `{command: ...code...}` binding which can be evaluated server-side and also client-side. The result is cached. Note that command bindings might be easier to create using the <see cref="CommandBindingExpression.CommandBindingExpression(BindingCompilationService, Func{object[], System.Threading.Tasks.Task}, string)" /> constructor. </summary>
         public CommandBindingExpression CreateCommand(string code, DataContextStack dataContext, BindingParserOptions? parserOptions = null)
         {
             return CreateCachedBinding($"Command:{code}", new object?[] { dataContext, parserOptions }, () =>
@@ -93,7 +93,7 @@ namespace DotVVM.Framework.Binding
                 }));
         }
 
-        /// <summary> Compiles a new `{command: ...code...}` binding which can be evaluated server-side and also client-side. The result is implicitly converted to <typeparamref name="TResult" />. The result is cached. </summary>
+        /// <summary> Compiles a new `{command: ...code...}` binding which can be evaluated server-side and also client-side. The result is implicitly converted to <typeparamref name="TResult" />. The result is cached. Note that command bindings might be easier to create using the <see cref="CommandBindingExpression.CommandBindingExpression(BindingCompilationService, Func{object[], System.Threading.Tasks.Task}, string)" /> constructor. </summary>
         public CommandBindingExpression<TResult> CreateCommand<TResult>(string code, DataContextStack dataContext, BindingParserOptions? parserOptions = null)
         {
             return CreateCachedBinding($"Command<{typeof(TResult).ToCode()}>:{code}", new object?[] { dataContext, parserOptions }, () =>

--- a/src/Framework/Framework/Binding/DotvvmBindingCacheHelper.cs
+++ b/src/Framework/Framework/Binding/DotvvmBindingCacheHelper.cs
@@ -60,6 +60,28 @@ namespace DotVVM.Framework.Binding
                 }));
         }
 
+        /// <summary> Compiles a new `{resource: ...code...}` binding which can be evaluated server-side. The result is cached. </summary>
+        public ResourceBindingExpression CreateResourceBinding(string code, DataContextStack dataContext, BindingParserOptions? parserOptions = null)
+        {
+            return CreateCachedBinding("ResourceBinding:" + code, new object?[] { dataContext, parserOptions }, () =>
+                new ResourceBindingExpression(compilationService, new object?[] {
+                    dataContext,
+                    new OriginalStringBindingProperty(code),
+                    parserOptions
+                }));
+        }
+
+        /// <summary> Compiles a new `{resource: ...code...}` binding which can be evaluated server-side. The result is implicitly converted to <typeparamref name="TResult" />. The result is cached. </summary>
+        public ResourceBindingExpression<TResult> CreateResourceBinding<TResult>(string code, DataContextStack dataContext, BindingParserOptions? parserOptions = null)
+        {
+            return CreateCachedBinding($"ResourceBinding<{typeof(TResult).ToCode()}>:{code}", new object?[] { dataContext, parserOptions }, () =>
+                new ResourceBindingExpression<TResult>(compilationService, new object?[] {
+                    dataContext,
+                    new OriginalStringBindingProperty(code),
+                    parserOptions
+                }));
+        }
+
         /// <summary> Compiles a new `{command: ...code...}` binding which can be evaluated server-side and also client-side. The result is cached. </summary>
         public CommandBindingExpression CreateCommand(string code, DataContextStack dataContext, BindingParserOptions? parserOptions = null)
         {

--- a/src/Framework/Framework/Binding/Expressions/CommandBindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/CommandBindingExpression.cs
@@ -30,7 +30,7 @@ namespace DotVVM.Framework.Binding.Expressions
     [Options]
     public class CommandBindingExpression : BindingExpression, ICommandBinding
     {
-        public CommandBindingExpression(BindingCompilationService service, IEnumerable<object> properties) : base(service, properties)
+        public CommandBindingExpression(BindingCompilationService service, IEnumerable<object?> properties) : base(service, properties)
         {
             AddNullResolvers();
         }
@@ -172,6 +172,6 @@ namespace DotVVM.Framework.Binding.Expressions
     public class CommandBindingExpression<T> : CommandBindingExpression, ICommandBinding<T>
     {
         public new BindingDelegate<T> BindingDelegate => base.BindingDelegate.ToGeneric<T>();
-        public CommandBindingExpression(BindingCompilationService service, IEnumerable<object> properties) : base(service, properties) { }
+        public CommandBindingExpression(BindingCompilationService service, IEnumerable<object?> properties) : base(service, properties) { }
     }
 }

--- a/src/Framework/Framework/Binding/Expressions/ResourceBindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/ResourceBindingExpression.cs
@@ -18,7 +18,7 @@ namespace DotVVM.Framework.Binding.Expressions
     [Options]
     public class ResourceBindingExpression : BindingExpression, IStaticValueBinding
     {
-        public ResourceBindingExpression(BindingCompilationService service, IEnumerable<object> properties) : base(service, properties) { }
+        public ResourceBindingExpression(BindingCompilationService service, IEnumerable<object?> properties) : base(service, properties) { }
 
         public BindingDelegate BindingDelegate => this.bindingDelegate.GetValueOrThrow(this);
 
@@ -34,7 +34,7 @@ namespace DotVVM.Framework.Binding.Expressions
 
     public class ResourceBindingExpression<T> : ResourceBindingExpression, IStaticValueBinding<T>
     {
-        public ResourceBindingExpression(BindingCompilationService service, IEnumerable<object> properties) : base(service, properties) { }
+        public ResourceBindingExpression(BindingCompilationService service, IEnumerable<object?> properties) : base(service, properties) { }
 
         public new BindingDelegate<T> BindingDelegate => base.BindingDelegate.ToGeneric<T>();
     }

--- a/src/Samples/Owin/Web.config
+++ b/src/Samples/Owin/Web.config
@@ -49,6 +49,12 @@
     </assemblyBinding>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+    </assemblyBinding>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>


### PR DESCRIPTION
The `bindingCompilationService.Cache` already had methods to build `value` and `staticCommand` bindings. 
I have added methods for creating `command` bindings as well.

Does `resource` binding also make sense here?