### PR TITLE
Bug in JS translator when using Where and using lambda in commands

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/binding-handlers/js-component.ts
+++ b/src/Framework/Framework/Resources/Scripts/binding-handlers/js-component.ts
@@ -23,7 +23,7 @@ export default {
                 for (const [n, v] of Object.entries(props)) {
 
                     if (ko.isObservable(v)) {
-                        result[n] = "state" in v ? (v as DotvvmObservable<any>).state : unmapKnockoutObservables(v, true)
+                        result[n] = unmapKnockoutObservables(v, true, true)
                     } else {
                         result[n] = v
                     }

--- a/src/Framework/Framework/Resources/Scripts/binding-handlers/markup-controls.ts
+++ b/src/Framework/Framework/Resources/Scripts/binding-handlers/markup-controls.ts
@@ -26,10 +26,7 @@ function createWrapperComputed<T>(valueAccessor: () => T,
     });
     (computed as any)["wrappedProperty"] = observableAccessor;
     Object.defineProperty(computed, "state", {
-        get: () => {
-            const x = observableAccessor() as any
-            return (x && x.state) ?? unmapKnockoutObservables(x, true)
-        }
+        get: () => unmapKnockoutObservables(observableAccessor(), true, true)
     })
     defineConstantProperty(computed, "setState", (state: any) => {
         const x = observableAccessor() as any

--- a/src/Framework/Framework/Resources/Scripts/controls/fileUpload.ts
+++ b/src/Framework/Framework/Resources/Scripts/controls/fileUpload.ts
@@ -1,5 +1,4 @@
 import { wrapObservable } from '../utils/knockout';
-import { deserialize } from '../serialization/deserialize';
 import { updateTypeInfo } from '../metadata/typeMap';
 
 export function showUploadDialog(sender: HTMLElement) {

--- a/src/Framework/Framework/Resources/Scripts/state-manager.ts
+++ b/src/Framework/Framework/Resources/Scripts/state-manager.ts
@@ -214,6 +214,10 @@ export function isDotvvmObservable(obj: any): obj is DotvvmObservable<any> {
     return obj?.[notifySymbol] && ko.isObservable(obj)
 }
 
+export function isFakeObservableObject(obj: any): obj is FakeObservableObject<any> {
+    return obj instanceof FakeObservableObject
+}
+
 /**
  * Recursively unwraps knockout observables from the object / array hierarchy. When nothing needs to be unwrapped, the original object is returned.
  * @param allowStateUnwrap Allows accessing [currentStateSymbol], which makes it faster, but doesn't register in the knockout dependency tracker

--- a/src/Framework/Framework/Resources/Scripts/state-manager.ts
+++ b/src/Framework/Framework/Resources/Scripts/state-manager.ts
@@ -221,8 +221,12 @@ export function isFakeObservableObject(obj: any): obj is FakeObservableObject<an
 /**
  * Recursively unwraps knockout observables from the object / array hierarchy. When nothing needs to be unwrapped, the original object is returned.
  * @param allowStateUnwrap Allows accessing [currentStateSymbol], which makes it faster, but doesn't register in the knockout dependency tracker
+ * @param preferStateAccess Also allows accessing observable.state, which also doesn't register in the knockout dependency tracker, but returns an realtime updated value directly from dotvvm.state
 */
-export function unmapKnockoutObservables(viewModel: any, allowStateUnwrap: boolean = false): any {
+export function unmapKnockoutObservables(viewModel: any, allowStateUnwrap: boolean = false, preferStateAccess: boolean = false): any {
+    if (preferStateAccess && ko.isObservable(viewModel) && "state" in viewModel) {
+        return viewModel.state
+    }
     const value = ko.unwrap(viewModel)
 
     if (isPrimitive(value)) {
@@ -241,7 +245,7 @@ export function unmapKnockoutObservables(viewModel: any, allowStateUnwrap: boole
     if (value instanceof Array) {
         let result: any = null
         for (let i = 0; i < value.length; i++) {
-            const unwrappedItem = unmapKnockoutObservables(ko.unwrap(value[i]), allowStateUnwrap)
+            const unwrappedItem = unmapKnockoutObservables(value[i], allowStateUnwrap, preferStateAccess)
             if (unwrappedItem !== value[i]) {
                 result ??= [...value]
                 result[i] = unwrappedItem
@@ -251,11 +255,10 @@ export function unmapKnockoutObservables(viewModel: any, allowStateUnwrap: boole
     }
 
     let result: any = null;
-    for (const prop of keys(value)) {
-        const v = ko.unwrap(value[prop])
-        if (typeof v != "function") {
-            const unwrappedProp = unmapKnockoutObservables(v, allowStateUnwrap)
-            if (unwrappedProp !== value[prop]) {
+    for (const [prop, v] of Object.entries(value)) {
+        if (typeof v != "function" || ko.isObservable(v)) {
+            const unwrappedProp = unmapKnockoutObservables(v, allowStateUnwrap, preferStateAccess)
+            if (unwrappedProp !== v) {
                 result ??= { ...value }
                 result[prop] = unwrappedProp
             }

--- a/src/Framework/Framework/Resources/Scripts/viewModules/viewModuleManager.ts
+++ b/src/Framework/Framework/Resources/Scripts/viewModules/viewModuleManager.ts
@@ -1,5 +1,4 @@
 import { getViewModelObservable } from "../dotvvm-base";
-import { deserialize } from "../serialization/deserialize";
 import { serialize } from "../serialization/serialize";
 import { unmapKnockoutObservables } from "../state-manager";
 import { debugQuoteString } from "../utils/logging";

--- a/src/Framework/Framework/Resources/Scripts/viewModules/viewModuleManager.ts
+++ b/src/Framework/Framework/Resources/Scripts/viewModules/viewModuleManager.ts
@@ -300,7 +300,7 @@ export class ModuleContext implements DotvvmModuleContext {
                 throw new Error('command already exists');
         }
 
-        this.namedCommands[name] = (...innerArgs) => mapCommandResult(command.apply(this, innerArgs.map(a => unmapKnockoutObservables(a, true))))
+        this.namedCommands[name] = (...innerArgs) => mapCommandResult(command.apply(this, innerArgs.map(a => unmapKnockoutObservables(a, true, true))))
     }
 
     public unregisterNamedCommand = (name: string) => {

--- a/src/Samples/Common/DotvvmStartup.cs
+++ b/src/Samples/Common/DotvvmStartup.cs
@@ -282,7 +282,7 @@ namespace DotVVM.Samples.BasicSamples
             config.Markup.AddCodeControls("cc", typeof(Loader));
             config.Markup.AddMarkupControl("sample", "EmbeddedResourceControls_Button", "embedded://EmbeddedResourceControls/Button.dotcontrol");
             config.Markup.AddMarkupControl("cc", "NodeControl", "Views/ControlSamples/HierarchyRepeater/NodeControl.dotcontrol");
-
+            config.Markup.AddMarkupControl("cc", "CommandInsideWhereControl", "Views/FeatureSamples/JavascriptTranslation/CommandInsideWhereControl.dotcontrol");
             config.Markup.AutoDiscoverControls(new DefaultControlRegistrationStrategy(config, "sample", "Views/"));
 
             if (config.Markup.Controls.FirstOrDefault(c => c.Src is not null && Path.IsPathRooted(c.Src)) is {} invalidControl)

--- a/src/Samples/Common/ViewModels/FeatureSamples/JavascriptTranslation/CommandInsideWhereViewModel.cs
+++ b/src/Samples/Common/ViewModels/FeatureSamples/JavascriptTranslation/CommandInsideWhereViewModel.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.ViewModel;
+using DotVVM.Framework.Hosting;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.JavascriptTranslation
+{
+	public class CommandInsideWhereViewModel : DotvvmViewModelBase
+	{
+        public int? LastMessageCustomerId { get; set; }
+
+        public List<CustomerData> Customers { get; set; } = [
+            new() { CustomerId = 1, Name = "John Doe", BirthDate = DateTime.Parse("1976-04-01"), MessageReceived = true },
+            new() { CustomerId = 2, Name = "John Deer", BirthDate = DateTime.Parse("1984-03-02") },
+            new() { CustomerId = 3, Name = "Johnny Walker", BirthDate = DateTime.Parse("1934-01-03") },
+            new() { CustomerId = 4, Name = "Jim Hacker", BirthDate = DateTime.Parse("1912-11-04"), MessageReceived = true },
+            new() { CustomerId = 5, Name = "Joe E. Brown", BirthDate = DateTime.Parse("1947-09-05"), MessageReceived = true },
+            new() { CustomerId = 6, Name = "Jim Harris", BirthDate = DateTime.Parse("1956-07-06") },
+            new() { CustomerId = 7, Name = "J. P. Morgan", BirthDate = DateTime.Parse("1969-05-07") },
+            new() { CustomerId = 8, Name = "J. R. Ewing", BirthDate = DateTime.Parse("1987-03-08"), MessageReceived = true },
+            new() { CustomerId = 9, Name = "Jeremy Clarkson", BirthDate = DateTime.Parse("1994-04-09") },
+            new() { CustomerId = 10, Name = "Jenny Green", BirthDate = DateTime.Parse("1947-02-10") },
+            new() { CustomerId = 11, Name = "Joseph Blue", BirthDate = DateTime.Parse("1948-12-11"), MessageReceived = true },
+            new() { CustomerId = 12, Name = "Jack Daniels", BirthDate = DateTime.Parse("1968-10-12") },
+            new() { CustomerId = 13, Name = "Jackie Chan", BirthDate = DateTime.Parse("1978-08-13") },
+            new() { CustomerId = 14, Name = "Jasper", BirthDate = DateTime.Parse("1934-06-14"), MessageReceived = true },
+            new() { CustomerId = 15, Name = "Jumbo", BirthDate = DateTime.Parse("1965-06-15"), MessageReceived = true },
+            new() { CustomerId = 16, Name = "Junkie Doodle", BirthDate = DateTime.Parse("1977-05-16"), MessageReceived = true }
+        ];
+
+        public void SendMessage(int? customerId)
+        {
+            LastMessageCustomerId = customerId;
+        }
+    }
+
+    public class CustomerData
+    {
+        public int CustomerId { get; set; }
+        public string Name { get; set; }
+
+        public DateTime BirthDate { get; set; }
+        public bool MessageReceived { get; set; }
+    }
+}
+

--- a/src/Samples/Common/Views/FeatureSamples/JavascriptTranslation/CommandInsideWhere.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/JavascriptTranslation/CommandInsideWhere.dothtml
@@ -1,0 +1,28 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.JavascriptTranslation.CommandInsideWhereViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+    <h1>Command inside Where</h1>
+
+    <h2>Without where</h2>
+    <cc:CommandInsideWhereControl Customers="{value: Customers}"
+                                  Click="{command: (int id) => _root.SendMessage(id)}" />
+
+    <h2>With where</h2>
+    <cc:CommandInsideWhereControl Customers="{value: Customers.Where(c => c.MessageReceived)}"
+                                  Click="{command: (int id) => _root.SendMessage(id)}" />
+
+    <p>
+        Last message customer ID: {{value: LastMessageCustomerId}}
+    </p>
+
+</body>
+</html>
+
+

--- a/src/Samples/Common/Views/FeatureSamples/JavascriptTranslation/CommandInsideWhereControl.dotcontrol
+++ b/src/Samples/Common/Views/FeatureSamples/JavascriptTranslation/CommandInsideWhereControl.dotcontrol
@@ -1,0 +1,10 @@
+﻿@viewModel System.Object, mscorlib
+@property System.Collections.Generic.IEnumerable<DotVVM.Samples.Common.ViewModels.FeatureSamples.JavascriptTranslation.CustomerData> Customers
+@property System.Action<int> Click
+
+<dot:Repeater DataSource="{value: _control.Customers}"
+              WrapperTagName="ul">
+    <li>
+        <dot:LinkButton Text="{value: Name}" Click="{staticCommand: _control.Click(CustomerId)}" />
+    </li>
+</dot:Repeater>


### PR DESCRIPTION
I have a scenario when an invalid value is passed as a command argument, caused when the JS translator uses `.state` on an observable that is not DotVVM observable.

The PR contains a sample page with a button inside Repeater. The button is nested in a custom control, and its `Click` property is exposed as `Action<int>` property. Therefore, the page needs to pass lambda there, and this is where the issue probably occurs.

If the Repeater is bound to a collection in the ViewModel, it works as the objects are FakeObservableObject with the `state` property. However, when the Repeater is bound to `collection.Where(...)`, it looks like the results are just classic observables and `state` is evaluated as `undefined`, which is then passed to the command argument as `null` (and produces an exception on the server).