### PR TITLE
Fix DotVVM02 warning on overriden ignored property

### DIFF
--- a/src/Analyzers/Analyzers.Tests/Serializability/ViewModelSerializabilityTest.cs
+++ b/src/Analyzers/Analyzers.Tests/Serializability/ViewModelSerializabilityTest.cs
@@ -548,6 +548,36 @@ namespace DotVVM.Analyzers.Tests.Serializability
         }
 
         [Fact]
+        public async Task Test_IgnoreNonSerializedMembers_BindDirectionNoneInherited_ViewModel()
+        {
+            var text = @"
+    using DotVVM.Framework.ViewModel;
+    using Newtonsoft.Json;
+    using System;
+    using System.IO;
+
+    namespace ConsoleApplication1
+    {
+        public class BaseVM : DotvvmViewModelBase
+        {
+            [Bind(Direction.None)]
+            public virtual Stream Property1 { get; }
+
+            [JsonIgnore]
+            public virtual Stream Property2 { get; }
+        }
+
+        public class DefaultViewModel : BaseVM
+        {
+            public override Stream Property1 { get; }
+            public override Stream Property2 { get; }
+        }
+    }";
+
+            await VerifyCS.VerifyAnalyzerAsync(text, expected: []);
+        }
+
+        [Fact]
         public async Task Test_SelfReferencingTypes_GenericArgs_ViewModel()
         {
             var text = @"

--- a/src/Analyzers/Analyzers/Serializability/ViewModelSerializabilityAnalyzer.cs
+++ b/src/Analyzers/Analyzers/Serializability/ViewModelSerializabilityAnalyzer.cs
@@ -317,9 +317,11 @@ namespace DotVVM.Analyzers.Serializability
             return false;
         }
 
+        /// <summary> Returns true if the property has a Bind(Direction.None) or JsonIgnore attribute </summary>
         private static bool IsSerializationIgnored(IPropertySymbol property, SerializabilityAnalysisContext context)
         {
-            return IsSerializationIgnoredUsingBindAttribute(property, context) || IsSerializationIgnoredUsingJsonIgnoreAttribute(property, context);
+            return IsSerializationIgnoredUsingBindAttribute(property, context) || IsSerializationIgnoredUsingJsonIgnoreAttribute(property, context) ||
+                property.OverriddenProperty is {} overriddenProperty && IsSerializationIgnored(overriddenProperty, context);
         }
 
         private static bool IsSerializationIgnoredUsingBindAttribute(ISymbol propertyOrFieldSymbol, SerializabilityAnalysisContext context)


### PR DESCRIPTION
We now ignore override properties if the base has JsonIgnore or Bind(None) attribute.

Technically, the patch introduces a false negative if the base is ignored and the derived isn't. However, DotVVM behavior regarding this is complex (you cannot override JsonIgnore, only Bind(None)...) and given the rarity of virtual properties, I don't want to unnecessarily complicate the analyzer.

fix #1784

I'd release this as a 4.3 patch