### PR TITLE
Upgraded actions/upload-artifact from deprecated version

### DIFF
--- a/.github/test-report/action.yml
+++ b/.github/test-report/action.yml
@@ -21,7 +21,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.report-name }}
         path: ${{ inputs.trx-path }}


### PR DESCRIPTION
`actions/upload-artifact@v3` will stop working in December.