### PR TITLE
Enhancements of localizable routes

### DIFF
--- a/src/Framework/Framework/Hosting/Middlewares/DotvvmRoutingMiddleware.cs
+++ b/src/Framework/Framework/Hosting/Middlewares/DotvvmRoutingMiddleware.cs
@@ -3,6 +3,7 @@ using DotVVM.Framework.Runtime.Filters;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
 using DotVVM.Framework.Runtime.Tracing;
@@ -40,9 +41,14 @@ namespace DotVVM.Framework.Hosting.Middlewares
 
         public static string GetRouteMatchUrl(IDotvvmRequestContext context)
         {
-            if (!TryParseGooglebotHashbangEscapedFragment(context.HttpContext.Request.Url.Query, out var url))
+            return GetRouteMatchUrl(context.HttpContext.Request.Path.Value!, context.HttpContext.Request.Url.Query);
+        }
+
+        public static string GetRouteMatchUrl(string requestPath, string queryString)
+        {
+            if (!TryParseGooglebotHashbangEscapedFragment(queryString, out var url))
             {
-                url = context.HttpContext.Request.Path.Value;
+                url = requestPath;
             }
             url = url?.Trim('/') ?? "";
 

--- a/src/Framework/Framework/Routing/LocalizedDotvvmRoute.cs
+++ b/src/Framework/Framework/Routing/LocalizedDotvvmRoute.cs
@@ -99,8 +99,14 @@ namespace DotVVM.Framework.Routing
 
         public bool IsPartialMatch(string url, [MaybeNullWhen(false)] out RouteBase matchedRoute, [MaybeNullWhen(false)] out IDictionary<string, object?> values)
         {
+            return IsPartialMatch(url, out matchedRoute, out values, out _);
+        }
+
+        public bool IsPartialMatch(string url, [MaybeNullWhen(false)] out RouteBase matchedRoute, [MaybeNullWhen(false)] out IDictionary<string, object?> values, [MaybeNullWhen(false)] out string? matchedCulture)
+        {
             RouteBase? twoLetterCultureMatch = null;
             IDictionary<string, object?>? twoLetterCultureMatchValues = null;
+            matchedCulture = null;
 
             foreach (var route in localizedRoutes)
             {
@@ -110,6 +116,7 @@ namespace DotVVM.Framework.Routing
                     {
                         // exact culture match - return immediately
                         matchedRoute = route.Value;
+                        matchedCulture = route.Key;
                         return true;
                     }
                     else if (route.Key.Length > 0 && twoLetterCultureMatch == null)
@@ -117,6 +124,7 @@ namespace DotVVM.Framework.Routing
                         // match for two-letter culture - continue searching if there is a better match
                         twoLetterCultureMatch = route.Value;
                         twoLetterCultureMatchValues = values;
+                        matchedCulture = route.Key;
                     }
                     else
                     {

--- a/src/Framework/Framework/Routing/RouteTableGroup.cs
+++ b/src/Framework/Framework/Routing/RouteTableGroup.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Text;
 using DotVVM.Framework.Hosting;
 
@@ -15,8 +16,9 @@ namespace DotVVM.Framework.Routing
         public string RouteNamePrefix { get; private set; }
         public string UrlPrefix { get; private set; }
         public string VirtualPathPrefix { get; private set; }
+        public ImmutableArray<LocalizedRouteUrl>? LocalizedUrls { get; private set; }
 
-        public RouteTableGroup(string groupName, string routeNamePrefix, string urlPrefix, string virtualPathPrefix, Action<RouteBase> addToParentRouteTable, Func<IServiceProvider, IDotvvmPresenter>? presenterFactory)
+        public RouteTableGroup(string groupName, string routeNamePrefix, string urlPrefix, string virtualPathPrefix, Action<RouteBase> addToParentRouteTable, Func<IServiceProvider, IDotvvmPresenter>? presenterFactory, LocalizedRouteUrl[]? localizedUrls = null)
         {
             GroupName = groupName;
             RouteNamePrefix = routeNamePrefix;
@@ -24,6 +26,7 @@ namespace DotVVM.Framework.Routing
             VirtualPathPrefix = virtualPathPrefix;
             AddToParentRouteTable = addToParentRouteTable;
             PresenterFactory = presenterFactory;
+            LocalizedUrls = localizedUrls?.ToImmutableArray();
         }
     }
 }

--- a/src/Framework/Hosting.AspNetCore/DotVVM.Framework.Hosting.AspNetCore.csproj
+++ b/src/Framework/Hosting.AspNetCore/DotVVM.Framework.Hosting.AspNetCore.csproj
@@ -21,15 +21,4 @@
     <ProjectReference Include="../Framework/DotVVM.Framework.csproj" />
     <ProjectReference Include="../Core/DotVVM.Core.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Localization" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="2.2.0" />
-  </ItemGroup>
 </Project>

--- a/src/Framework/Hosting.AspNetCore/Localization/DotvvmRoutingRequestCultureProvider.cs
+++ b/src/Framework/Hosting.AspNetCore/Localization/DotvvmRoutingRequestCultureProvider.cs
@@ -1,0 +1,60 @@
+﻿#nullable enable
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using DotVVM.Framework.Configuration;
+using DotVVM.Framework.Hosting.Middlewares;
+using DotVVM.Framework.Routing;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DotVVM.Framework.Hosting.AspNetCore.Localization;
+
+public class DotvvmRoutingRequestCultureProvider : IRequestCultureProvider
+{
+    private static readonly object locker = new();
+    private static IReadOnlyList<LocalizedDotvvmRoute>? cachedRoutes;
+
+    public Task<ProviderCultureResult?> DetermineProviderCultureResult(HttpContext httpContext)
+    {
+        EnsureCachedRoutes(httpContext);
+
+        // find matching localizable route and extract culture from it
+        var url = DotvvmRoutingMiddleware.GetRouteMatchUrl(httpContext.Request.Path.Value!, httpContext.Request.QueryString.Value!);
+        foreach (var route in cachedRoutes!)
+        {
+            if (route.IsPartialMatch(url, out _, out var values, out var matchedCulture))
+            {
+                return Task.FromResult<ProviderCultureResult?>(new ProviderCultureResult(matchedCulture));
+            }
+        }
+
+        return Task.FromResult<ProviderCultureResult?>(null);
+    }
+
+    private void EnsureCachedRoutes(HttpContext httpContext)
+    {
+        if (cachedRoutes == null)
+        {
+            lock (locker)
+            {
+                if (cachedRoutes == null)
+                {
+                    // try to obtain DotVVM configuration
+                    if (httpContext.RequestServices.GetService<DotvvmConfiguration>() is not { } config)
+                    {
+                        throw new InvalidOperationException("DotVVM configuration not found in the service provider.");
+                    }
+
+                    // try to obtain DotVVM routes
+                    cachedRoutes = config.RouteTable
+                        .OfType<LocalizedDotvvmRoute>()
+                        .ToArray();
+                }
+            }
+        }
+    }
+}

--- a/src/Tests/Routing/RouteTableGroupTests.cs
+++ b/src/Tests/Routing/RouteTableGroupTests.cs
@@ -187,6 +187,62 @@ namespace DotVVM.Framework.Tests.Routing
         }
 
         [TestMethod]
+        public void RouteTableGroup_LocalizedUrls_RouteOnly()
+        {
+            var table = new DotvvmRouteTable(configuration);
+            table.AddGroup("Group", "group", "", opt => {
+                opt.Add("Route", "route", "route.dothtml", null, null, [
+                    new LocalizedRouteUrl("cs-CZ", "cesta")
+                ]);
+            });
+
+            var route = table["Group_Route"];
+            Assert.IsInstanceOfType(route, typeof(LocalizedDotvvmRoute));
+            var csCzRoute = ((LocalizedDotvvmRoute)route).GetRouteForCulture("cs-CZ");
+
+            Assert.AreEqual("group/route", route.Url);
+            Assert.AreEqual("group/cesta", csCzRoute.Url);
+        }
+
+        [TestMethod]
+        public void RouteTableGroup_LocalizedUrls_GroupOnly()
+        {
+            var table = new DotvvmRouteTable(configuration);
+            table.AddGroup("Group", "group", "", opt => {
+                opt.Add("Route", "route", "route.dothtml", null, null, null);
+            }, localizedUrls: [
+                new LocalizedRouteUrl("cs-CZ", "skupina")
+            ]);
+
+            var route = table["Group_Route"];
+            Assert.IsInstanceOfType(route, typeof(LocalizedDotvvmRoute));
+            var csCzRoute = ((LocalizedDotvvmRoute)route).GetRouteForCulture("cs-CZ");
+
+            Assert.AreEqual("group/route", route.Url);
+            Assert.AreEqual("skupina/route", csCzRoute.Url);
+        }
+
+        [TestMethod]
+        public void RouteTableGroup_LocalizedUrls()
+        {
+            var table = new DotvvmRouteTable(configuration);
+            table.AddGroup("Group", "group", "", opt => {
+                opt.Add("Route", "route", "route.dothtml", null, null, [
+                    new LocalizedRouteUrl("cs-CZ", "cesta")
+                ]);
+            }, localizedUrls: [
+                new LocalizedRouteUrl("cs-CZ", "skupina")
+            ]);
+
+            var route = table["Group_Route"];
+            Assert.IsInstanceOfType(route, typeof(LocalizedDotvvmRoute));
+            var csCzRoute = ((LocalizedDotvvmRoute)route).GetRouteForCulture("cs-CZ");
+
+            Assert.AreEqual("group/route", route.Url);
+            Assert.AreEqual("skupina/cesta", csCzRoute.Url);
+        }
+
+        [TestMethod]
         public void RouteTableGroup_Redirections()
         {
             var table = new DotvvmRouteTable(configuration);


### PR DESCRIPTION
When using the localizable routes feature, I discovered two unpleasant things:

* Route groups did not have support localized route fragments.

* The `IsPartialMatch` method did not return which culture was matched. I needed that when using ASP.NET Core's Request Localization feature to be able to determine the culture from the URL. 