### PR TITLE
Fix ko.observable handling in Linq translations

### DIFF
--- a/src/Framework/Framework/Compilation/Javascript/GenericMethodCompiler.cs
+++ b/src/Framework/Framework/Compilation/Javascript/GenericMethodCompiler.cs
@@ -29,6 +29,14 @@ namespace DotVVM.Framework.Compilation.Javascript
                 : builder(new[] { t?.JsExpression()! }.Concat(arg.Select(a => a.JsExpression())).ToArray(), arg.Select(a => a.OriginalExpression).ToArray());
         }
 
+        public GenericMethodCompiler(Func<JsExpression[], Expression[], MethodInfo, JsExpression> builder, Func<MethodInfo, Expression?, Expression[], bool>? check = null)
+        {
+            TryTranslateDelegate =
+                (t, arg, m) => check?.Invoke(m, t?.OriginalExpression, arg.Select(a => a.OriginalExpression).ToArray()) == false
+                ? null
+                : builder(new[] { t?.JsExpression()! }.Concat(arg.Select(a => a.JsExpression())).ToArray(), arg.Select(a => a.OriginalExpression).ToArray(), m);
+        }
+
         public GenericMethodCompiler(Func<JsExpression[], MethodInfo, JsExpression> builder, Func<MethodInfo, Expression?, Expression[], bool>? check = null)
         {
             TryTranslateDelegate =

--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslator.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslator.cs
@@ -261,19 +261,25 @@ namespace DotVVM.Framework.Compilation.Javascript
         }
     }
 
+    /// <summary> Specified if properties of the current object are wrapped in knockout observables or not. Observability of the current value is not specified in this annotation, but using <see cref="ResultIsObservableAnnotation" />. </summary>
     public sealed record JsObjectObservableMap: IEquatable<JsObjectObservableMap>
     {
-        /// <summary> The default value for all descendants, unless overriden using the other properties </summary>
+        /// <summary> The default value for all descendants, unless overridden using the other properties. If null, the default nullability for the current expression will be used. </summary>
         public bool? ContainsObservables { get; set; }
 
         /// <summary> Default value for all properties. Null means that `ContainsObservables` is assumed to be the same as the parent's </summary>
         public JsObjectObservableMap? DefaultChild { get; set; }
 
+        /// <summary> Observable mapping for child objects. </summary>
         public Dictionary<string, JsObjectObservableMap>? ChildObjects { get; set; }
 
+        /// <summary> Specifies if the specific property is ko.observable or not. Does not include more nested properties, that is specified in the <see cref="ChildObjects" /> property. </summary>
         public Dictionary<string, bool>? PropertyIsObservable { get; set; }
 
+        /// <summary> If <paramref name="name" /> is null, returns the default property observability. </summary>
         public bool? IsPropertyObservable(string? name) => name is {} && PropertyIsObservable?.TryGetValue(name, out var value) == true ? value : ContainsObservables;
+
+        /// <summary> If <c>objectPath[x]</c> is null, returns the default property observability. </summary>
         public bool? IsPropertyObservable(ReadOnlySpan<string?> objectPath)
         {
             if (objectPath.Length == 0) return null;
@@ -297,6 +303,7 @@ namespace DotVVM.Framework.Compilation.Javascript
             return current;
         }
 
+        /// <summary> Replaces properties in this with non-default properties in <paramref name="override"/> </summary>
         public JsObjectObservableMap OverrideWith(JsObjectObservableMap? @override)
         {
             if (@override is null || @override == Default || this == @override || this == Default) return this;

--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslator.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
@@ -224,7 +225,12 @@ namespace DotVVM.Framework.Compilation.Javascript
         public BindingExtensionParameter? ExtensionParameter { get; set; }
 
         public ViewModelSerializationMap? SerializationMap { get; set; }
-        public bool? ContainsObservables { get; set; }
+        public JsObjectObservableMap ObservableMap { get; set; } = JsObjectObservableMap.Default;
+        public bool? ContainsObservables
+        {
+            get => ObservableMap.ContainsObservables;
+            set => ObservableMap = ObservableMap with { ContainsObservables = value };
+        }
 
         public bool Equals(ViewModelInfoAnnotation? other) =>
             object.ReferenceEquals(this, other) ||
@@ -232,7 +238,7 @@ namespace DotVVM.Framework.Compilation.Javascript
             Type == other.Type &&
             IsControl == other.IsControl &&
             ExtensionParameter == other.ExtensionParameter &&
-            ContainsObservables == other.ContainsObservables;
+            ObservableMap == other.ObservableMap;
 
         public override bool Equals(object? obj) => obj is ViewModelInfoAnnotation obj2 && this.Equals(obj2);
 
@@ -243,32 +249,230 @@ namespace DotVVM.Framework.Compilation.Javascript
             this.Type = type;
             this.IsControl = isControl;
             this.ExtensionParameter = extensionParameter;
-            this.ContainsObservables = containsObservables;
+            this.ObservableMap = JsObjectObservableMap.FromBool(containsObservables);
+        }
+
+        public ViewModelInfoAnnotation(Type type, bool isControl, BindingExtensionParameter? extensionParameter, JsObjectObservableMap? observableMap)
+        {
+            this.Type = type;
+            this.IsControl = isControl;
+            this.ExtensionParameter = extensionParameter;
+            this.ObservableMap = observableMap ?? JsObjectObservableMap.Default;
         }
     }
 
-    /// <summary> Marks that the expression is essentially a member access on the target. We use this to keep track which objects have observables and which don't. </summary>
+    public sealed record JsObjectObservableMap: IEquatable<JsObjectObservableMap>
+    {
+        /// <summary> The default value for all descendants, unless overriden using the other properties </summary>
+        public bool? ContainsObservables { get; set; }
+
+        /// <summary> Default value for all properties. Null means that `ContainsObservables` is assumed to be the same as the parent's </summary>
+        public JsObjectObservableMap? DefaultChild { get; set; }
+
+        public Dictionary<string, JsObjectObservableMap>? ChildObjects { get; set; }
+
+        public Dictionary<string, bool>? PropertyIsObservable { get; set; }
+
+        public bool? IsPropertyObservable(string? name) => name is {} && PropertyIsObservable?.TryGetValue(name, out var value) == true ? value : ContainsObservables;
+        public bool? IsPropertyObservable(ReadOnlySpan<string?> objectPath)
+        {
+            if (objectPath.Length == 0) return null;
+            var current = this.GetChildObject(objectPath.Slice(0, objectPath.Length - 1));
+            return current.IsPropertyObservable(objectPath[objectPath.Length - 1]);
+        }
+
+        public JsObjectObservableMap GetChildObject(string? name)
+        {
+            if (name is {} && ChildObjects?.TryGetValue(name, out var value) == true)
+                return value;
+            if (DefaultChild is {})
+                return DefaultChild;
+            return FromBool(ContainsObservables);
+        }
+        public JsObjectObservableMap GetChildObject(ReadOnlySpan<string?> objectPath)
+        {
+            var current = this;
+            foreach (var name in objectPath)
+                current = current.GetChildObject(name);
+            return current;
+        }
+
+        public JsObjectObservableMap OverrideWith(JsObjectObservableMap? @override)
+        {
+            if (@override is null || @override == Default || this == @override || this == Default) return this;
+
+            var result = this with { ContainsObservables = @override.ContainsObservables ?? ContainsObservables };
+
+            if (@override.DefaultChild is not null)
+            {
+                result.DefaultChild = DefaultChild?.OverrideWith(@override.DefaultChild) ?? @override.DefaultChild;
+            }
+
+            if (@override.ChildObjects is not null)
+            {
+                result.ChildObjects = result.ChildObjects is {} ? new(result.ChildObjects) : new();
+                foreach (var (key, value) in @override.ChildObjects)
+                    result.ChildObjects[key] = result.ChildObjects.TryGetValue(key, out var existing) ? existing.OverrideWith(value) : value;
+            }
+            if (@override.PropertyIsObservable is not null)
+            {
+                result.PropertyIsObservable = result.PropertyIsObservable is {} ? new(result.PropertyIsObservable) : new();
+                foreach (var (key, value) in @override.PropertyIsObservable)
+                    result.PropertyIsObservable[key] = value;
+            }
+            return result;
+        }
+
+        public override string ToString()
+        {
+            if (this == Default) return "Default";
+            if (this == Observables) return "Observables";
+            if (this == Plain) return "Plain";
+
+            var sb = new System.Text.StringBuilder().Append("{ ");
+            if (ContainsObservables is {})
+                sb.Append("ContainsObservables = ").Append(ContainsObservables).Append(", ");
+            if (PropertyIsObservable is {Count: > 0})
+                sb.Append("Properties = { ").Append(string.Join(", ", PropertyIsObservable.Select(k => $"{k.Key}: {(k.Value ? "observable" : "plain")}"))).Append(" }, ");
+            if (DefaultChild is {})
+                sb.Append("DefaultChild = ").Append(DefaultChild).Append(", ");
+            if (ChildObjects is {Count: > 0})
+                sb.Append("ChildObjects = { ").Append(string.Join(", ", ChildObjects.Select(k => $"{k.Key}: {k.Value}"))).Append(" }, ");
+            return sb.Append("}").ToString();
+        }
+
+        public bool Equals(JsObjectObservableMap? other)
+        {
+            if (other == (object)this) return true;
+            if (other is null) return false;
+            return ContainsObservables == other.ContainsObservables &&
+                (this.ChildObjects?.Count ?? 0) == (other.ChildObjects?.Count ?? 0) &&
+                (this.PropertyIsObservable?.Count ?? 0) == (other.PropertyIsObservable?.Count ?? 0) &&
+                DefaultChild == other.DefaultChild &&
+                dictEquals(ChildObjects, other.ChildObjects) &&
+                dictEquals(PropertyIsObservable, other.PropertyIsObservable);
+
+            static bool dictEquals<K, V>(Dictionary<K, V>? a, Dictionary<K, V>? b) where V: IEquatable<V> where K: notnull
+            {
+                if (a is null or { Count: 0 } && b is null or { Count: 0 })
+                    return true;
+                if (a is null || b is null || a.Count != b.Count)
+                    return false;
+
+                foreach (var (k, v) in a)
+                {
+                    if (!b.TryGetValue(k, out var v2) || Equals(v, v2))
+                        return false;
+                }
+                return true;
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            var hash = (ContainsObservables, DefaultChild, ChildObjects?.Count, PropertyIsObservable?.Count).GetHashCode();
+            if (ChildObjects is not null)
+                foreach (var (k, v) in ChildObjects)
+                    hash += (k, v).GetHashCode(); // plus is commutative, because dict order should not matter
+            if (PropertyIsObservable is not null)
+                foreach (var (k, v) in PropertyIsObservable)
+                    hash += (k, v).GetHashCode();
+            return hash;
+        }
+
+        /// <summary> Assume the current preference - i.e. observables in value bindings and plain objects in staticCommands </summary>
+        public static readonly JsObjectObservableMap Default = new();
+        /// <summary> The object is wrapped in observables all the way down </summary>
+        public static readonly JsObjectObservableMap Observables = new() { ContainsObservables = true };
+        /// <summary> The object contains plain JS values without knockout observables. </summary>
+        public static readonly JsObjectObservableMap Plain = new() { ContainsObservables = false };
+        internal static JsObjectObservableMap FromBool(bool? containsObservables) =>
+            containsObservables switch {
+                true => Observables,
+                false => Plain,
+                null => Default
+            };
+    }
+
+    /// <summary>
+    /// Marks that the expression is essentially a member access on the target - i.e. an expression which accesses part of a viewmodel. We use this to keep track which objects have observables and which don't.
+    /// DotVVM will primarily use this annotate to determine if the current expression is ko.observable or not, based on the target <see cref="ViewModelInfoAnnotation.ContainsObservables" />.
+    /// </summary>
     public class VMPropertyInfoAnnotation
     {
-        public VMPropertyInfoAnnotation(MemberInfo? memberInfo, Type? resultType = null, ViewModelPropertyMap? serializationMap = null)
+        public VMPropertyInfoAnnotation(MemberInfo? memberInfo, Type? resultType = null, ViewModelPropertyMap? serializationMap = null, bool? isObservable = null, ImmutableArray<(JsTreeRole role, int index)>? targetPath = null, ImmutableArray<string?>? objectPath = null)
         {
             ResultType = resultType ?? memberInfo!.GetResultType();
             MemberInfo = memberInfo;
             SerializationMap = serializationMap;
+            IsObservable = isObservable;
+            TargetPath = targetPath ?? DefaultTargetPath;
+            ObjectPath = objectPath ?? ImmutableArray.Create(memberInfo?.Name);
         }
 
-        public VMPropertyInfoAnnotation(Type resultType)
-        {
-            ResultType = resultType;
-        }
+        public VMPropertyInfoAnnotation(Type resultType) : this(null, resultType) { }
 
+        /// <summary> C# type of the expression output value </summary>
         public Type ResultType { get; }
+        /// <summary> Property/Field/Indexer or method info this expression represents </summary>
         public MemberInfo? MemberInfo { get; }
+        /// <summary> Serialziation map of this property </summary>
         public ViewModelPropertyMap? SerializationMap { get; set; }
+        /// <summary> If this property (i.e. the result of this expression) is wrapped in knockout observable. If null, the default based on <see cref="ViewModelInfoAnnotation.ObservableMap" /> will be assumed. </summary>
+        public bool? IsObservable { get; }
+
+        /// <summary> By default, it is the first <see cref="JsTreeRoles.TargetExpression" /> expression, but can be configured to be any sub-expression (i.e., the first method argument). </summary>
+        public ImmutableArray<(JsTreeRole role, int index)> TargetPath { get; set; }
+
+        /// <summary> Path of the projection in terms of object properties, which is then used assess property observability based on <see cref="JsObjectObservableMap" />. Fields can be <c>null</c>, if the property name is unknown - the <see cref="JsObjectObservableMap.DefaultChild" /> will then be used. If the projection returns a modified version of the original object, empty array should be used as the ObjectPath </summary>
+        public ImmutableArray<string?> ObjectPath { get; set; }
 
         public static VMPropertyInfoAnnotation FromDotvvmProperty(DotvvmProperty p) =>
             p.PropertyInfo is null ? new VMPropertyInfoAnnotation(p.PropertyType)
                                    : new VMPropertyInfoAnnotation(p.PropertyInfo, p.PropertyType);
+
+        /// <summary> This expression is a projection of the object in the `Target` property. </summary>
+        public static ImmutableArray<(JsTreeRole role, int index)> DefaultTargetPath = ImmutableArray.Create(((JsTreeRole)JsTreeRoles.TargetExpression, 0));
+        /// <summary> This expression a method invocation on the projected object - i.e. the object is is Target.Target </summary>
+        public static ImmutableArray<(JsTreeRole role, int index)> InstanceMethodTargetPath = ImmutableArray.Create(((JsTreeRole)JsTreeRoles.TargetExpression, 0), ((JsTreeRole)JsTreeRoles.TargetExpression, 0));
+        /// <summary> The expression a function invocation with the projected object as the first argument - i.e. the object is in Arguments[0] </summary>
+        public static ImmutableArray<(JsTreeRole role, int index)> FirstArgumentMethodTargetPath = ImmutableArray.Create(((JsTreeRole)JsTreeRoles.Argument, 0));
+
+        /// <summary> Gets the target expression from the annotated expression. </summary>
+        public JsNode? EvaluateTargetPath(JsNode expression)
+        {
+            JsNode? node = expression;
+            foreach (var (role, index) in TargetPath)
+            {
+                if (index < 0) throw new Exception("Invalid target path index");
+
+                if (node is null)
+                {
+                    return null;
+                }
+
+                node = GetChild(node, role, index);
+            }
+            return node;
+
+            static JsNode? GetChild(JsNode node, JsTreeRole role, int index)
+            {
+                foreach (var child in node.Children)
+                {
+                    if (child.Role == role)
+                    {
+                        if (index == 0)
+                        {
+                            return child;
+                        }
+
+                        index--;
+                    }
+                }
+                return null;
+            }
+        }
+
     }
 
     public class CompositeJavascriptTranslator: IJavascriptMethodTranslator

--- a/src/Framework/Framework/Compilation/Javascript/JsViewModelPropertyAdjuster.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JsViewModelPropertyAdjuster.cs
@@ -178,37 +178,43 @@ namespace DotVVM.Framework.Compilation.Javascript
         }
     }
 
+    /// <summary> Indicates that this invocation only unwraps a knockout observable and was automatically inserted by <see cref="KnockoutObservableHandlingVisitor" /> </summary>
     public sealed class ObservableUnwrapInvocationAnnotation
     {
         private ObservableUnwrapInvocationAnnotation() { }
         public static ObservableUnwrapInvocationAnnotation Instance = new ObservableUnwrapInvocationAnnotation();
     }
+    /// <summary> Indicates that this invocation is a knockout observable value assignment and was automatically inserted by <see cref="KnockoutObservableHandlingVisitor" /> </summary>
     public sealed class ObservableSetterInvocationAnnotation
     {
         private ObservableSetterInvocationAnnotation() { }
         public static ObservableSetterInvocationAnnotation Instance = new ObservableSetterInvocationAnnotation();
     }
+    /// <summary> Result of the annotated expression is always a knockout observable. DotVVM will automatically unwrap the observable, unless the <see cref="ShouldBeObservableAnnotation" /> is also specified. </summary>
     public sealed class ResultIsObservableAnnotation
     {
         private ResultIsObservableAnnotation() { }
         public static ResultIsObservableAnnotation Instance = new ResultIsObservableAnnotation();
     }
+    /// <summary> Result is a knockout observable array. </summary>
     public sealed class ResultIsObservableArrayAnnotation
     {
         private ResultIsObservableArrayAnnotation() { }
         public static ResultIsObservableArrayAnnotation Instance = new ResultIsObservableArrayAnnotation();
     }
+    /// <summary> Result of the annotated expression may or may not be a knockout observable. DotVVM will automatically unwrap the observable, unless the <see cref="ShouldBeObservableAnnotation" /> is also specified. </summary>
     public sealed class ResultMayBeObservableAnnotation
     {
         private ResultMayBeObservableAnnotation() { }
         public static ResultMayBeObservableAnnotation Instance = new ResultMayBeObservableAnnotation();
     }
+    /// <summary> This node should return observable -  instructs the <see cref="KnockoutObservableHandlingVisitor" /> to not unwrap the node and the <see cref="JsViewModelPropertyAdjuster" /> to not use .state in the subexpression. </summary>
     public sealed class ShouldBeObservableAnnotation
     {
         private ShouldBeObservableAnnotation() { }
         public static ShouldBeObservableAnnotation Instance = new ShouldBeObservableAnnotation();
     }
-    /// Instruct the <see cref="KnockoutObservableHandlingVisitor" /> to process the node after it's children are resolved and before it is handled itself by the rules
+    /// <summary> Instruct the <see cref="KnockoutObservableHandlingVisitor" /> to process the node after it's children are resolved and before it is handled itself by the rules </summary>
     public sealed class ObservableTransformationAnnotation
     {
         public readonly Func<JsExpression, JsExpression> TransformExpression;
@@ -217,7 +223,7 @@ namespace DotVVM.Framework.Compilation.Javascript
             TransformExpression = transformExpression;
         }
 
-        /// Makes sure that the observable is fully wrapped in observable (i.e. wraps the expression in `ko.pureComputed(...)` when needed)
+        /// <summary> Makes sure that the observable is fully wrapped in observable (i.e. wraps the expression in `ko.pureComputed(...)` when needed) </summary>
         public static readonly ObservableTransformationAnnotation EnsureWrapped = new ObservableTransformationAnnotation(JsAstHelpers.EnsureObservableWrapped);
     }
 }

--- a/src/Framework/Framework/Compilation/Javascript/JsViewModelPropertyAdjuster.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JsViewModelPropertyAdjuster.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -56,22 +56,25 @@ namespace DotVVM.Framework.Compilation.Javascript
 
             if (node.Annotation<VMPropertyInfoAnnotation>() is { MemberInfo: var member } propAnnotation)
             {
-                var target = node.GetChildByRole(JsTreeRoles.TargetExpression)!;
-                if (target.HasAnnotation(ObservableUnwrapInvocationAnnotation.Instance))
+                var target = propAnnotation.EvaluateTargetPath(node);
+
+                if (target is {} && target.HasAnnotation(ObservableUnwrapInvocationAnnotation.Instance))
                     target = target.GetChildByRole(JsTreeRoles.TargetExpression);
-                else if (target.HasAnnotation(ObservableSetterInvocationAnnotation.Instance))
+                else if (target is {} && target.HasAnnotation(ObservableSetterInvocationAnnotation.Instance))
                     throw new NotImplementedException();
 
                 var propertyType = propAnnotation.ResultType;
                 var annotation = node.Annotation<ViewModelInfoAnnotation>() ?? new ViewModelInfoAnnotation(propertyType);
 
                 var targetAnnotation = target?.Annotation<ViewModelInfoAnnotation>();
+                var propertyIsObservable = propAnnotation.IsObservable;
                 if (targetAnnotation is {})
                 {
                     propAnnotation.SerializationMap ??=
                         targetAnnotation.SerializationMap?.Properties
                         .FirstOrDefault(p => p.PropertyInfo == member);
-                    annotation.ContainsObservables ??= targetAnnotation.ContainsObservables;
+                    annotation.ObservableMap = targetAnnotation.ObservableMap.GetChildObject(propAnnotation.ObjectPath.AsSpan()).OverrideWith(annotation.ObservableMap);
+                    propertyIsObservable ??= targetAnnotation.ObservableMap.IsPropertyObservable(propAnnotation.ObjectPath.AsSpan());
                 }
                 if (propAnnotation.SerializationMap is ViewModelPropertyMap propertyMap)
                 {
@@ -99,9 +102,7 @@ namespace DotVVM.Framework.Compilation.Javascript
                     throw new NotSupportedException($"Cannot translate property {member.Name} on custom primitive type {member.DeclaringType.ToCode()} to Javascript. Use the ToString() method to get the underlying value.");
                 }
 
-                annotation.ContainsObservables ??= !this.preferUsingState; // we don't know -> guess what is the current preference
-
-                if (annotation.ContainsObservables == true)
+                if (propertyIsObservable ?? !preferUsingState) // if we don't know -> assume what is the current preference
                 {
                     node.AddAnnotation(ResultIsObservableAnnotation.Instance);
 

--- a/src/Framework/Framework/Hosting/DotvvmPresenter.cs
+++ b/src/Framework/Framework/Hosting/DotvvmPresenter.cs
@@ -538,7 +538,8 @@ namespace DotVVM.Framework.Hosting
                         await context.RejectRequest($"""
                             Pages can not be loaded using Javascript for security reasons.
                             Try refreshing the page to get rid of the error.
-                            If you are the developer, you can disable this check by setting DotvvmConfiguration.Security.VerifySecFetchForPages.ExcludeRoute("{route}"). [dest: {dest}, site: {site}]
+                            If you are the developer, you can disable this check by setting DotvvmConfiguration.Security.VerifySecFetchForPages.ExcludeRoute("{route}"). [dest: {dest}, site: {site}].
+                            Note that this security check is not compatible with JavaScript-based prefetching, such as TurboLinks, Cloudflare Speed Brain, or similar, and you'll need to disable one of them. The check is "only" a deference-in-depth measure against XSS, and disabling it is not a vulnerability by itself.
                             """);
                     if (site != "same-origin")
                         await context.RejectRequest($"Cross site SPA requests are disabled.");

--- a/src/Framework/Framework/Hosting/DotvvmPresenter.cs
+++ b/src/Framework/Framework/Hosting/DotvvmPresenter.cs
@@ -538,8 +538,7 @@ namespace DotVVM.Framework.Hosting
                         await context.RejectRequest($"""
                             Pages can not be loaded using Javascript for security reasons.
                             Try refreshing the page to get rid of the error.
-                            If you are the developer, you can disable this check by setting DotvvmConfiguration.Security.VerifySecFetchForPages.ExcludeRoute("{route}"). [dest: {dest}, site: {site}].
-                            Note that this security check is not compatible with JavaScript-based prefetching, such as TurboLinks, Cloudflare Speed Brain, or similar, and you'll need to disable one of them. The check is "only" a deference-in-depth measure against XSS, and disabling it is not a vulnerability by itself.
+                            If you are the developer, you can disable this check by setting DotvvmConfiguration.Security.VerifySecFetchForPages.ExcludeRoute("{route}"). [dest: {dest}, site: {site}]
                             """);
                     if (site != "same-origin")
                         await context.RejectRequest($"Cross site SPA requests are disabled.");

--- a/src/Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/Tests/Binding/JavascriptCompilationTests.cs
@@ -30,13 +30,17 @@ namespace DotVVM.Framework.Tests.Binding
         {
             configuration = DotvvmTestHelper.CreateConfiguration();
             configuration.RegisterApiClient(typeof(TestApiClient), "http://server/api", "./apiscript.js", "_testApi");
+            var methods = configuration.Markup.JavascriptTranslator.MethodCollection;
+            methods.AddMethodTranslator(() => TestJsTransations.GetTestPlainObject(), new GenericMethodCompiler(args => new JsIdentifierExpression("testPlainObject").WithAnnotation(new ViewModelInfoAnnotation(typeof(TestArraysViewModel), containsObservables: false))));
+            methods.AddMethodTranslator(() => TestJsTransations.GetTestObjectWithObservables(), new GenericMethodCompiler(args => new JsIdentifierExpression("testPlainObject").WithAnnotation(new ViewModelInfoAnnotation(typeof(TestArraysViewModel), containsObservables: true))));
+            configuration.Freeze();
             bindingHelper = new BindingTestHelper(configuration);
         }
         public string CompileBinding(string expression, params Type[] contexts) => CompileBinding(expression, contexts, expectedType: typeof(object));
         public string CompileBinding(string expression, NamespaceImport[] imports, params Type[] contexts) => CompileBinding(expression, contexts, expectedType: typeof(object), imports);
-        public string CompileBinding(string expression, Type[] contexts, Type expectedType, NamespaceImport[] imports = null)
+        public string CompileBinding(string expression, Type[] contexts, Type expectedType, NamespaceImport[] imports = null, bool nullChecks = false)
         {
-            return bindingHelper.ValueBindingToJs(expression, contexts, expectedType, imports, niceMode: false);
+            return bindingHelper.ValueBindingToJs(expression, contexts, expectedType, imports, nullChecks, niceMode: false);
         }
 
         public static string FormatKnockoutScript(ParametrizedCode code) => JavascriptTranslator.FormatKnockoutScript(code);
@@ -532,6 +536,13 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        public void JsTranslator_DictionaryIndexer_GetObject()
+        {
+            var result = CompileBinding("StringVmDictionary['test'].Collection[5].StringValue.Length", [typeof(TestViewModel)], typeof(object), nullChecks: true);
+            Assert.AreEqual("(()=>{let a;return ((a=dotvvm.translations.dictionary.getItem(StringVmDictionary(),\"test\")?.Collection())&&a[5]())?.StringValue()?.length;})()", result);
+        }
+
+        [TestMethod]
         public void JsTranslator_ReadOnlyDictionaryIndexer_Get()
         {
             var result = CompileBinding("ReadOnlyDictionary[1]", typeof(TestViewModel5));
@@ -608,6 +619,62 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        public void JsTranslator_EnumerableSelectObservableHandling1()
+        {
+            var result = CompileBinding("VmArray.Select(item => item.MyProperty).ToArray()[0] == 1", new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
+            Assert.AreEqual("VmArray().map((item)=>ko.unwrap(item).MyProperty())[0]==1", result);
+        }
+
+        [TestMethod]
+        public void JsTranslator_EnumerableSelectObservableHandling2()
+        {
+            var result = CompileBinding("VmArray.Select(item => item.MyProperty + 1).ToArray()[0] == 1", new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
+            Assert.AreEqual("VmArray().map((item)=>ko.unwrap(item).MyProperty()+1)[0]==1", result);
+        }
+
+        [TestMethod]
+        public void JsTranslator_EnumerableSelectObservableHandling3()
+        {
+            var result = CompileBinding("VmArray.Select(item => item.ChildObject).ToArray()[0].SomeString == 'abc'", new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
+            Assert.AreEqual("VmArray().map((item)=>ko.unwrap(item).ChildObject())[0].SomeString()==\"abc\"", result);
+        }
+
+        [TestMethod]
+        public void JsTranslator_EnumerableSelectFirstObservableHandling()
+        {
+            var result = CompileBinding("VmArray.Select(item => item.ChildObject).FirstOrDefault(i => i.SomeString.StartsWith('a')).SomeString == 'abc'", new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
+            Assert.AreEqual("VmArray().map((item)=>ko.unwrap(item).ChildObject()).find((i)=>ko.unwrap(i).SomeString().startsWith(\"a\")).SomeString()==\"abc\"", result);
+            //                                                                    ^^^^^        not observable, because .map unwraps it ^^
+            // without the select, we'd need observable unwrap after .find
+            var withoutSelect = CompileBinding("VmArray.FirstOrDefault(i => i.ChildObject.SomeString.StartsWith('a')).ChildObject.SomeString == 'abc'", new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
+            Assert.AreEqual("VmArray().find((i)=>ko.unwrap(i).ChildObject().SomeString().startsWith(\"a\"))().ChildObject().SomeString()==\"abc\"", withoutSelect);
+        }
+
+        [TestMethod]
+        public void JsTranslator_EnumerableSelectOrderObservableHandling()
+        {
+            var result = CompileBinding("VmArray.Select(item => item.ChildObject).OrderBy(i => i.SomeString).ToArray()[0].SomeString == 'abc'", new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
+            Assert.AreEqual("dotvvm.translations.array.orderBy(VmArray().map((item)=>ko.unwrap(item).ChildObject()),(i)=>ko.unwrap(i).SomeString(),null)[0].SomeString()==\"abc\"", result);
+            //                                                                                                  not observable, because .map unwraps it ^^^
+        }
+
+        [TestMethod]
+        public void JsTranslator_EnumerableSelectFilterObservableHandling()
+        {
+            var result = CompileBinding("VmArray.Select(item => item.ChildObject).Where(i => i != null).ElementAt(1).SomeString == 'abc'", new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
+            Assert.AreEqual("VmArray().map((item)=>ko.unwrap(item).ChildObject()).filter((i)=>ko.unwrap(i)!=null)[1].SomeString()==\"abc\"", result);
+            //                                                           not observable, because .map unwraps it ^^^
+        }
+
+        [TestMethod]
+        public void JsTranslator_EnumerableSelectSliceObservableHandling()
+        {
+            var result = CompileBinding("VmArray.Select(item => item.ChildObject).Take(4).LastOrDefault().SomeString == 'abc'", new[] { new NamespaceImport("System.Linq") }, new[] { typeof(TestViewModel) });
+            Assert.AreEqual("VmArray().map((item)=>ko.unwrap(item).ChildObject()).slice(0,4).at(-1).SomeString()==\"abc\"", result);
+            //                                       not observable, because .map unwraps it ^^^^^^^
+        }
+
+        [TestMethod]
         [DataRow("Enumerable.Concat(LongArray, LongArray)", DisplayName = "Regular call of Enumerable.Concat")]
         [DataRow("LongArray.Concat(LongArray)", DisplayName = "Syntax sugar - extension method")]
         [DataRow("LongArray.ToImmutableArray().Concat(LongArray.ToImmutableArray())", DisplayName = "Immutable arrays")]
@@ -657,23 +724,23 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
-        [DataRow("Enumerable.All(LongArray, (long item) => item > 0)", DisplayName = "Regular call of Enumerable.All")]
-        [DataRow("LongArray.All((long item) => item > 0)", DisplayName = "Syntax sugar - extension method")]
-        [DataRow("LongArray.ToImmutableArray().All((long item) => item > 0)", DisplayName = "Immutable array - extension method")]
+        [DataRow("!Enumerable.All(LongArray, (long item) => item > 0)", DisplayName = "Regular call of Enumerable.All")]
+        [DataRow("!LongArray.All((long item) => item > 0)", DisplayName = "Syntax sugar - extension method")]
+        [DataRow("!LongArray.ToImmutableArray().All((long item) => item > 0)", DisplayName = "Immutable array - extension method")]
         public void JsTranslator_EnumerableAll(string binding)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq"), new NamespaceImport("System.Collections.Immutable") }, new[] { typeof(TestViewModel) });
-            Assert.AreEqual("LongArray().every((item)=>ko.unwrap(item)>0)", result);
+            Assert.AreEqual("!LongArray().every((item)=>ko.unwrap(item)>0)", result);
         }
 
         [TestMethod]
-        [DataRow("Enumerable.Any(LongArray, (long item) => item > 0)", DisplayName = "Regular call of Enumerable.Any")]
-        [DataRow("LongArray.Any((long item) => item > 0)", DisplayName = "Syntax sugar - extension method")]
-        [DataRow("LongArray.ToImmutableArray().Any((long item) => item > 0)", DisplayName = "Immutable array - extension method")]
+        [DataRow("!Enumerable.Any(LongArray, (long item) => item > 0)", DisplayName = "Regular call of Enumerable.Any")]
+        [DataRow("!LongArray.Any((long item) => item > 0)", DisplayName = "Syntax sugar - extension method")]
+        [DataRow("!LongArray.ToImmutableArray().Any((long item) => item > 0)", DisplayName = "Immutable array - extension method")]
         public void JsTranslator_EnumerableAny(string binding)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq"), new NamespaceImport("System.Collections.Immutable") }, new[] { typeof(TestViewModel) });
-            Assert.AreEqual("LongArray().some((item)=>ko.unwrap(item)>0)", result);
+            Assert.AreEqual("!LongArray().some((item)=>ko.unwrap(item)>0)", result);
         }
 
         [TestMethod]
@@ -703,13 +770,13 @@ namespace DotVVM.Framework.Tests.Binding
 
 
         [TestMethod]
-        [DataRow("Enumerable.FirstOrDefault(LongArray)", DisplayName = "Regular call of Enumerable.FirstOrDefault")]
-        [DataRow("LongArray.FirstOrDefault()", DisplayName = "Syntax sugar - extension method")]
-        [DataRow("LongArray.ToImmutableArray().FirstOrDefault()", DisplayName = "Immutable array - extension method")]
+        [DataRow("Enumerable.FirstOrDefault(LongArray) == 1", DisplayName = "Regular call of Enumerable.FirstOrDefault")]
+        [DataRow("LongArray.FirstOrDefault() == 1", DisplayName = "Syntax sugar - extension method")]
+        [DataRow("LongArray.ToImmutableArray().FirstOrDefault() == 1", DisplayName = "Immutable array - extension method")]
         public void JsTranslator_EnumerableFirstOrDefault(string binding)
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq"), new NamespaceImport("System.Collections.Immutable") }, new[] { typeof(TestViewModel) });
-            Assert.AreEqual("LongArray()[0]", result);
+            Assert.AreEqual("LongArray()[0]()==1", result);
         }
 
         [TestMethod]
@@ -720,6 +787,22 @@ namespace DotVVM.Framework.Tests.Binding
         {
             var result = CompileBinding(binding, new[] { new NamespaceImport("System.Linq"), new NamespaceImport("System.Collections.Immutable") }, new[] { typeof(TestViewModel) });
             Assert.AreEqual("LongArray().find((item)=>ko.unwrap(item)>0)", result);
+        }
+
+        [TestMethod]
+        public void JsTranslator_EnumerableFirstOrDefaultObservableHandling()
+        {
+            var withUnwraps = CompileBinding("TestJsTransations.GetTestObjectWithObservables().ObjectArray.FirstOrDefault(o => o.Enum == 'Value1').Int == 12", new[] { new NamespaceImport("System.Linq"), new NamespaceImport(typeof(TestJsTransations).Namespace) }, new[] { typeof(TestViewModel) });
+
+            Assert.AreEqual("testPlainObject.ObjectArray().find((o)=>ko.unwrap(o).Enum()==\"Value1\")().Int()==12", withUnwraps);
+        }
+
+        [TestMethod]
+        public void JsTranslator_EnumerableFirstOrDefaultObservableHandling2()
+        {
+            var withoutUnwraps = CompileBinding("TestJsTransations.GetTestPlainObject().ObjectArray.OrderBy(a => a.Enum).LastOrDefault().Int == 12", new[] { new NamespaceImport("System.Linq"), new NamespaceImport(typeof(TestJsTransations).Namespace) }, new[] { typeof(TestViewModel) });
+
+            Assert.AreEqual("dotvvm.translations.array.orderBy(testPlainObject.ObjectArray,(a)=>ko.unwrap(a).Enum(),\"ObApbFFA2mUjzIJF\").at(-1).Int==12", withoutUnwraps);
         }
 
         [TestMethod]
@@ -777,7 +860,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JsTranslator_EnumerableLastOrDefaultObservable()
         {
             var result = CompileBinding("LongArray.LastOrDefault()==1", new[] { new NamespaceImport("System.Linq"), new NamespaceImport("System.Collections.Immutable") }, new[] { typeof(TestViewModel) });
-            Assert.AreEqual("ko.unwrap(LongArray().at(-1))==1", result);
+            Assert.AreEqual("LongArray().at(-1)()==1", result);
         }
 
         [TestMethod]
@@ -1446,6 +1529,14 @@ namespace DotVVM.Framework.Tests.Binding
 
             public string NonUsableProperty { get; set; }
         }
+    }
+
+    public static class TestJsTransations
+    {
+        // returns object which is not wrapped in ko.observables
+        public static TestArraysViewModel GetTestPlainObject() => new TestArraysViewModel();
+        // returns object which is wrapped in ko.observables
+        public static TestArraysViewModel GetTestObjectWithObservables() => new TestArraysViewModel();
     }
 
     public class TestExtensionParameterConflictViewModel

--- a/src/Tests/Binding/StaticCommandCompilationTests.cs
+++ b/src/Tests/Binding/StaticCommandCompilationTests.cs
@@ -369,7 +369,7 @@ namespace DotVVM.Framework.Tests.Binding
             Console.WriteLine(result);
             var expectedResult = @"{
  	let vm = options.viewModel;
- 	vm.StringProp(ko.unwrap(vm.VmArray.state.filter((x) => ko.unwrap(x).ChildObject.SomeString == ""x"")[0]).SomeString);
+ 	vm.StringProp(vm.VmArray.state.filter((x) => ko.unwrap(x).ChildObject.SomeString == ""x"")[0].SomeString);
  }";
 
             AreEqual(expectedResult, result);


### PR DESCRIPTION
* FirstOrDefault, LastOrDefault, ... should behave like indexers
    - return observable, if the array contains observables, which then needs to be unwrapped
    - this is a regression in 4.3
* Where, Order, Take, ... return the same structure which the original array has
* Select is weird as it unwraps all observables in the array, but not recursively. That's why patch adds the JsObjectObservableMap object, which can represent this mid-state (and many other combinations)
   - Indexing after Select was apparently always broken in DotVVM