### PR TITLE
Special-case parsing of <script> and <style> elements, similarly to HTML

### DIFF
--- a/src/Framework/Framework/Compilation/Parser/Dothtml/DotvvmSyntaxConfiguration.cs
+++ b/src/Framework/Framework/Compilation/Parser/Dothtml/DotvvmSyntaxConfiguration.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DotVVM.Framework.Configuration;
+
+namespace DotVVM.Framework.Compilation.Parser.Dothtml;
+
+public sealed class DotvvmSyntaxConfiguration
+{
+    private readonly HashSet<string> rawTextElements;
+    public IEnumerable<string> RawTextElements => rawTextElements;
+
+    public bool IsRawTextElement(string elementName) =>
+        rawTextElements.Contains(elementName);
+
+    public DotvvmSyntaxConfiguration(IEnumerable<string> rawTextElements)
+    {
+        this.rawTextElements = rawTextElements.ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public static DotvvmSyntaxConfiguration FromMarkupConfig(DotvvmMarkupConfiguration markupConfiguration)
+    {
+        var rawTextElements = markupConfiguration.RawTextElements;
+
+        return new DotvvmSyntaxConfiguration(rawTextElements);
+    }
+
+    public static DotvvmSyntaxConfiguration Default { get; } = new DotvvmSyntaxConfiguration(["script", "style", "dot:InlineScript", "dot:HtmlLiteral"]);
+}

--- a/src/Framework/Framework/Compilation/Parser/TokenizerBase.cs
+++ b/src/Framework/Framework/Compilation/Parser/TokenizerBase.cs
@@ -188,12 +188,7 @@ namespace DotVVM.Framework.Compilation.Parser
 		protected bool PeekIsString(string? str)
 		{
 			if (str is null) return false;
-			if (Peek() != str[0]) return false;
-			for (int i = 1; i < str.Length; i++)
-			{
-				if (Peek(i) != str[i]) return false;
-			}
-			return true;
+			return PeekSpan(str.Length).SequenceEqual(str.AsSpan());
 		}
 
 		protected string? ReadOneOf(params string[] strings)
@@ -211,8 +206,6 @@ namespace DotVVM.Framework.Compilation.Parser
 		}
 
 		protected abstract TToken NewToken(string text, TTokenType type, int lineNumber, int columnNumber, int length, int startPosition);
-
-		char[] tokenCharBuffer = new char[20];
 
 		protected string GetCurrentTokenText(int charsFromEndToSkip = 0)
 		{
@@ -301,6 +294,9 @@ namespace DotVVM.Framework.Compilation.Parser
 		{
 			TokenFound?.Invoke(token);
 		}
+
+		protected ReadOnlySpan<char> PeekSpan(int length) =>
+			sourceText.AsSpan(position, Math.Min(length, sourceText.Length - position));
 
 		/// <summary>
 		/// Peeks the current char.

--- a/src/Framework/Framework/Configuration/DotvvmMarkupConfiguration.cs
+++ b/src/Framework/Framework/Configuration/DotvvmMarkupConfiguration.cs
@@ -9,6 +9,7 @@ using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Compilation.ControlTree.Resolved;
 using DotVVM.Framework.Compilation.Javascript;
 using System.Text.Json.Serialization;
+using DotVVM.Framework.Compilation.Parser.Dothtml;
 
 namespace DotVVM.Framework.Configuration
 {
@@ -70,6 +71,15 @@ namespace DotVVM.Framework.Configuration
         private IList<BindingExtensionParameter> _defaultExtensionParameters = new FreezableList<BindingExtensionParameter>();
 
         public ViewCompilationConfiguration ViewCompilation { get; private set; } = new ViewCompilationConfiguration();
+
+        /// <summary> List of HTML elements which content is not parsed as [dot]html, but streated as raw text until the end tag. By default it is <c>script</c> and <c>style</c> tags in addition to DotVVM <c>dot:InlineScript</c>. The property is meant primarily as compatibility option, as it may be ignored by tooling. </summary>
+        [JsonPropertyName("rawTextElements")]
+        public IList<string> RawTextElements
+        {
+            get => _rawTextElements;
+            set { ThrowIfFrozen(); _rawTextElements = [..value]; }
+        }
+        private IList<string> _rawTextElements = new FreezableList<string>(DotvvmSyntaxConfiguration.Default.RawTextElements);
 
 
         public void AddServiceImport(string identifier, Type type)
@@ -197,6 +207,7 @@ namespace DotVVM.Framework.Configuration
             FreezableList.Freeze(ref _importedNamespaces);
             JavascriptTranslator.Freeze();
             FreezableList.Freeze(ref _defaultExtensionParameters);
+            FreezableList.Freeze(ref _rawTextElements);
         }
     }
 }

--- a/src/Tests/Parser/Dothtml/DothtmlTokenizerElementsTests.cs
+++ b/src/Tests/Parser/Dothtml/DothtmlTokenizerElementsTests.cs
@@ -796,5 +796,199 @@ namespace DotVVM.Framework.Tests.Parser.Dothtml
             Assert.AreEqual(DothtmlTokenType.Text, tokenizer.Tokens[i++].Type);
         }
 
+
+        [TestMethod]
+        public void DothtmlTokenizer_ElementParsing_Script()
+        {
+            var input = """
+                <body>
+                <script>
+                    const a = '<a href="#" title="<test>">Test</a>'
+                    const b = 1<4 && 4>1
+                    const c = '</'+'script>'
+                    const d = '<style></style>'
+                </SCRIPT  >
+                <script />
+                </body>
+                """;
+
+            var tokens = Tokenize(input);
+            
+            Assert.AreEqual(DothtmlTokenType.OpenTag, tokens[0].Type);
+            Assert.AreEqual("<", tokens[0].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Text, tokens[1].Type);
+            Assert.AreEqual("body", tokens[1].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.CloseTag, tokens[2].Type);
+            Assert.AreEqual(">", tokens[2].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Text, tokens[3].Type);
+            Assert.AreEqual("\n", tokens[3].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.OpenTag, tokens[4].Type);
+            Assert.AreEqual("<", tokens[4].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Text, tokens[5].Type);
+            Assert.AreEqual("script", tokens[5].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.CloseTag, tokens[6].Type);
+            Assert.AreEqual(">", tokens[6].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Text, tokens[7].Type);
+            Assert.AreEqual("\n    const a = '<a href=\"#\" title=\"<test>\">Test</a>'\n    const b = 1<4 && 4>1\n    const c = '</'+'script>'\n    const d = '<style></style>'\n", tokens[7].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.OpenTag, tokens[8].Type);
+            Assert.AreEqual("<", tokens[8].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Slash, tokens[9].Type);
+            Assert.AreEqual("/", tokens[9].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Text, tokens[10].Type);
+            Assert.AreEqual("SCRIPT", tokens[10].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.WhiteSpace, tokens[11].Type);
+            Assert.AreEqual("  ", tokens[11].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.CloseTag, tokens[12].Type);
+            Assert.AreEqual(">", tokens[12].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Text, tokens[13].Type);
+            Assert.AreEqual("\n", tokens[13].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.OpenTag, tokens[14].Type);
+            Assert.AreEqual("<", tokens[14].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Text, tokens[15].Type);
+            Assert.AreEqual("script", tokens[15].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.WhiteSpace, tokens[16].Type);
+            Assert.AreEqual(" ", tokens[16].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Slash, tokens[17].Type);
+            Assert.AreEqual("/", tokens[17].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.CloseTag, tokens[18].Type);
+            Assert.AreEqual(">", tokens[18].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Text, tokens[19].Type);
+            Assert.AreEqual("\n", tokens[19].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.OpenTag, tokens[20].Type);
+            Assert.AreEqual("<", tokens[20].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Slash, tokens[21].Type);
+            Assert.AreEqual("/", tokens[21].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Text, tokens[22].Type);
+            Assert.AreEqual("body", tokens[22].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.CloseTag, tokens[23].Type);
+            Assert.AreEqual(">", tokens[23].Text);
+        }
+
+        [TestMethod]
+        public void DothtmlTokenizer_ElementParsing_HtmlLiteral()
+        {
+            var input = """
+                <body>
+                <dot:HtmlLiteral>
+                    const a = '<a href="#" title="<test>">Test</a>'
+                    const b = 1<4 && 4>1
+                    const c = ''
+                    const d = '</script> </HtmlLiteral> </cc:HtmlLiteral> </dot:HtmlLiteralOrNo>'
+                </doT:htmlliteral  >
+                <script />
+                </body>
+                """;
+
+            var tokens = Tokenize(input);
+
+            // Console.WriteLine(CreateTest(tokens));
+            Assert.AreEqual(DothtmlTokenType.OpenTag, tokens[0].Type);
+            Assert.AreEqual("<", tokens[0].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Text, tokens[1].Type);
+            Assert.AreEqual("body", tokens[1].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.CloseTag, tokens[2].Type);
+            Assert.AreEqual(">", tokens[2].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Text, tokens[3].Type);
+            Assert.AreEqual("\n", tokens[3].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.OpenTag, tokens[4].Type);
+            Assert.AreEqual("<", tokens[4].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Text, tokens[5].Type);
+            Assert.AreEqual("dot", tokens[5].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Colon, tokens[6].Type);
+            Assert.AreEqual(":", tokens[6].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Text, tokens[7].Type);
+            Assert.AreEqual("HtmlLiteral", tokens[7].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.CloseTag, tokens[8].Type);
+            Assert.AreEqual(">", tokens[8].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Text, tokens[9].Type);
+            Assert.AreEqual("\n    const a = '<a href=\"#\" title=\"<test>\">Test</a>'\n    const b = 1<4 && 4>1\n    const c = ''\n    const d = '</script> </HtmlLiteral> </cc:HtmlLiteral> </dot:HtmlLiteralOrNo>'\n", tokens[9].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.OpenTag, tokens[10].Type);
+            Assert.AreEqual("<", tokens[10].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Slash, tokens[11].Type);
+            Assert.AreEqual("/", tokens[11].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Text, tokens[12].Type);
+            Assert.AreEqual("doT", tokens[12].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Colon, tokens[13].Type);
+            Assert.AreEqual(":", tokens[13].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Text, tokens[14].Type);
+            Assert.AreEqual("htmlliteral", tokens[14].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.WhiteSpace, tokens[15].Type);
+            Assert.AreEqual("  ", tokens[15].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.CloseTag, tokens[16].Type);
+            Assert.AreEqual(">", tokens[16].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Text, tokens[17].Type);
+            Assert.AreEqual("\n", tokens[17].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.OpenTag, tokens[18].Type);
+            Assert.AreEqual("<", tokens[18].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Text, tokens[19].Type);
+            Assert.AreEqual("script", tokens[19].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.WhiteSpace, tokens[20].Type);
+            Assert.AreEqual(" ", tokens[20].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Slash, tokens[21].Type);
+            Assert.AreEqual("/", tokens[21].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.CloseTag, tokens[22].Type);
+            Assert.AreEqual(">", tokens[22].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Text, tokens[23].Type);
+            Assert.AreEqual("\n", tokens[23].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.OpenTag, tokens[24].Type);
+            Assert.AreEqual("<", tokens[24].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Slash, tokens[25].Type);
+            Assert.AreEqual("/", tokens[25].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.Text, tokens[26].Type);
+            Assert.AreEqual("body", tokens[26].Text);
+            
+            Assert.AreEqual(DothtmlTokenType.CloseTag, tokens[27].Type);
+            Assert.AreEqual(">", tokens[27].Text);
+        }
+        
     }
 }

--- a/src/Tests/Parser/Dothtml/DothtmlTokenizerElementsTests.cs
+++ b/src/Tests/Parser/Dothtml/DothtmlTokenizerElementsTests.cs
@@ -812,7 +812,7 @@ namespace DotVVM.Framework.Tests.Parser.Dothtml
                 </body>
                 """;
 
-            var tokens = Tokenize(input);
+            var tokens = Tokenize(input.Replace("\r", ""));
             
             Assert.AreEqual(DothtmlTokenType.OpenTag, tokens[0].Type);
             Assert.AreEqual("<", tokens[0].Text);
@@ -902,7 +902,7 @@ namespace DotVVM.Framework.Tests.Parser.Dothtml
                 </body>
                 """;
 
-            var tokens = Tokenize(input);
+            var tokens = Tokenize(input.Replace("\r", ""));
 
             // Console.WriteLine(CreateTest(tokens));
             Assert.AreEqual(DothtmlTokenType.OpenTag, tokens[0].Type);

--- a/src/Tests/Parser/Dothtml/DothtmlTokenizerTestsBase.cs
+++ b/src/Tests/Parser/Dothtml/DothtmlTokenizerTestsBase.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using DotVVM.Framework.Compilation.Parser;
 using DotVVM.Framework.Compilation.Parser.Dothtml.Tokenizer;
+using DotVVM.Framework.Controls;
 
 namespace DotVVM.Framework.Tests.Parser.Dothtml
 {
@@ -28,11 +29,13 @@ namespace DotVVM.Framework.Tests.Parser.Dothtml
                 {
                     test.AppendLine($"Assert.IsTrue(tokens[{i}].HasError)");
                 }
-                test.AppendLine($"Assert.AreEqual(@\"{ token.Text.Replace("\"", "\"\"") }\", tokens[{i}].Text);");
+                test.AppendLine($"Assert.AreEqual({ literal(token.Text) }, tokens[{i}].Text);");
                 test.AppendLine();
                 i++;
             }
             return test.ToString();
+
+            string literal(string a) => KnockoutHelper.MakeStringLiteral(a, htmlSafe: false);
         }
 
         protected void CheckForErrors(DothtmlTokenizer tokenizer, int inputLength)


### PR DESCRIPTION
In HTML, the content of <script> and <style> tags should not be parsed as HTML, the parser should simply look for the end tag.
This eliminates the need to HTML-encode all `<` operators (or even HTML inlined in string literals).

To align dothtml and HTML, the patch implements this behavior in dothtml. The change may easily break someone's code, if they already have a script element with entities like &lt;, so it is possible to configure which tags will be parsed as "raw text".
By default, it is script, style and also dot:InlineScript and dot:HtmlLiteral (as suggested in #1428). This setting is up for debate.

resolves #1445