### PR TITLE
Add memory barries to writes at the end of a lock

### DIFF
--- a/src/Framework/Framework/Binding/DotvvmProperty.cs
+++ b/src/Framework/Framework/Binding/DotvvmProperty.cs
@@ -115,7 +115,11 @@ namespace DotVVM.Framework.Binding
             if (p is object)
                 lock(this)
                 {
-                    UsedInCapabilities = UsedInCapabilities.Add(p);
+                    if (UsedInCapabilities.Contains(p)) return;
+
+                    var newArray = UsedInCapabilities.Add(p);
+                    Thread.MemoryBarrier(); // make sure the array is complete before we let other threads use it lock-free
+                    UsedInCapabilities = newArray;
                 }
         }
 

--- a/src/Framework/Framework/Binding/Expressions/BindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/BindingExpression.cs
@@ -260,7 +260,7 @@ namespace DotVVM.Framework.Binding.Expressions
 
 
 
-        string? toStringValue;
+        volatile string? toStringValue;
         public override string ToString()
         {
             if (toStringValue is null)

--- a/src/Framework/Framework/Compilation/ControlTree/DotvvmPropertyGroup.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/DotvvmPropertyGroup.cs
@@ -9,6 +9,7 @@ using DotVVM.Framework.Compilation.ControlTree.Resolved;
 using DotVVM.Framework.Utils;
 using System.Runtime.CompilerServices;
 using System.Collections.Immutable;
+using System.Threading;
 
 namespace DotVVM.Framework.Compilation.ControlTree
 {
@@ -81,8 +82,11 @@ namespace DotVVM.Framework.Compilation.ControlTree
             if (p is object)
                 lock(this)
                 {
-                    if (!UsedInCapabilities.Contains(p))
-                        UsedInCapabilities = UsedInCapabilities.Add(p);
+                    if (UsedInCapabilities.Contains(p)) return;
+
+                    var newArray = UsedInCapabilities.Add(p);
+                    Thread.MemoryBarrier();
+                    UsedInCapabilities = newArray;
                 }
         }
 

--- a/src/Framework/Framework/Compilation/ExtensionMethodsCache.cs
+++ b/src/Framework/Framework/Compilation/ExtensionMethodsCache.cs
@@ -38,7 +38,6 @@ namespace DotVVM.Framework.Compilation
             // it's most likely the same namespaces, so it won't help at all - only run into lock contention in System.Reflection
             lock (methodsCache)
             {
-                results = namespaces.Select(x => methodsCache.GetValueOrDefault(x)).ToArray();
                 var missingNamespaces = namespaces.Where(x => !methodsCache.ContainsKey(x)).ToArray();
 
                 var createdNamespaces = CreateExtensionsForNamespaces(missingNamespaces);

--- a/src/Framework/Framework/Compilation/Styles/ResolvedControlHelper.cs
+++ b/src/Framework/Framework/Compilation/Styles/ResolvedControlHelper.cs
@@ -19,6 +19,7 @@ using DotVVM.Framework.Hosting;
 using DotVVM.Framework.Compilation.ViewCompiler;
 using DotVVM.Framework.Runtime;
 using FastExpressionCompiler;
+using System.Threading;
 
 namespace DotVVM.Framework.Compilation.Styles
 {
@@ -417,6 +418,7 @@ namespace DotVVM.Framework.Compilation.Styles
                     var services = context?.Services ?? this.services;
 
                     Children.Add((DotvvmControl)ResolvedControl.ToRuntimeControl(services));
+                    Thread.MemoryBarrier(); // make sure write to Children is done before we let other threads read without lock
                     initialized = true;
                 }
             }


### PR DESCRIPTION
There could have been a race condition on systems with weak memory ordering:

Another thread can read the result value before we exit the critical section. Without a strong memory ordering, the pointer to the result value might get written before the value itself. The other thread might therefore read zeroed-out memory.