### PR TITLE
Disallow asigning to init-only properties in bindings

### DIFF
--- a/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
+++ b/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
@@ -58,6 +58,10 @@ namespace DotVVM.Framework.Compilation.Binding
         {
             var replacementVisitor = new BindingCompiler.ParameterReplacementVisitor(dataContext);
             var expr = replacementVisitor.Visit(expression.Expression);
+            var initOnlyPropertyChecker = binding is IStaticCommandBinding
+                                        ? InitOnlyPropertyCheckingVisitor.InstanceDynamicError // allow this client-side
+                                        : InitOnlyPropertyCheckingVisitor.Instance;
+            expr = initOnlyPropertyChecker.Visit(expr);
             expr = new ExpressionNullPropagationVisitor(e => true).Visit(expr);
             expr = ExpressionUtils.ConvertToObject(expr);
             expr = replacementVisitor.WrapExpression(expr, contextObject: binding);

--- a/src/Framework/Framework/Compilation/Binding/InitOnlyPropertyCheckingVisitor.cs
+++ b/src/Framework/Framework/Compilation/Binding/InitOnlyPropertyCheckingVisitor.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using DotVVM.Framework.Utils;
+
+namespace DotVVM.Framework.Compilation.Binding
+{
+    /// <summary> Checks that assigned properties have setters without the <see cref="IsExternalInit" /> attribute.
+    ///           <paramref name="staticError"/> specifies if the error should be thrown immediately, or only when actually executed at runtime. </summary>
+    public class InitOnlyPropertyCheckingVisitor(bool staticError = true): ExpressionVisitor
+    {
+        public static InitOnlyPropertyCheckingVisitor Instance { get; } = new InitOnlyPropertyCheckingVisitor(true);
+        public static InitOnlyPropertyCheckingVisitor InstanceDynamicError { get; } = new InitOnlyPropertyCheckingVisitor(false);
+
+        protected override Expression VisitBinary(BinaryExpression node)
+        {
+            if (node is { NodeType: ExpressionType.Assign, Left: MemberExpression { Member: PropertyInfo assignedProperty } } &&
+                assignedProperty.IsInitOnly())
+            {
+                var message = $"Property '{assignedProperty.DeclaringType!.Name}.{assignedProperty.Name}' is init-only and cannot be assigned to in bindings executed server-side. You can only assign to such properties in staticCommand bindings executed on the client.";
+                if (staticError)
+                {
+                    throw new Exception(message);
+                }
+                else
+                {
+                    return Expression.Throw(Expression.New(typeof(Exception).GetConstructor([typeof(string)]), [Expression.Constant(message)]));
+                }
+            }
+
+            return base.VisitBinary(node);
+        }
+    }
+}

--- a/src/Framework/Framework/Compilation/Binding/InitOnlyPropertyCheckingVisitor.cs
+++ b/src/Framework/Framework/Compilation/Binding/InitOnlyPropertyCheckingVisitor.cs
@@ -6,7 +6,7 @@ using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.Compilation.Binding
 {
-    /// <summary> Checks that assigned properties have setters without the <see cref="IsExternalInit" /> attribute.
+    /// <summary> Checks that assigned properties have setters without the [IsExternalInit] attribute.
     ///           <paramref name="staticError"/> specifies if the error should be thrown immediately, or only when actually executed at runtime. </summary>
     public class InitOnlyPropertyCheckingVisitor(bool staticError = true): ExpressionVisitor
     {
@@ -25,7 +25,7 @@ namespace DotVVM.Framework.Compilation.Binding
                 }
                 else
                 {
-                    return Expression.Throw(Expression.New(typeof(Exception).GetConstructor([typeof(string)]), [Expression.Constant(message)]));
+                    return Expression.Throw(Expression.New(typeof(Exception).GetConstructor([typeof(string)])!, [Expression.Constant(message)]));
                 }
             }
 

--- a/src/Tests/Binding/BindingCompilationTests.cs
+++ b/src/Tests/Binding/BindingCompilationTests.cs
@@ -1354,6 +1354,17 @@ namespace DotVVM.Framework.Tests.Binding
             var result = ExecuteBinding("Strings.SomeResource", new[] { new NamespaceImport("DotVVM.Framework.Tests.Ambiguous"), new NamespaceImport("DotVVM.Framework.Tests") }, new TestViewModel());
             Assert.AreEqual("hello", result);
         }
+
+        [TestMethod]
+        public void BindingCompiler_InitOnlyPropertyCannotBeAsigned()
+        {
+            var vm = new TestViewModelWithInitOnlyProperties() {  MyProperty = 999 };
+
+            var exception = XAssert.ThrowsAny<Exception>(() => ExecuteBinding("_this.MyProperty = 1", vm));
+            XAssert.Contains("Property 'TestViewModelWithInitOnlyProperties.MyProperty' is init-only", exception.Message);
+
+            Assert.AreEqual(999, vm.MyProperty);
+        }
     }
     public class TestViewModel
     {
@@ -1572,6 +1583,11 @@ namespace DotVVM.Framework.Tests.Binding
 
         public List<int> List { get; set; } = new List<int>() { 1, 2, 3 };
         public int[] Array { get; set; } = new int[] { 1, 2, 3 };
+    }
+
+    public class TestViewModelWithInitOnlyProperties
+    {
+        public int MyProperty { get; init; }
     }
 
     public struct TestStruct

--- a/src/Tests/Binding/BindingCompilationTests.cs
+++ b/src/Tests/Binding/BindingCompilationTests.cs
@@ -1356,9 +1356,9 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
-        public void BindingCompiler_InitOnlyPropertyCannotBeAsigned()
+        public void BindingCompiler_InitOnlyPropertyCannotBeAssigned()
         {
-            var vm = new TestViewModelWithInitOnlyProperties() {  MyProperty = 999 };
+            var vm = new TestViewModelWithInitOnlyProperties() { MyProperty = 999 };
 
             var exception = XAssert.ThrowsAny<Exception>(() => ExecuteBinding("_this.MyProperty = 1", vm));
             XAssert.Contains("Property 'TestViewModelWithInitOnlyProperties.MyProperty' is init-only", exception.Message);

--- a/src/Tests/Binding/StaticCommandCompilationTests.cs
+++ b/src/Tests/Binding/StaticCommandCompilationTests.cs
@@ -385,6 +385,16 @@ namespace DotVVM.Framework.Tests.Binding
             Assert.AreEqual("Member 'Int32 GetCharCode(Char)' is not static.", result.GetBaseException().Message);
         }
 
+
+        [TestMethod]
+        public void StaticCommandCompilation_InitOnlyPropertyCanBeAssigned()
+        {
+            // on client, we allow this (we don't support with nor calling constructor, so it would be very annoying without this)
+            var result = CompileBinding("_this.MyProperty = 1", niceMode: true, new[] { typeof(TestViewModelWithInitOnlyProperties) }, typeof(Command));
+            Console.WriteLine(result);
+            AreEqual("{options.viewModel.MyProperty(1);}", result);
+        }
+
         public void AreEqual(string expected, string actual)
         => Assert.AreEqual(RemoveWhitespaces(expected), RemoveWhitespaces(actual));
 


### PR DESCRIPTION
See https://forum.dotvvm.com/t/intended-behaviour-coherence-of-init-only-properties-between-c-code-and-dotvvm-front-end/295 for some context. In short, it is OK to allow this in JS code (IMHO we want to simplify staticCommands with records, given that we don't support `with` / `new` yet it's necessary).

However, it can be quite dangerous on server, where this might allow you to accidentally mutate a shared singleton object (imagine defining `public static readonly MyRecord Default = new() { ... }` and then using it to initialize a view model property)