### PR TITLE
v5 cleanup: Add IControlBuilderFactory.InvalidateCache method

### DIFF
--- a/src/Framework/Framework/Compilation/DotvvmViewCompilationService.cs
+++ b/src/Framework/Framework/Compilation/DotvvmViewCompilationService.cs
@@ -184,8 +184,7 @@ namespace DotVVM.Framework.Compilation
                 try
                 {
                     if (forceRecompile)
-                        // TODO: next major version - add method to interface
-                        (controlBuilderFactory as DefaultControlBuilderFactory)?.InvalidateCache(file.VirtualPath);
+                        controlBuilderFactory.InvalidateCache(file.VirtualPath);
 
                     var pageBuilder = controlBuilderFactory.GetControlBuilder(file.VirtualPath);
 

--- a/src/Framework/Framework/Compilation/IControlBuilderFactory.cs
+++ b/src/Framework/Framework/Compilation/IControlBuilderFactory.cs
@@ -6,7 +6,6 @@ namespace DotVVM.Framework.Compilation
     public interface IControlBuilderFactory
     {
         (ControlBuilderDescriptor descriptor, Lazy<IControlBuilder> builder) GetControlBuilder(string virtualPath);
-        // TODO: next major version
-        // void InvalidateCache(string virtualPath);
+        void InvalidateCache(string virtualPath);
     }
 }


### PR DESCRIPTION
it has previously only been added to our default implementation for backwards compatibility reasons