### PR TITLE
Block postbacks for 5s after redirects

### DIFF
--- a/src/Framework/Framework/Hosting/DotvvmRequestContextExtensions.cs
+++ b/src/Framework/Framework/Hosting/DotvvmRequestContextExtensions.cs
@@ -141,8 +141,8 @@ public static class DotvvmRequestContextExtensions
         context.RedirectToUrlPermanent(url, replaceInHistory, allowSpaRedirect);
     }
 
-    public static void SetRedirectResponse(this IDotvvmRequestContext context, string url, int statusCode = (int)HttpStatusCode.Redirect, bool replaceInHistory = false, bool allowSpaRedirect = false) =>
-        context.Configuration.ServiceProvider.GetRequiredService<IHttpRedirectService>().WriteRedirectResponse(context.HttpContext, url, statusCode, replaceInHistory, allowSpaRedirect);
+    public static void SetRedirectResponse(this IDotvvmRequestContext context, string url, int statusCode = (int)HttpStatusCode.Redirect, bool replaceInHistory = false, bool allowSpaRedirect = false, string? downloadName = null) =>
+        context.Configuration.ServiceProvider.GetRequiredService<IHttpRedirectService>().WriteRedirectResponse(context.HttpContext, url, statusCode, replaceInHistory, allowSpaRedirect, downloadName);
 
     internal static Task SetCachedViewModelMissingResponse(this IDotvvmRequestContext context)
     {
@@ -262,8 +262,10 @@ public static class DotvvmRequestContextExtensions
             AttachmentDispositionType = attachmentDispositionType ?? "attachment"
         };
 
+        var downloadAttribute = attachmentDispositionType == "inline" ? null : fileName;
+
         var generatedFileId = await returnedFileStorage.StoreFileAsync(stream, metadata).ConfigureAwait(false);
-        context.SetRedirectResponse(context.TranslateVirtualPath("~/dotvvmReturnedFile?id=" + generatedFileId));
+        context.SetRedirectResponse(context.TranslateVirtualPath("~/dotvvmReturnedFile?id=" + generatedFileId), downloadName: downloadAttribute);
         throw new DotvvmInterruptRequestExecutionException(InterruptReason.ReturnFile, fileName);
     }
 

--- a/src/Framework/Framework/Hosting/HttpRedirectService.cs
+++ b/src/Framework/Framework/Hosting/HttpRedirectService.cs
@@ -25,14 +25,13 @@ namespace DotVVM.Framework.Hosting
 {
     public interface IHttpRedirectService
     {
-        void WriteRedirectResponse(IHttpContext httpContext, string url, int statusCode = (int)HttpStatusCode.Redirect, bool replaceInHistory = false, bool allowSpaRedirect = false);
+        void WriteRedirectResponse(IHttpContext httpContext, string url, int statusCode = (int)HttpStatusCode.Redirect, bool replaceInHistory = false, bool allowSpaRedirect = false, string? downloadName = null);
     }
 
     public class DefaultHttpRedirectService: IHttpRedirectService
     {
-        public void WriteRedirectResponse(IHttpContext httpContext, string url, int statusCode = (int)HttpStatusCode.Redirect, bool replaceInHistory = false, bool allowSpaRedirect = false)
+        public void WriteRedirectResponse(IHttpContext httpContext, string url, int statusCode = (int)HttpStatusCode.Redirect, bool replaceInHistory = false, bool allowSpaRedirect = false, string? downloadName = null)
         {
-            
             if (DotvvmRequestContext.DetermineRequestType(httpContext) is DotvvmRequestType.Navigate)
             {
                 httpContext.Response.Headers["Location"] = url;
@@ -43,7 +42,7 @@ namespace DotVVM.Framework.Hosting
                 httpContext.Response.StatusCode = 200;
                 httpContext.Response.ContentType = "application/json";
                 httpContext.Response
-                    .WriteAsync(DefaultViewModelSerializer.GenerateRedirectActionResponse(url, replaceInHistory, allowSpaRedirect))
+                    .WriteAsync(DefaultViewModelSerializer.GenerateRedirectActionResponse(url, replaceInHistory, allowSpaRedirect, downloadName))
                     .GetAwaiter().GetResult();
                //   ^ we just wait for this Task. Redirect API never was async and the response size is small enough that we can't quite safely wait for the result
                //     .GetAwaiter().GetResult() preserves stack traces across async calls, thus I like it more that .Wait()

--- a/src/Framework/Framework/Resources/Scripts/postback/redirect.ts
+++ b/src/Framework/Framework/Resources/Scripts/postback/redirect.ts
@@ -1,17 +1,23 @@
 import * as events from '../events';
 import * as magicNavigator from '../utils/magic-navigator'
 import { handleSpaNavigationCore } from "../spa/spa";
+import { delay } from '../utils/promise';
+
 
 export function performRedirect(url: string, replace: boolean, allowSpa: boolean): Promise<any> {
     if (replace) {
         location.replace(url);
-        return Promise.resolve();
     } else if (compileConstants.isSpa && allowSpa) {
         return handleSpaNavigationCore(url);
     } else {
         magicNavigator.navigate(url);
-        return Promise.resolve();
     }
+
+    // When performing redirect, we pretend that the request takes additional X second to avoid
+    // double submit with Postback.Concurrency=Deny or Queue.
+    // We do not want to block the page forever, as the redirect might just return a file (or HTTP 204/205),
+    // and the page will continue to live.
+    return delay(5_000);
 }
 
 export async function handleRedirect(options: PostbackOptions, resultObject: any, response: Response, replace: boolean = false): Promise<DotvvmRedirectEventArgs> {
@@ -28,7 +34,12 @@ export async function handleRedirect(options: PostbackOptions, resultObject: any
     }
     events.redirect.trigger(redirectArgs);
 
-    await performRedirect(url, replace, resultObject.allowSpa);
+    const downloadFileName = resultObject.download
+    if (downloadFileName != null) {
+        magicNavigator.navigate(url, downloadFileName)
+    } else {
+        await performRedirect(url, replace, resultObject.allowSpa);
+    }
 
     return redirectArgs;
 }

--- a/src/Framework/Framework/Resources/Scripts/tests/eventArgs.test.ts
+++ b/src/Framework/Framework/Resources/Scripts/tests/eventArgs.test.ts
@@ -174,7 +174,8 @@ const fetchDefinitions = {
     postbackRedirect: async <T>(url: string, init: RequestInit) => {
         return {
             action: "redirect",
-            url: "/newUrl"
+            url: "/newUrl",
+            download: "some-file" // say it's a file, so that DotVVM does not block postback queue after the test
         } as any;
     },
 
@@ -213,7 +214,8 @@ const fetchDefinitions = {
         return {
             action: "redirect",
             url: "/newUrl",
-            allowSpa: true
+            allowSpa: true,
+            download: "some-file"
         } as any;
     },
     spaNavigateError: async <T>(url: string, init: RequestInit) => {

--- a/src/Framework/Framework/Resources/Scripts/utils/magic-navigator.ts
+++ b/src/Framework/Framework/Resources/Scripts/utils/magic-navigator.ts
@@ -1,9 +1,14 @@
 let fakeAnchor: HTMLAnchorElement | undefined;
-export function navigate(url: string) {
+export function navigate(url: string, downloadName: string | null | undefined = null) {
     if (!fakeAnchor) {
         fakeAnchor = <HTMLAnchorElement> document.createElement("a");
         fakeAnchor.style.display = "none";
         document.body.appendChild(fakeAnchor);
+    }
+    if (downloadName == null) {
+        fakeAnchor.removeAttribute("download");
+    } else {
+        fakeAnchor.download = downloadName
     }
     fakeAnchor.href = url;
     fakeAnchor.click();

--- a/src/Framework/Framework/Resources/Scripts/utils/promise.ts
+++ b/src/Framework/Framework/Resources/Scripts/utils/promise.ts
@@ -1,2 +1,3 @@
 /** Runs the callback in the next event loop cycle */ 
 export const defer = <T>(callback: () => T) => Promise.resolve().then(callback)
+export const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))

--- a/src/Framework/Framework/ViewModel/Serialization/DefaultViewModelSerializer.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/DefaultViewModelSerializer.cs
@@ -258,7 +258,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
         /// <summary>
         /// Serializes the redirect action.
         /// </summary>
-        public static string GenerateRedirectActionResponse(string url, bool replace, bool allowSpa)
+        public static string GenerateRedirectActionResponse(string url, bool replace, bool allowSpa, string? downloadName)
         {
             // create result object
             var result = new JObject();
@@ -266,6 +266,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
             result["action"] = "redirect";
             if (replace) result["replace"] = true;
             if (allowSpa) result["allowSpa"] = true;
+            if (downloadName is object) result["download"] = downloadName;
             return result.ToString(Formatting.None);
         }
 

--- a/src/Samples/Common/ViewModels/FeatureSamples/Redirect/RedirectPostbackConcurrencyViewModel.cs
+++ b/src/Samples/Common/ViewModels/FeatureSamples/Redirect/RedirectPostbackConcurrencyViewModel.cs
@@ -1,0 +1,65 @@
+using System.Diagnostics.Metrics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using DotVVM.Core.Storage;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.Redirect
+{
+    class RedirectPostbackConcurrencyViewModel : DotvvmViewModelBase
+    {
+        public static int GlobalCounter = 0;
+        private readonly IReturnedFileStorage returnedFileStorage;
+
+        [Bind(Direction.ServerToClient)]
+        public int Counter { get; set; } = GlobalCounter;
+
+        public int MiniCounter { get; set; } = 0;
+
+        [FromQuery("empty")]
+        public bool IsEmptyPage { get; set; } = false;
+        [FromQuery("loadDelay")]
+        public int LoadDelay { get; set; } = 0;
+
+        public RedirectPostbackConcurrencyViewModel(IReturnedFileStorage returnedFileStorage)
+        {
+            this.returnedFileStorage = returnedFileStorage;
+        }
+        public override async Task Init()
+        {
+            await Task.Delay(LoadDelay); // delay to enable user to click DelayIncrement button between it succeeding and loading the next page
+            await base.Init();
+        }
+
+        public async Task DelayIncrement()
+        {
+            await Task.Delay(1000);
+
+            Interlocked.Increment(ref GlobalCounter);
+
+            Context.RedirectToRoute(Context.Route.RouteName, query: new { empty = true, loadDelay = 2000 });
+        }
+
+        public async Task GetFileStandard()
+        {
+            await Context.ReturnFileAsync("test file"u8.ToArray(), "test.txt", "text/plain");
+        }
+
+        public async Task GetFileCustom()
+        {
+            var metadata = new ReturnedFileMetadata()
+            {
+                FileName = "test_custom.txt",
+                MimeType = "text/plain",
+                AttachmentDispositionType = "attachment"
+            };
+
+            var stream = new MemoryStream("test custom file"u8.ToArray());
+            var generatedFileId = await returnedFileStorage.StoreFileAsync(stream, metadata).ConfigureAwait(false);
+
+            var url = Context.TranslateVirtualPath("~/dotvvmReturnedFile?id=" + generatedFileId);
+            Context.RedirectToUrl(url);
+        }
+    }
+}

--- a/src/Samples/Common/Views/FeatureSamples/Redirect/RedirectPostbackConcurrency.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/Redirect/RedirectPostbackConcurrency.dothtml
@@ -1,0 +1,33 @@
+@viewModel DotVVM.Samples.BasicSamples.ViewModels.FeatureSamples.Redirect.RedirectPostbackConcurrencyViewModel, DotVVM.Samples.Common
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>Hello from DotVVM!</title>
+</head>
+<body>
+    <div IncludeInPage={resource: IsEmptyPage}>
+        <dot:RouteLink RouteName={resource: Context.Route.RouteName}  Query-empty=false>Back</dot:RouteLink>
+    </div>
+    <div class="container" IncludeInPage={resource: !IsEmptyPage}>
+        <h1>Redirect and postback concurrency test</h1>
+        <p>
+            Testing Concurrency=Deny / Concurrency=Queue with redirect and file returns.
+        </p>
+        <p>First, we have a set of buttons incrementing a static variable, each takes about 2sec and redirects to a blank page afterwards</p>
+        <p>GlobalCounter = <span data-ui="counter" InnerText={value: Counter} /></p>
+        <p>MiniCounter(Concurrency=Deny) = <dot:Button data-ui=minicounter Text={value: MiniCounter} PostBack.Concurrency=Deny Click={staticCommand: MiniCounter = MiniCounter + 1} /></p>
+
+        <p>
+            <dot:Button data-ui="inc-default" Click={command: DelayIncrement()} PostBack.Concurrency=Default>Increment (Concurrency=Default)</dot:Button>
+            <dot:Button data-ui="inc-deny" Click={command: DelayIncrement()} PostBack.Concurrency=Deny>Increment (Concurrency=Deny)</dot:Button>
+            <dot:Button data-ui="inc-queue" Click={command: DelayIncrement()} PostBack.Concurrency=Queue>Increment (Concurrency=Queue)</dot:Button>
+        </p>
+
+        <p>We also test that returning files does not block the page forever, </p>
+
+        <p>
+            <dot:Button data-ui="file-std" Click={command: GetFileStandard()}>Standard return file</dot:Button>
+            <dot:Button data-ui="file-custom" Click={command: GetFileCustom()}>Custom return file (will have delay before page works)</dot:Button>
+        </p>
+    </div>
+</body>
+</html>

--- a/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
@@ -327,6 +327,7 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_Redirect_RedirectionHelpers_PageC = "FeatureSamples/Redirect/RedirectionHelpers_PageC";
         public const string FeatureSamples_Redirect_RedirectionHelpers_PageD = "FeatureSamples/Redirect/RedirectionHelpers_PageD";
         public const string FeatureSamples_Redirect_RedirectionHelpers_PageE = "FeatureSamples/Redirect/RedirectionHelpers_PageE";
+        public const string FeatureSamples_Redirect_RedirectPostbackConcurrency = "FeatureSamples/Redirect/RedirectPostbackConcurrency";
         public const string FeatureSamples_Redirect_Redirect_StaticCommand = "FeatureSamples/Redirect/Redirect_StaticCommand";
         public const string FeatureSamples_RenderSettingsModeServer_RenderSettingModeServerProperty = "FeatureSamples/RenderSettingsModeServer/RenderSettingModeServerProperty";
         public const string FeatureSamples_RenderSettingsModeServer_RepeaterCollectionExchange = "FeatureSamples/RenderSettingsModeServer/RepeaterCollectionExchange";


### PR DESCRIPTION
The page does not unload right after we  perform
a navigation, and allows the user to hit the submit button a second time. In the past, we used to disable all postbacks after a redirect, but that also blocks the page after a file is returned. There probably isn't a 100% reliable way to detect if the location change is a navigation or a file return.

With this patch, we will block the page again, but only for a limited time (5 seconds). We also only only block the postback queue, which means that only postbacks with Concurrency=Deny or Queue will be affected.

Standard file returns as provided by DotVVM are
excluded from this, but it should also work acceptably with custom file returns (some buttons will not work for 5 seconds after the file return)