### PR TITLE
Do not hide SPA page while JS is loading

### DIFF
--- a/src/Framework/Framework/Controls/SpaContentPlaceHolder.cs
+++ b/src/Framework/Framework/Controls/SpaContentPlaceHolder.cs
@@ -109,12 +109,6 @@ namespace DotVVM.Framework.Controls
 
         protected override void AddAttributesToRender(IHtmlWriter writer, IDotvvmRequestContext context)
         {
-            if (context.RequestType == DotvvmRequestType.Navigate)
-            {
-                writer.AddStyleAttribute("display", "none");
-            }
-            writer.AddKnockoutDataBind("if", "dotvvm.isSpaReady");
-
             base.AddAttributesToRender(writer, context);
         }
 

--- a/src/Framework/Framework/Controls/SpaContentPlaceHolder.cs
+++ b/src/Framework/Framework/Controls/SpaContentPlaceHolder.cs
@@ -109,6 +109,7 @@ namespace DotVVM.Framework.Controls
 
         protected override void AddAttributesToRender(IHtmlWriter writer, IDotvvmRequestContext context)
         {
+            writer.AddKnockoutDataBind("if", "true"); // yep, go ahead and try to remove it
             base.AddAttributesToRender(writer, context);
         }
 

--- a/src/Framework/Framework/Resources/Scripts/postback/updater.ts
+++ b/src/Framework/Framework/Resources/Scripts/postback/updater.ts
@@ -67,6 +67,7 @@ export function updateViewModelAndControls(resultObject: any, updateTypeInfo: (t
 
     // we have to update knockout viewmodel before we try to apply new data into the observables
     getStateManager().doUpdateNow()
+    ko.tasks.runEarly()
 
     // add new updated controls
     restoreUpdatedControls(resultObject, updatedControls);


### PR DESCRIPTION
Should improve "visual" loads times, and SEO.

Hiding the page is currently unnecessary
it was added back in 2015 (9c11159), because we used to rely on the URL path fragment (`#/something`), which could be different from the page which was currently being loaded.