### PR TITLE
js translations: TimeOnly, DateOnly and DateTime.Now

### DIFF
--- a/src/Framework/Framework/Compilation/Javascript/Ast/JsAstHelpers.cs
+++ b/src/Framework/Framework/Compilation/Javascript/Ast/JsAstHelpers.cs
@@ -19,6 +19,9 @@ namespace DotVVM.Framework.Compilation.Javascript.Ast
         public static JsExpression Invoke(this JsExpression target, params JsExpression?[] arguments) =>
             new JsInvocationExpression(target, arguments);
 
+        public static JsExpression CallMethod(this JsExpression target, string methodName, params JsExpression?[] arguments) =>
+            target.Member(methodName).Invoke(arguments);
+
         public static JsExpression Indexer(this JsExpression target, JsExpression argument)
         {
             return new JsIndexerExpression(target, argument);

--- a/src/Framework/Framework/Resources/Scripts/dotvvm-root.ts
+++ b/src/Framework/Framework/Resources/Scripts/dotvvm-root.ts
@@ -4,7 +4,7 @@ import * as spa from "./spa/spa"
 import * as validation from './validation/validation'
 import { postBack } from './postback/postback'
 import { serialize } from './serialization/serialize'
-import { serializeDate, parseDate } from './serialization/date'
+import { serializeDate, parseDate, parseDateOnly, parseTimeOnly } from './serialization/date'
 import { deserialize } from './serialization/deserialize'
 import registerBindingHandlers from './binding-handlers/register'
 import * as evaluator from './utils/evaluator'
@@ -97,6 +97,8 @@ const dotvvmExports = {
         serialize,
         serializeDate,
         parseDate,
+        parseDateOnly,
+        parseTimeOnly,
         deserialize
     },
     metadata: {

--- a/src/Samples/Common/Views/FeatureSamples/JavascriptTranslation/DateOnlyTranslations.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/JavascriptTranslation/DateOnlyTranslations.dothtml
@@ -1,0 +1,36 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.JavascriptTranslation.DateTimeTranslationsViewModel, DotVVM.Samples.Common
+@import System
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+    <style>
+        *[data-ui] {
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body>
+
+    <h1>DateOnly testing</h1>
+
+    <dot:TextBox data-ui="textbox" Text="{value: NullableDateTimeProp}" />
+    <dot:Button Text="now" Click="{staticCommand: NullableDateTimeProp = DateTime.Now}" />
+
+    <p>
+        <span>DateOnly.ToString: </span>
+        <span data-ui="dateOnlyToString" InnerText="{value: DateOnly.FromDateTime(NullableDateTimeProp)}" />
+    </p>
+    <p>
+        <span>DateOnly properties: </span>
+        <span data-ui="dateOnlyProperties">
+            {{value: DateOnly.FromDateTime(NullableDateTimeProp).Day}}. {{value: DateOnly.FromDateTime(NullableDateTimeProp).Month}}. {{value: DateOnly.FromDateTime(NullableDateTimeProp).Year}}
+        </span>
+    </p>
+</body>
+</html>
+
+

--- a/src/Samples/Common/Views/FeatureSamples/JavascriptTranslation/DateTimeTranslations.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/JavascriptTranslation/DateTimeTranslations.dothtml
@@ -24,11 +24,19 @@
             TimeShift.setTimezoneOffset(-120);
         }())
     </script>
+    <style>
+        *[data-ui] {
+            font-weight: bold;
+        }
+    </style>
 </head>
 <body>
 
     <h1>DateTime testing</h1>
     <dot:TextBox data-ui="textbox" Text="{value: DateTimeProp}" />
+    <dot:Button Text="now" Click="{staticCommand: DateTimeProp = DateTime.Now}" />
+    <dot:Button Text="UTC now" Click="{staticCommand: DateTimeProp = DateTime.UtcNow}" />
+    <dot:Button Text="today" Click="{staticCommand: DateTimeProp = DateTime.Today}" />
 
     <p>
         <span>Year: </span>

--- a/src/Samples/Common/Views/FeatureSamples/JavascriptTranslation/TimeOnlyTranslations.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/JavascriptTranslation/TimeOnlyTranslations.dothtml
@@ -1,0 +1,35 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.JavascriptTranslation.DateTimeTranslationsViewModel, DotVVM.Samples.Common
+@import System
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+    <style>
+        *[data-ui] {
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body>
+
+    <h1>TimeOnly testing</h1>
+    <dot:TextBox data-ui="textbox" Text="{value: NullableDateTimeProp}" />
+    <dot:Button Text="now" Click="{staticCommand: NullableDateTimeProp = DateTime.Now}" />
+
+    <p>
+        <span>TimeOnly.ToString: </span>
+        <span data-ui="timeOnlyToString" InnerText="{value: TimeOnly.FromDateTime(NullableDateTimeProp)}" />
+    </p>
+    <p>
+        <span>TimeOnly properties: </span>
+        <span data-ui="timeOnlyProperties">
+            {{value: TimeOnly.FromDateTime(NullableDateTimeProp).Hour}} hours {{value: TimeOnly.FromDateTime(NullableDateTimeProp).Minute}} minues {{value: TimeOnly.FromDateTime(NullableDateTimeProp).Second}} seconds and {{value: TimeOnly.FromDateTime(NullableDateTimeProp).Millisecond}} milliseconds
+        </span>
+
+</body>
+</html>
+
+

--- a/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
@@ -264,12 +264,14 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_IdGeneration_IdGeneration = "FeatureSamples/IdGeneration/IdGeneration";
         public const string FeatureSamples_JavascriptEvents_JavascriptEvents = "FeatureSamples/JavascriptEvents/JavascriptEvents";
         public const string FeatureSamples_JavascriptTranslation_ArrayTranslation = "FeatureSamples/JavascriptTranslation/ArrayTranslation";
+        public const string FeatureSamples_JavascriptTranslation_DateOnlyTranslations = "FeatureSamples/JavascriptTranslation/DateOnlyTranslations";
         public const string FeatureSamples_JavascriptTranslation_DateTimeTranslations = "FeatureSamples/JavascriptTranslation/DateTimeTranslations";
         public const string FeatureSamples_JavascriptTranslation_DictionaryIndexerTranslation = "FeatureSamples/JavascriptTranslation/DictionaryIndexerTranslation";
         public const string FeatureSamples_JavascriptTranslation_GenericMethodTranslation = "FeatureSamples/JavascriptTranslation/GenericMethodTranslation";
         public const string FeatureSamples_JavascriptTranslation_ListIndexerTranslation = "FeatureSamples/JavascriptTranslation/ListIndexerTranslation";
         public const string FeatureSamples_JavascriptTranslation_ListMethodTranslations = "FeatureSamples/JavascriptTranslation/ListMethodTranslations";
         public const string FeatureSamples_JavascriptTranslation_MathMethodTranslation = "FeatureSamples/JavascriptTranslation/MathMethodTranslation";
+        public const string FeatureSamples_JavascriptTranslation_TimeOnlyTranslations = "FeatureSamples/JavascriptTranslation/TimeOnlyTranslations";
         public const string FeatureSamples_JavascriptTranslation_StringMethodTranslations = "FeatureSamples/JavascriptTranslation/StringMethodTranslations";
         public const string FeatureSamples_JavascriptTranslation_WebUtilityTranslations = "FeatureSamples/JavascriptTranslation/WebUtilityTranslations";
         public const string FeatureSamples_JsComponentIntegration_ReactComponentIntegration = "FeatureSamples/JsComponentIntegration/ReactComponentIntegration";

--- a/src/Samples/Tests/Tests/Feature/DateTimeTranslationTests.cs
+++ b/src/Samples/Tests/Tests/Feature/DateTimeTranslationTests.cs
@@ -68,6 +68,43 @@ namespace DotVVM.Samples.Tests.Feature
             });
         }
 
+        [Fact]
+        public void Feature_DateOnly_PropertyTranslations()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_JavascriptTranslation_DateOnlyTranslations);
+
+                var stringDateTime = "6/28/2021 3:28:31 PM";
+
+                var textbox = browser.Single("input[data-ui=textbox]");
+                textbox.Clear().SendKeys(stringDateTime).SendEnterKey();
+
+                var str = browser.Single("span[data-ui=dateOnlyToString]");
+                AssertUI.TextEquals(str, "Monday, June 28, 2021");
+                var props = browser.Single("span[data-ui=dateOnlyProperties]");
+                AssertUI.TextEquals(props, "28. 6. 2021");
+            });
+        }
+
+        [Fact]
+        public void Feature_TimeOnly_PropertyTranslations()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_JavascriptTranslation_TimeOnlyTranslations);
+
+                var stringDateTime = "6/28/2021 3:28:31 PM";
+
+                var textbox = browser.Single("input[data-ui=textbox]");
+                textbox.Clear().SendKeys(stringDateTime).SendEnterKey();
+
+                var str = browser.Single("span[data-ui=timeOnlyToString]");
+                AssertUI.TextEquals(str, "3:28:31 PM");
+                var props = browser.Single("span[data-ui=timeOnlyProperties]");
+                AssertUI.TextEquals(props, "15 hours 28 minues 31 seconds and 0 milliseconds");
+            });
+        }
+
+
         public DateTimeTranslationTests(ITestOutputHelper output) : base(output)
         {
         }

--- a/src/Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/Tests/Binding/JavascriptCompilationTests.cs
@@ -1113,6 +1113,17 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        [DataRow("DateTime.Now", "dotvvm.serialization.serializeDate(new Date(),false)")]
+        [DataRow("DateTime.UtcNow", "dotvvm.serialization.serializeDate(new Date(),true)")]
+        [DataRow("DateTime.Today", "dotvvm.serialization.serializeDate(new Date(),false).substring(0,10)+\"T00:00:00.000\"")]
+        public void JsTranslator_DateTime_Now(string binding, string expected)
+        {
+            var result = CompileBinding(binding);
+            Assert.AreEqual(expected, result);
+        }
+
+
+        [TestMethod]
         [DataRow("DateOnly.ToString()", "")]
         [DataRow("DateOnly.ToString('D')", "\"D\"")]
         public void JsTranslator_DateOnly_ToString(string binding, string args)
@@ -1127,6 +1138,16 @@ namespace DotVVM.Framework.Tests.Binding
         {
             var result = CompileBinding(binding, new[] { typeof(TestViewModel) });
             Assert.AreEqual($"dotvvm.globalize.bindingDateOnlyToString(NullableDateOnly{((args.Length > 0) ? $",{args}" : string.Empty)})", result);
+        }
+
+        [DataTestMethod]
+        [DataRow("DateOnly.Year", "getFullYear()")]
+        [DataRow("DateOnly.Month", "getMonth()+1")]
+        [DataRow("DateOnly.Day", "getDate()")]
+        public void JsTranslator_DateOnly_Property_Getters(string binding, string jsFunction)
+        {
+            var result = CompileBinding(binding, new[] { typeof(TestViewModel) });
+            Assert.AreEqual($"dotvvm.serialization.parseDateOnly(DateOnly()).{jsFunction}", result);
         }
 
         [TestMethod]
@@ -1144,6 +1165,17 @@ namespace DotVVM.Framework.Tests.Binding
         {
             var result = CompileBinding(binding, new[] { typeof(TestViewModel) });
             Assert.AreEqual($"dotvvm.globalize.bindingTimeOnlyToString(NullableTimeOnly{((args.Length > 0) ? $",{args}" : string.Empty)})", result);
+        }
+
+        [DataTestMethod]
+        [DataRow("TimeOnly.Hour", "getHours()")]
+        [DataRow("TimeOnly.Minute", "getMinutes()")]
+        [DataRow("TimeOnly.Second", "getSeconds()")]
+        [DataRow("TimeOnly.Millisecond", "getMilliseconds()")]
+        public void JsTranslator_TimeOnly_Property_Getters(string binding, string jsFunction)
+        {
+            var result = CompileBinding(binding, new[] { typeof(TestViewModel) });
+            Assert.AreEqual($"dotvvm.serialization.parseTimeOnly(TimeOnly()).{jsFunction}", result);
         }
 
         [TestMethod]


### PR DESCRIPTION
Support for TimeOnly, and DateOnly instance properties (Year, Month, ..., Hour, Minute, ...) in JS bindings. Similar DateTime properties are already supported.

Support for DateOnly.FromDateTime and TimeOnly.FromDateTime methods

Support for DateTime.Now, DateTime.UtcNow and DateTime.Today static properties. Before this patch, these properties expanded into the compile-time value, which could give the impression of working correctly during development.