### PR TITLE
Refactoring & cleanup in routes & route groups + bug fixes

### DIFF
--- a/src/Framework/Framework/Compilation/DotHtmlFileInfo.cs
+++ b/src/Framework/Framework/Compilation/DotHtmlFileInfo.cs
@@ -14,7 +14,7 @@ namespace DotVVM.Framework.Compilation
         public ImmutableArray<CompilationDiagnosticViewModel> Warnings { get; internal set; } = ImmutableArray<CompilationDiagnosticViewModel>.Empty;
 
         /// <summary>Gets or sets the virtual path to the view.</summary>
-        public string VirtualPath { get; }
+        public string? VirtualPath { get; }
 
         public string? TagName { get; }
         public string? Namespace { get; }
@@ -25,7 +25,7 @@ namespace DotVVM.Framework.Compilation
         public ImmutableArray<string>? DefaultValues { get; }
         public bool? HasParameters { get; }
 
-        public DotHtmlFileInfo(string virtualPath, string? tagName = null, string? nameSpace = null, string? assembly = null, string? tagPrefix = null, string? url = null, string? routeName = null, ImmutableArray<string>? defaultValues = null, bool? hasParameters = null)
+        public DotHtmlFileInfo(string? virtualPath, string? tagName = null, string? nameSpace = null, string? assembly = null, string? tagPrefix = null, string? url = null, string? routeName = null, ImmutableArray<string>? defaultValues = null, bool? hasParameters = null)
         {
             VirtualPath = virtualPath;
             Status = IsDothtmlFile(virtualPath) ? CompilationState.None : CompilationState.NonCompilable;
@@ -40,7 +40,7 @@ namespace DotVVM.Framework.Compilation
             HasParameters = hasParameters;
         }
 
-        private static bool IsDothtmlFile(string virtualPath)
+        private static bool IsDothtmlFile(string? virtualPath)
         {
             return !string.IsNullOrWhiteSpace(virtualPath) &&
                 (

--- a/src/Framework/Framework/Compilation/DotvvmViewCompilationService.cs
+++ b/src/Framework/Framework/Compilation/DotvvmViewCompilationService.cs
@@ -184,7 +184,7 @@ namespace DotVVM.Framework.Compilation
                 try
                 {
                     if (forceRecompile)
-                        controlBuilderFactory.InvalidateCache(file.VirtualPath);
+                        controlBuilderFactory.InvalidateCache(file.VirtualPath!);
 
                     var pageBuilder = controlBuilderFactory.GetControlBuilder(file.VirtualPath!);
 

--- a/src/Framework/Framework/Compilation/DotvvmViewCompilationService.cs
+++ b/src/Framework/Framework/Compilation/DotvvmViewCompilationService.cs
@@ -122,7 +122,7 @@ namespace DotVVM.Framework.Compilation
                 var compilationTaskFactory = (DotHtmlFileInfo t) => () => {
                     BuildView(t, forceRecompile, out var masterPage);
                     if (masterPage != null && masterPage.Status == CompilationState.None)
-                        discoveredMasterPages.TryAdd(masterPage.VirtualPath, masterPage);
+                        discoveredMasterPages.TryAdd(masterPage.VirtualPath!, masterPage);
                 };
 
                 var compileTasks = filesToCompile.Select(compilationTaskFactory).ToArray();
@@ -186,7 +186,7 @@ namespace DotVVM.Framework.Compilation
                     if (forceRecompile)
                         controlBuilderFactory.InvalidateCache(file.VirtualPath);
 
-                    var pageBuilder = controlBuilderFactory.GetControlBuilder(file.VirtualPath);
+                    var pageBuilder = controlBuilderFactory.GetControlBuilder(file.VirtualPath!);
 
                     using var scopedServices = dotvvmConfiguration.ServiceProvider.CreateScope(); // dependencies that are configured as scoped cannot be resolved from root service provider
                     scopedServices.ServiceProvider.GetRequiredService<DotvvmRequestContextStorage>().Context = new ViewCompilationFakeRequestContext(scopedServices.ServiceProvider);

--- a/src/Framework/Framework/Compilation/Static/StaticViewCompiler.cs
+++ b/src/Framework/Framework/Compilation/Static/StaticViewCompiler.cs
@@ -10,6 +10,7 @@ using DotVVM.Framework.Compilation.ViewCompiler;
 using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Hosting;
 using DotVVM.Framework.Security;
+using DotVVM.Framework.Utils;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -33,7 +34,7 @@ namespace DotVVM.Framework.Compilation.Static
                 diagnostics.AddRange(CompileNoThrow(configuration, markupControl!));
             }
 
-            var views = configuration.RouteTable.Select(r => r.VirtualPath).ToImmutableArray();
+            var views = configuration.RouteTable.Select(r => r.VirtualPath).WhereNotNull().ToImmutableArray();
             foreach(var view in views)
             {
                 diagnostics.AddRange(CompileNoThrow(configuration, view));

--- a/src/Framework/Framework/Configuration/FreezableDictionary.cs
+++ b/src/Framework/Framework/Configuration/FreezableDictionary.cs
@@ -23,7 +23,7 @@ namespace DotVVM.Framework.Configuration
             }
         }
     }
-    sealed class FreezableDictionary<K, V> : IDictionary<K, V>, IReadOnlyCollection<KeyValuePair<K, V>>
+    sealed class FreezableDictionary<K, V> : IDictionary<K, V>, IReadOnlyCollection<KeyValuePair<K, V>>, IReadOnlyDictionary<K, V>
         where K : notnull
     {
         private readonly Dictionary<K, V> dict;
@@ -102,5 +102,9 @@ namespace DotVVM.Framework.Configuration
         public ICollection<K> Keys => ((IDictionary<K, V>)dict).Keys.ToArray();
 
         public ICollection<V> Values => ((IDictionary<K, V>)dict).Values.ToArray();
+
+        IEnumerable<K> IReadOnlyDictionary<K, V>.Keys => Keys;
+
+        IEnumerable<V> IReadOnlyDictionary<K, V>.Values => Values;
     }
 }

--- a/src/Framework/Framework/Configuration/FreezableDictionary.cs
+++ b/src/Framework/Framework/Configuration/FreezableDictionary.cs
@@ -95,6 +95,8 @@ namespace DotVVM.Framework.Configuration
             set { ThrowIfFrozen(); dict[index] = value; }
         }
 
+        public Dictionary<K, V> CreateCopy() => new(dict, dict.Comparer);
+
         public int Count => dict.Count;
 
         public bool IsReadOnly => isFrozen;

--- a/src/Framework/Framework/Controls/RouteLinkHelpers.cs
+++ b/src/Framework/Framework/Controls/RouteLinkHelpers.cs
@@ -194,7 +194,7 @@ namespace DotVVM.Framework.Controls
 
         private static Dictionary<string, object?> ComposeNewRouteParameters(RouteLink control, IDotvvmRequestContext context, RouteBase route)
         {
-            var parameters = new Dictionary<string, object?>(route.DefaultValues, StringComparer.OrdinalIgnoreCase);
+            var parameters = route.CloneDefaultValues();
             foreach (var param in context.Parameters!)
             {
                 parameters[param.Key] = param.Value;

--- a/src/Framework/Framework/Hosting/AggregateMarkupFileLoader.cs
+++ b/src/Framework/Framework/Hosting/AggregateMarkupFileLoader.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using DotVVM.Framework.Configuration;
+using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Hosting
 {
@@ -39,7 +40,8 @@ namespace DotVVM.Framework.Hosting
         /// </summary>
         public string GetMarkupFileVirtualPath(IDotvvmRequestContext context)
         {
-            return context.Route!.VirtualPath;
+            return context.Route!.VirtualPath
+                ?? throw new Exception($"The route {context.Route.RouteName} must have a non-null virtual path.");
         }
     }
 }

--- a/src/Framework/Framework/Hosting/DefaultMarkupFileLoader.cs
+++ b/src/Framework/Framework/Hosting/DefaultMarkupFileLoader.cs
@@ -38,7 +38,8 @@ namespace DotVVM.Framework.Hosting
         /// </summary>
         public string GetMarkupFileVirtualPath(IDotvvmRequestContext context)
         {
-            return context.Route!.VirtualPath;
+            return context.Route!.VirtualPath
+                ?? throw new Exception($"The route {context.Route.RouteName} must have a non-null virtual path.");
         }
     }
 }

--- a/src/Framework/Framework/Hosting/EmbeddedMarkupFileLoader.cs
+++ b/src/Framework/Framework/Hosting/EmbeddedMarkupFileLoader.cs
@@ -63,7 +63,8 @@ namespace DotVVM.Framework.Hosting
         /// </summary>
         public string GetMarkupFileVirtualPath(IDotvvmRequestContext context)
         {
-            return context.Route!.VirtualPath;
+            return context.Route!.VirtualPath
+                ?? throw new Exception($"The route {context.Route.RouteName} must have a non-null virtual path.");
         }
     }
 }

--- a/src/Framework/Framework/ResourceManagement/LocalResourceUrlManager.cs
+++ b/src/Framework/Framework/ResourceManagement/LocalResourceUrlManager.cs
@@ -28,6 +28,7 @@ namespace DotVVM.Framework.ResourceManagement
             this.resourceRoute = new DotvvmRoute(
                 url: $"{HostingConstants.ResourceRouteName}/{{{HashParameterName}}}/{{{NameParameterName}:regex(.*)}}",
                 virtualPath: "",
+                name: $"_dotvvm_{nameof(LocalResourceUrlManager)}",
                 defaultValues: null,
                 presenterFactory: _ => throw new NotSupportedException(),
                 configuration: configuration);

--- a/src/Framework/Framework/Routing/DefaultRouteStrategy.cs
+++ b/src/Framework/Framework/Routing/DefaultRouteStrategy.cs
@@ -107,10 +107,7 @@ namespace DotVVM.Framework.Routing
             var defaultParameters = GetRouteDefaultParameters(file);
             var presenterFactory = GetRoutePresenterFactory(file);
 
-            return new DotvvmRoute(url, file.AppRelativePath, defaultParameters, presenterFactory, configuration)
-            {
-                RouteName = routeName
-            };
+            return new DotvvmRoute(url, file.AppRelativePath, routeName, defaultParameters, presenterFactory, configuration);
         }
 
         protected virtual string GetRouteName(RouteStrategyMarkupFileInfo file)
@@ -162,7 +159,7 @@ namespace DotVVM.Framework.Routing
         protected override IEnumerable<RouteBase> BuildRoutes(RouteStrategyMarkupFileInfo file)
         {
             return getRouteList(file.AppRelativePath)
-                   .Select(url => new DotvvmRoute(url, file.AppRelativePath, GetRouteDefaultParameters(file), GetRoutePresenterFactory(file), this.configuration) { RouteName = url });
+                   .Select(url => new DotvvmRoute(url, file.AppRelativePath, url, GetRouteDefaultParameters(file), GetRoutePresenterFactory(file), this.configuration));
         }
     }
 }

--- a/src/Framework/Framework/Routing/DotvvmRouteParser.cs
+++ b/src/Framework/Framework/Routing/DotvvmRouteParser.cs
@@ -16,7 +16,7 @@ namespace DotVVM.Framework.Routing
             this.routeConstraints = routeConstrains;
         }
 
-        public UrlParserResult ParseRouteUrl(string url, IDictionary<string, object?> defaultValues)
+        public UrlParserResult ParseRouteUrl(string url, IReadOnlyDictionary<string, object?> defaultValues)
         {
             if (url.StartsWith("/", StringComparison.Ordinal))
                 throw new ArgumentException("The route URL must not start with '/'!");
@@ -85,7 +85,7 @@ namespace DotVVM.Framework.Routing
             };
         }
 
-        private UrlParameterParserResult ParseParameter(string url, string prefix, ref int index, IDictionary<string, object?> defaultValues)
+        private UrlParameterParserResult ParseParameter(string url, string prefix, ref int index, IReadOnlyDictionary<string, object?> defaultValues)
         {
             // find the end of the route parameter name
             var startIndex = index;

--- a/src/Framework/Framework/Routing/DotvvmRouteTable.cs
+++ b/src/Framework/Framework/Routing/DotvvmRouteTable.cs
@@ -312,18 +312,19 @@ namespace DotVVM.Framework.Routing
         [return: NotNullIfNotNull(nameof(appendedPath))]
         private string? CombinePath(string? prefix, string? appendedPath)
         {
+            if (appendedPath == null)
+            {
+                // NB: if you are adding presenter route inside a group, we ignore the group's virtual path because presenter routes have VirtualPath = null
+                return null;
+            }
+
             if (string.IsNullOrEmpty(prefix))
             {
                 return appendedPath;
             }
-
-            if (appendedPath == null)
+            else if (string.IsNullOrEmpty(appendedPath))
             {
-                return null;
-            }
-            else if (appendedPath == string.Empty)
-            {
-                return prefix ?? string.Empty;
+                return prefix;
             }
 
             return $"{prefix}/{appendedPath}";

--- a/src/Framework/Framework/Routing/LocalizedDotvvmRoute.cs
+++ b/src/Framework/Framework/Routing/LocalizedDotvvmRoute.cs
@@ -1,13 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
-using System.Net.WebSockets;
-using System.Text;
-using System.Threading;
 using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Hosting;
 
@@ -36,34 +31,18 @@ namespace DotVVM.Framework.Routing
 
         public override IEnumerable<KeyValuePair<string, DotvvmRouteParameterMetadata>> ParameterMetadata => GetRouteForCulture(CultureInfo.CurrentUICulture).ParameterMetadata;
 
-        public override string RouteName
-        {
-            get
-            {
-                return base.RouteName;
-            }
-            internal set
-            {
-                base.RouteName = value;
-                foreach (var route in localizedRoutes)
-                {
-                    route.Value.RouteName = value;
-                }
-            }
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="DotvvmRoute"/> class.
         /// </summary>
-        public LocalizedDotvvmRoute(string defaultLanguageUrl, LocalizedRouteUrl[] localizedUrls, string virtualPath, object? defaultValues, Func<IServiceProvider, IDotvvmPresenter> presenterFactory, DotvvmConfiguration configuration)
-            : base(defaultLanguageUrl, virtualPath, defaultValues)
+        public LocalizedDotvvmRoute(string defaultLanguageUrl, LocalizedRouteUrl[] localizedUrls, string? virtualPath, string name, object? defaultValues, Func<IServiceProvider, IDotvvmPresenter> presenterFactory, DotvvmConfiguration configuration)
+            : base(defaultLanguageUrl, virtualPath, name, defaultValues, presenterFactory)
         {
             if (!localizedUrls.Any())
             {
                 throw new ArgumentException("There must be at least one localized route URL!", nameof(localizedUrls));
             }
 
-            var defaultRoute = new DotvvmRoute(defaultLanguageUrl, virtualPath, defaultValues, presenterFactory, configuration);
+            var defaultRoute = new DotvvmRoute(defaultLanguageUrl, virtualPath, name, defaultValues, presenterFactory, configuration);
 
             var sortedParameters = defaultRoute.ParameterMetadata
                 .OrderBy(n => n.Key)
@@ -71,7 +50,7 @@ namespace DotVVM.Framework.Routing
 
             foreach (var localizedUrl in localizedUrls)
             {
-                var localizedRoute = new DotvvmRoute(localizedUrl.RouteUrl, virtualPath, defaultValues, presenterFactory, configuration);
+                var localizedRoute = new DotvvmRoute(localizedUrl.RouteUrl, virtualPath, name, defaultValues, presenterFactory, configuration);
                 if (!localizedRoute.ParameterMetadata.OrderBy(n => n.Key)
                         .SequenceEqual(sortedParameters))
                 {

--- a/src/Framework/Framework/Routing/RouteBase.cs
+++ b/src/Framework/Framework/Routing/RouteBase.cs
@@ -16,7 +16,7 @@ namespace DotVVM.Framework.Routing
         /// <summary>
         /// Gets the URL pattern for the route.
         /// </summary>
-        public string Url { get; private set; }
+        public string Url { get; }
 
         /// <summary>
         /// Gets the URL pattern for the route, but it must not contain type parameter types (i.e. should turn a/{id:int}/{name:regex(...)} into a/{id}/{name}
@@ -31,8 +31,8 @@ namespace DotVVM.Framework.Routing
         /// <summary>
         /// Gets the default values of the optional parameters.
         /// </summary>
-        public IReadOnlyDictionary<string, object?> DefaultValues => _defaultValues;
-        private FreezableDictionary<string, object?> _defaultValues;
+        public IReadOnlyDictionary<string, object?> DefaultValues => defaultValues;
+        private readonly FreezableDictionary<string, object?> defaultValues;
 
         /// <summary>
         /// Gets or sets the virtual path to the view.
@@ -45,7 +45,7 @@ namespace DotVVM.Framework.Routing
         public RouteBase(string url, string? virtualPath, string name, object? defaultValues, Func<IServiceProvider, IDotvvmPresenter> presenterFactory)
             : this(url, virtualPath, name, new Dictionary<string, object?>(), presenterFactory)
         {
-            AddOrUpdateParameterCollection(_defaultValues, defaultValues);
+            AddOrUpdateParameterCollection(this.defaultValues, defaultValues);
         }
 
         /// <summary>
@@ -65,11 +65,11 @@ namespace DotVVM.Framework.Routing
 
             if (defaultValues != null)
             {
-                _defaultValues = new FreezableDictionary<string, object?>(defaultValues, StringComparer.OrdinalIgnoreCase);
+                this.defaultValues = new FreezableDictionary<string, object?>(defaultValues, StringComparer.OrdinalIgnoreCase);
             }
             else
             {
-                _defaultValues = new FreezableDictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+                this.defaultValues = new FreezableDictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
             }
         }
 
@@ -100,7 +100,7 @@ namespace DotVVM.Framework.Routing
             if (newRouteValues == null)
                 throw new ArgumentNullException(nameof(newRouteValues));
 
-            var values = new Dictionary<string, object?>(_defaultValues, StringComparer.OrdinalIgnoreCase);
+            var values = new Dictionary<string, object?>(defaultValues, StringComparer.OrdinalIgnoreCase);
             AddOrUpdateParameterCollection(values, currentRouteValues);
             AddOrUpdateParameterCollection(values, newRouteValues);
 
@@ -115,7 +115,7 @@ namespace DotVVM.Framework.Routing
             if (currentRouteValues == null)
                 throw new ArgumentNullException(nameof(currentRouteValues));
 
-            var values = new Dictionary<string, object?>(_defaultValues, StringComparer.OrdinalIgnoreCase);
+            var values = new Dictionary<string, object?>(defaultValues, StringComparer.OrdinalIgnoreCase);
             AddOrUpdateParameterCollection(values, currentRouteValues);
             AddOrUpdateParameterCollection(values, newRouteValues);
 
@@ -127,7 +127,7 @@ namespace DotVVM.Framework.Routing
         /// </summary>
         public string BuildUrl(object? routeValues = null)
         {
-            var values = new Dictionary<string, object?>(_defaultValues, StringComparer.OrdinalIgnoreCase);
+            var values = new Dictionary<string, object?>(defaultValues, StringComparer.OrdinalIgnoreCase);
             AddOrUpdateParameterCollection(values, routeValues);
 
             return BuildUrl(values);
@@ -143,7 +143,7 @@ namespace DotVVM.Framework.Routing
                 routeValues = new Dictionary<string, object?>();
             }
 
-            var values = new Dictionary<string, object?>(_defaultValues, StringComparer.OrdinalIgnoreCase);
+            var values = new Dictionary<string, object?>(defaultValues, StringComparer.OrdinalIgnoreCase);
             AddOrUpdateParameterCollection(values, routeValues);
 
             return BuildUrlCore(values);
@@ -199,12 +199,12 @@ namespace DotVVM.Framework.Routing
         /// </summary>
         public virtual IDotvvmPresenter GetPresenter(IServiceProvider provider) => PresenterFactory(provider);
 
-        public Dictionary<string, object?> CloneDefaultValues() => new Dictionary<string, object?>(_defaultValues, StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, object?> CloneDefaultValues() => defaultValues.CreateCopy();
 
 
         private bool isFrozen = false;
 
-        private void ThrowIfFrozen()
+        protected void ThrowIfFrozen()
         {
             if (isFrozen)
                 throw FreezableUtils.Error(this.GetType().Name);
@@ -212,7 +212,7 @@ namespace DotVVM.Framework.Routing
         public void Freeze()
         {
             this.isFrozen = true;
-            this._defaultValues.Freeze();
+            this.defaultValues.Freeze();
 
             Freeze2();
         }

--- a/src/Framework/Framework/Routing/RouteHelper.cs
+++ b/src/Framework/Framework/Routing/RouteHelper.cs
@@ -52,7 +52,7 @@ namespace DotVVM.Framework.Routing
                     invalidRoutes.Add(new DotvvmConfigurationAssertResult<RouteBase>(route, DotvvmConfigurationAssertReason.MissingRouteName));
                 }
 
-                var content = loader.GetMarkup(config, route.VirtualPath);
+                var content = loader.GetMarkup(config, route.VirtualPath!);
                 if (content == null)
                 {
                     invalidRoutes.Add(new DotvvmConfigurationAssertResult<RouteBase>(route, DotvvmConfigurationAssertReason.MissingFile));

--- a/src/Framework/Framework/Routing/RouteHelper.cs
+++ b/src/Framework/Framework/Routing/RouteHelper.cs
@@ -32,7 +32,7 @@ namespace DotVVM.Framework.Routing
         {
             foreach (var route in strategy.GetRoutes())
             {
-                table.Add(route.RouteName, route);
+                table.Add(route);
             }
         }
         /// <summary>

--- a/src/Framework/Framework/Routing/RouteTableGroup.cs
+++ b/src/Framework/Framework/Routing/RouteTableGroup.cs
@@ -7,7 +7,7 @@ namespace DotVVM.Framework.Routing
 {
     public class RouteTableGroup
     {
-        public Action<string, RouteBase> AddToParentRouteTable { get; private set; }
+        public Action<RouteBase> AddToParentRouteTable { get; private set; }
 
         public Func<IServiceProvider, IDotvvmPresenter>? PresenterFactory { get; }
 
@@ -16,7 +16,7 @@ namespace DotVVM.Framework.Routing
         public string UrlPrefix { get; private set; }
         public string VirtualPathPrefix { get; private set; }
 
-        public RouteTableGroup(string groupName, string routeNamePrefix, string urlPrefix, string virtualPathPrefix, Action<string, RouteBase> addToParentRouteTable, Func<IServiceProvider, IDotvvmPresenter>? presenterFactory)
+        public RouteTableGroup(string groupName, string routeNamePrefix, string urlPrefix, string virtualPathPrefix, Action<RouteBase> addToParentRouteTable, Func<IServiceProvider, IDotvvmPresenter>? presenterFactory)
         {
             GroupName = groupName;
             RouteNamePrefix = routeNamePrefix;

--- a/src/Framework/Framework/Routing/RouteTableJsonConverter.cs
+++ b/src/Framework/Framework/Routing/RouteTableJsonConverter.cs
@@ -17,25 +17,6 @@ namespace DotVVM.Framework.Routing
         public override DotvvmRouteTable Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             throw new NotImplementedException();
-            // var rt = new DotvvmRouteTable();
-            // if (reader.TokenType != JsonTokenType.StartObject) throw new JsonException("Expected StartObject");
-            // reader.Read();
-
-            // while (reader.TokenType == JsonTokenType.PropertyName)
-            // {
-            //     var routeName = reader.GetString();
-            //     reader.Read();
-            //     var route = (JObject)prop.Value.NotNull();
-            //     try
-            //     {
-            //         rt.Add(prop.Key, route["url"].NotNull("route.url is required").Value<string>(), (route["virtualPath"]?.Value<string>()).NotNull("route.virtualPath is required"), route["defaultValues"]?.ToObject<IDictionary<string, object>>());
-            //     }
-            //     catch (Exception error)
-            //     {
-            //         rt.Add(prop.Key, new ErrorRoute(route["url"]?.Value<string>(), route["virtualPath"]?.Value<string>(), prop.Key, route["defaultValues"]?.ToObject<IDictionary<string, object?>>(), error));
-            //     }
-            // }
-            // return rt;
         }
 
         public override void Write(Utf8JsonWriter writer, DotvvmRouteTable value, JsonSerializerOptions options)
@@ -59,34 +40,6 @@ namespace DotVVM.Framework.Routing
                 writer.WriteEndObject();
             }
             writer.WriteEndObject();
-        }
-
-        sealed class ErrorRoute : RouteBase
-        {
-            private readonly Exception error;
-
-            public ErrorRoute(string? url, string? virtualPath, string? name, IDictionary<string, object?>? defaultValues, Exception error)
-                : base(url ?? "<unknown>", virtualPath ?? "<unknown>", name ?? "<unknown>", defaultValues)
-            {
-                this.error = error;
-            }
-
-            public override IEnumerable<string> ParameterNames { get; } = new string[0];
-
-            public override IEnumerable<KeyValuePair<string, DotvvmRouteParameterMetadata>> ParameterMetadata { get; } = new KeyValuePair<string, DotvvmRouteParameterMetadata>[0];
-
-            public override string UrlWithoutTypes => base.Url;
-
-            public override IDotvvmPresenter GetPresenter(IServiceProvider provider) => throw new InvalidOperationException($"Could not create route {RouteName}", error);
-
-            public override bool IsMatch(string url, [MaybeNullWhen(false)] out IDictionary<string, object?> values) => throw new InvalidOperationException($"Could not create route {RouteName}", error);
-
-            protected internal override string BuildUrlCore(Dictionary<string, object?> values) => throw new InvalidOperationException($"Could not create route {RouteName}", error);
-
-            protected override void Freeze2()
-            {
-                // no mutable properties in this class
-            }
         }
     }
 }

--- a/src/Framework/Testing/ControlTestHelper.cs
+++ b/src/Framework/Testing/ControlTestHelper.cs
@@ -87,7 +87,7 @@ namespace DotVVM.Framework.Testing
 
             var context = DotvvmTestHelper.CreateContext(
                 Configuration,
-                route: new Framework.Routing.DotvvmRoute("testpage", fileName, null, _ => throw new Exception(), Configuration),
+                route: new Framework.Routing.DotvvmRoute("testpage", fileName, "testpage", null, _ => throw new Exception(), Configuration),
                 requestType: postback is object ? DotvvmRequestType.Command : DotvvmRequestType.Navigate
             );
             context.CsrfToken = null;

--- a/src/Framework/Testing/ControlTestHelper.cs
+++ b/src/Framework/Testing/ControlTestHelper.cs
@@ -206,7 +206,7 @@ namespace DotVVM.Framework.Testing
             Console.WriteLine(viewModel);
             return new PageRunResult(
                 this,
-                context.Route.VirtualPath,
+                context.Route!.VirtualPath!,
                 JsonNode.Parse(viewModel)!.AsObject(),
                 htmlOutput,
                 headResources,

--- a/src/Framework/Testing/FakeMarkupFileLoader.cs
+++ b/src/Framework/Testing/FakeMarkupFileLoader.cs
@@ -21,7 +21,7 @@ namespace DotVVM.Framework.Testing
 
         public string GetMarkupFileVirtualPath(Hosting.IDotvvmRequestContext context)
         {
-            return context.Route!.VirtualPath;
+            return context.Route!.VirtualPath!;
         }
     }
 }

--- a/src/Tests/Routing/DotvvmRouteTests.cs
+++ b/src/Tests/Routing/DotvvmRouteTests.cs
@@ -24,7 +24,7 @@ namespace DotVVM.Framework.Tests.Routing
         public void DotvvmRoute_IsMatch_RouteMustNotStartWithSlash()
         {
             Assert.ThrowsException<ArgumentException>(() => {
-                var route = new DotvvmRoute("/Test", null, null, null, configuration);
+                var route = new DotvvmRoute("/Test", null, "testpage", null, null, configuration);
             });
         }
 
@@ -33,14 +33,14 @@ namespace DotVVM.Framework.Tests.Routing
         public void DotvvmRoute_IsMatch_RouteMustNotEndWithSlash()
         {
             Assert.ThrowsException<ArgumentException>(() => {
-                var route = new DotvvmRoute("Test/", null, null, null, configuration);
+                var route = new DotvvmRoute("Test/", null, "testpage", null, null, configuration);
             });
         }
 
         [TestMethod]
         public void DotvvmRoute_IsMatch_EmptyRouteMatchesEmptyUrl()
         {
-            var route = new DotvvmRoute("", null, null, null, configuration);
+            var route = new DotvvmRoute("", null, "testpage", null, null, configuration);
 
             IDictionary<string, object> parameters;
             var result = route.IsMatch("", out parameters);
@@ -51,7 +51,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_IsMatch_UrlWithoutParametersExactMatch()
         {
-            var route = new DotvvmRoute("Hello/Test/Page.txt", null, null, null, configuration);
+            var route = new DotvvmRoute("Hello/Test/Page.txt", null, "testpage", null, null, configuration);
 
             IDictionary<string, object> parameters;
             var result = route.IsMatch("Hello/Test/Page.txt", out parameters);
@@ -62,7 +62,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_IsMatch_UrlWithoutParametersNoMatch()
         {
-            var route = new DotvvmRoute("Hello/Test/Page.txt", null, null, null, configuration);
+            var route = new DotvvmRoute("Hello/Test/Page.txt", null, "testpage", null, null, configuration);
 
             IDictionary<string, object> parameters;
             var result = route.IsMatch("Hello/Test/Page", out parameters);
@@ -73,7 +73,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_IsMatch_UrlTwoParametersBothSpecified()
         {
-            var route = new DotvvmRoute("Article/{Id}/{Title}", null, new { Title = "test" }, null, configuration);
+            var route = new DotvvmRoute("Article/{Id}/{Title}", null, "testpage", new { Title = "test" }, null, configuration);
 
             IDictionary<string, object> parameters;
             var result = route.IsMatch("Article/15/Test-title", out parameters);
@@ -87,7 +87,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_IsMatch_UrlTwoParametersOneSpecifiedOneDefault()
         {
-            var route = new DotvvmRoute("Article/{Id}/{Title}", null, new { Title = "test" }, null, configuration);
+            var route = new DotvvmRoute("Article/{Id}/{Title}", null, "testpage", new { Title = "test" }, null, configuration);
 
             IDictionary<string, object> parameters;
             var result = route.IsMatch("Article/15", out parameters);
@@ -102,7 +102,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_IsMatch_UrlTwoParametersBothRequired_NoMatchWhenOneSpecified()
         {
-            var route = new DotvvmRoute("Article/{Id}/{Title}", null, null, null, configuration);
+            var route = new DotvvmRoute("Article/{Id}/{Title}", null, "testpage", null, null, configuration);
 
             IDictionary<string, object> parameters;
             var result = route.IsMatch("Article/15", out parameters);
@@ -113,7 +113,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_IsMatch_UrlTwoParametersBothRequired_DifferentPart()
         {
-            var route = new DotvvmRoute("Article/id_{Id}/{Title}", null, null, null, configuration);
+            var route = new DotvvmRoute("Article/id_{Id}/{Title}", null, "testpage", null, null, configuration);
 
             IDictionary<string, object> parameters;
             var result = route.IsMatch("Articles/id_15", out parameters);
@@ -124,7 +124,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_IsMatch_UrlOneParameterRequired_TwoSpecified()
         {
-            var route = new DotvvmRoute("Article/{Id}", null, null, null, configuration);
+            var route = new DotvvmRoute("Article/{Id}", null, "testpage", null, null, configuration);
 
             IDictionary<string, object> parameters;
             var result = route.IsMatch("Article/15/test", out parameters);
@@ -135,7 +135,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_IsMatch_UrlTwoParametersBothRequired_BothSpecified()
         {
-            var route = new DotvvmRoute("Article/id_{Id}/{Title}", null, null, null, configuration);
+            var route = new DotvvmRoute("Article/id_{Id}/{Title}", null, "testpage", null, null, configuration);
 
             IDictionary<string, object> parameters;
             var result = route.IsMatch("Article/id_15/test", out parameters);
@@ -149,7 +149,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_IsMatch_OneOptionalPrefixedParameter()
         {
-            var route = new DotvvmRoute("{Id?}/Article", null, null, null, configuration);
+            var route = new DotvvmRoute("{Id?}/Article", null, "testpage", null, null, configuration);
 
             IDictionary<string, object> parameters;
             var result = route.IsMatch("Article", out parameters);
@@ -161,7 +161,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_IsMatch_OneOptionalSuffixedParameter_WithConstraint()
         {
-            var route = new DotvvmRoute("Article/{Id?:int}", null, null, null, configuration);
+            var route = new DotvvmRoute("Article/{Id?:int}", null, "testpage", null, null, configuration);
 
             IDictionary<string, object> parameters;
             var result = route.IsMatch("Article", out parameters);
@@ -173,7 +173,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_IsMatch_OneOptionalSuffixedParameter_WithConstraint_SlashAtTheEnd()
         {
-            var route = new DotvvmRoute("Article/{Id?:int}", null, null, null, configuration);
+            var route = new DotvvmRoute("Article/{Id?:int}", null, "testpage", null, null, configuration);
 
             IDictionary<string, object> parameters;
             var result = route.IsMatch("Article/", out parameters);
@@ -185,7 +185,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_IsMatch_JustOneOptionalParameter()
         {
-            var route = new DotvvmRoute("{Id?}", null, null, null, configuration);
+            var route = new DotvvmRoute("{Id?}", null, "testpage", null, null, configuration);
 
             Assert.IsTrue(route.IsMatch("", out var params1));
             Assert.AreEqual(0, params1.Count);
@@ -198,7 +198,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_IsMatch_JustOneOptionalParameterWithConstraint()
         {
-            var route = new DotvvmRoute("{Id?:int}", null, null, null, configuration);
+            var route = new DotvvmRoute("{Id?:int}", null, "testpage", null, null, configuration);
 
             Assert.IsTrue(route.IsMatch("", out var params1));
             Assert.AreEqual(0, params1.Count);
@@ -213,7 +213,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_IsMatch_JustOneOptionalParameterWithConstraint_DefaultValue()
         {
-            var route = new DotvvmRoute("{Id?:int}", null, new { Id = 0 }, null, configuration);
+            var route = new DotvvmRoute("{Id?:int}", null, "testpage", new { Id = 0 }, null, configuration);
 
             Assert.IsTrue(route.IsMatch("", out var params1));
             Assert.AreEqual(1, params1.Count);
@@ -229,7 +229,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_IsMatch_OneOptionalParameter()
         {
-            var route = new DotvvmRoute("Article/{Id?}/edit", null, null, null, configuration);
+            var route = new DotvvmRoute("Article/{Id?}/edit", null, "testpage", null, null, configuration);
 
             IDictionary<string, object> parameters;
             var result = route.IsMatch("Article/edit", out parameters);
@@ -241,7 +241,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_IsMatch_OneOptionalParameter_DefaultValue()
         {
-            var route = new DotvvmRoute("Article/{Id?}/edit", null, new { Id = 0 }, null, configuration);
+            var route = new DotvvmRoute("Article/{Id?}/edit", null, "testpage", new { Id = 0 }, null, configuration);
 
             IDictionary<string, object> parameters;
             var result = route.IsMatch("Article/edit", out parameters);
@@ -254,7 +254,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_IsMatch_TwoParameters_OneOptional_Suffix()
         {
-            var route = new DotvvmRoute("Article/Test/{Id?}/{Id2}/suffix", null, null, null, configuration);
+            var route = new DotvvmRoute("Article/Test/{Id?}/{Id2}/suffix", null, "testpage", null, null, configuration);
 
             IDictionary<string, object> parameters;
             var result = route.IsMatch("Article/Test/5/suffix", out parameters);
@@ -272,7 +272,7 @@ namespace DotVVM.Framework.Tests.Routing
                     new LocalizedRouteUrl("cs", "cs"),
                     new LocalizedRouteUrl("cs-CZ", "cs-CZ"),
                     new LocalizedRouteUrl("en", "en")
-                }, "", null, _ => null, configuration);
+                }, "", "testpage", null, _ => null, configuration);
 
                 var result = route.IsMatch("cs-CZ", out var parameters);
                 Assert.IsTrue(result);
@@ -287,7 +287,7 @@ namespace DotVVM.Framework.Tests.Routing
                     new LocalizedRouteUrl("cs", "cs"),
                     new LocalizedRouteUrl("cs-CZ", "cs-CZ"),
                     new LocalizedRouteUrl("en", "en")
-                }, "", null, _ => null, configuration);
+                }, "", "testpage", null, _ => null, configuration);
 
                 var result = route.IsMatch("en", out var parameters);
                 Assert.IsTrue(result);
@@ -302,7 +302,7 @@ namespace DotVVM.Framework.Tests.Routing
                     new LocalizedRouteUrl("cs", "cs"),
                     new LocalizedRouteUrl("cs-CZ", "cs-CZ"),
                     new LocalizedRouteUrl("en", "en")
-                }, "", null, _ => null, configuration);
+                }, "", "testpage", null, _ => null, configuration);
 
                 var result = route.IsMatch("cs", out var parameters);
                 Assert.IsFalse(result);
@@ -317,7 +317,7 @@ namespace DotVVM.Framework.Tests.Routing
                     new LocalizedRouteUrl("cs", "cs"),
                     new LocalizedRouteUrl("cs-CZ", "cs-CZ"),
                     new LocalizedRouteUrl("en", "en")
-                }, "", null, _ => null, configuration);
+                }, "", "testpage", null, _ => null, configuration);
 
                 var result = route.IsPartialMatch("cs", out var matchedRoute, out var parameters);
                 Assert.IsTrue(result);
@@ -336,14 +336,14 @@ namespace DotVVM.Framework.Tests.Routing
             Assert.ThrowsException<ArgumentException>(() => {
                 var route = new LocalizedDotvvmRoute(defaultRoute, new[] {
                     new LocalizedRouteUrl("en", localizedRoute)
-                }, "", null, _ => null, configuration);
+                }, "", "testpage", null, _ => null, configuration);
             });
         }
 
         [TestMethod]
         public void DotvvmRoute_BuildUrl_UrlTwoParameters()
         {
-            var route = new DotvvmRoute("Article/id_{Id}/{Title}", null, null, null, configuration);
+            var route = new DotvvmRoute("Article/id_{Id}/{Title}", null, "testpage", null, null, configuration);
 
             var result = route.BuildUrl(new { Id = 15, Title = "Test" });
 
@@ -353,7 +353,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_Static_OnePart()
         {
-            var route = new DotvvmRoute("Article", null, null, null, configuration);
+            var route = new DotvvmRoute("Article", null, "testpage", null, null, configuration);
 
             var result = route.BuildUrl(new { });
 
@@ -363,7 +363,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_Static_TwoParts()
         {
-            var route = new DotvvmRoute("Article/Test", null, null, null, configuration);
+            var route = new DotvvmRoute("Article/Test", null, "testpage", null, null, configuration);
 
             var result = route.BuildUrl(new { });
 
@@ -373,7 +373,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_Static_TwoParts_OptionalParameter_NoValue()
         {
-            var route = new DotvvmRoute("Article/Test/{Id?}", null, null, null, configuration);
+            var route = new DotvvmRoute("Article/Test/{Id?}", null, "testpage", null, null, configuration);
 
             var result = route.BuildUrl(new { });
 
@@ -384,7 +384,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_Static_TwoParts_OptionalParameter_WithValue()
         {
-            var route = new DotvvmRoute("Article/Test/{Id?}", null, null, null, configuration);
+            var route = new DotvvmRoute("Article/Test/{Id?}", null, "testpage", null, null, configuration);
 
             var result = route.BuildUrl(new { Id = 5 });
 
@@ -394,7 +394,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_Static_TwoParts_TwoParameters_OneOptional_NoValue()
         {
-            var route = new DotvvmRoute("Article/Test/{Id}/{Id2?}", null, null, null, configuration);
+            var route = new DotvvmRoute("Article/Test/{Id}/{Id2?}", null, "testpage", null, null, configuration);
 
             var result = route.BuildUrl(new { Id = 5 });
 
@@ -404,7 +404,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_Static_TwoParts_TwoParameters_OneOptional_NoValue_Suffix()
         {
-            var route = new DotvvmRoute("Article/Test/{Id}/{Id2?}/suffix", null, null, null, configuration);
+            var route = new DotvvmRoute("Article/Test/{Id}/{Id2?}/suffix", null, "testpage", null, null, configuration);
 
             var result = route.BuildUrl(new { Id = 5 });
 
@@ -415,7 +415,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_Static_TwoParts_TwoParameters_OneOptional_WithValue()
         {
-            var route = new DotvvmRoute("Article/Test/{Id}/{Id2?}", null, null, null, configuration);
+            var route = new DotvvmRoute("Article/Test/{Id}/{Id2?}", null, "testpage", null, null, configuration);
 
             var result = route.BuildUrl(new { Id = 5, Id2 = "aaa" });
 
@@ -427,7 +427,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_Static_TwoParts_TwoParameters_OneOptional_WithValue_Suffix()
         {
-            var route = new DotvvmRoute("Article/Test/{Id}/{Id2?}/suffix", null, null, null, configuration);
+            var route = new DotvvmRoute("Article/Test/{Id}/{Id2?}/suffix", null, "testpage", null, null, configuration);
 
             var result = route.BuildUrl(new { Id = 5, Id2 = "aaa" });
 
@@ -439,7 +439,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_Static_TwoParts_TwoParameters_FirstOptionalOptional_Suffix()
         {
-            var route = new DotvvmRoute("Article/Test/{Id?}/{Id2}/suffix", null, null, null, configuration);
+            var route = new DotvvmRoute("Article/Test/{Id?}/{Id2}/suffix", null, "testpage", null, null, configuration);
 
             var result = route.BuildUrl(new { Id2 = "aaa" });
 
@@ -450,7 +450,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_CombineParameters_OneOptional()
         {
-            var route = new DotvvmRoute("Article/{Id?}", null, null, null, configuration);
+            var route = new DotvvmRoute("Article/{Id?}", null, "testpage", null, null, configuration);
 
             var result = route.BuildUrl(new Dictionary<string, object>() { { "Id", 5 } }, new { });
 
@@ -460,7 +460,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_ParameterOnly()
         {
-            var route = new DotvvmRoute("{Id?}", null, null, null, configuration);
+            var route = new DotvvmRoute("{Id?}", null, "testpage", null, null, configuration);
 
             var result = route.BuildUrl(new { });
 
@@ -470,7 +470,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_OptionalParameter()
         {
-            var route = new DotvvmRoute("myPage/{Id?}/edit", null, null, null, configuration);
+            var route = new DotvvmRoute("myPage/{Id?}/edit", null, "testpage", null, null, configuration);
 
             var result = route.BuildUrl(new { });
             var result2 = route.BuildUrl(new Dictionary<string, object> { ["Id"] = null });
@@ -482,7 +482,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_OneOptionalPrefixedParameter()
         {
-            var route = new DotvvmRoute("{Id?}/Article", null, null, null, configuration);
+            var route = new DotvvmRoute("{Id?}/Article", null, "testpage", null, null, configuration);
 
             var result = route.BuildUrl(new { });
             var result2 = route.BuildUrl(new Dictionary<string, object> { ["Id"] = 0 });
@@ -494,7 +494,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_NullInParameter()
         {
-            var route = new DotvvmRoute("myPage/{Id}/edit", null, null, null, configuration);
+            var route = new DotvvmRoute("myPage/{Id}/edit", null, "testpage", null, null, configuration);
 
             var ex = Assert.ThrowsException<DotvvmRouteException>(() => {
                 route.BuildUrl(new Dictionary<string, object> { ["Id"] = null });
@@ -505,7 +505,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_NoParameter()
         {
-            var route = new DotvvmRoute("RR", null, null, null, configuration);
+            var route = new DotvvmRoute("RR", null, "testpage", null, null, configuration);
 
             var result = route.BuildUrl(null);
 
@@ -517,7 +517,7 @@ namespace DotVVM.Framework.Tests.Routing
         {
             CultureUtils.RunWithCulture("cs-CZ", () =>
             {
-                var route = new DotvvmRoute("RR-{p}", null, null, null, configuration);
+                var route = new DotvvmRoute("RR-{p}", null, "testpage", null, null, configuration);
 
                 var result = route.BuildUrl(new { p = 1.1 });
 
@@ -529,7 +529,7 @@ namespace DotVVM.Framework.Tests.Routing
         public void DotvvmRoute_BuildUrl_UrlEncode()
         {
             CultureUtils.RunWithCulture("cs-CZ", () => {
-                var route = new DotvvmRoute("RR-{p}", null, null, null, configuration);
+                var route = new DotvvmRoute("RR-{p}", null, "testpage", null, null, configuration);
 
                 var result = route.BuildUrl(new { p = 1.1});
 
@@ -542,7 +542,7 @@ namespace DotVVM.Framework.Tests.Routing
         public void DotvvmRoute_BuildUrl_CustomPrimitiveType()
         {
             CultureUtils.RunWithCulture("cs-CZ", () => {
-                var route = new DotvvmRoute("Test/{Id}", null, null, null, configuration);
+                var route = new DotvvmRoute("Test/{Id}", null, "testpage", null, null, configuration);
 
                 var result = route.BuildUrl(new { Id = new DecimalNumber(123.4m) }) + UrlHelper.BuildUrlSuffix(null, new { Id = new DecimalNumber(555.5m) });
                 Assert.AreEqual("~/Test/123%2C4?Id=555%2C5", result);
@@ -554,7 +554,7 @@ namespace DotVVM.Framework.Tests.Routing
         {
             Assert.ThrowsException<ArgumentException>(() => {
 
-                var route = new DotvvmRoute("{Id", null, null, null, configuration);
+                var route = new DotvvmRoute("{Id", null, "testpage", null, null, configuration);
 
                 var result = route.BuildUrl(new { });
             });
@@ -566,7 +566,7 @@ namespace DotVVM.Framework.Tests.Routing
         {
             Assert.ThrowsException<ArgumentException>(() => {
 
-                var route = new DotvvmRoute("{Id:int", null, null, null, configuration);
+                var route = new DotvvmRoute("{Id:int", null, "testpage", null, null, configuration);
 
                 var result = route.BuildUrl(new { });
             });
@@ -575,7 +575,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_Parameter_UrlDecode()
         {
-            var route = new DotvvmRoute("Article/{Title}", null, null, null, configuration);
+            var route = new DotvvmRoute("Article/{Title}", null, "testpage", null, null, configuration);
 
             IDictionary<string, object> parameters;
             var result = route.IsMatch("Article/" + Uri.EscapeDataString("x a d # ? %%%%% | ://"), out parameters);
@@ -588,7 +588,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_ParameterConstraint_Int()
         {
-            var route = new DotvvmRoute("Article/id_{Id:int}/{Title}", null, null, null, configuration);
+            var route = new DotvvmRoute("Article/id_{Id:int}/{Title}", null, "testpage", null, null, configuration);
 
             IDictionary<string, object> parameters;
             var result = route.IsMatch("Article/id_15/test", out parameters);
@@ -601,7 +601,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_ParameterConstraint_FloatingPoints()
         {
-            var route = new DotvvmRoute("R/{float:float}-{double:double}-{decimal:decimal}", null, null, null, configuration);
+            var route = new DotvvmRoute("R/{float:float}-{double:double}-{decimal:decimal}", null, "testpage", null, null, configuration);
 
             IDictionary<string, object> parameters;
             var result = route.IsMatch("R/1.12-1.12-1.12", out parameters);
@@ -616,7 +616,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_ParameterConstraint_Guid()
         {
-            var route = new DotvvmRoute("{guid1:guid}{guid2:guid}{guid3:guid}{guid4:guid}", null, null, null, configuration);
+            var route = new DotvvmRoute("{guid1:guid}{guid2:guid}{guid3:guid}{guid4:guid}", null, "testpage", null, null, configuration);
             var guids = new[]
             {
                 Guid.NewGuid(),
@@ -639,7 +639,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_ParameterConstraint_Max()
         {
-            var route = new DotvvmRoute("{p:max(100)}", null, null, null, configuration);
+            var route = new DotvvmRoute("{p:max(100)}", null, "testpage", null, null, configuration);
 
             IDictionary<string, object> parameters;
             Assert.IsFalse(route.IsMatch("101", out parameters));
@@ -654,7 +654,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_ParameterConstraint_Ranges()
         {
-            var route = new DotvvmRoute("{range:range(1, 100.1)}/{max:max(100)}/{min:min(-55)}/{negrange:range(-100, -12)}/{posint:posint}", null, null, null, configuration);
+            var route = new DotvvmRoute("{range:range(1, 100.1)}/{max:max(100)}/{min:min(-55)}/{negrange:range(-100, -12)}/{posint:posint}", null, "testpage", null, null, configuration);
 
             IDictionary<string, object> parameters;
             Assert.IsTrue(route.IsMatch("50/0/0/-50/5", out parameters));
@@ -677,7 +677,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_ParameterConstraint_Bool()
         {
-            var route = new DotvvmRoute("la{bool:bool}eheh", null, null, null, configuration);
+            var route = new DotvvmRoute("la{bool:bool}eheh", null, "testpage", null, null, configuration);
 
             IDictionary<string, object> parameters;
             Assert.IsTrue(route.IsMatch("latrueeheh", out parameters));
@@ -690,7 +690,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_BuildUrl_ParameterConstraintAlpha()
         {
-            var route = new DotvvmRoute("la1{aplha:alpha}7huh", null, null, null, configuration);
+            var route = new DotvvmRoute("la1{aplha:alpha}7huh", null, "testpage", null, null, configuration);
 
             IDictionary<string, object> parameters;
             Assert.IsTrue(route.IsMatch("la1lala7huh", out parameters));
@@ -703,7 +703,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_Performance()
         {
-            var route = new DotvvmRoute("Article/{name}@{domain}/{id:int}", null, null, null, configuration);
+            var route = new DotvvmRoute("Article/{name}@{domain}/{id:int}", null, "testpage", null, null, configuration);
             IDictionary<string, object> parameters;
             Assert.IsFalse(route.IsMatch("Article/f" + new string('@', 2000) + "f/4f", out parameters));
         }
@@ -739,7 +739,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_RegexConstraint()
         {
-            var route = new DotvvmRoute("test/{Name:regex((aa|bb|cc))}", null, null, null, configuration);
+            var route = new DotvvmRoute("test/{Name:regex((aa|bb|cc))}", null, "testpage", null, null, configuration);
             Assert.IsTrue(route.IsMatch("test/aa", out var parameters));
             Assert.IsTrue(route.IsMatch("test/bb", out parameters));
             Assert.IsTrue(route.IsMatch("test/cc", out parameters));
@@ -749,7 +749,7 @@ namespace DotVVM.Framework.Tests.Routing
         [TestMethod]
         public void DotvvmRoute_UrlWithoutTypes()
         {
-            string parse(string url) => new DotvvmRoute(url, null, null, null, configuration).UrlWithoutTypes;
+            string parse(string url) => new DotvvmRoute(url, null, "testpage", null, null, configuration).UrlWithoutTypes;
 
             Assert.AreEqual(parse("test/xx/12"), "test/xx/12");
             Assert.AreEqual(parse("test/{Param}-{PaRAM2}"), "test/{param}-{param2}");

--- a/src/Tests/Routing/RouteSerializationTests.cs
+++ b/src/Tests/Routing/RouteSerializationTests.cs
@@ -27,9 +27,9 @@ namespace DotVVM.Framework.Tests.Routing
             config1.RouteTable.Add("route2", "url2/{int:posint}", "file1.dothtml", new { a = "ccc" });
 
             // Add unknown constraint, simulate user defined constraint that is not known to the VS Extension
-            var r = new DotvvmRoute("url3", "file1.dothtml", new { }, provider => null, config1);
+            var r = new DotvvmRoute("url3", "file1.dothtml", "route3", new { }, provider => null, config1);
             typeof(RouteBase).GetProperty("Url").SetMethod.Invoke(r, new[] { "url3/{a:unsuppotedConstraint}" });
-            config1.RouteTable.Add("route3", r);
+            config1.RouteTable.Add(r);
 
             var settings = VisualStudioHelper.GetSerializerOptions();
             var config2 = JsonSerializer.Deserialize<DotvvmConfiguration>(JsonSerializer.Serialize(config1, settings), settings);

--- a/src/Tests/Routing/RouteTableGroupTests.cs
+++ b/src/Tests/Routing/RouteTableGroupTests.cs
@@ -27,8 +27,8 @@ namespace DotVVM.Framework.Tests.Routing
 
             var group = table.GetGroup("Group");
             var route = group.First();
-            Assert.AreEqual(route.RouteName, "Group_Route");
-            Assert.AreEqual(route.VirtualPath, "PathPrefix/route.dothtml");
+            Assert.AreEqual("Group_Route", route.RouteName);
+            Assert.AreEqual("PathPrefix/route.dothtml", route.VirtualPath);
             Assert.IsTrue(route.IsMatch("UrlPrefix/5/Article/test", out var parameters));
 
             Assert.AreEqual("5", parameters["Id"]);
@@ -40,7 +40,7 @@ namespace DotVVM.Framework.Tests.Routing
         {
             var table = new DotvvmRouteTable(configuration);
             table.AddGroup("Group", "UrlPrefix/{Id}", null, opt => {
-                opt.Add("Default", "", null, null, null, null);
+                opt.Add("Default", "", "route.dothtml", null, null, null);
             });
 
             var group = table.GetGroup("Group");
@@ -56,7 +56,7 @@ namespace DotVVM.Framework.Tests.Routing
         {
             var table = new DotvvmRouteTable(configuration);
             table.AddGroup("Group", "UrlPrefix/{Id}", null, opt => {
-                opt.Add("Route", "Article/{Title}", null, new { Title = "test" }, null, null);
+                opt.Add("Route", "Article/{Title}", "route.dothtml", new { Title = "test" }, null, null);
             });
 
             var group = table.GetGroup("Group");
@@ -74,8 +74,8 @@ namespace DotVVM.Framework.Tests.Routing
         {
             var table = new DotvvmRouteTable(configuration);
             table.AddGroup("Group", "UrlPrefix/{Id}", null, opt => {
-                opt.Add("Route0", "Article0/{Title}", null, null, null, null);
-                opt.Add("Route1", "Article1/{Title}", null, null, null, null);
+                opt.Add("Route0", "Article0/{Title}", "route.dothtml", null, null, null);
+                opt.Add("Route1", "Article1/{Title}", "route.dothtml", null, null, null);
             });
 
             var group = table.GetGroup("Group");
@@ -90,8 +90,8 @@ namespace DotVVM.Framework.Tests.Routing
         {
             var table = new DotvvmRouteTable(configuration);
             table.AddGroup("Group", "UrlPrefix/{Id}", null, opt => {
-                opt.Add("Route0", "Article0/{Title}", null, null, null, null);
-                opt.Add("Route1", "Article1/{Title}", null, null, null, null);
+                opt.Add("Route0", "Article0/{Title}", "route.dothtml", null, null, null);
+                opt.Add("Route1", "Article1/{Title}", "route.dothtml", null, null, null);
             });
 
             var group = table.GetGroup("Group");
@@ -110,11 +110,11 @@ namespace DotVVM.Framework.Tests.Routing
             table.AddGroup("Group1", "UrlPrefix1", null, opt1 => {
                 opt1.AddGroup("Group2", "UrlPrefix2", null, opt2 => {
                     opt2.AddGroup("Group3", "UrlPrefix3", null, opt3 => {
-                        opt3.Add("Route3", "Article3", null, null, null, null);
+                        opt3.Add("Route3", "Article3", "route.dothtml", null, null, null);
                     });
-                    opt2.Add("Route2", "Article2", null, null, null, null);
+                    opt2.Add("Route2", "Article2", "route.dothtml", null, null, null);
                 });
-                opt1.Add("Route1", "Article1", null, null, null, null);
+                opt1.Add("Route1", "Article1", "route.dothtml", null, null, null);
             });
 
             var group = table.GetGroup("Group1");
@@ -181,9 +181,37 @@ namespace DotVVM.Framework.Tests.Routing
 
             var table = new DotvvmRouteTable(configuration);
             table.AddGroup("Group", null, null, opt => {
-                opt.Add("Article", "");
+                opt.Add("Article", "", "");
             }, p => p.GetRequiredService<TestPresenter>());
             Assert.IsInstanceOfType(table.First().GetPresenter(configuration.ServiceProvider), typeof(TestPresenter));
+        }
+
+        [TestMethod]
+        public void RouteTableGroup_Redirections()
+        {
+            var table = new DotvvmRouteTable(configuration);
+            table.AddGroup("Group", "Prefix", "VirtualPathPrefix", opt => {
+                opt.AddUrlRedirection("Url", "", "redirect.dothtml");
+                opt.AddRouteRedirection("Route", "RedirectRoute", "Group_Url");
+                opt.Add("Normal", "Normal", "normal.dothtml");
+            });
+
+            var group = table.GetGroup("Group");
+
+            var urlRedirection = group.ElementAt(0);
+            Assert.AreEqual("Group_Url", urlRedirection.RouteName);
+            Assert.AreEqual("Prefix", urlRedirection.Url);
+            Assert.IsNull(urlRedirection.VirtualPath);
+
+            var routeRedirection = group.ElementAt(1);
+            Assert.AreEqual("Group_Route", routeRedirection.RouteName);
+            Assert.AreEqual("Prefix/RedirectRoute", routeRedirection.Url);
+            Assert.IsNull(routeRedirection.VirtualPath);
+
+            var normalRoute = group.ElementAt(2);
+            Assert.AreEqual("Group_Normal", normalRoute.RouteName);
+            Assert.AreEqual("Prefix/Normal", normalRoute.Url);
+            Assert.AreEqual("VirtualPathPrefix/normal.dothtml", normalRoute.VirtualPath);
         }
     }
 }

--- a/src/Tests/Runtime/DotvvmControlRenderedHtmlTests.cs
+++ b/src/Tests/Runtime/DotvvmControlRenderedHtmlTests.cs
@@ -81,7 +81,7 @@ namespace DotVVM.Framework.Tests.Runtime
                 routeLink.SetValue(Internal.IsSpaPageProperty, true);
 
                 configuration = DotvvmTestHelper.CreateConfiguration();
-                configuration.RouteTable.Add("TestRoute", "TestRoute");
+                configuration.RouteTable.Add("TestRoute", "TestRoute", "");
                 configuration.Freeze();
                 return routeLink;
             }


### PR DESCRIPTION
We had several issues in route groups when used in combination with URL and route redirections:

```csharp
config.RouteTable.AddGroup(
    "CmsAdmin", urlPrefix, "embedded://Shared.Infrastructure.Cms.Admin", routes =>
{
    routes.AddRouteRedirection(
        "Index", 
        "", // this URL was not concatenated with the group prefix, 
        "CmsAdmin_Articles");
    routes.Add("Preview", 
        "articles/preview", 
        "some_valid_virtual_path", // this cannot be null and requires a valid embedded resource path even though it is not used 
        presenterFactory: _ => new PreviewPopupPresenter());
});
```