### PR TITLE
Export the JS StateManager instance

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/dotvvm-root.ts
+++ b/src/Framework/Framework/Resources/Scripts/dotvvm-root.ts
@@ -91,7 +91,8 @@ const dotvvmExports = {
         getStateManager().patchState(a)
     },
     setState(a: any) { getStateManager().setState(a) },
-    updateState(updateFunction: StateUpdate<any>) { getStateManager().update(updateFunction) },
+    updateState(updateFunction: StateUpdate<any>) { getStateManager().updateState(updateFunction) },
+    get rootStateManager() { return getStateManager() },
     viewModelObservables: {
         get root() { return getViewModelObservable(); }
     },

--- a/src/Framework/Framework/Resources/Scripts/postback/http.ts
+++ b/src/Framework/Framework/Resources/Scripts/postback/http.ts
@@ -86,7 +86,7 @@ export async function retryOnInvalidCsrfToken<TResult>(postbackFunction: () => P
             if (err.reason.type === "serverError") {
                 if (err.reason.responseObject?.action === "invalidCsrfToken") {
                     logInfoVerbose("postback", "Resending postback due to invalid CSRF token.");
-                    getStateManager().update(u => ({ ...u, $csrfToken: undefined }))
+                    getStateManager().updateState(u => ({ ...u, $csrfToken: undefined }))
 
                     if (iteration < 3) {
                         return await retryOnInvalidCsrfToken(postbackFunction, iteration + 1);


### PR DESCRIPTION
Most notably, this makes it possible to manually dispatch a ko.observable update using

```js
    dotvvm.rootStateManager.doUpdateNow()
```

The patch should be fully backwards compatible and I'd consider releasing it as a 4.3 patch, as it will allow us to gradually migrate parts of BP and fix some of its ko.observable related bugs sooner.