### PR TITLE
Disable lambda conversion in normal bindings

### DIFF
--- a/src/Framework/Framework/Binding/Expressions/StaticCommandBindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/StaticCommandBindingExpression.cs
@@ -60,19 +60,13 @@ namespace DotVVM.Framework.Binding.Expressions
 
         public class OptionsAttribute : BindingCompilationOptionsAttribute
         {
-            public override IEnumerable<Delegate> GetResolvers() => new Delegate[] {
+            public override IEnumerable<Delegate> GetResolvers() => [
+                ..BindingCompilationService.GetDelegates([ new CommandBindingExpression.OptionsAttribute.CommonCommandMethods() ]),
                 new Func<StaticCommandJsAstProperty, RequiredRuntimeResourcesBindingProperty>(js => {
                     var resources = js.Expression.DescendantNodesAndSelf().Select(n => n.Annotation<RequiredRuntimeResourcesBindingProperty>()).Where(n => n != null).SelectMany(n => n!.Resources).ToImmutableArray();
                     return resources.Length == 0 ? RequiredRuntimeResourcesBindingProperty.Empty : new RequiredRuntimeResourcesBindingProperty(resources);
-                }),
-                
-                new Func<AssignedPropertyBindingProperty, ExpectedTypeBindingProperty>(property => {
-                    var prop = property?.DotvvmProperty;
-                    if (prop == null) return new ExpectedTypeBindingProperty(typeof(Command));
-
-                    return new ExpectedTypeBindingProperty(prop.IsBindingProperty ? (prop.PropertyType.GenericTypeArguments.SingleOrDefault() ?? typeof(Command)) : prop.PropertyType);
                 })
-            };
+            ];
         }
     }
 

--- a/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
+++ b/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
@@ -75,12 +75,8 @@ namespace DotVVM.Framework.Compilation.Binding
         public CastedExpressionBindingProperty ConvertExpressionToType(ParsedExpressionBindingProperty expr, ExpectedTypeBindingProperty? expectedType = null)
         {
             var destType = expectedType?.Type ?? typeof(object);
-            var convertedExpr = TypeConversion.ImplicitConversion(expr.Expression, destType, throwException: false, allowToString: true);
             return new CastedExpressionBindingProperty(
-                // if the expression is of type object (i.e. null literal) try the lambda conversion.
-                convertedExpr != null && expr.Expression.Type != typeof(object) ? convertedExpr :
-                TypeConversion.MagicLambdaConversion(expr.Expression, destType) ?? convertedExpr ??
-                TypeConversion.EnsureImplicitConversion(expr.Expression, destType, allowToString: true)!
+                TypeConversion.EnsureImplicitConversion(expr.Expression, destType, allowToString: true)
             );
         }
 


### PR DESCRIPTION
In command bindings, expressions get automatically wrapped in a lambda function. Surprisingly, the behavior was also present in value/resource, which lead to some surprising effects when value/resource was accidentally assigned to a command property (#1742).

We also unify that untyped ICommandBinding and IStaticCommandBinding produce delegate of type Command (i.e. async function with no argument and no return value). Previously Delegate was used for commands,
which had the effect of sending the return value to the client