### PR TITLE
Add IDebugHtmlFormattableObject for error page formatting

### DIFF
--- a/src/Framework/Core/Runtime/IDebugHtmlFormattableObject.cs
+++ b/src/Framework/Core/Runtime/IDebugHtmlFormattableObject.cs
@@ -1,0 +1,15 @@
+
+using System;
+
+
+/// <summary> The object will be formatted by the DotVVM error page as HTML rich text </summary>
+public interface IDebugHtmlFormattableObject
+{
+    /// <summary>
+    /// Returns text similar to <see cref="object.ToString()"/>, but formatted as HTML.
+    /// If the object is exception, only the same information as <see cref="Exception.Message"/> should be returned (no stack trace).
+    /// </summary>
+    /// <param name="formatProvider">Locale</param>
+    /// <param name="isBlock">If true, the text is allowed to be formatted as a block element (i.e. &lt;ul&gt;)</param>
+    string DebugHtmlString(IFormatProvider? formatProvider, bool isBlock);
+}

--- a/src/Framework/Framework/Controls/DotvvmControl.cs
+++ b/src/Framework/Framework/Controls/DotvvmControl.cs
@@ -198,16 +198,14 @@ namespace DotVVM.Framework.Controls
             {
                 RenderControl(writer, context);
             }
-            catch (Exception e)
+            catch (Exception e) when (e is not IDotvvmException { RelatedControl: {} })
             {
-                if (e is IDotvvmException { RelatedControl: not null })
-                    throw;
                 if (e is DotvvmExceptionBase dotvvmException)
                 {
                     dotvvmException.RelatedControl = this;
                     throw;
                 }
-                throw new DotvvmControlException(this, "Error occurred in Render method", e);
+                throw new DotvvmControlException(this, $"Error occurred in {GetType().Name}.Render method", e);
             }
         }
 

--- a/src/Framework/Framework/Controls/DotvvmControlException.cs
+++ b/src/Framework/Framework/Controls/DotvvmControlException.cs
@@ -29,5 +29,14 @@ namespace DotVVM.Framework.Controls
             : base(message, Location: location, InnerException: innerException)
         {
         }
+
+        protected override bool PrintMembers(System.Text.StringBuilder builder)
+        {
+            if (base.PrintMembers(builder))
+                builder.Append(", ");
+            if (FileName != null)
+                builder.Append("FileName = ").Append(FileName).Append(", ");
+            return false;
+        }
     }
 }

--- a/src/Framework/Framework/Hosting/ErrorPages/CookiesSection.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/CookiesSection.cs
@@ -24,7 +24,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
             // this would allow it.
             // We will thus fill the cookie table with "redacted" values and then fill it in JS.
             var table = Cookies.Select(c => new KeyValuePair<string, string>(c.Key, "redacted value of HTTP only cookie"));
-            writer.WriteKVTable(table, "cookie-table");
+            writer.WriteKVTable(table, "cookie-table", "Name", "Value");
 
             writer.WriteUnencoded(@"
             <script>

--- a/src/Framework/Framework/Hosting/ErrorPages/DictionarySection.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/DictionarySection.cs
@@ -7,10 +7,12 @@ namespace DotVVM.Framework.Hosting.ErrorPages
 {
     public class DictionarySection<K, V> : IErrorSectionFormatter
     {
-        public string DisplayName { get; set; }
+        public string DisplayName { get; init; }
+        public string KeyTitle { get; init; } = "Variable";
+        public string ValueTitle { get; init; } = "Value";
 
-        public string Id { get; set; }
-        public KeyValuePair<K, V>[] Table { get; set; }
+        public string Id { get; init; }
+        public KeyValuePair<K, V>[] Table { get; init; }
 
         public DictionarySection(string name, string id, IEnumerable<KeyValuePair<K, V>> table)
         {

--- a/src/Framework/Framework/Hosting/ErrorPages/DotvvmMarkupErrorSection.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/DotvvmMarkupErrorSection.cs
@@ -142,7 +142,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
             var iex =
                 exs.OfType<DotvvmCompilationException>().FirstOrDefault() ??
                 exs.OfType<IDotvvmException>()
-                   .Where(dex => dex.GetLocation() != null)
+                   .Where(dex => dex.GetLocation() is { FileName: { } })
                    .FirstOrDefault()?.TheException;
 
             if (iex != null) return new DotvvmMarkupErrorSection(ex);

--- a/src/Framework/Framework/Hosting/ErrorPages/DotvvmMarkupErrorSection.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/DotvvmMarkupErrorSection.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using DotVVM.Framework.Binding;
@@ -11,6 +12,7 @@ using DotVVM.Framework.Compilation.Binding;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.Runtime;
 using DotVVM.Framework.Utils;
+using FastExpressionCompiler;
 
 namespace DotVVM.Framework.Hosting.ErrorPages
 {
@@ -38,10 +40,10 @@ namespace DotVVM.Framework.Hosting.ErrorPages
 
             var source = ExtractSource(exc);
 
-            w.WriteUnencoded("<div class='exception'><span class='exceptionType'>");
-            w.WriteText(exc.GetType().FullName);
-            w.WriteUnencoded("</span><pre class='exceptionMessage'>");
-            w.WriteText(exc.Message);
+            w.WriteUnencoded($"<div class='exception'><span class='exceptionType' title='{WebUtility.HtmlEncode(exc.GetType().FullName)}'>");
+            w.WriteUnencoded(exc.GetType().DebugHtmlString(false, false));
+            w.WriteUnencoded("</span>: <pre class='exceptionMessage'>");
+            w.WriteUnencoded(HtmlFormattingUtils.TryFormatAsHtml(exc, null, isBlock: true));
             w.WriteUnencoded("</pre>");
             if (source != null)
             {

--- a/src/Framework/Framework/Hosting/ErrorPages/ExceptionModel.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/ExceptionModel.cs
@@ -8,20 +8,18 @@ namespace DotVVM.Framework.Hosting.ErrorPages
 {
     public class ExceptionModel
     {
-        public ExceptionModel(string typeName, string message, StackFrameModel[] stack, Exception originalException, ExceptionAdditionalInfo[] additionalInfos)
+        public ExceptionModel(Type exceptionType, StackFrameModel[] stack, Exception originalException, ExceptionAdditionalInfo[] additionalInfos)
         {
-            TypeName = typeName;
-            Message = message;
+            ExceptionType = exceptionType;
             Stack = stack;
-            OriginalException = originalException;
+            Exception = originalException;
             AdditionalInfo = additionalInfos;
         }
 
-        public string TypeName { get; set; }
-        public string Message { get; set; }
+        public Type ExceptionType { get; set; }
         public StackFrameModel[] Stack { get; set; }
         public ExceptionModel? InnerException { get; set; }
-        public Exception OriginalException { get; set; }
+        public Exception Exception { get; set; }
         public ExceptionAdditionalInfo[] AdditionalInfo { get; set; }
     }
 }

--- a/src/Framework/Framework/Hosting/ErrorPages/ExceptionSectionFormatter.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/ExceptionSectionFormatter.cs
@@ -33,10 +33,10 @@ namespace DotVVM.Framework.Hosting.ErrorPages
             {
                 WriteException(w, model.InnerException);
             }
-            w.WriteUnencoded("<div class='exception'><span class='exceptionType'>");
-            w.WriteText(model.TypeName);
-            w.WriteUnencoded("</span><pre class='exceptionMessage'>");
-            w.WriteText(model.Message);
+            w.WriteUnencoded($"<div class='exception'><span class='exceptionType' title='{WebUtility.HtmlEncode(model.ExceptionType.FullName)}'>");
+            w.WriteUnencoded(model.ExceptionType.DebugHtmlString(false, false));
+            w.WriteUnencoded("</span>: <pre class='exceptionMessage'>");
+            w.WriteUnencoded(HtmlFormattingUtils.TryFormatAsHtml(model.Exception, null, isBlock: true));
             w.WriteUnencoded("</pre><hr />");
             if (model.AdditionalInfo != null && model.AdditionalInfo.Length > 0)
             {
@@ -80,7 +80,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
                 }
                 w.WriteUnencoded("</div>");
             }
-            w.ObjectBrowser(model.OriginalException);
+            w.ObjectBrowser(model.Exception);
             w.WriteUnencoded("<hr /><div class='exceptionStackTrace'>");
             foreach (var frame in model.Stack)
             {
@@ -137,10 +137,8 @@ namespace DotVVM.Framework.Hosting.ErrorPages
         public void WriteStyle(IErrorWriter w)
         {
             w.WriteUnencoded(@"
-.exception .exceptionType:after { content: ': '; }
-.exception .exceptionType { font-size: 1.1em; font-weight: bold; }
-.exception .exceptionMessage { font-style: italic; }
-.exceptionStackTrace {  }
+.exception .exceptionType { font-weight: bold; }
+.exception .exceptionType, .exception .exceptionMessage { font-size: 1.25em; }
 .exceptionStackTrace .frame { padding: 2px; margin: 0 0 0 30px; border-bottom: 1px #ddd solid; }
 .exceptionStackTrace .frame:hover { background-color: #f0f0f0; }
 ");

--- a/src/Framework/Framework/Hosting/ErrorPages/IErrorWriter.cs
+++ b/src/Framework/Framework/Hosting/ErrorPages/IErrorWriter.cs
@@ -12,7 +12,7 @@ namespace DotVVM.Framework.Hosting.ErrorPages
         void WriteUnencoded(string? str);
         void WriteText(string? str);
         void ObjectBrowser(object? obj);
-        void WriteKVTable<K, V>(IEnumerable<KeyValuePair<K, V>> table, string className = "");
+        void WriteKVTable<K, V>(IEnumerable<KeyValuePair<K, V>> table, string className = "", string keyTitle = "Variable", string valueTitle = "Values");
         void WriteSourceCode(SourceModel source, bool collapse = true);
     }
 }

--- a/src/Framework/Framework/Resources/Styles/DotVVM.Internal.css
+++ b/src/Framework/Framework/Resources/Styles/DotVVM.Internal.css
@@ -35,7 +35,6 @@ html {
     width: 100%;
     height: 100%;
     font-size: 62.5%;
-    line-height: 1;
     scroll-behavior: smooth;
 }
 
@@ -44,23 +43,28 @@ html {
 :root {
     --heading-color: #333333;
     --nav-color: #2980b9;
-    --activate-color: #de1212;
-    --idle-color: #bcbcbc;
+    --execute-color: #a82f23;
+    --idle-color: #969696;
     --text-color: #333333;
-    --hint-color: #bbbbbb;
+    --hint-color: #7c7878;
+    --border-color: #bbbbbb;
     --error-color: #de1212;
     --error-dark-color: #a82f23;
     --warning-color: #ffa322;
-    --warning-dark-color: #940c00;
+    --warning-dark-color: #ac7c00;
     --success-color: green;
 
 
     /* stolen colors from VSCode light theme */
     --syntax-class: #267f99;
     --syntax-prop: #001080;
+    --syntax-literal: #a20d0d;
     --syntax-method: #795e26;
     --syntax-keyword: #0000ff;
-    --syntax-pink: color: #af00db;;
+    --syntax-pink: #af00db;
+    --syntax-comment: #007f00;
+    --syntax-value: #008557; /* CSS numeric values have this color */
+    --syntax-value2: #0050a4; /* CSS unquoted string values have this color */
     --syntax-black: #000000;
     --font-monospace: "Droid Sans Mono", "Consolas", "monospace", monospace
 }
@@ -71,12 +75,11 @@ body {
     font-size: 1.5rem;
     color: var(--text-color);
     margin: 1rem;
-    line-height: 1.2;
 }
 
 h1 {
     font-weight: normal;
-    font-size: 3.2rem;
+    font-size: 3rem;
     font-style: italic;
     color: var(--heading-color);
     margin: 2rem 0;
@@ -96,7 +99,15 @@ h3 {
 }
 
 .summary {
-    margin: 1.5rem 0;
+    display: block;
+    /* padding: 1.5rem 0; */
+    font-size: 2rem;
+
+    /* limit to 20 lines with fadeout effect (the message is repeated later, but now let's show the menu, source etc.) */
+    max-height: 15em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    mask-image: linear-gradient(180deg, #000 11em, transparent);
 }
 
 .hint-text {
@@ -144,7 +155,7 @@ table {
         border-right: none;
         border-bottom: none;
         border-left: none;
-        border-top: 0.1rem var(--hint-color) solid;
+        border-top: 0.1rem var(--border-color) solid;
         box-sizing: border-box;
     }
         table tr:first-child th, table tr:first-child td {
@@ -152,7 +163,7 @@ table {
         }
 
         table tr.row-continues td {
-            /* border-top: 0.1rem var(--hint-color) dashed; */
+            /* border-top: 0.1rem var(--border-color) dashed; */
             border-top: none;
         }
 
@@ -272,6 +283,9 @@ nav {
     cursor: pointer;
     background-color: var(--idle-color);
 }
+    .nav:hover {
+        background-color: color-mix(in srgb, var(--idle-color), black 20%)
+    }
 
     .nav.active {
         background-color: var(--nav-color);
@@ -284,7 +298,7 @@ nav {
 
 /* Interaction */
 input.execute, button.execute {
-    background-color: var(--hint-color);
+    background-color: var(--idle-color);
     padding: 0.4rem 2rem;
     color: white;
     cursor: pointer;
@@ -292,7 +306,7 @@ input.execute, button.execute {
 }
 
     input.execute:hover, button.execute:hover {
-        background-color: var(--activate-color);
+        background-color: var(--execute-color);
     }
 
 a.execute {
@@ -302,7 +316,7 @@ a.execute {
 }
 
     a.execute:hover {
-        color: var(--activate-color);
+        color: var(--execute-color);
     }
 
 .header-toolbox {
@@ -330,7 +344,7 @@ hr {
         display: inline-block;
         padding: 0.5rem;
         background-color: white;
-        border: 0.1rem solid var(--hint-color);
+        border: 0.1rem solid var(--border-color);
         min-width: 20rem;
     }
 
@@ -362,6 +376,49 @@ ul {
 code {
     font-family: var(--font-monospace);
     color: var(--syntax-black);
+}
+
+.syntax-class, .syntax-typeparam, .syntax-interface {
+    color: var(--syntax-class);
+}
+.syntax-prop {
+    color: var(--syntax-prop);
+}
+.syntax-literal {
+    color: var(--syntax-literal);
+}
+.syntax-method {
+    color: var(--syntax-method);
+}
+.syntax-keyword {
+    color: var(--syntax-keyword);
+}
+.syntax-pink {
+    color: var(--syntax-pink);
+}
+.syntax-value {
+    color: var(--syntax-value);
+}
+.syntax-value2 {
+    color: var(--syntax-value2);
+}
+.syntax-black {
+    color: var(--syntax-black);
+}
+.syntax-comment {
+    color: var(--syntax-comment);
+    font-style: italic;
+}
+
+
+.syntax-underline-error {
+    text-decoration: var(--error-dark-color) wavy underline;
+}
+.syntax-underline-warning {
+    text-decoration: var(--warning-dark-color) wavy underline;
+}
+.syntax-underline-info {
+    text-decoration: var(--success-color) wavy underline;
 }
 
 code.element {

--- a/src/Framework/Framework/Runtime/IDotvvmException.cs
+++ b/src/Framework/Framework/Runtime/IDotvvmException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 using DotVVM.Framework.Binding;
 using DotVVM.Framework.Binding.Expressions;
 using DotVVM.Framework.Compilation;
@@ -7,6 +8,7 @@ using DotVVM.Framework.Compilation.Parser.Dothtml.Parser;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.ResourceManagement;
 using DotVVM.Framework.Utils;
+using FastExpressionCompiler;
 
 namespace DotVVM.Framework.Runtime
 {
@@ -41,6 +43,46 @@ namespace DotVVM.Framework.Runtime
         public DotvvmBindableObject? RelatedControl { get; set; } = RelatedControl;
         public DotvvmLocationInfo? Location { get; set; } = Location;
         Exception IDotvvmException.TheException => this;
+
+        protected override bool PrintMembers(StringBuilder builder)
+        {
+            if (base.PrintMembers(builder))
+                builder.Append(", ");
+
+            if (Location is {})
+            {
+                var str = Location switch {
+                    { FileName: {} file, LineNumber: {} line } => $"{file}:{line}",
+                    { FileName: {} file } => file,
+                    { LineNumber: {} line } => $"Line {line}",
+                    _ => null
+                };
+                if (str != null)
+                    builder.Append("Location = ").Append(str).Append(", ");
+                if (Location.ControlType is {} && RelatedControl is null)
+                    builder.Append("ControlType = ").Append(Location.ControlType.ToCode(stripNamespace: true)).Append(", ");
+            }
+
+            if (RelatedProperty is {})
+                builder.Append("Property = ").Append(RelatedProperty.Name).Append(", ");
+
+            if (RelatedControl is {})
+                builder.Append("Control = ").Append(RelatedControl.DebugString(multiline: false)).Append(", ");
+
+            if (RelatedBinding is {})
+                builder.Append("Binding = ").Append(RelatedBinding.ToString()).Append(", ");
+
+            if (RelatedResolvedControl is {})
+                builder.Append("ResolvedControl = ").Append(RelatedResolvedControl.ToString()).Append(", ");
+
+            if (RelatedDothtmlNode is {})
+                builder.Append("DothtmlNode = ").Append(RelatedDothtmlNode.ToString()).Append(", ");
+
+            if (RelatedResource is {})
+                builder.Append("Resource = ").Append(RelatedResource).Append(", ");
+
+            return false;
+        }
     }
 
     public static class DotvvmExceptionExtensions

--- a/src/Framework/Framework/Utils/HtmlFormattingUtils.cs
+++ b/src/Framework/Framework/Utils/HtmlFormattingUtils.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Web;
+using DotVVM.Framework.Compilation.ControlTree;
+using DotVVM.Framework.Compilation.ControlTree.Resolved;
+using DotVVM.Framework.Compilation.Parser.Binding.Tokenizer;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Utils;
+using FastExpressionCompiler;
+
+internal static class HtmlFormattingUtils
+{
+    public static string DebugHtmlString(this Type? type, bool fullName, bool titleFullName)
+    {
+        if (type is null)
+            return "<span class=syntax-keyword>null</span>";
+
+        if (type.IsGenericParameter)
+            return "<span class=syntax-typeparam>" + type.Name + "</span>";
+
+        if (type.IsGenericTypeDefinition)
+        {
+            var args = type.GetGenericArguments();
+            return AddTitleFullName(type, $"{JustName(type, fullName)}<{new string(',', args.Length - 1)}>", titleFullName);
+        }
+
+        if (type.IsGenericType)
+        {
+            if (Nullable.GetUnderlyingType(type) is Type nullableElement)
+                return AddTitleFullName(type, nullableElement.DebugHtmlString(fullName, false) + "?", titleFullName);
+
+            var def = type.GetGenericTypeDefinition();
+            var args = type.GetGenericArguments();
+            var argsHtml = string.Join(", ", args.Select(a => a.DebugHtmlString(fullName, false)));
+
+            if (def.Namespace == "System" && def.Name == "ValueTuple")
+                return AddTitleFullName(type, $"({argsHtml})", titleFullName);
+            else
+                return AddTitleFullName(type, $"{JustName(def, fullName)}<{argsHtml}>", titleFullName);
+        }
+
+        if (type.IsArray)
+        {
+            var elementType = type.GetElementType()!;
+            var rank = type.GetArrayRank();
+            return AddTitleFullName(type, $"{elementType.DebugHtmlString(fullName, false)}[{new string(',', rank - 1)}]", titleFullName);
+        }
+
+        if (type.IsByRef)
+        {
+            var elementType = type.GetElementType()!;
+            return AddTitleFullName(type, $"{elementType.DebugHtmlString(fullName, false)}&", titleFullName);
+        }
+
+        if (type.IsPointer)
+        {
+            var elementType = type.GetElementType()!;
+            return AddTitleFullName(type, $"{elementType.DebugHtmlString(fullName, false)}*", titleFullName);
+        }
+
+        if (type.DeclaringType is { } declaringType)
+        {
+            var declaringTypeHtml = declaringType.DebugHtmlString(fullName, false);
+            return AddTitleFullName(type, $"{declaringTypeHtml}.{JustName(type, false, false)}", titleFullName);
+        }
+
+        if (type == typeof(object))
+                return "<span class=syntax-keyword>object</span>";
+        if (type == typeof(void))
+            return "<span class=syntax-keyword>void</span>";
+        if (type == typeof(string))
+            return "<span class=syntax-keyword>string</span>";
+        if (type == typeof(char))
+            return "<span class=syntax-keyword>char</span>";
+        if (type == typeof(decimal))
+            return "<span class=syntax-keyword>decimal</span>";
+        if (type == typeof(bool))
+            return "<span class=syntax-keyword>bool</span>";
+        if (type == typeof(sbyte))
+            return "<span class=syntax-keyword>sbyte</span>";
+        if (type == typeof(byte))
+            return "<span class=syntax-keyword>byte</span>";
+        if (type == typeof(short))
+            return "<span class=syntax-keyword>short</span>";
+        if (type == typeof(ushort))
+            return "<span class=syntax-keyword>ushort</span>";
+        if (type == typeof(int))
+            return "<span class=syntax-keyword>int</span>";
+        if (type == typeof(uint))
+            return "<span class=syntax-keyword>uint</span>";
+        if (type == typeof(long))
+            return "<span class=syntax-keyword>long</span>";
+        if (type == typeof(ulong))
+            return "<span class=syntax-keyword>ulong</span>";
+        if (type == typeof(IntPtr))
+            return "<span class=syntax-keyword>nint</span>";
+        if (type == typeof(UIntPtr))
+            return "<span class=syntax-keyword>nuint</span>";
+        if (type == typeof(float))
+            return "<span class=syntax-keyword>float</span>";
+        if (type == typeof(double))
+            return "<span class=syntax-keyword>double</span>";
+
+        return JustName(type, fullName, titleFullName);
+
+
+
+        static string TitleFullName(Type t, bool condition = true) =>
+                                                condition ? $" title='{WebUtility.HtmlEncode(t.ToCode())}'" : "";
+        static string AddTitleFullName(Type t, string html, bool condition = true)
+        {
+            if (condition)
+            {
+                var title = WebUtility.HtmlEncode(t.ToCode(stripNamespace: false));
+                if (title != html)
+                {
+                    return $"<span title='{title}'>{html}</span>";
+                }
+            }
+
+            return html;
+        }
+        static string JustName(Type t, bool fullName, bool titleFullName = false)
+        {
+            var name = t.Name;
+            if (t.IsGenericType && name.LastIndexOf('`') > 0)
+            {
+                name = name.Substring(0, name.LastIndexOf('`'));
+            }
+
+            var className = t.IsInterface ? "syntax-interface" : "syntax-class";
+            if (fullName && !string.IsNullOrEmpty(t.Namespace))
+            {
+                return $"<span class=syntax-prop>{t.Namespace}</span>.<span class={className}>{WebUtility.HtmlEncode(name)}</span>";
+            }
+            else
+            {
+                return $"<span class={className} {TitleFullName(t, titleFullName)}>{WebUtility.HtmlEncode(name)}</span>";
+            }
+        }
+    }
+
+    public static string DebugHtmlString(this ITypeDescriptor typeDescriptor, bool fullName, bool titleFullName)
+    {
+        if (typeDescriptor is ResolvedTypeDescriptor resolvedType)
+            return resolvedType.Type.DebugHtmlString(fullName, titleFullName);
+        return WebUtility.HtmlEncode(fullName ? typeDescriptor.CSharpFullName : typeDescriptor.CSharpName);
+    }
+
+    public sealed class PreformattedHtmlObject : IDebugHtmlFormattableObject
+    {
+        public string? PlainText { get; }
+        public string HtmlText { get; }
+        public string HtmlBlockText { get; }
+        public PreformattedHtmlObject(string? plainText, string htmlText, string? htmlBlockText = null)
+        {
+            ThrowHelpers.ArgumentNull(htmlText);
+
+            PlainText = plainText;
+            HtmlText = htmlText;
+            HtmlBlockText = htmlBlockText ?? htmlText;
+        }
+
+        public static PreformattedHtmlObject Create(object? obj)
+        {
+            var htmlText = TryFormatAsHtml(obj, null, isBlock: false);
+            var htmlBlockText = TryFormatAsHtml(obj, null, isBlock: true);
+            return new PreformattedHtmlObject(
+                plainText: Convert.ToString(obj, null),
+                htmlText: htmlText,
+                htmlBlockText: htmlBlockText == htmlText ? null : htmlBlockText);
+        }
+
+        public PreformattedHtmlObject Append(PreformattedHtmlObject? other) =>
+            other is null ? this :
+            new(PlainText + other.PlainText,
+                HtmlText + other.HtmlText,
+                HtmlBlockText + other.HtmlBlockText);
+
+        public PreformattedHtmlObject Append(string plain, string? html = null)
+        {
+            html ??= WebUtility.HtmlEncode(plain);
+            return new(PlainText + plain, HtmlText + html, HtmlBlockText + html);
+        }
+
+        public static PreformattedHtmlObject operator +(PreformattedHtmlObject? a, PreformattedHtmlObject? b)
+        {
+            if (a is null) return b ?? Empty;
+            if (b is null) return a;
+            return a.Append(b);
+        }
+        public static PreformattedHtmlObject operator +(PreformattedHtmlObject? a, string? b)
+        {
+            if (b is null) return a ?? Empty;
+            if (a is null) return new PreformattedHtmlObject(b, b);
+            return new PreformattedHtmlObject(a.PlainText + b, a.HtmlText + WebUtility.HtmlEncode(b));
+        }
+
+        public string DebugHtmlString(IFormatProvider? formatProvider, bool isBlock)
+        {
+            if (isBlock && HtmlBlockText is { })
+                return HtmlBlockText;
+
+            return HtmlText;
+        }
+
+        public override string ToString() => PlainText ?? HtmlText;
+
+        public static PreformattedHtmlObject Empty { get; } = new PreformattedHtmlObject("", "");
+    }
+
+
+    public static string TryFormatAsHtml(object? obj, IFormatProvider? formatProvider, bool isBlock, string plainPrefix = "", string plainSuffix = "")
+    {
+        if (obj is null)
+            return "<span class=syntax-keyword>null</span>";
+
+        try
+        {
+            if (obj is IDebugHtmlFormattableObject htmlFormattable)
+                return htmlFormattable.DebugHtmlString(formatProvider, isBlock);
+
+            if (obj is Type type)
+                return type.DebugHtmlString(fullName: isBlock, titleFullName: true);
+
+            if (obj is ITypeDescriptor typeDescriptor)
+                return typeDescriptor.DebugHtmlString(fullName: isBlock, titleFullName: true);
+        }
+        catch (Exception ex)
+        {
+            Debug.Assert(false, "Error while formatting object as HTML: " + ex.ToString());
+        }
+
+        var enumerable = obj as IEnumerable<object> ?? (obj as IEnumerable)?.Cast<object>();
+        if (enumerable is {} && obj is not string)
+        {
+            var items = enumerable.Select(o => TryFormatAsHtml(o, formatProvider, isBlock, plainPrefix, plainSuffix)).ToArray();
+            if (items.Length == 0)
+                return "[]";
+            if (isBlock)
+                return "<ul>" + string.Concat(items.Select(i => "<li>" + i + "</li>")) + "</ul>";
+            else
+                return "[ " + string.Join(", ", items) + " ]";
+        }
+
+
+        try
+        {
+            return plainPrefix + WebUtility.HtmlEncode((
+                obj is Exception ex ? ex.Message
+                                    : Convert.ToString(obj, formatProvider)) ?? "") + plainSuffix;
+        }
+        catch (Exception ex)
+        {
+            Debug.Assert(false, "Error while formatting object as HTML: " + ex.ToString());
+            return "" + WebUtility.HtmlEncode(ex.Message) + "</span>";
+        }
+    }
+}

--- a/src/Framework/Framework/ViewModel/Serialization/DefaultViewModelSerializer.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/DefaultViewModelSerializer.cs
@@ -23,16 +23,21 @@ using Microsoft.Extensions.Logging;
 using DotVVM.Framework.Runtime.Tracing;
 using Microsoft.Extensions.DependencyInjection;
 using System.Text.Encodings.Web;
+using System.Net;
 
 namespace DotVVM.Framework.ViewModel.Serialization
 {
     public class DefaultViewModelSerializer : IViewModelSerializer
     {
-        private const string GeneralViewModelRecommendations = "Check out general viewModel recommendation at http://www.dotvvm.com/docs/tutorials/basics-viewmodels.";
+        private const string GeneralViewModelRecommendations = "Check out general viewModel recommendation at https://www.dotvvm.com/docs/tutorials/basics-viewmodels.";
+        private const string GeneralViewModelRecommendationsHtml = "Check out general viewModel recommendation at <a href='https://www.dotvvm.com/docs/tutorials/basics-viewmodels'>dotvvm.com/docs/tutorials/basics-viewmodels</a>.";
 
-        public record SerializationException(bool Serialize, Type? ViewModelType, string JsonPath, Exception InnerException): RecordException(InnerException)
+        public record SerializationException(bool Serialize, Type? ViewModelType, string JsonPath, Exception InnerException) : RecordException(InnerException), IDebugHtmlFormattableObject
         {
-            public override string Message => $"Could not {(Serialize ? "" : "de")}serialize viewModel of type { ViewModelType?.Name ?? null }. Serialization failed at property { JsonPath }. {GeneralViewModelRecommendations}";
+            public override string Message => $"Could not {(Serialize ? "" : "de")}serialize viewModel of type {ViewModelType?.Name ?? null}. Serialization failed at property {JsonPath}. {GeneralViewModelRecommendations}";
+
+            public string DebugHtmlString(IFormatProvider? formatProvider, bool isBlock) =>
+                $"Could not {(Serialize ? "" : "de")}serialize viewModel of type {ViewModelType.DebugHtmlString(false, true)}. Serialization failed at property <b class=syntax-prop>{WebUtility.HtmlEncode(JsonPath)}</b>. {GeneralViewModelRecommendationsHtml}";
         }
 
         private CommandResolver commandResolver = new CommandResolver();

--- a/src/Framework/Hosting.AspNetCore/Hosting/DotvvmHttpContext.cs
+++ b/src/Framework/Hosting.AspNetCore/Hosting/DotvvmHttpContext.cs
@@ -4,6 +4,7 @@ using System.Security.Claims;
 using DotVVM.Framework.Hosting;
 using Microsoft.AspNetCore.Http;
 using System.Linq;
+using FastExpressionCompiler;
 
 namespace DotVVM.Framework.Hosting
 {
@@ -31,10 +32,10 @@ namespace DotVVM.Framework.Hosting
         public IEnumerable<Tuple<string, IEnumerable<KeyValuePair<string, object>>>> GetEnvironmentTabs()
         {
             yield return Tuple.Create("Features", OriginalContext.Features
-                .Select(k => new KeyValuePair<string, object>(k.Key.ToString(), k.Value)));
+                .Select(k => new KeyValuePair<string, object>(k.Key.ToCode(), k.Value.ToString())));
 
             yield return Tuple.Create("Items", OriginalContext.Items
-                .Select(k => new KeyValuePair<string, object>(k.Key.ToString(), k.Value)));
+                .Select(k => new KeyValuePair<string, object>(k.Key.ToString(), k.Value.ToString())));
         }
     }
 }

--- a/src/Samples/Tests/Tests/Control/ButtonTests.cs
+++ b/src/Samples/Tests/Tests/Control/ButtonTests.cs
@@ -43,9 +43,9 @@ namespace DotVVM.Samples.Tests.Control
             {
                 browser.NavigateToUrl(SamplesRouteUrls.ControlSamples_Button_InputTypeButton_HtmlContentInside);
 
+                AssertUI.Attribute(browser.First(".exceptionType"), "title", a => a == "DotVVM.Framework.Controls.DotvvmControlException");
                 AssertUI.InnerText(browser.First(".summary"),
                       t =>
-                          t.Trim().Contains("DotVVM.Framework.Controls.DotvvmControlException") &&
                           t.Trim().Contains("The <dot:Button> control cannot have inner HTML connect unless the 'ButtonTagName' property is set to 'button'!")
                       , "");
             });

--- a/src/Samples/Tests/Tests/Control/ComboBoxTests.cs
+++ b/src/Samples/Tests/Tests/Control/ComboBoxTests.cs
@@ -163,7 +163,7 @@ namespace DotVVM.Samples.Tests.Control
                 browser.NavigateToUrl(SamplesRouteUrls.ControlSamples_ComboBox_ItemBinding_ItemValueBinding_Complex_Error);
 
                 AssertUI.InnerText(browser.First(".exceptionMessage"), s => s.Contains("Return type") && s.Contains("ItemValueBinding") && s.Contains("primitive type"));
-                AssertUI.InnerText(browser.First(".summary"), s => s.Contains("DotVVM.Framework.Compilation.DotvvmCompilationException"));
+                AssertUI.Attribute(browser.First(".exceptionType"), "title", s => s == "DotVVM.Framework.Compilation.DotvvmCompilationException");
                 AssertUI.InnerText(browser.First(".errorUnderline"), s => s.Contains("ItemValueBinding=") && s.Contains("{value:"));
             });
         }
@@ -220,7 +220,7 @@ namespace DotVVM.Samples.Tests.Control
                 browser.NavigateToUrl(SamplesRouteUrls.ControlSamples_ComboBox_ItemBinding_ItemValueBinding_SelectedValue_ComplexToInt_Error);
 
                 AssertUI.InnerText(browser.First(".exceptionMessage"), s => s.Contains("DotVVM.Samples.Common.ViewModels.ControlSamples.ComboBox.ComboxItemBindingViewModel.ComplexType") && s.Contains("not assignable") && s.Contains("int"));
-                AssertUI.InnerText(browser.First(".summary"), s => s.Contains("DotVVM.Framework.Compilation.DotvvmCompilationException"));
+                AssertUI.Attribute(browser.First(".exceptionType"), "title", s => s == "DotVVM.Framework.Compilation.DotvvmCompilationException");
                 AssertUI.InnerText(browser.First(".errorUnderline"), s => s.Contains("{value: SelectedInt}"));
             });
         }
@@ -233,7 +233,7 @@ namespace DotVVM.Samples.Tests.Control
                 browser.NavigateToUrl(SamplesRouteUrls.ControlSamples_ComboBox_ItemBinding_ItemValueBinding_SelectedValue_StringToInt_Error);
 
                 AssertUI.InnerText(browser.First(".exceptionMessage"), s => s.Contains("string") && s.Contains("not assignable") && s.Contains("int"));
-                AssertUI.InnerText(browser.First(".summary"), s => s.Contains("DotVVM.Framework.Compilation.DotvvmCompilationException"));
+                AssertUI.Attribute(browser.First(".exceptionType"), "title", s => s == "DotVVM.Framework.Compilation.DotvvmCompilationException");
                 AssertUI.InnerText(browser.First(".errorUnderline"), s => s.Contains("{value: SelectedInt}"));
             });
         }

--- a/src/Samples/Tests/Tests/ErrorsTests.cs
+++ b/src/Samples/Tests/Tests/ErrorsTests.cs
@@ -21,13 +21,12 @@ namespace DotVVM.Samples.Tests
         {
             RunInAllBrowsers(browser => {
                 browser.NavigateToUrl(SamplesRouteUrls.Errors_MissingViewModel);
-                AssertUI.InnerText(browser.First(".summary")
-                      ,
+                AssertUI.InnerText(browser.First(".summary"),
                           s =>
-                              s.Contains("DotVVM.Framework.Compilation.DotvvmCompilationException") &&
                               s.Contains("@viewModel") &&
                               s.Contains("missing")
                           );
+                AssertUI.Attribute(browser.First("exceptionType", By.ClassName), "title", a => a == "DotVVM.Framework.Compilation.DotvvmCompilationException");
             });
         }
 
@@ -39,9 +38,9 @@ namespace DotVVM.Samples.Tests
                 AssertUI.InnerText(browser.First(".summary")
                     ,
                         s =>
-                            s.Contains("DotVVM.Framework.Compilation.DotvvmCompilationException", StringComparison.OrdinalIgnoreCase) &&
                             s.Contains("Could not resolve type 'invalid_viewmodel_class'", StringComparison.OrdinalIgnoreCase)
                             );
+                AssertUI.Attribute(browser.First("exceptionType", By.ClassName), "title", a => a == "DotVVM.Framework.Compilation.DotvvmCompilationException");
             });
         }
 
@@ -242,9 +241,10 @@ namespace DotVVM.Samples.Tests
                 AssertUI.InnerText(browser.First(".summary")
                     ,
                         s =>
-                            s.Contains("DotVVM.Framework.Compilation.DotvvmCompilationException") &&
                             s.Contains("requires a DataContext of type")
                         );
+                AssertUI.Attribute(browser.First("exceptionType", By.ClassName), "title", a => a == "DotVVM.Framework.Compilation.DotvvmCompilationException");
+                AssertUI.InnerTextEquals(browser.First(".exceptionType"), "DotvvmCompilationException");
             });
         }
 
@@ -388,7 +388,7 @@ namespace DotVVM.Samples.Tests
                 browser.NavigateToUrl(SamplesRouteUrls.Errors_InvalidServiceDirective);
 
                 AssertUI.TextEquals(browser.First("exceptionType", By.ClassName),
-                    "DotVVM.Framework.Compilation.DotvvmCompilationException");
+                    "DotvvmCompilationException");
                 AssertUI.TextEquals(browser.First("exceptionMessage", By.ClassName),
                     "Could not resolve type 'DotVVM.InvalidNamespace.NonExistingService'.");
             });
@@ -400,7 +400,7 @@ namespace DotVVM.Samples.Tests
             RunInAllBrowsers(browser => {
                 browser.NavigateToUrl(SamplesRouteUrls.Errors_InvalidLocationFallback);
 
-                AssertUI.TextEquals(browser.First(".exceptionType"), "System.NotSupportedException");
+                AssertUI.TextEquals(browser.First(".exceptionType"), "NotSupportedException");
                 AssertUI.TextEquals(browser.First(".exceptionMessage"), "LocationFallback is " +
                     "not supported on resources with Location of type ILocalResourceLocation.");
             });
@@ -413,7 +413,7 @@ namespace DotVVM.Samples.Tests
                 browser.NavigateToUrl(SamplesRouteUrls.Errors_ResourceCircularDependency);
 
                 AssertUI.TextEquals(browser.First("exceptionType", By.ClassName),
-                    "DotVVM.Framework.ResourceManagement.DotvvmCyclicResourceDependencyException");
+                    "DotvvmCyclicResourceDependencyException");
                 AssertUI.TextEquals(browser.First("exceptionMessage", By.ClassName),
                     "Resource \"Errors_ResourceCircularDependency\" has a cyclic dependency: Errors_ResourceCircularDependency --> Errors_ResourceCircularDependency");
             });
@@ -428,9 +428,9 @@ namespace DotVVM.Samples.Tests
                 AssertUI.InnerText(browser.First(".summary")
                     ,
                     s =>
-                        s.Contains("DotVVM.Framework.Compilation.DotvvmCompilationException", StringComparison.OrdinalIgnoreCase) &&
                         s.Contains("The WrapperTagName property cannot be set when RenderWrapperTag is false!", StringComparison.OrdinalIgnoreCase)
                 );
+                AssertUI.Attribute(browser.First("exceptionType", By.ClassName), "title", a => a == "DotVVM.Framework.Compilation.DotvvmCompilationException");
             });
         }
 
@@ -440,10 +440,10 @@ namespace DotVVM.Samples.Tests
             RunInAllBrowsers(browser => {
                 browser.NavigateToUrl(SamplesRouteUrls.Errors_UndefinedRouteLinkParameters);
 
-                AssertUI.TextEquals(browser.First("exceptionType", By.ClassName), "DotVVM.Framework.Compilation.DotvvmCompilationException");
                 AssertUI.InnerText(browser.First(".exceptionMessage"),
                     s => s.Contains("The following parameters are not present in route", StringComparison.OrdinalIgnoreCase),
                     "Exception should contain information about the route name and undefined parameters");
+                AssertUI.TextEquals(browser.First("exceptionType", By.ClassName), "DotvvmCompilationException");
             });
         }
 
@@ -453,7 +453,7 @@ namespace DotVVM.Samples.Tests
             RunInAllBrowsers(browser => {
                 browser.NavigateToUrl(SamplesRouteUrls.Errors_InvalidRouteName);
 
-                AssertUI.TextEquals(browser.First("exceptionType", By.ClassName), "DotVVM.Framework.Compilation.DotvvmCompilationException");
+                AssertUI.TextEquals(browser.First("exceptionType", By.ClassName), "DotvvmCompilationException");
                 AssertUI.TextEquals(browser.First(".exceptionMessage"), "RouteLink validation at line 18: RouteName \"NonExistingRouteName\" does not exist.",
                    failureMessage: "Exception should contain information about the undefined route name");
             });

--- a/src/Samples/Tests/Tests/Feature/HotReloadTests.cs
+++ b/src/Samples/Tests/Tests/Feature/HotReloadTests.cs
@@ -56,7 +56,7 @@ namespace DotVVM.Samples.Tests.Feature
                     a.writeContents(updated);
 
                     browser.Wait(1000);
-                    AssertUI.TextEquals(browser.First("h1"), "Server Error, HTTP 500: Unhandled exception occurred");
+                    AssertUI.TextEquals(browser.First("h1"), "Server Error: ViewChanges.dothtml compilation failed.");
 
                     updated = a.original.Replace("<dot:TextBox Text='{value: NonExistentValue}' />", "<dot:TextBox Text='{value: Value}' />");
                     a.writeContents(updated);

--- a/src/Samples/Tests/Tests/Feature/ViewModelProtectionTests.cs
+++ b/src/Samples/Tests/Tests/Feature/ViewModelProtectionTests.cs
@@ -41,7 +41,7 @@ namespace DotVVM.Samples.Tests.Feature
             RunInAllBrowsers(browser => {
                 browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_ViewModelProtection_SignedNestedInServerToClient);
 
-                AssertUI.InnerTextEquals(browser.First("h1"), "Server Error, HTTP 500: Unhandled exception occurred");
+                AssertUI.InnerTextEquals(browser.First("h1"), "Server Error: DotvvmControlException was not handled.");
             });
         }
 


### PR DESCRIPTION
* Any exception can implement the interface, the returned string will be used instead of its message
* Some other object such as binding properties also may implement the interface. The return value is used instead of ToString

While adjusting the error page I also made slight changes it appearance:

<img width="1249" height="1014" alt="image" src="https://github.com/user-attachments/assets/cbcb5cae-1b20-49c4-94a3-38ac976013f5" />

This is how the Binding tab looks like after changes:

<img width="1244" height="629" alt="image" src="https://github.com/user-attachments/assets/ede743dc-d2e8-492d-ac59-4cf032ee1aa4" />
