### PR TITLE
Fix viewmodel restore on back/forward navigation

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/dotvvm-base.ts
+++ b/src/Framework/Framework/Resources/Scripts/dotvvm-base.ts
@@ -69,6 +69,10 @@ export function getStateManager(): StateManager<RootViewModel> { return getCoreS
 
 let initialViewModelWrapper: any;
 
+function isBackForwardNavigation() {
+    return (performance.getEntriesByType?.("navigation").at(-1) as PerformanceNavigationTiming)?.type == "back_forward";
+}
+
 export function initCore(culture: string): void {
     if (currentCoreState) {
         throw new Error("DotVVM is already loaded");
@@ -124,8 +128,10 @@ const getViewModelStorageElement = () =>
     <HTMLInputElement>document.getElementById("__dot_viewmodel_root")
 
 function persistViewModel() {
-    const viewModel = getState()
-    const persistedViewModel = { ...initialViewModelWrapper, viewModel };
-
-    getViewModelStorageElement().value = JSON.stringify(persistedViewModel);
+    history.replaceState({
+        ...history.state,
+        viewModel: { ...initialViewModelWrapper, viewModel: getState() }
+    }, "")
+    // avoid storing the viewmodel hidden field, as Firefox would also reuse it on page reloads
+    getViewModelStorageElement()?.remove()
 }

--- a/src/Framework/Framework/Resources/Scripts/dotvvm-base.ts
+++ b/src/Framework/Framework/Resources/Scripts/dotvvm-base.ts
@@ -79,7 +79,9 @@ export function initCore(culture: string): void {
     }
 
     // load the viewmodel
-    const thisViewModel = initialViewModelWrapper = JSON.parse(getViewModelStorageElement().value);
+    const thisViewModel = initialViewModelWrapper =
+        (isBackForwardNavigation() ? history.state?.viewModel : null) ??
+        JSON.parse(getViewModelStorageElement().value);
 
     resourceLoader.registerResources(thisViewModel.renderedResources)
 

--- a/src/Samples/Tests/Tests/Complex/TaskListTests.cs
+++ b/src/Samples/Tests/Tests/Complex/TaskListTests.cs
@@ -62,5 +62,46 @@ namespace DotVVM.Samples.Tests.Complex
                     "Last task is not marked as completed.");
             });
         }
+
+        [Fact]
+        public void Complex_TaskList_TaskListAsyncCommands_ViewModelRestore()
+        {
+            // view model should be restored after back/forward navigation, but not on refresh
+            RunInAllBrowsers(browser =>
+            {
+                browser.NavigateToUrl("/");
+                browser.NavigateToUrl(SamplesRouteUrls.ComplexSamples_TaskList_TaskListAsyncCommands);
+
+                browser.SendKeys("input[type=text]", "test1");
+                browser.Click("input[type=button]");
+
+                browser.FindElements(".table tr").ThrowIfDifferentCountThan(4);
+
+                browser.NavigateBack();
+                browser.WaitUntilDotvvmInited();
+                browser.NavigateForward();
+
+                browser.FindElements(".table tr").ThrowIfDifferentCountThan(4);
+
+                browser.Refresh();
+
+                browser.FindElements(".table tr").ThrowIfDifferentCountThan(3);
+
+                browser.SendKeys("input[type=text]", "test2");
+                browser.Click("input[type=button]");
+                browser.FindElements(".table tr").ThrowIfDifferentCountThan(4);
+
+                browser.NavigateToUrl("/");
+                browser.NavigateToUrl(SamplesRouteUrls.ComplexSamples_TaskList_TaskListAsyncCommands);
+
+                browser.FindElements(".table tr").ThrowIfDifferentCountThan(3);
+
+                browser.NavigateBack();
+                browser.WaitUntilDotvvmInited();
+                browser.NavigateBack();
+
+                browser.FindElements(".table tr").ThrowIfDifferentCountThan(4);
+            });
+        }
     }
 }

--- a/src/Samples/Tests/Tests/Feature/FormControlsEnabledTests.cs
+++ b/src/Samples/Tests/Tests/Feature/FormControlsEnabledTests.cs
@@ -84,7 +84,7 @@ namespace DotVVM.Samples.Tests.Feature
 
         private void TestLinkButton(IBrowserWrapper browser, string id, bool shouldBeEnabled, ref int currentPresses)
         {
-            browser.First($"#{id}").Click();
+            browser.First($"#{id}").ScrollTo().Wait(500).Click();
             if (shouldBeEnabled)
             {
                 currentPresses++;


### PR DESCRIPTION
* In Firefox, this worked, but also restored it on page reloads
* In Chromium, viewmodel was always reset to the initial state

This patch unifies the behavior to restore the viewmodel, but not if it is in page reload