### PR TITLE
UI tests tolerate whispace changes in datetime format

### DIFF
--- a/src/Samples/Tests/Tests/Control/TextBoxTests.cs
+++ b/src/Samples/Tests/Tests/Control/TextBoxTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Text.RegularExpressions;
 using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
 using OpenQA.Selenium;
@@ -125,6 +126,9 @@ window.getSelectionText = function (dataui) {
                 new object[] { "cs-CZ", SamplesRouteUrls.ControlSamples_TextBox_TextBox_Format, "#czech"},
                 new object[] { "en-US", SamplesRouteUrls.ControlSamples_TextBox_TextBox_Format, "#english"},
             };
+        
+        // different versions of localization libraries may produce different whitespace (no space before AM/PM, no-break spaces, ...)
+        static bool EqualsIgnoreSpace(string a, string b) => Regex.Replace(a, @"\s+", "") == Regex.Replace(b, @"\s+", "");
 
         [Theory]
         [MemberData(nameof(TextBoxStringFormatChangedCommandData))]
@@ -145,13 +149,13 @@ window.getSelectionText = function (dataui) {
                 AssertUI.Attribute(dateTextBox, "value", dateResult1);
 
                 var dateText = browser.First("#DateValueText");
-                AssertUI.InnerTextEquals(dateText, new DateTime(2015, 12, 27).ToString("G", culture));
+                AssertUI.InnerText(dateText, t => EqualsIgnoreSpace(t, new DateTime(2015, 12, 27).ToString("G", culture)));
 
                 var nullableDateTextBox = browser.First("#nullableDateTextbox");
-                AssertUI.Attribute(nullableDateTextBox, "value", new DateTime(2015, 12, 27).ToString("G", culture));
+                AssertUI.Attribute(nullableDateTextBox, "value", t => EqualsIgnoreSpace(t, new DateTime(2015, 12, 27).ToString("G", culture)));
 
                 var nullableDateText = browser.First("#nullableDateValueText");
-                AssertUI.InnerTextEquals(nullableDateText, new DateTime(2015, 12, 27).ToString("G", culture));
+                AssertUI.InnerText(nullableDateText, t => EqualsIgnoreSpace(t, new DateTime(2015, 12, 27).ToString("G", culture)));
 
                 var numberTextbox = browser.First("#numberTextbox");
                 AssertUI.Attribute(numberTextbox, "value", 123.1235.ToString(culture));
@@ -171,7 +175,7 @@ window.getSelectionText = function (dataui) {
                 dateTextBox.Click();
 
                 //check new values
-                AssertUI.InnerTextEquals(dateText, new DateTime(2018, 12, 27).ToString("G", culture));
+                AssertUI.InnerText(dateText, t => EqualsIgnoreSpace(t, new DateTime(2018, 12, 27).ToString("G", culture)));
                 AssertUI.InnerTextEquals(numberValueText, 2000.ToString(culture));
 
                 AssertUI.Attribute(numberTextbox, "value", 2000.ToString("n4", culture));
@@ -183,7 +187,7 @@ window.getSelectionText = function (dataui) {
                 dateTextBox.Click();
 
                 //check displayed values (behavior change in 3.0 - previous values should stay there)
-                AssertUI.InnerTextEquals(dateText, new DateTime(2018, 12, 27).ToString("G", culture));
+                AssertUI.InnerText(dateText, t => EqualsIgnoreSpace(t, new DateTime(2018, 12, 27).ToString("G", culture)));
                 AssertUI.InnerTextEquals(numberValueText, 2000.ToString(culture));
 
                 AssertUI.Attribute(numberTextbox, "value", "000//a");
@@ -195,20 +199,20 @@ window.getSelectionText = function (dataui) {
                 dateTextBox.Click();
 
                 //check new values
-                AssertUI.InnerTextEquals(dateText, new DateTime(2018, 1, 1).ToString("G", culture));
+                AssertUI.InnerText(dateText, t => EqualsIgnoreSpace(t, new DateTime(2018, 1, 1).ToString("G", culture)));
                 AssertUI.InnerTextEquals(numberValueText, 1000.550277.ToString(culture));
 
                 AssertUI.Attribute(numberTextbox, "value", 1000.550277.ToString("n4", culture));
                 AssertUI.Attribute(dateTextBox, "value", dateResult3);
 
                 // try to supply different date formats
-                dateTextBox.Clear().SendKeys(new DateTime(2020, 2, 16).ToString("G", culture)).SendKeys(Keys.Tab);
-                AssertUI.Attribute(dateTextBox, "value", new DateTime(2020, 2, 16).ToString("d", culture));
-                AssertUI.InnerTextEquals(dateText, new DateTime(2020, 2, 16).ToString("G", culture));
+                dateTextBox.Clear().SendKeys(cultureName switch { "en-US" => "2/16/2020 12:00:00 AM", "cs-CZ" => "16.02.2020 0:00:00", _ => "" }).SendKeys(Keys.Tab);
+                AssertUI.Attribute(dateTextBox, "value", t => EqualsIgnoreSpace(t, new DateTime(2020, 2, 16).ToString("d", culture)));
+                AssertUI.InnerText(dateText, t => EqualsIgnoreSpace(t, new DateTime(2020, 2, 16).ToString("G", culture)));
 
                 nullableDateTextBox.Clear().SendKeys(new DateTime(2020, 4, 2).ToString("d", culture)).SendKeys(Keys.Tab);
-                AssertUI.Attribute(nullableDateTextBox, "value", new DateTime(2020, 4, 2).ToString("G", culture));
-                AssertUI.InnerTextEquals(nullableDateText, new DateTime(2020, 4, 2).ToString("G", culture));
+                AssertUI.Attribute(nullableDateTextBox, "value", t => EqualsIgnoreSpace(t, new DateTime(2020, 4, 2).ToString("G", culture)));
+                AssertUI.InnerText(nullableDateText, t => EqualsIgnoreSpace(t, new DateTime(2020, 4, 2).ToString("G", culture)));
             });
         }
 

--- a/src/Samples/Tests/Tests/Feature/AutoUITests.cs
+++ b/src/Samples/Tests/Tests/Feature/AutoUITests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
@@ -128,7 +129,7 @@ namespace DotVVM.Samples.Tests.Feature
                     .ThrowIfDifferentCountThan(4);
                 AssertUI.TextEquals(cells[0].Single("span"), "1");
                 AssertUI.TextEquals(cells[1].Single("h2"), "John Doe");
-                AssertUI.TextEquals(cells[2].Single("span"), "4/1/1976 12:00:00 AM");
+                AssertUI.Text(cells[2].Single("span"), t => Regex.Replace(t, "\\s+", "") == "4/1/197612:00:00AM");
                 AssertUI.IsNotChecked(cells[3].Single("input[type=checkbox]"));
             });
         }

--- a/src/Samples/Tests/Tests/Feature/DataSetTests.cs
+++ b/src/Samples/Tests/Tests/Feature/DataSetTests.cs
@@ -55,51 +55,41 @@ namespace DotVVM.Samples.Tests.Feature
                 browser.NavigateToUrl(url);
                 VerifyPageIsNotThrowingAuthError(browser);
 
-                var grid = browser.Single("next-history-grid", SelectByDataUi);
-                var pager = browser.Single("next-history-pager", SelectByDataUi);
+                var grid = "[data-ui='next-history-grid']";
+                var pager = "[data-ui='next-history-pager']";
 
                 // get first issue on the first page
-                var issueId1 = grid.ElementAt("tbody tr td", 0).GetInnerText();
+                var issueId1 = browser.ElementAt($"{grid} tbody tr td", 0).GetInnerText();
 
                 // go to page 2
-                pager.ElementAt("li", 3).Single("a").Click().Wait(500);
+                browser.ElementAt($"{pager} li", 3).Single("a").Click().Wait(500);
 
-                grid = browser.Single("next-history-grid", SelectByDataUi);
-                pager = browser.Single("next-history-pager", SelectByDataUi);
-                AssertUI.TextNotEquals(grid.ElementAt("tbody tr td", 0), issueId1);
-                var issueId2 = grid.ElementAt("tbody tr td", 0).GetInnerText();
+                AssertUI.TextNotEquals(browser.ElementAt($"{grid} tbody tr td", 0), issueId1);
+                var issueId2 = browser.ElementAt($"{grid} tbody tr td", 0).GetInnerText();
 
                 // go to next page
-                pager.ElementAt("li", 5).Single("a").Click().Wait(500);
+                browser.ElementAt($"{pager} li", 5).Single("a").Click().Wait(500);
 
-                grid = browser.Single("next-history-grid", SelectByDataUi);
-                pager = browser.Single("next-history-pager", SelectByDataUi);
-                AssertUI.TextNotEquals(grid.ElementAt("tbody tr td", 0), issueId1);
-                AssertUI.TextNotEquals(grid.ElementAt("tbody tr td", 0), issueId2);
-                var issueId3 = grid.ElementAt("tbody tr td", 0).GetInnerText();
+                AssertUI.TextNotEquals(browser.ElementAt($"{grid} tbody tr td", 0), issueId1);
+                AssertUI.TextNotEquals(browser.ElementAt($"{grid} tbody tr td", 0), issueId2);
+                var issueId3 = browser.ElementAt($"{grid} tbody tr td", 0).GetInnerText();
 
                 // go to first page
-                pager.ElementAt("li", 0).Single("a").Click().Wait(500);
+                browser.ElementAt($"{pager} li", 0).Single("a").Click().Wait(500);
 
-                grid = browser.Single("next-history-grid", SelectByDataUi);
-                pager = browser.Single("next-history-pager", SelectByDataUi);
-                AssertUI.TextEquals(grid.ElementAt("tbody tr td", 0), issueId1);
+                AssertUI.TextEquals(browser.ElementAt($"{grid} tbody tr td", 0), issueId1);
 
                 // go to page 4
-                pager.ElementAt("li", 5).Single("a").Click().Wait(500);
+                browser.ElementAt($"{pager} li", 5).Single("a").Click().Wait(500);
 
-                grid = browser.Single("next-history-grid", SelectByDataUi);
-                pager = browser.Single("next-history-pager", SelectByDataUi);
-                AssertUI.TextNotEquals(grid.ElementAt("tbody tr td", 0), issueId1);
-                AssertUI.TextNotEquals(grid.ElementAt("tbody tr td", 0), issueId2);
-                AssertUI.TextNotEquals(grid.ElementAt("tbody tr td", 0), issueId3);
+                AssertUI.TextNotEquals(browser.ElementAt($"{grid} tbody tr td", 0), issueId1);
+                AssertUI.TextNotEquals(browser.ElementAt($"{grid} tbody tr td", 0), issueId2);
+                AssertUI.TextNotEquals(browser.ElementAt($"{grid} tbody tr td", 0), issueId3);
 
                 // go to previous page
-                pager.ElementAt("li", 1).Single("a").Click().Wait(500);
+                browser.ElementAt($"{pager} li", 1).Single("a").Click().Wait(500);
 
-                grid = browser.Single("next-history-grid", SelectByDataUi);
-                pager = browser.Single("next-history-pager", SelectByDataUi);
-                AssertUI.TextEquals(grid.ElementAt("tbody tr td", 0), issueId3);
+                AssertUI.TextEquals(browser.ElementAt($"{grid} tbody tr td", 0), issueId3);
             });
         }
         private void VerifyPageIsNotThrowingAuthError(IBrowserWrapper browser)

--- a/src/Samples/Tests/Tests/Feature/DateTimeTranslationTests.cs
+++ b/src/Samples/Tests/Tests/Feature/DateTimeTranslationTests.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
@@ -14,6 +15,9 @@ namespace DotVVM.Samples.Tests.Feature
 {
     public class DateTimeTranslationTests : AppSeleniumTest
     {
+        // different versions of localization libraries may produce different whitespace (no space before AM/PM, no-break spaces, ...)
+        static bool EqualsIgnoreSpace(string a, string b) => Regex.Replace(a, @"\s+", "") == Regex.Replace(b, @"\s+", "");
+
         [Fact]
         public void Feature_DateTime_PropertyTranslations()
         {
@@ -45,10 +49,10 @@ namespace DotVVM.Samples.Tests.Feature
 
                 // try the conversion
                 var localTextBox = browser.Single("input[data-ui=toBrowserLocalTime]");
-                AssertUI.TextEquals(localTextBox, localDateTime);
+                AssertUI.Text(localTextBox, t => EqualsIgnoreSpace(t, localDateTime));
 
                 localTextBox.Clear().SendKeys(localDateTime2).SendEnterKey();
-                AssertUI.TextEquals(textbox, stringDateTime2);
+                AssertUI.Text(textbox, t => EqualsIgnoreSpace(t, stringDateTime2));
 
                 // try the conversion on nullable
                 var localTextBoxNullable = browser.Single("input[data-ui=toBrowserLocalTimeOnNullable]");
@@ -56,7 +60,7 @@ namespace DotVVM.Samples.Tests.Feature
                 AssertUI.TextEquals(localTextBoxNullable, "");
 
                 localTextBoxNullable.Clear().SendKeys(localDateTime2).SendEnterKey();
-                AssertUI.TextEquals(spanNullable, stringDateTime2);
+                AssertUI.Text(spanNullable, t => EqualsIgnoreSpace(t, stringDateTime2));
 
                 // try the null propagation
                 var localTextBoxNullPropagation = browser.Single("input[data-ui=toBrowserLocalTimeNullPropagation]");

--- a/src/Samples/Tests/Tests/Feature/DateTimeTranslationTests.cs
+++ b/src/Samples/Tests/Tests/Feature/DateTimeTranslationTests.cs
@@ -102,7 +102,7 @@ namespace DotVVM.Samples.Tests.Feature
                 textbox.Clear().SendKeys(stringDateTime).SendEnterKey();
 
                 var str = browser.Single("span[data-ui=timeOnlyToString]");
-                AssertUI.TextEquals(str, "3:28:31 PM");
+                AssertUI.Text(str, t => EqualsIgnoreSpace(t, "3:28:31 PM"));
                 var props = browser.Single("span[data-ui=timeOnlyProperties]");
                 AssertUI.TextEquals(props, "15 hours 28 minues 31 seconds and 0 milliseconds");
             });

--- a/src/Samples/Tests/Tests/Feature/SerializationTests.cs
+++ b/src/Samples/Tests/Tests/Feature/SerializationTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Text.RegularExpressions;
 using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
 using OpenQA.Selenium;
@@ -253,6 +254,10 @@ namespace DotVVM.Samples.Tests.Feature
             });
         }
 
+        // different versions of localization libraries may produce different whitespace (no space before AM/PM, no-break spaces, ...)
+        static bool EqualsIgnoreSpace(string a, string b) => Regex.Replace(a, @"\s+", "") == Regex.Replace(b, @"\s+", "");
+
+
         [Fact]
         public void Feature_Serialization_DateOnly()
         {
@@ -290,16 +295,16 @@ namespace DotVVM.Samples.Tests.Feature
 
                 // Initial state
                 const string initialTimeOnlyValue = "11:56:42 PM";
-                AssertUI.TextEquals(timeOnlyTextBox, initialTimeOnlyValue);
-                AssertUI.TextEquals(timeOnlySpan, initialTimeOnlyValue);
-                AssertUI.TextEquals(timeOnlyPlain, "TimeOnly: " + initialTimeOnlyValue);
+                AssertUI.Text(timeOnlyTextBox, t => EqualsIgnoreSpace(t, initialTimeOnlyValue));
+                AssertUI.Text(timeOnlySpan, t => EqualsIgnoreSpace(t, initialTimeOnlyValue));
+                AssertUI.Text(timeOnlyPlain, t => EqualsIgnoreSpace(t, "TimeOnly: " + initialTimeOnlyValue));
 
                 // Change date
                 const string newTimeOnlyValue = "9:23:00 AM";
                 timeOnlyTextBox.Clear().SendKeys(newTimeOnlyValue).SendEnterKey();
-                AssertUI.TextEquals(timeOnlyTextBox, newTimeOnlyValue);
-                AssertUI.TextEquals(timeOnlySpan, newTimeOnlyValue);
-                AssertUI.TextEquals(timeOnlyPlain, "TimeOnly: " + newTimeOnlyValue);
+                AssertUI.Text(timeOnlyTextBox, t => EqualsIgnoreSpace(t, newTimeOnlyValue));
+                AssertUI.Text(timeOnlySpan, t => EqualsIgnoreSpace(t, newTimeOnlyValue));
+                AssertUI.Text(timeOnlyPlain, t => EqualsIgnoreSpace(t, "TimeOnly: " + newTimeOnlyValue));
             });
         }
 

--- a/src/Samples/Tests/Tests/Feature/StaticCommandTests.cs
+++ b/src/Samples/Tests/Tests/Feature/StaticCommandTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using DotVVM.Samples.Tests.Base;
@@ -878,7 +879,9 @@ namespace DotVVM.Samples.Tests.Feature
             var content = new List<string>();
             foreach (var col in cols)
             {
-                content.Add(cells.ElementAt(col).GetInnerText());
+                var text = cells.ElementAt(col).GetInnerText();
+                text = Regex.Replace(text, "\\s+", " "); // diffrent version of localization libraries can produce different whitespace (space, or no-break space)
+                content.Add(text);
             }
 
             return content;

--- a/src/Samples/Tests/Tests/Feature/ViewModelDeserializationTests.cs
+++ b/src/Samples/Tests/Tests/Feature/ViewModelDeserializationTests.cs
@@ -1,4 +1,5 @@
-﻿using DotVVM.Samples.Tests.Base;
+﻿using System.Text.RegularExpressions;
+using DotVVM.Samples.Tests.Base;
 using DotVVM.Testing.Abstractions;
 using Riganti.Selenium.Core;
 using Xunit;
@@ -52,6 +53,10 @@ namespace DotVVM.Samples.Tests.Feature
             });
         }
 
+        // different versions of localization libraries may produce different whitespace (no space before AM/PM, no-break spaces, ...)
+        static bool EqualsIgnoreSpace(string a, string b) => Regex.Replace(a, @"\s+", "") == Regex.Replace(b, @"\s+", "");
+
+
         [Fact]
         public void Feature_ViewModelDeserialization_PropertyNullAssignment()
         {
@@ -64,13 +69,13 @@ namespace DotVVM.Samples.Tests.Feature
                 AssertUI.InnerTextEquals(value, "");
 
                 buttons[0].Click();
-                AssertUI.InnerTextEquals(value, "1/2/2023 3:04:05 AM");
+                AssertUI.InnerText(value, t => EqualsIgnoreSpace(t, "1/2/2023 3:04:05 AM"));
 
                 buttons[1].Click();
                 AssertUI.InnerTextEquals(value, "");
 
                 buttons[0].Click();
-                AssertUI.InnerTextEquals(value, "1/2/2023 3:04:05 AM");
+                AssertUI.InnerText(value, t => EqualsIgnoreSpace(t, "1/2/2023 3:04:05 AM"));
 
                 buttons[2].Click();
                 AssertUI.InnerTextEquals(value, "");


### PR DESCRIPTION
ICU update probably caused different whitespace
being generated before AM/PM (no whitespace,
&nbsp, and simple space are all possible).