### PR TITLE
Drop support for 4.1 and 4.0, provide clear support timelines for other versions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-When it comes to security updates, we always support the current major version together with the latest preview version.
+When it comes to security updates, we always support the current stable version together with the latest preview version.
 Each older stable version will continue to be supported for at least one year after the release of the subsequent stable version.
 Any vulnerabilities that affect unsupported versions will be considered on a case-by-case basis.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,14 +3,15 @@
 ## Supported Versions
 
 When it comes to security updates, we always support the current major version together with the latest preview version.
-Any vulnerabilities that affect older versions will be considered on a case-by-case basis.
+Each older stable version will continue to be supported for at least one year after the release of the subsequent stable version.
+Any vulnerabilities that affect unsupported versions will be considered on a case-by-case basis.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 4.2.x   | :white_check_mark: |
-| 4.1.x   | :white_check_mark: |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+| Version     | Supported          | Expires         |
+| ----------- | ------------------ | --------------- |
+| 5.0 preview | :white_check_mark: |                 |
+| 4.3         | :white_check_mark: |                 |
+| 4.2         | :white_check_mark: | September 2025  |
+| ≤ 4.1       | :x:                | November 2024   |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Update the security policy:

* deprecate 4.0 and 4.1 releases, we will no longer guarantee security fixes
* promise that users will always have at least 1 year to upgrade
* old stable versions now have support expiration date in the table

In practice we will backport fixes of critical vulnerabilities even for unsupported versions, but don't need to promise that.