### PR TITLE
Binding translation issue in PostBackHandler properties

### DIFF
--- a/src/Framework/Framework/Compilation/Javascript/ParametrizedCode.cs
+++ b/src/Framework/Framework/Compilation/Javascript/ParametrizedCode.cs
@@ -173,7 +173,7 @@ namespace DotVVM.Framework.Compilation.Javascript
                     var isGlobalContext = a.IsGlobalContext && param.IsSafeMemberAccess;
 
                     if (isGlobalContext)
-                        builder.Add(stringParts[1 + i].AsSpan(1, stringParts[i].Length - 1).DotvvmInternString()); // skip `.`
+                        builder.Add(stringParts[1 + i].AsSpan(1, stringParts[1 + i].Length - 1).DotvvmInternString()); // skip `.`
                     else
                     {
                         builder.Add(a.Code, param.OperatorPrecedence);

--- a/src/Framework/Framework/Controls/KnockoutHelper.cs
+++ b/src/Framework/Framework/Controls/KnockoutHelper.cs
@@ -355,8 +355,8 @@ namespace DotVVM.Framework.Controls
             {
                 case IValueBinding binding: {
                     var adjustedCode = binding.GetParametrizedKnockoutExpression(handler, unwrapped: true).AssignParameters(o =>
-                        o == JavascriptTranslator.KnockoutContextParameter ? new ParametrizedCode("c") :
-                        o == JavascriptTranslator.KnockoutViewModelParameter ? new ParametrizedCode("d") :
+                        o == JavascriptTranslator.KnockoutContextParameter ? CodeParameterAssignment.FromIdentifier("c") :
+                        o == JavascriptTranslator.KnockoutViewModelParameter ? CodeParameterAssignment.FromIdentifier("d") :
                         default(CodeParameterAssignment)
                     );
                     return new JsSymbolicParameter(new CodeSymbolicParameter("tmp symbol", defaultAssignment: adjustedCode));

--- a/src/Samples/Common/ViewModels/FeatureSamples/PostBack/PostBackHandlerBindingViewModel.cs
+++ b/src/Samples/Common/ViewModels/FeatureSamples/PostBack/PostBackHandlerBindingViewModel.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+using DotVVM.Framework.Hosting;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.PostBack
+{
+    public class PostBackHandlerBindingViewModel : DotvvmViewModelBase
+    {
+        public bool Enabled { get; set; } = false;
+
+        public int Counter { get; set; } = 0;
+
+        public string[] Items { get; set; } = new string[] { "Item 1", "Item 2", "Item 3" };
+    }
+}
+

--- a/src/Samples/Common/Views/FeatureSamples/PostBack/PostBackHandlerBinding.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/PostBack/PostBackHandlerBinding.dothtml
@@ -12,7 +12,7 @@
     <p>
         <dot:CheckBox Text="Suppress postbacks" Checked="{value: Enabled}" />
     </p>
-    <p>Counter: {{value: Counter}}</p>
+    <p>Counter: <span class="result">{{value: Counter}}</span></p>
 
     <p>Click on grid rows to increment the counter.</p>
 

--- a/src/Samples/Common/Views/FeatureSamples/PostBack/PostBackHandlerBinding.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/PostBack/PostBackHandlerBinding.dothtml
@@ -1,0 +1,35 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.PostBack.PostBackHandlerBindingViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+
+    <p>
+        <dot:CheckBox Text="Suppress postbacks" Checked="{value: Enabled}" />
+    </p>
+    <p>Counter: {{value: Counter}}</p>
+
+    <p>Click on grid rows to increment the counter.</p>
+
+    <dot:GridView DataSource="{value: Items}">
+        <Columns>
+            <dot:GridViewTextColumn HeaderText="Column 1" ValueBinding="{value: _this}" />
+        </Columns>
+        <RowDecorators>
+            <dot:Decorator Events.Click="{command: _parent.Counter = _parent.Counter + 1}" style="cursor: pointer">
+                <PostBack.Handlers>
+                    <dot:SuppressPostBackHandler Suppress="{value: _parent.Enabled}" />
+                </PostBack.Handlers>
+            </dot:Decorator>
+        </RowDecorators>
+    </dot:GridView>
+
+</body>
+</html>
+
+

--- a/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
@@ -309,6 +309,7 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_ParameterBinding_OptionalParameterBinding = "FeatureSamples/ParameterBinding/OptionalParameterBinding";
         public const string FeatureSamples_ParameterBinding_ParameterBinding = "FeatureSamples/ParameterBinding/ParameterBinding";
         public const string FeatureSamples_PostBack_ConfirmPostBackHandler = "FeatureSamples/PostBack/ConfirmPostBackHandler";
+        public const string FeatureSamples_PostBack_PostBackHandlerBinding = "FeatureSamples/PostBack/PostBackHandlerBinding";
         public const string FeatureSamples_PostBack_PostBackHandlerCommandTypes = "FeatureSamples/PostBack/PostBackHandlerCommandTypes";
         public const string FeatureSamples_PostBack_PostbackUpdate = "FeatureSamples/PostBack/PostbackUpdate";
         public const string FeatureSamples_PostBack_PostbackUpdateRepeater = "FeatureSamples/PostBack/PostbackUpdateRepeater";

--- a/src/Samples/Tests/Tests/Feature/PostBackTests.cs
+++ b/src/Samples/Tests/Tests/Feature/PostBackTests.cs
@@ -87,6 +87,24 @@ namespace DotVVM.Samples.Tests.Feature
             });
         }
 
+        [Fact]
+        public void Feature_PostBack_PostBackHandlerBinding()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_PostBack_PostBackHandlerBinding);
+
+                var counter = browser.Single(".result");
+                AssertUI.TextEquals(counter, "0");
+
+                browser.ElementAt("td", 0).Click();
+                AssertUI.TextEquals(counter, "1");
+
+                browser.Single("input[type=checkbox]").Click();
+                browser.ElementAt("td", 0).Click();
+                AssertUI.TextEquals(counter, "1");
+            });
+        }
+
         private void ValidatePostbackHandlersComplexSection(string sectionSelector, IBrowserWrapper browser)
         {
             IElementWrapper section = null;

--- a/src/Tests/Binding/BindingCompilationTests.cs
+++ b/src/Tests/Binding/BindingCompilationTests.cs
@@ -1493,7 +1493,7 @@ namespace DotVVM.Framework.Tests.Binding
             return SomeString + ": " + MyProperty;
         }
     }
-    class TestViewModel3 : DotvvmViewModelBase
+    public class TestViewModel3 : DotvvmViewModelBase
     {
         public string SomeString { get; set; }
     }

--- a/src/Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/Tests/Binding/JavascriptCompilationTests.cs
@@ -1395,6 +1395,40 @@ namespace DotVVM.Framework.Tests.Binding
             Assert.AreEqual("VehicleNumber()==\"123\"", result);
         }
 
+        [TestMethod]
+        public void JavascriptCompilation_ParametrizedCode_ParentContexts()
+        {
+            // root: TestViewModel
+            // parent: TestViewModel2 + _index + _collection
+            // this: TestViewModel3 + _index
+            var context0 = DataContextStack.Create(typeof(TestViewModel));
+            var context1 = DataContextStack.Create(typeof(TestViewModel2), parent: context0, extensionParameters: [ new CurrentCollectionIndexExtensionParameter(), new BindingCollectionInfoExtensionParameter("_collection") ]);
+            var context2 = DataContextStack.Create(typeof(TestViewModel3), parent: context1, extensionParameters: [ new CurrentCollectionIndexExtensionParameter() ]);
+
+            var result = bindingHelper.ValueBindingToParametrizedCode("_root.IntProp + _parent._index + _parent._collection.Index + _parent.MyProperty + _index + SomeString.Length", context2);
+
+            Assert.AreEqual("$parents[1].IntProp() + $parentContext.$index() + $parentContext.$index() + $parent.MyProperty() + $index() + SomeString().length", result.ToDefaultString());
+
+            // assign `context` and `vm` variables
+            var formatted2 = result.ToString(o =>
+                o == JavascriptTranslator.KnockoutContextParameter ? new ParametrizedCode("context", OperatorPrecedence.Max) :
+                o == JavascriptTranslator.KnockoutViewModelParameter ? new ParametrizedCode("vm", OperatorPrecedence.Max) :
+                default(CodeParameterAssignment)
+            );
+            Console.WriteLine(formatted2);
+
+            var symbolicParameters = result.Parameters.ToArray();
+            Assert.AreEqual(6, symbolicParameters.Length);
+            Assert.AreEqual(2, XAssert.IsAssignableFrom<JavascriptTranslator.ViewModelSymbolicParameter>(symbolicParameters[0].Parameter).ParentIndex);
+            Assert.AreEqual(JavascriptTranslator.KnockoutContextParameter, symbolicParameters[1].Parameter); // JavascriptTranslator.ParentKnockoutContextParameter would also work
+            Assert.AreEqual(JavascriptTranslator.KnockoutContextParameter, symbolicParameters[2].Parameter); // JavascriptTranslator.ParentKnockoutContextParameter would also work
+            Assert.AreEqual(JavascriptTranslator.ParentKnockoutViewModelParameter, symbolicParameters[3].Parameter);
+            Assert.AreEqual(JavascriptTranslator.KnockoutContextParameter, symbolicParameters[4].Parameter);
+            Assert.AreEqual(JavascriptTranslator.KnockoutViewModelParameter, symbolicParameters[5].Parameter);
+
+            Assert.AreEqual("context.$parents[1].IntProp() + context.$parentContext.$index() + context.$parentContext.$index() + context.$parent.MyProperty() + context.$index() + vm.SomeString().length", formatted2);
+        }
+
         public class TestMarkupControl: DotvvmMarkupControl
         {
             public string SomeProperty

--- a/src/Tests/ControlTests/PostbackHandlerTests.cs
+++ b/src/Tests/ControlTests/PostbackHandlerTests.cs
@@ -33,7 +33,8 @@ namespace DotVVM.Framework.Tests.ControlTests
                 <!-- suppress postback -->
                 <dot:Button DataContext={value: Nested} Click={staticCommand: 0} Text="Test supress">
                     <Postback.Handlers>
-                        <dot:SuppressPostBackHandler Suppress={value: _parent.Integer > 100 || SomeString.Length < 5} />
+                        <dot:SuppressPostBackHandler Suppress={value: _parent.Integer > 100} />
+                        <dot:SuppressPostBackHandler Suppress={value: SomeString.Length < 5} />
                     </Postback.Handlers>
                 </dot:Button>
 

--- a/src/Tests/ControlTests/PostbackHandlerTests.cs
+++ b/src/Tests/ControlTests/PostbackHandlerTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Threading.Tasks;
+using CheckTestOutput;
+using DotVVM.Framework.Compilation;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Tests.Binding;
+using DotVVM.Framework.ViewModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DotVVM.Framework.Testing;
+using System.Security.Claims;
+using System.Collections;
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Compilation.ControlTree;
+using DotVVM.Framework.Hosting;
+
+namespace DotVVM.Framework.Tests.ControlTests
+{
+    [TestClass]
+    public class PostbackHandlerTests
+    {
+        static readonly ControlTestHelper cth = new ControlTestHelper(config: config => {
+        });
+        readonly OutputChecker check = new OutputChecker("testoutputs");
+
+
+        [TestMethod]
+        public async Task ButtonHandlers()
+        {
+            var r = await cth.RunPage(typeof(BasicTestViewModel), """
+                <!-- suppress postback -->
+                <dot:Button DataContext={value: Nested} Click={staticCommand: 0} Text="Test supress">
+                    <Postback.Handlers>
+                        <dot:SuppressPostBackHandler Suppress={value: _parent.Integer > 100 || SomeString.Length < 5} />
+                    </Postback.Handlers>
+                </dot:Button>
+
+                <!-- confirm -->
+                <dot:Button DataContext={value: Nested} Click={staticCommand: 0} Text="Test confirm">
+                    <Postback.Handlers>
+                        <dot:ConfirmPostBackHandler Message={value: $"String={_root.String} SomeString={SomeString}"} />
+                    </Postback.Handlers>
+                </dot:Button>
+                """
+            );
+
+            check.CheckString(r.FormattedHtml, fileExtension: "html");
+        }
+
+        public class BasicTestViewModel: DotvvmViewModelBase
+        {
+            public int Integer { get; set; } = 123;
+            public bool Boolean { get; set; } = false;
+            public string String { get; set; } = "some-string";
+
+            public TestViewModel3 Nested { get; set; } = new TestViewModel3 { SomeString = "a" };
+        }
+    }
+}

--- a/src/Tests/ControlTests/testoutputs/PostbackHandlerTests.ButtonHandlers.html
+++ b/src/Tests/ControlTests/testoutputs/PostbackHandlerTests.ButtonHandlers.html
@@ -6,7 +6,7 @@
 		<!-- ko with: Nested -->
 		<input onclick="dotvvm.applyPostbackHandlers((options) => {
 	0;
-},this,[[&quot;suppress&quot;,(c,d)=>({suppress:c.$parent.Integer() > 100 || d.SomeString()?.length < 5})]]).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="Test supress">
+},this,[[&quot;suppress&quot;,(c,d)=>({suppress:c.$parent.Integer() > 100})],[&quot;suppress&quot;,(c,d)=>({suppress:d.SomeString()?.length < 5})]]).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="Test supress">
 		<!-- /ko -->  
 		<!-- confirm --> 
 		<!-- ko with: Nested -->

--- a/src/Tests/ControlTests/testoutputs/PostbackHandlerTests.ButtonHandlers.html
+++ b/src/Tests/ControlTests/testoutputs/PostbackHandlerTests.ButtonHandlers.html
@@ -1,0 +1,21 @@
+<html>
+	<head></head>
+	<body>
+		
+		<!-- suppress postback --> 
+		<!-- ko with: Nested -->
+		<input onclick="dotvvm.applyPostbackHandlers((options) => {
+	0;
+},this,[[&quot;suppress&quot;,(c,d)=>({suppress:c.$parent.Integer() > 100 || d.SomeString()?.length < 5})]]).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="Test supress">
+		<!-- /ko -->  
+		<!-- confirm --> 
+		<!-- ko with: Nested -->
+		<input onclick="dotvvm.applyPostbackHandlers((options) => {
+	0;
+},this,[[&quot;confirm&quot;,(c,d)=>({message:dotvvm.translations.string.format(&quot;String={0} SomeString={1}&quot;, [
+	c.$parent.String()
+	, d.SomeString()
+])})]]).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="Test confirm">
+		<!-- /ko -->
+	</body>
+</html>

--- a/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.PostbackHandlers.html
+++ b/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.PostbackHandlers.html
@@ -6,7 +6,7 @@
 		Two handlers
 		<input data-msg="ahoj" onclick="dotvvm.postBack(this,[],&quot;2suRIvLX7+StPC7x&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,{message:&quot;ahoj&quot;}]],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
 		Two handlers, value binding message
-		<input data-bind="attr: { &quot;data-msg&quot;: Label }" data-msg="My Label" onclick="dotvvm.postBack(this,[],&quot;b80b5Lh9K50jj3q2&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,(c,d)=>({message:(d).Label()})]],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
+		<input data-bind="attr: { &quot;data-msg&quot;: Label }" data-msg="My Label" onclick="dotvvm.postBack(this,[],&quot;b80b5Lh9K50jj3q2&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,(c,d)=>({message:d.Label()})]],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
 		Two handlers, resource binding message
 		<input data-msg="My Label" onclick="dotvvm.postBack(this,[],&quot;mH2HraWjqc1sx3p+&quot;,&quot;&quot;,null,[[&quot;confirm&quot;,{message:&quot;a&quot;}],[&quot;confirm&quot;,{message:&quot;My Label&quot;}]],[],undefined).catch(dotvvm.log.logPostBackScriptError);event.stopPropagation();return false;" type="button" value="">
 		Two handlers, default message

--- a/src/Tests/Runtime/JavascriptCompilation/JsFormatterTests.cs
+++ b/src/Tests/Runtime/JavascriptCompilation/JsFormatterTests.cs
@@ -1,9 +1,7 @@
 ﻿using DotVVM.Framework.Compilation.Javascript.Ast;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 using System.Collections.Generic;
 using System.Text;
-using DotVVM.Framework.Compilation.Javascript;
 using static DotVVM.Framework.Tests.Runtime.JavascriptCompilation.JsParensInsertionTests;
 
 namespace DotVVM.Framework.Tests.Runtime.JavascriptCompilation
@@ -45,17 +43,6 @@ namespace DotVVM.Framework.Tests.Runtime.JavascriptCompilation
         public void JsFormatter_Indexer()
         {
             AssertFormatting("a[b]", new JsIdentifierExpression("a").Indexer(new JsIdentifierExpression("b")));
-        }
-
-        [TestMethod]
-        public void JsFormatter_SymbolicParameter_Global()
-        {
-            var symbol = new CodeSymbolicParameter();
-            Assert.AreEqual("a+global",
-                new JsBinaryExpression(new JsMemberAccessExpression(new JsSymbolicParameter(symbol), "a"), BinaryOperatorType.Plus,
-                    new JsSymbolicParameter(symbol))
-                .FormatParametrizedScript().ToString(o => o == symbol ? CodeParameterAssignment.FromExpression(new JsIdentifierExpression("global"), isGlobalContext: true) :
-                                                          throw new Exception()));
         }
 
         [TestMethod]

--- a/src/Tests/Runtime/JavascriptCompilation/JsParametrizedCodeTests.cs
+++ b/src/Tests/Runtime/JavascriptCompilation/JsParametrizedCodeTests.cs
@@ -1,0 +1,125 @@
+using DotVVM.Framework.Compilation.Javascript.Ast;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using DotVVM.Framework.Compilation.Javascript;
+
+namespace DotVVM.Framework.Tests.Runtime.JavascriptCompilation
+{
+    [TestClass]
+    public class JsParametrizedCodeTests
+    {
+        static CodeSymbolicParameter symbolA = new CodeSymbolicParameter("A");
+        static CodeSymbolicParameter symbolB = new CodeSymbolicParameter("B");
+        static CodeSymbolicParameter symbolC = new CodeSymbolicParameter("C", defaultAssignment: new JsIdentifier("defaultValue").FormatParametrizedScript());
+        static CodeSymbolicParameter symbolD = new CodeSymbolicParameter("D", defaultAssignment: new JsBinaryExpression(new JsSymbolicParameter(symbolA), BinaryOperatorType.Times, new JsSymbolicParameter(symbolC)).FormatParametrizedScript());
+        static CodeSymbolicParameter symbolE = new CodeSymbolicParameter("E", defaultAssignment: new JsBinaryExpression(new JsSymbolicParameter(symbolA), BinaryOperatorType.Plus, new JsSymbolicParameter(symbolD)).FormatParametrizedScript());
+
+        [TestMethod]
+        public void SymbolicParameters_Global()
+        {
+            // full would be "global.a+global
+            var pcode = new JsBinaryExpression(new JsMemberAccessExpression(new JsSymbolicParameter(symbolA), "a"), BinaryOperatorType.Plus,
+                    new JsSymbolicParameter(symbolA))
+                .FormatParametrizedScript();
+            Assert.AreEqual("a+global",
+                pcode.ToString(o => o == symbolA ? CodeParameterAssignment.FromExpression(new JsIdentifierExpression("global"), isGlobalContext: true) :
+                                    throw new Exception()));
+            Assert.AreEqual("a+global",
+                pcode.AssignParameters(o => o == symbolA ? CodeParameterAssignment.FromExpression(new JsIdentifierExpression("global"), isGlobalContext: true) :
+                                            throw new Exception())
+                    .ToString(o => default));
+        }
+
+        [TestMethod]
+        public void SymbolicParameters_Global_ThroughDefault()
+        {
+            var globalDefaultSymbol = new CodeSymbolicParameter("global", defaultAssignment: symbolA.ToParametrizedCode());
+            // may be "global.a+global" or "a+global" - doesn't matter if the optimization works in this case, but it shouldn't be broken
+            var pcode = new JsBinaryExpression(new JsMemberAccessExpression(new JsSymbolicParameter(globalDefaultSymbol), "a"), BinaryOperatorType.Plus,
+                                new JsSymbolicParameter(globalDefaultSymbol))
+                            .FormatParametrizedScript();
+            Assert.AreEqual("global.a+global",
+                pcode.ToString(o => o == symbolA ? CodeParameterAssignment.FromExpression(new JsIdentifierExpression("global"), isGlobalContext: true) :
+                                    default));
+            Assert.AreEqual("global.a+global",
+                pcode.AssignParameters(o => o == symbolA ? CodeParameterAssignment.FromExpression(new JsIdentifierExpression("global"), isGlobalContext: true) :
+                                            default)
+                    .ToString(o => default));
+        }
+
+        [TestMethod]
+        public void SymbolicParameters_Throws_Unassigned()
+        {
+            var pcode = new JsBinaryExpression(new JsMemberAccessExpression(new JsSymbolicParameter(symbolA), "a"), BinaryOperatorType.Plus, new JsSymbolicParameter(symbolA)).FormatParametrizedScript();
+            
+            var pcode2 = pcode.AssignParameters(o => default); // fine, not all have to be assigned
+            var pcodeResolved = pcode.AssignParameters(o => o == symbolA ? CodeParameterAssignment.FromIdentifier("x") : default);
+
+            Assert.AreEqual("y.a+y", pcode.ToString(o => o == symbolA ? CodeParameterAssignment.FromIdentifier("y") : default));
+            Assert.AreEqual("z.a+z", pcode2.ToString(o => o == symbolA ? CodeParameterAssignment.FromIdentifier("z") : default));
+            Assert.AreEqual("x.a+x", pcodeResolved.ToString(o => default));
+            Assert.AreEqual("x.a+x", pcodeResolved.ToString(o => o == symbolA ? CodeParameterAssignment.FromIdentifier("AREADY_ASSIGNED_BEFORE") : default));
+
+            var ex = Assert.ThrowsException<InvalidOperationException>(() => pcode.ToString(o => default));
+            XAssert.Contains("Assignment of parameter '{A|", ex.Message);
+
+            ex = Assert.ThrowsException<InvalidOperationException>(() => pcode2.ToString(o => default));
+            XAssert.Contains("Assignment of parameter '{A|", ex.Message);
+        }
+
+        [TestMethod]
+        public void SymbolicParameters_Partial_DefaultChain()
+        {
+            var expr = new JsBinaryExpression(symbolA.ToExpression(), BinaryOperatorType.Plus, symbolE.ToExpression());
+            var pcode = expr.FormatParametrizedScript();
+
+            Assert.AreEqual("x+(x+x*defaultValue)", pcode.ToString(o => o == symbolA ? CodeParameterAssignment.FromIdentifier("x") : default));
+            Assert.AreEqual("y+(y+y*defaultValue)", pcode.ToString(o => o == symbolA ? CodeParameterAssignment.FromIdentifier("y") : default));
+
+            // substitute symbolD for identifier, order doesn't matter
+            Assert.AreEqual("x+(x+D)",
+                pcode.AssignParameters(o => o == symbolA ? CodeParameterAssignment.FromIdentifier("x") : default)
+                     .ToString(o => o == symbolD ? CodeParameterAssignment.FromExpression(new JsIdentifierExpression("D")) : default));
+            Assert.AreEqual("x+(x+D)",
+                pcode.AssignParameters(o => o == symbolD ? CodeParameterAssignment.FromExpression(new JsIdentifierExpression("D")) : default)
+                     .ToString(o => o == symbolA ? CodeParameterAssignment.FromIdentifier("x") : default));
+
+            // substitute symbolD for symbolA, order now matters
+            Assert.AreEqual("x+(x+x)",
+                pcode.AssignParameters(o => o == symbolD ? CodeParameterAssignment.FromExpression(new JsSymbolicParameter(symbolA)) : default)
+                     .ToString(o => o == symbolA ? CodeParameterAssignment.FromIdentifier("x") : default));
+            Assert.AreEqual("x+(x+y)",
+                pcode.AssignParameters(o => o == symbolA ? CodeParameterAssignment.FromIdentifier("x") : default)
+                     .AssignParameters(o => o == symbolD ? CodeParameterAssignment.FromExpression(new JsSymbolicParameter(symbolA)) : default)
+                     .ToString(o => o == symbolA ? CodeParameterAssignment.FromIdentifier("y") : default));
+        }
+
+        [TestMethod]
+        public void SymbolicParameters_AddDefault()
+        {
+            var expr = new JsBinaryExpression(symbolA.ToExpression(), BinaryOperatorType.Plus, symbolE.ToExpression());
+            var pcode = expr.FormatParametrizedScript();
+
+            // add default for symbolA
+            var assigned = pcode.AssignParameters(o => o == symbolA ? symbolA.ToExpression(CodeParameterAssignment.FromIdentifier("a")).FormatParametrizedScript() : default);
+
+            Assert.AreEqual("a+(a+a*defaultValue)", assigned.ToString(o => default));
+            Assert.AreEqual("a+(a+a*defaultValue)", assigned.ToDefaultString());
+
+            Assert.AreEqual("x+(x+x*defaultValue)", assigned.ToString(o => o == symbolA ? CodeParameterAssignment.FromIdentifier("x") : default));
+            Assert.AreEqual("a+x", assigned.ToString(o => o == symbolE ? CodeParameterAssignment.FromIdentifier("x") : default));
+        }
+
+        [TestMethod]
+        public void SymbolicParameters_NoAssignmentNoAllocation()
+        {
+            var expr = new JsBinaryExpression(symbolA.ToExpression(), BinaryOperatorType.Plus, symbolE.ToExpression());
+            var pcode = expr.FormatParametrizedScript();
+            Func<CodeSymbolicParameter, CodeParameterAssignment> noAssignment = o => default;
+
+            var b = GC.GetAllocatedBytesForCurrentThread();
+            pcode.AssignParameters(noAssignment);
+            Assert.AreEqual(0, GC.GetAllocatedBytesForCurrentThread() - b);
+        }
+    }
+}

--- a/src/Tests/Runtime/JavascriptCompilation/JsParametrizedCodeTests.cs
+++ b/src/Tests/Runtime/JavascriptCompilation/JsParametrizedCodeTests.cs
@@ -110,6 +110,7 @@ namespace DotVVM.Framework.Tests.Runtime.JavascriptCompilation
             Assert.AreEqual("a+x", assigned.ToString(o => o == symbolE ? CodeParameterAssignment.FromIdentifier("x") : default));
         }
 
+#if DotNetCore
         [TestMethod]
         public void SymbolicParameters_NoAssignmentNoAllocation()
         {
@@ -121,5 +122,6 @@ namespace DotVVM.Framework.Tests.Runtime.JavascriptCompilation
             pcode.AssignParameters(noAssignment);
             Assert.AreEqual(0, GC.GetAllocatedBytesForCurrentThread() - b);
         }
+#endif
     }
 }


### PR DESCRIPTION
Referencing `_parent` in properties of postback handlers is translated to an incorrect JS:

```
DotHTML:
<dot:SuppressPostBackHandler Suppress="{value: _parent.Enabled}" />

Translated JS:
(c,d) => $parent.Enabled
```