### PR TITLE
Added AlternateCultureLinks control

### DIFF
--- a/src/Framework/Framework/Controls/AlternateCultureLinks.cs
+++ b/src/Framework/Framework/Controls/AlternateCultureLinks.cs
@@ -30,7 +30,7 @@ namespace DotVVM.Framework.Controls
                     if (alternateCultureRoute.Value == currentCultureRoute) continue;
 
                     var languageCode = alternateCultureRoute.Key == "" ? "x-default" : alternateCultureRoute.Key.ToLowerInvariant();
-                    var alternateUrl = context.TranslateVirtualPath(alternateCultureRoute.Value.BuildUrl(context.Parameters));
+                    var alternateUrl = context.TranslateVirtualPath(alternateCultureRoute.Value.BuildUrl(context.Parameters!));
                     var absoluteAlternateUrl = BuildAbsoluteAlternateUrl(alternateUrl);
 
                     yield return new HtmlGenericControl("link")

--- a/src/Framework/Framework/Controls/AlternateCultureLinks.cs
+++ b/src/Framework/Framework/Controls/AlternateCultureLinks.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using DotVVM.Framework.Configuration;
+using DotVVM.Framework.Hosting;
+using DotVVM.Framework.Routing;
+
+namespace DotVVM.Framework.Controls
+{
+    public class AlternateCultureLinks : CompositeControl 
+    {
+        private readonly IDotvvmRequestContext context;
+
+        public AlternateCultureLinks(IDotvvmRequestContext context)
+        {
+            this.context = context;
+        }
+
+        public IEnumerable<DotvvmControl> GetContents(string? routeName = null)
+        {
+            var route = routeName != null ? context.Configuration.RouteTable[routeName] : context.Route;
+            if (route is LocalizedDotvvmRoute localizedRoute)
+            {
+                var currentCultureRoute = localizedRoute.GetRouteForCulture(CultureInfo.CurrentUICulture);
+
+                foreach (var alternateCultureRoute in localizedRoute.GetAllCultureRoutes())
+                {
+                    if (alternateCultureRoute.Value == currentCultureRoute) continue;
+
+                    var languageCode = alternateCultureRoute.Key == "" ? "x-default" : alternateCultureRoute.Key.ToLowerInvariant();
+                    var alternateUrl = context.TranslateVirtualPath(alternateCultureRoute.Value.BuildUrl(context.Parameters));
+                    var absoluteAlternateUrl = BuildAbsoluteAlternateUrl(alternateUrl);
+
+                    yield return new HtmlGenericControl("link")
+                        .SetAttribute("rel", "alternate")
+                        .SetAttribute("hreflang", languageCode)
+                        .SetAttribute("href", absoluteAlternateUrl);
+                }
+
+            }
+        }
+
+        protected virtual string BuildAbsoluteAlternateUrl(string alternateUrl)
+        {
+            return new Uri(context.HttpContext.Request.Url, alternateUrl).AbsoluteUri;
+        }
+    }
+}

--- a/src/Framework/Framework/Controls/AlternateCultureLinks.cs
+++ b/src/Framework/Framework/Controls/AlternateCultureLinks.cs
@@ -9,16 +9,18 @@ using DotVVM.Framework.Routing;
 
 namespace DotVVM.Framework.Controls
 {
+    /// <summary>
+    /// Renders a <c>&lt;link rel=alternate</c> element for each localized route equivalent to the current route.
+    /// On non-localized routes, it renders nothing (the control is therefore safe to use in a master page).
+    /// The href must be an absolute URL, so it will only work correctly if <c>Context.Request.Url</c> contains the corrent domain.
+    /// </summary>
+    /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#alternate" />
+    /// <seealso href="https://developers.google.com/search/docs/specialty/international/localized-versions#html" />
+    /// <seealso cref="DotvvmRouteTable.Add(string, string, Type, object, LocalizedRouteUrl[])"/>
     public class AlternateCultureLinks : CompositeControl 
     {
-        private readonly IDotvvmRequestContext context;
-
-        public AlternateCultureLinks(IDotvvmRequestContext context)
-        {
-            this.context = context;
-        }
-
-        public IEnumerable<DotvvmControl> GetContents(string? routeName = null)
+        /// <param name="routeName">The name of the route to generate alternate links for. If not set, the current route is used. </param>
+        public IEnumerable<DotvvmControl> GetContents(IDotvvmRequestContext context, string? routeName = null)
         {
             var route = routeName != null ? context.Configuration.RouteTable[routeName] : context.Route;
             if (route is LocalizedDotvvmRoute localizedRoute)
@@ -31,7 +33,7 @@ namespace DotVVM.Framework.Controls
 
                     var languageCode = alternateCultureRoute.Key == "" ? "x-default" : alternateCultureRoute.Key.ToLowerInvariant();
                     var alternateUrl = context.TranslateVirtualPath(alternateCultureRoute.Value.BuildUrl(context.Parameters!));
-                    var absoluteAlternateUrl = BuildAbsoluteAlternateUrl(alternateUrl);
+                    var absoluteAlternateUrl = BuildAbsoluteAlternateUrl(context, alternateUrl);
 
                     yield return new HtmlGenericControl("link")
                         .SetAttribute("rel", "alternate")
@@ -42,7 +44,7 @@ namespace DotVVM.Framework.Controls
             }
         }
 
-        protected virtual string BuildAbsoluteAlternateUrl(string alternateUrl)
+        protected virtual string BuildAbsoluteAlternateUrl(IDotvvmRequestContext context, string alternateUrl)
         {
             return new Uri(context.HttpContext.Request.Url, alternateUrl).AbsoluteUri;
         }

--- a/src/Framework/Framework/Routing/LocalizedDotvvmRoute.cs
+++ b/src/Framework/Framework/Routing/LocalizedDotvvmRoute.cs
@@ -98,6 +98,8 @@ namespace DotVVM.Framework.Routing
                 : throw new NotSupportedException("Invalid localized route - no default route found!");
         }
 
+        public IReadOnlyDictionary<string, DotvvmRoute> GetAllCultureRoutes() => localizedRoutes;
+
         public static void ValidateCultureName(string cultureIdentifier)
         {
             if (!AvailableCultureNames.Contains(cultureIdentifier))

--- a/src/Samples/Common/Views/FeatureSamples/Localization/LocalizableRoute.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/Localization/LocalizableRoute.dothtml
@@ -6,6 +6,8 @@
 <head>
     <meta charset="utf-8" />
     <title></title>
+
+    <dot:AlternateCultureLinks />
 </head>
 <body>
 

--- a/src/Samples/Tests/Tests/Feature/LocalizationTests.cs
+++ b/src/Samples/Tests/Tests/Feature/LocalizationTests.cs
@@ -146,6 +146,8 @@ namespace DotVVM.Samples.Tests.Feature
                 AssertUI.Attribute(links[1], "href", v => v.EndsWith("/de/FeatureSamples/Localization/lokalisierte-route"));
                 AssertUI.Attribute(links[2], "href", v => v.EndsWith("/FeatureSamples/Localization/LocalizableRoute"));
                 AssertUI.Attribute(links[3], "href", links[2].GetAttribute("href"));
+                AssertAlternateLink("cs-cz", "/cs/FeatureSamples/Localization/lokalizovana-routa");
+                AssertAlternateLink("de", "/de/FeatureSamples/Localization/lokalisierte-route");
 
                 links[0].Click().Wait(500);
                 culture = browser.Single("span[data-ui=culture]");
@@ -155,6 +157,8 @@ namespace DotVVM.Samples.Tests.Feature
                 AssertUI.Attribute(links[1], "href", v => v.EndsWith("/de/FeatureSamples/Localization/lokalisierte-route"));
                 AssertUI.Attribute(links[2], "href", v => v.EndsWith("/FeatureSamples/Localization/LocalizableRoute"));
                 AssertUI.Attribute(links[3], "href", links[0].GetAttribute("href"));
+                AssertAlternateLink("x-default", "/FeatureSamples/Localization/LocalizableRoute");
+                AssertAlternateLink("de", "/de/FeatureSamples/Localization/lokalisierte-route");
 
                 links[1].Click().Wait(500);
                 culture = browser.Single("span[data-ui=culture]");
@@ -164,6 +168,8 @@ namespace DotVVM.Samples.Tests.Feature
                 AssertUI.Attribute(links[1], "href", v => v.EndsWith("/de/FeatureSamples/Localization/lokalisierte-route"));
                 AssertUI.Attribute(links[2], "href", v => v.EndsWith("/FeatureSamples/Localization/LocalizableRoute"));
                 AssertUI.Attribute(links[3], "href", links[1].GetAttribute("href"));
+                AssertAlternateLink("x-default", "/FeatureSamples/Localization/LocalizableRoute");
+                AssertAlternateLink("cs-cz", "/cs/FeatureSamples/Localization/lokalizovana-routa");
 
                 links[2].Click().Wait(500);
                 culture = browser.Single("span[data-ui=culture]");
@@ -173,6 +179,13 @@ namespace DotVVM.Samples.Tests.Feature
                 AssertUI.Attribute(links[1], "href", v => v.EndsWith("/de/FeatureSamples/Localization/lokalisierte-route"));
                 AssertUI.Attribute(links[2], "href", v => v.EndsWith("/FeatureSamples/Localization/LocalizableRoute"));
                 AssertUI.Attribute(links[3], "href", links[2].GetAttribute("href"));
+                AssertAlternateLink("cs-cz", "/cs/FeatureSamples/Localization/lokalizovana-routa");
+                AssertAlternateLink("de", "/de/FeatureSamples/Localization/lokalisierte-route");
+
+                void AssertAlternateLink(string culture, string url)
+                {
+                    AssertUI.Attribute(browser.Single($"link[rel=alternate][hreflang={culture}]"), "href", this.TestSuiteRunner.Configuration.BaseUrls[0].TrimEnd('/') + url);
+                }
             });
         }
 

--- a/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
+++ b/src/Tests/Runtime/config-tests/ConfigurationSerializationTests.SerializeDefaultConfig.json
@@ -360,6 +360,12 @@
         "mappingMode": "InnerElement"
       }
     },
+    "DotVVM.Framework.Controls.AlternateCultureLinks": {
+      "RouteName": {
+        "type": "System.String",
+        "onlyHardcoded": true
+      }
+    },
     "DotVVM.Framework.Controls.AuthenticatedView": {
       "AuthenticatedTemplate": {
         "type": "DotVVM.Framework.Controls.ITemplate, DotVVM.Framework",
@@ -2004,6 +2010,12 @@
       "assembly": "DotVVM.Framework",
       "baseType": "DotVVM.Framework.Controls.Decorator, DotVVM.Framework",
       "withoutContent": true
+    },
+    "DotVVM.Framework.Controls.AlternateCultureLinks": {
+      "assembly": "DotVVM.Framework",
+      "baseType": "DotVVM.Framework.Controls.CompositeControl, DotVVM.Framework",
+      "withoutContent": true,
+      "isComposite": true
     },
     "DotVVM.Framework.Controls.AuthenticatedView": {
       "assembly": "DotVVM.Framework",


### PR DESCRIPTION
Since we have localizable routes, we are able to automatically generate the list of `<link rel=alternate>` elements, as described at https://developers.google.com/search/docs/specialty/international/localized-versions#html