### PR TITLE
HtmlWriter: remove upper attribute warning, as it is redundant

### DIFF
--- a/src/Framework/Framework/Controls/HtmlWriter.cs
+++ b/src/Framework/Framework/Controls/HtmlWriter.cs
@@ -322,11 +322,6 @@ namespace DotVVM.Framework.Controls
             {
                 WriteHtmlAttribute(attributeName, attributeValue);
             }
-
-            if (this.enableWarnings && char.IsUpper(attributeName[0]))
-            {
-                Warn($"{attributeName} is used as an HTML attribute on element {name}, but it starts with an uppercase letter. Did you intent to use a DotVVM property instead? To silence this warning, just use all lowercase letters for standard HTML attributes.");
-            }
         }
 
         private string ConvertHtmlAttributeValue(object value)


### PR DESCRIPTION
The same warning is emitted compile-time, which makes this one redundant. Moreover, the compile-time warning includes smarter checks, and allows certain cases of uppercase attributes (in prefixed capabilities)