### PR TITLE
Fix control prefixes in error page "Control Hierarchy" section

### DIFF
--- a/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
+++ b/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Net;
@@ -484,13 +485,23 @@ namespace DotVVM.Framework.Controls
 
             return toStringed;
         }
-
         internal static (string? prefix, string tagName) FormatControlName(DotvvmBindableObject control, DotvvmConfiguration? config)
         {
             var type = control.GetType();
             if (type == typeof(HtmlGenericControl))
                 return (null, ((HtmlGenericControl)control).TagName!);
+
+            if (control is DotvvmMarkupControl && control.GetValue(Internal.MarkupFileNameProperty, inherit: false) is string markupFileName)
+                return FormatMarkupControlName(markupFileName, config);
             return FormatControlName(type, config);
+        }
+        internal static (string? prefix, string tagName) FormatMarkupControlName(string fileName, DotvvmConfiguration? config)
+        {
+            var reg = config?.Markup.Controls.FirstOrDefault(c => c.Src?.Replace('\\', '/') == fileName.Replace('\\', '/'));
+            if (reg is { TagName.Length: >0 })
+                return (reg.TagPrefix, reg.TagName);
+            else
+                return (null, Path.GetFileNameWithoutExtension(fileName));
         }
         internal static (string? prefix, string tagName) FormatControlName(Type type, DotvvmConfiguration? config)
         {

--- a/src/Framework/Framework/Hosting/ErrorPages/DotvvmErrorPageRenderer.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/DotvvmErrorPageRenderer.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
+using DotVVM.Framework.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace DotVVM.Framework.Hosting.ErrorPages
@@ -13,11 +14,13 @@ namespace DotVVM.Framework.Hosting.ErrorPages
     public class DotvvmErrorPageRenderer
     {
         private readonly ILogger<DotvvmErrorPageRenderer>? logger;
+        private readonly DotvvmConfiguration config;
 
         public ErrorFormatter? Formatter { get; set; }
 
-        public DotvvmErrorPageRenderer(ILogger<DotvvmErrorPageRenderer>? logger = null)
+        public DotvvmErrorPageRenderer(DotvvmConfiguration config, ILogger<DotvvmErrorPageRenderer>? logger = null)
         {
+            this.config = config;
             this.logger = logger;
         }
 
@@ -62,7 +65,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
 
         private ErrorFormatter CreateDefaultWithDemystifier()
         {
-            var errorFormatter = ErrorFormatter.CreateDefault();
+            var errorFormatter = ErrorFormatter.CreateDefault(config);
 
             var insertPosition = errorFormatter.Formatters.Count > 0 ? 1 : 0;
 

--- a/src/Framework/Framework/Hosting/ErrorPages/ErrorFormatter.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/ErrorFormatter.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using DotVVM.Framework.Binding;
 using DotVVM.Framework.Binding.Expressions;
 using DotVVM.Framework.Compilation;
+using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.Runtime;
 using DotVVM.Framework.Runtime.Commands;
@@ -386,7 +387,9 @@ namespace DotVVM.Framework.Hosting.ErrorPages
         }
 
 
-        public static ErrorFormatter CreateDefault()
+        public static ErrorFormatter CreateDefault() => CreateDefault(null);
+
+        public static ErrorFormatter CreateDefault(DotvvmConfiguration? config)
         {
             var f = new ErrorFormatter();
             f.Formatters.Add((e, o) => DotvvmMarkupErrorSection.Create(e));
@@ -462,7 +465,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
                     return null;
                 return new ExceptionAdditionalInfo(
                     "Control Hierarchy",
-                    control.GetAllAncestors(includingThis: true).Select(c => c.DebugString(useHtml: true, multiline: false)).ToArray(),
+                    control.GetAllAncestors(includingThis: true).Select(c => c.DebugString(config: config, useHtml: true, multiline: false)).ToArray(),
                     ExceptionAdditionalInfo.DisplayMode.ToHtmlListUnencoded
                 );
             });

--- a/src/Tests/Runtime/ErrorPageTests.cs
+++ b/src/Tests/Runtime/ErrorPageTests.cs
@@ -31,7 +31,7 @@ namespace DotVVM.Framework.Tests.Runtime
 
         private static ErrorFormatter CreateFormatter()
         {
-            var errorFormatter = ErrorFormatter.CreateDefault();
+            var errorFormatter = ErrorFormatter.CreateDefault(config);
             return errorFormatter;
         }
 


### PR DESCRIPTION
Before it would show `<_:Control1>` and `<_:Control2>`, now:

![image](https://github.com/user-attachments/assets/0e324788-1ac7-4fe0-a0a1-120c16f06391)
