### PR TITLE
Fix default values of PostbackScriptOptions

### DIFF
--- a/src/Framework/Framework/Compilation/Javascript/ParametrizedCode.cs
+++ b/src/Framework/Framework/Compilation/Javascript/ParametrizedCode.cs
@@ -303,6 +303,7 @@ namespace DotVVM.Framework.Compilation.Javascript
 
             public void Add(ParametrizedCode code, byte operatorPrecedence = 20)
             {
+                ThrowHelpers.ArgumentNull(code);
                 var needsParens = code.OperatorPrecedence.NeedsParens(operatorPrecedence);
                 if (needsParens) Add("(");
                 code.CopyTo(this);

--- a/src/Framework/Framework/Controls/PostbackScriptOptions.cs
+++ b/src/Framework/Framework/Controls/PostbackScriptOptions.cs
@@ -8,19 +8,20 @@ namespace DotVVM.Framework.Controls
     /// <summary> Options for the <see cref="KnockoutHelper.GenerateClientPostBackExpression(string, Binding.Expressions.ICommandBinding, DotvvmBindableObject, PostbackScriptOptions)" /> method. </summary>
     public sealed record PostbackScriptOptions
     {
-        /// <summary>If true, the command invocation will be wrapped in window.setTimeout with timeout 0. This is necessary for some event handlers, when the handler is invoked before the change is actually applied.</summary>
-        public bool UseWindowSetTimeout { get; init; }
-        /// <summary>Return value of the event handler. If set to false, the script will also include event.stopPropagation()</summary>
+        /// <summary>If true, the command invocation will be wrapped in window.setTimeout with timeout 0. This is necessary for some event handlers, when the handler is invoked before the change is actually applied. Default is false</summary>
+        public bool? UseWindowSetTimeout { get; init; }
+        /// <summary>Return value of the event handler. If set to false, the script will also include event.stopPropagation(). Null means that `null` will be returned.</summary>
         public bool? ReturnValue { get; init; }
-        public bool IsOnChange { get; init; }
+        /// <summary> When true, the invocation is suppressed while viewmodel is being updated. Default is false. </summary>
+        public bool? IsOnChange { get; init; }
         /// <summary>Javascript variable where the sender element can be found. Set to $element when in knockout binding.</summary>
-        public CodeParameterAssignment ElementAccessor { get; init; }
+        public CodeParameterAssignment? ElementAccessor { get; init; }
         /// <summary>Javascript variable current knockout binding context can be found. By default, `ko.contextFor({elementAccessor})` is used</summary>
         public CodeParameterAssignment? KoContext { get; init; }
         /// <summary>Javascript expression returning an array of command arguments.</summary>
         public CodeParameterAssignment? CommandArgs { get; init; }
-        /// <summary>When set to false, postback handlers will not be invoked for this command.</summary>
-        public bool AllowPostbackHandlers { get; init; }
+        /// <summary>When set to false, postback handlers will not be invoked for this command. Default is true.</summary>
+        public bool? AllowPostbackHandlers { get; init; }
         /// <summary>Javascript expression returning <see href="https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal">AbortSignal</see> which can be used to cancel the postback (it's a JS variant of CancellationToken). </summary>
         public CodeParameterAssignment? AbortSignal { get; init; }
         public Func<CodeSymbolicParameter, CodeParameterAssignment>? ParameterAssignment { get; init; }
@@ -28,25 +29,26 @@ namespace DotVVM.Framework.Controls
         /// <param name="useWindowSetTimeout">If true, the command invocation will be wrapped in window.setTimeout with timeout 0. This is necessary for some event handlers, when the handler is invoked before the change is actually applied.</param>
         /// <param name="returnValue">Return value of the event handler. If set to false, the script will also include event.stopPropagation()</param>
         /// <param name="isOnChange">If set to true, the command will be suppressed during updating of view model. This is necessary for certain onChange events, if we don't want to trigger the command when the view model changes.</param>
-        /// <param name="elementAccessor">Javascript variable where the sender element can be found. Set to $element when in knockout binding.</param>
+        /// <param name="elementAccessor">Javascript variable where the sender element can be found. Set to $element when in knockout binding, and this when in JS event.</param>
         /// <param name="koContext">Javascript variable current knockout binding context can be found. By default, `ko.contextFor({elementAccessor})` is used</param>
         /// <param name="commandArgs">Javascript expression returning an array of command arguments.</param>
         /// <param name="allowPostbackHandlers">When set to false, postback handlers will not be invoked for this command.</param>
         /// <param name="abortSignal">Javascript expression returning <see href="https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal">AbortSignal</see> which can be used to cancel the postback (it's a JS variant of CancellationToken). </param>
-        public PostbackScriptOptions(bool useWindowSetTimeout = false,
+        public PostbackScriptOptions(
+            bool? useWindowSetTimeout = null,
             bool? returnValue = false,
-            bool isOnChange = false,
-            string elementAccessor = "this",
+            bool? isOnChange = null,
+            string? elementAccessor = null,
             CodeParameterAssignment? koContext = null,
             CodeParameterAssignment? commandArgs = null,
-            bool allowPostbackHandlers = true,
+            bool? allowPostbackHandlers = null,
             CodeParameterAssignment? abortSignal = null,
             Func<CodeSymbolicParameter, CodeParameterAssignment>? parameterAssignment = null)
         {
             this.UseWindowSetTimeout = useWindowSetTimeout;
             this.ReturnValue = returnValue;
             this.IsOnChange = isOnChange;
-            this.ElementAccessor = new CodeParameterAssignment(elementAccessor, OperatorPrecedence.Max);
+            this.ElementAccessor = elementAccessor is null ? (CodeParameterAssignment?)null : new CodeParameterAssignment(elementAccessor, OperatorPrecedence.Max);
             this.KoContext = koContext;
             this.CommandArgs = commandArgs;
             this.AllowPostbackHandlers = allowPostbackHandlers;
@@ -55,19 +57,44 @@ namespace DotVVM.Framework.Controls
         }
 
         /// <summary> Default postback options, optimal for placing the script into a `onxxx` event attribute. </summary>
-        public static readonly PostbackScriptOptions JsEvent = new PostbackScriptOptions();
-        public static readonly PostbackScriptOptions KnockoutBinding = new PostbackScriptOptions(elementAccessor: "$element", koContext: new CodeParameterAssignment("$context", OperatorPrecedence.Max, isGlobalContext: true));
+        public static readonly PostbackScriptOptions JsEvent = new PostbackScriptOptions(
+            elementAccessor: "this",
+            koContext: new CodeParameterAssignment(new ParametrizedCode(["ko.contextFor(", ")"], [JavascriptTranslator.CurrentElementParameter.ToInfo()], OperatorPrecedence.Max))
+        );
+        public static readonly PostbackScriptOptions KnockoutBinding = new PostbackScriptOptions(
+            elementAccessor: "$element",
+            koContext: new CodeParameterAssignment("$context", OperatorPrecedence.Max, isGlobalContext: true)
+        );
+
+        public PostbackScriptOptions WithDefaults(PostbackScriptOptions? defaults)
+        {
+            if (defaults is null) return this;
+            return this with {
+                UseWindowSetTimeout = UseWindowSetTimeout ?? defaults.UseWindowSetTimeout,
+                // ReturnValue is ignored on purpose, because it is set to false in the constructor
+                IsOnChange = IsOnChange ?? defaults.IsOnChange,
+                ElementAccessor = ElementAccessor ?? defaults.ElementAccessor,
+                KoContext = KoContext ?? defaults.KoContext,
+                CommandArgs = CommandArgs ?? defaults.CommandArgs,
+                AllowPostbackHandlers = AllowPostbackHandlers ?? defaults.AllowPostbackHandlers,
+                AbortSignal = AbortSignal ?? defaults.AbortSignal,
+                ParameterAssignment = ParameterAssignment ?? defaults.ParameterAssignment,
+            };
+        }
+
+        public PostbackScriptOptions Override(PostbackScriptOptions? overrides) =>
+            overrides is null ? this : overrides.WithDefaults(this);
 
         public override string ToString()
         {
             var fields = new List<string>();
-            if (UseWindowSetTimeout) fields.Add("useWindowSetTimeout: true");
+            if (UseWindowSetTimeout is {}) fields.Add($"useWindowSetTimeout: {UseWindowSetTimeout}");
             if (ReturnValue != false) fields.Add($"returnValue: {(ReturnValue == true ? "true" : "null")}");
-            if (IsOnChange) fields.Add("isOnChange: true");
+            if (IsOnChange is {}) fields.Add($"isOnChange: {IsOnChange}");
             if (ElementAccessor.ToString() != "this") fields.Add($"elementAccessor: \"{ElementAccessor}\"");
             if (KoContext != null) fields.Add($"koContext: \"{KoContext}\"");
             if (CommandArgs != null) fields.Add($"commandArgs: \"{CommandArgs}\"");
-            if (!AllowPostbackHandlers) fields.Add("allowPostbackHandlers: false");
+            if (AllowPostbackHandlers is {}) fields.Add($"allowPostbackHandlers: {AllowPostbackHandlers}");
             if (AbortSignal != null) fields.Add($"abortSignal: \"{AbortSignal}\"");
             if (ParameterAssignment != null) fields.Add($"parameterAssignment: \"{ParameterAssignment}\"");
             return new StringBuilder("new PostbackScriptOptions(").Append(string.Join(", ", fields.ToArray())).Append(")").ToString();

--- a/src/Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/Tests/Binding/JavascriptCompilationTests.cs
@@ -1637,5 +1637,4 @@ namespace DotVVM.Framework.Tests.Binding
         public TestEnum Enum { get; set; }
         public string String { get; set; }
     }
-
 }

--- a/src/Tests/Binding/KnockoutHelperTests.cs
+++ b/src/Tests/Binding/KnockoutHelperTests.cs
@@ -1,0 +1,62 @@
+using DotVVM.Framework.Binding;
+using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Compilation.ControlTree;
+using DotVVM.Framework.Compilation.Javascript;
+using DotVVM.Framework.Configuration;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotVVM.Framework.Tests.Binding;
+[TestClass]
+public class KnockoutHelperTests
+{
+    static readonly DotvvmConfiguration config = DotvvmTestHelper.DebugConfig;
+    static readonly BindingCompilationService bindingService = config.ServiceProvider.GetRequiredService<BindingCompilationService>();
+    static readonly ICommandBinding command = bindingService.Cache.CreateCommand("_this.BoolMethod()", DataContextStack.Create(typeof(TestViewModel)));
+    static readonly IStaticCommandBinding clientOnlyStaticCommand = bindingService.Cache.CreateStaticCommand("_this.BoolProp = true", DataContextStack.Create(typeof(TestViewModel)));
+
+
+    [TestMethod]
+    public void NormalEvent_Command()
+    {
+        var result = KnockoutHelper.GenerateClientPostBackExpression("Click", command, new PlaceHolder(), new PostbackScriptOptions(abortSignal: CodeParameterAssignment.FromIdentifier("signal")));
+        Assert.AreEqual("dotvvm.postBack(this,[],\"aS4YcJnv6U6PpCmC\",\"\",null,[\"validate-root\"],[],signal)", result);
+    }
+
+    [TestMethod]
+    public void NormalEvent_StaticCommand()
+    {
+        var result = KnockoutHelper.GenerateClientPostBackExpression("Click", clientOnlyStaticCommand, new PlaceHolder(), new PostbackScriptOptions(abortSignal: CodeParameterAssignment.FromIdentifier("signal")));
+        Assert.AreEqual("dotvvm.applyPostbackHandlers((options) => options.viewModel.BoolProp(true).BoolProp(),this,[],[],undefined,signal)", result);
+    }
+
+    [TestMethod]
+    public void KnockoutExpression_Command()
+    {
+        var result = KnockoutHelper.GenerateClientPostBackExpression("Click", command, new PlaceHolder(), PostbackScriptOptions.KnockoutBinding with { AbortSignal = CodeParameterAssignment.FromIdentifier("signal") });
+        Assert.AreEqual("dotvvm.postBack($element,[],\"aS4YcJnv6U6PpCmC\",\"\",$context,[\"validate-root\"],[],signal)", result);
+    }
+
+    [TestMethod]
+    public void KnockoutExpression_StaticCommand()
+    {
+        var result = KnockoutHelper.GenerateClientPostBackExpression("Click", clientOnlyStaticCommand, new PlaceHolder(), new PostbackScriptOptions(abortSignal: CodeParameterAssignment.FromIdentifier("signal")).WithDefaults(PostbackScriptOptions.KnockoutBinding));
+        Assert.AreEqual("dotvvm.applyPostbackHandlers((options) => options.viewModel.BoolProp(true).BoolProp(),$element,[],[],$context,signal)", result);
+    }
+
+    [TestMethod]
+    public void Lambda_Command()
+    {
+        var result = KnockoutHelper.GenerateClientPostbackLambda("Click", command, new PlaceHolder(), new PostbackScriptOptions(abortSignal: CodeParameterAssignment.FromIdentifier("signal")));
+        Assert.AreEqual("()=>(dotvvm.postBack($element,[],\"aS4YcJnv6U6PpCmC\",\"\",$context,[\"validate-root\"],[],signal))", result);
+    }
+
+    [TestMethod]
+    public void Lambda_StaticCommand()
+    {
+        var result = KnockoutHelper.GenerateClientPostbackLambda("Click", clientOnlyStaticCommand, new PlaceHolder(), new PostbackScriptOptions(abortSignal: CodeParameterAssignment.FromIdentifier("signal")));
+        Assert.AreEqual("(...args)=>(dotvvm.applyPostbackHandlers((options) => options.viewModel.BoolProp(true).BoolProp(),$element,[],args,$context,signal))", result);
+    }
+}


### PR DESCRIPTION
Resolves #1908

We now store all options as nullable, and the default value is determined by the KnockoutHelper function called. It is necessary, as GenerateClientPostbackLambda has a different set of default values than GenerateClientPostbackLambda, and GenerateClientPostbackScript.

Notable exception is the ReturnValue, which already is nullable and null means that `null` should be returned. It's thus technically difficult to make this property "optional", and this issue isn't really relevant for this property anyway