### PR TITLE
Optimize LocalizableString implementation (cache ResourceManager)

### DIFF
--- a/src/AutoUI/Core/Metadata/LocalizableString.cs
+++ b/src/AutoUI/Core/Metadata/LocalizableString.cs
@@ -1,24 +1,32 @@
 using System;
-using System.Linq.Expressions;
+using System.Collections.Concurrent;
 using System.Resources;
+using System.Threading;
 using DotVVM.Framework.Binding;
 using DotVVM.Framework.Binding.Expressions;
 using DotVVM.Framework.Binding.Properties;
-using DotVVM.Framework.Compilation.Binding;
 using DotVVM.Framework.Utils;
 
 namespace DotVVM.AutoUI.Metadata
 {
-    public class LocalizableString
+    public sealed class LocalizableString: IEquatable<LocalizableString>
     {
         public string? Value { get; private init; }
         public string? ResourceKey { get; private init; }
         public Type? ResourceType { get; private init; }
+        private volatile ResourceManager? resourceManager;
 
         public bool IsLocalized => ResourceKey is {};
 
+        private LocalizableString() { }
+
         public static LocalizableString Constant(string value) => new() { Value = value };
-        public static LocalizableString Localized(Type type, string resourceKey) => new() { ResourceKey = resourceKey, ResourceType = type };
+        public static LocalizableString Localized(Type type, string resourceKey)
+        {
+            ThrowHelpers.ArgumentNull(type);
+            ThrowHelpers.ArgumentNull(resourceKey);
+            return new() { ResourceKey = resourceKey, ResourceType = type };
+        }
 
 
         public static LocalizableString? CreateNullable(string? value, Type? resourceType) =>
@@ -41,14 +49,20 @@ namespace DotVVM.AutoUI.Metadata
         {
             if (IsLocalized)
             {
-                var binding = new ResourceBindingExpression<string>(
-                    bindingCompilationService,
-                    new object[] {
-                        new ParsedExpressionBindingProperty(
-                            ExpressionUtils.Replace(() => this.Localize())
-                        ),
-                        (BindingDelegate)(_ => this.Localize()) // skip the expression compilation
-                    }
+                // most likely, the same resource is used on multiple places; the init isn't too expensive, but duplicate bindings still take up quite some memory
+                var binding = bindingCompilationService.Cache.CreateCachedBinding("DotVVM.AutoUI.Metadata.LocalizableString", [ this ], () =>
+                    new ResourceBindingExpression<string>(
+                        bindingCompilationService,
+                        new object[] {
+                            new ParsedExpressionBindingProperty(
+                                ExpressionUtils.Replace(() => this.Localize())
+                            ),
+                            new ResultTypeBindingProperty(typeof(string)),
+                            new ExpectedTypeBindingProperty(typeof(string)),
+                            new OriginalStringBindingProperty($"{ResourceType.Name}.{ResourceKey}"), // make ToString more useful
+                            (BindingDelegate)(_ => this.Localize()) // skip the expression compilation
+                        }
+                    )
                 );
                 return new ValueOrBinding<string>(binding);
             }
@@ -63,7 +77,22 @@ namespace DotVVM.AutoUI.Metadata
             if (!IsLocalized)
                 return Value ?? "";
             else
-                return new ResourceManager(ResourceType!).GetString(ResourceKey!) ?? Value ?? ResourceKey ?? "";
+            {
+                var manager = this.resourceManager ??= GetResourceManager(ResourceType!);
+                return manager.GetString(ResourceKey!) ?? Value ?? ResourceKey ?? "";
+            }
         }
+
+        public bool Equals(LocalizableString? other) =>
+            other is not null &&
+            other.Value == Value && other.ResourceType == ResourceType && other.ResourceKey == ResourceKey;
+        public override bool Equals(object? other) =>
+            other is LocalizableString otherLS && Equals(otherLS);
+        public override int GetHashCode() =>
+            HashCode.Combine(Value?.GetHashCode() ?? 0, ResourceType?.GetHashCode() ?? 0, ResourceKey?.GetHashCode() ?? 0);
+
+        private static ConcurrentDictionary<Type, ResourceManager> resourceManagers = new(concurrencyLevel: 1, capacity: 4);
+        private static ResourceManager GetResourceManager(Type type) =>
+            resourceManagers.GetOrAdd(type, type => new ResourceManager(type));
     }
 }

--- a/src/Framework/Framework/Utils/ExpressionUtils.cs
+++ b/src/Framework/Framework/Utils/ExpressionUtils.cs
@@ -77,7 +77,7 @@ namespace DotVVM.Framework.Utils
 
         public static Expression Replace<TRes>(Expression<Func<TRes>> ex)
         {
-            return Replace(ex as LambdaExpression);
+            return ex.Body;
         }
         public static Expression Replace<T1, TRes>(Expression<Func<T1, TRes>> ex, Expression p1)
         {


### PR DESCRIPTION
Turns out the ResourceManager is not a cheap class to initialize. It itself contains caches for the localized entries.

Since there is going to be a very limited number of resource types, I think it's safe to cache them in a ConcurrentDictionary indefinitely.