### PR TITLE
Change dotvvm resource URL to /_dotvvm/resource-{name}/{name}

### DIFF
--- a/src/Framework/Framework/Configuration/DotvvmRuntimeConfiguration.cs
+++ b/src/Framework/Framework/Configuration/DotvvmRuntimeConfiguration.cs
@@ -34,6 +34,23 @@ namespace DotVVM.Framework.Configuration
         [JsonPropertyName("maxPostbackSizeBytes")]
         public long MaxPostbackSizeBytes { get; set; } = 1024 * 1024 * 128; // 128 MB
 
+        /// <summary> Whether DotVVM resources requests must have the correct version hash to be served, or any hash will be accepted by the server and possibly an unexpected resource version will be returned. </summary>
+        /// <remarks>
+        /// Enabling this option may improve security, as users should only be able to download scripts, which are used on pages which they can access.
+        /// Unauthorized attacker will therefore only have access to the resources used on the login page.
+        /// However, if application is updated while a user is loading a page, it may fail to load resources which have changed in the meantime.
+        /// </remarks>
+        [JsonPropertyName("requireResourceVersionHash")]
+        public DotvvmGlobal3StateFeatureFlag RequireResourceVersionHash { get; } = new("RequireResourceVersionHash") { Enabled = null };
+
+        /// <summary> Allows loading of *.map files from the same directory as the resource itself (for FileResourceLocation, or EmbeddedResourceLocation with DebugFilePath set). By default, this is enabled in debug mode. </summary>
+        [JsonPropertyName("allowResourceMapFiles")]
+        public DotvvmGlobal3StateFeatureFlag AllowResourceMapFiles { get; } = new("AllowResourceMapFiles") { Enabled = null };
+
+        /// <summary> Whether DotVVM should add version hash to the resource URL and use immutable caching. Since v5.0, this is enabled by default in all configurations, the v4 behavior can be reverted by setting <c>AllowResourceVersionHash.Enable = null</c>. </summary>
+        [JsonPropertyName("allowResourceVersionHash")]
+        public DotvvmGlobal3StateFeatureFlag AllowResourceVersionHash { get; } = new("AllowResourceVersionHash") { Enabled = null };
+
         /// <summary>
         /// When enabled, the DotVVM runtime only automatically load assemblies listed in <see cref="DotvvmMarkupConfiguration.Assemblies"/>. This may prevent failures during startup and reduce startup time.
         /// See <see href="https://www.dotvvm.com/docs/4.0/pages/concepts/configuration/explicit-assembly-loading"> documentation page </see> for more information

--- a/src/Framework/Framework/ResourceManagement/ClientGlobalize/JQueryGlobalizeResourceLocation.cs
+++ b/src/Framework/Framework/ResourceManagement/ClientGlobalize/JQueryGlobalizeResourceLocation.cs
@@ -5,20 +5,21 @@ using System.Linq;
 using System.Threading.Tasks;
 using DotVVM.Framework.Hosting;
 using System.Globalization;
+using DotVVM.Framework.Utils;
 
 namespace DotVVM.Framework.ResourceManagement.ClientGlobalize
 {
     public class JQueryGlobalizeResourceLocation : LocalResourceLocation
     {
-        private readonly Lazy<string> resultJavascript;
+        private readonly Lazy<byte[]> resultJavascript;
         public JQueryGlobalizeResourceLocation(CultureInfo cultureInfo)
         {
-            this.resultJavascript = new Lazy<string>(() => JQueryGlobalizeScriptCreator.BuildCultureInfoScript(cultureInfo));
+            this.resultJavascript = new Lazy<byte[]>(() => StringUtils.Utf8.GetBytes(JQueryGlobalizeScriptCreator.BuildCultureInfoScript(cultureInfo)));
         }
 
         public override Stream LoadResource(IDotvvmRequestContext context)
         {
-            return new MemoryStream(System.Text.Encoding.UTF8.GetBytes(resultJavascript.Value));
+            return new MemoryStream(resultJavascript.Value, writable: false);
         }
     }
 }

--- a/src/Framework/Framework/ResourceManagement/DefaultResourceHashService.cs
+++ b/src/Framework/Framework/ResourceManagement/DefaultResourceHashService.cs
@@ -11,7 +11,7 @@ namespace DotVVM.Framework.ResourceManagement
 {
     public class DefaultResourceHashService : IResourceHashService
     {
-        private ConditionalWeakTable<ILocalResourceLocation, byte[]> hashCache = new ConditionalWeakTable<ILocalResourceLocation, byte[]>();
+        private ConditionalWeakTable<ILocalResourceLocation, byte[]> hashCache = new();
 
         private Func<HashAlgorithm> hashFactory = SHA256.Create;
         private string hashFunctionName = "sha256";
@@ -20,7 +20,7 @@ namespace DotVVM.Framework.ResourceManagement
         {
             this.hashFactory = factory;
             this.hashFunctionName = functionName;
-            hashCache = new ConditionalWeakTable<ILocalResourceLocation, byte[]>();
+            hashCache = new();
         }
 
         protected virtual byte[] ComputeHash(Stream stream)

--- a/src/Framework/Framework/ResourceManagement/ILinkResource.cs
+++ b/src/Framework/Framework/ResourceManagement/ILinkResource.cs
@@ -11,7 +11,7 @@ namespace DotVVM.Framework.ResourceManagement
     /// </summary>
     public interface ILinkResource : IResource
     {
-        IEnumerable<IResourceLocation> GetLocations(string? type = null);
+        IEnumerable<IResourceLocation> GetLocations();
         string MimeType { get; }
     }
 }

--- a/src/Framework/Framework/ResourceManagement/LinkResourceBase.cs
+++ b/src/Framework/Framework/ResourceManagement/LinkResourceBase.cs
@@ -44,10 +44,8 @@ namespace DotVVM.Framework.ResourceManagement
             this.Location = null!; // TODO: deprecate this overload
         }
 
-        public virtual IEnumerable<IResourceLocation> GetLocations(string? type = null)
+        public virtual IEnumerable<IResourceLocation> GetLocations()
         {
-            if (type is object) yield break;
-
             yield return Location;
             if (LocationFallback != null)
             {

--- a/src/Framework/Framework/ResourceManagement/LocalResourceUrlManager.cs
+++ b/src/Framework/Framework/ResourceManagement/LocalResourceUrlManager.cs
@@ -3,49 +3,57 @@ using DotVVM.Framework.Hosting;
 using DotVVM.Framework.Hosting.Middlewares;
 using DotVVM.Framework.Routing;
 using DotVVM.Framework.Utils;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace DotVVM.Framework.ResourceManagement
 {
     public class LocalResourceUrlManager : ILocalResourceUrlManager
     {
-        private const string HashParameterName = "hash";
-        private const string NameParameterName = "name";
-
+        private readonly ILogger logger;
         private readonly IResourceHashService hasher;
         private readonly RouteBase resourceRoute;
         private readonly DotvvmResourceRepository resources;
-        private readonly ConcurrentDictionary<string, string?>? alternateDirectories;
-        private readonly bool suppressVersionHash;
+        private readonly bool allowDebugFileResources;
+        private readonly bool requireResourceVersionHash;
+        private readonly bool allowResourceVersionHash;
 
-        public LocalResourceUrlManager(DotvvmConfiguration configuration, IResourceHashService hasher)
+        public LocalResourceUrlManager(DotvvmConfiguration configuration, IResourceHashService hasher, ILogger<LocalResourceUrlManager> logger)
         {
             this.resourceRoute = new DotvvmRoute(
-                url: $"{HostingConstants.ResourceRouteName}/{{{HashParameterName}}}/{{{NameParameterName}:regex(.*)}}",
+                url: HostingConstants.ResourceRouteName + "-{name}/{fileName}",
                 virtualPath: "",
                 name: $"_dotvvm_{nameof(LocalResourceUrlManager)}",
                 defaultValues: null,
                 presenterFactory: _ => throw new NotSupportedException(),
                 configuration: configuration);
             this.hasher = hasher;
+            this.logger = logger;
             this.resources = configuration.Resources;
-            this.alternateDirectories = configuration.Debug ? new ConcurrentDictionary<string, string?>() : null;
-            this.suppressVersionHash = configuration.Debug;
+            this.allowDebugFileResources = configuration.Runtime.AllowResourceMapFiles.Enabled ?? configuration.Debug;
+            this.requireResourceVersionHash = configuration.Runtime.RequireResourceVersionHash.Enabled ?? !configuration.Debug;
+            this.allowResourceVersionHash = configuration.Runtime.AllowResourceVersionHash.Enabled ?? !configuration.Debug;
         }
 
         public string GetResourceUrl(ILocalResourceLocation resource,
             IDotvvmRequestContext context,
             string name)
         {
-            return resourceRoute.BuildUrl(new Dictionary<string, object?> {
-                [HashParameterName] = GetVersionHash(resource, context, name),
-                [NameParameterName] = EncodeResourceName(name)
-            });
+            var encodedName = EncodeResourceName(name);
+
+            if (allowResourceVersionHash)
+            {
+                var versionHash = GetVersionHash(resource, context, name);
+                return context.TranslateVirtualPath($"~/{HostingConstants.ResourceRouteName}-{encodedName}/{encodedName}?v={versionHash}");
+            }
+            else
+            {
+                return context.TranslateVirtualPath($"~/{HostingConstants.ResourceRouteName}-{encodedName}/{encodedName}");
+            }
         }
 
         protected virtual string EncodeResourceName(string name)
@@ -59,38 +67,42 @@ namespace DotVVM.Framework.ResourceManagement
         }
 
         protected virtual string GetVersionHash(ILocalResourceLocation location, IDotvvmRequestContext context, string name) =>
-            suppressVersionHash ? // don't generate the hash iff !Debug, as it clears breakpoints in debugger when url changes
-            EncodeResourceName(name) :
             hasher.GetVersionHash(location, context);
 
         public ILocalResourceLocation? FindResource(string url, IDotvvmRequestContext context, out string? mimeType)
         {
             mimeType = null;
 
-            var routeMatchUrl = DotvvmRoutingMiddleware.GetRouteMatchUrl(context);
-            if (DotvvmRoutingMiddleware.FindExactMatchRoute(new[] { resourceRoute }, routeMatchUrl, out var parameters) == null)
+            if (DotvvmRoutingMiddleware.FindExactMatchRoute([ resourceRoute ], url, out var parameters) == null)
             {
                 return null;
             }
 
-            var name = DecodeResourceName((string)parameters![NameParameterName]!);
-            var hash = (string)parameters[HashParameterName].NotNull();
+            var requestedName = (string)parameters!["name"]!;
+            var name = DecodeResourceName(requestedName);
+            var fileName = (string)parameters["fileName"]!;
+            var hash = (string?)context.Query["v"];
             var type = context.Query.TryGetValue("type", out var x) ? x : null;
             if (resources.FindResource(name) is IResource resource &&
                 FindLocation(resource, type, out mimeType) is ILocalResourceLocation location)
             {
-                if (GetVersionHash(location, context, name) == hash) // check if the resource matches so that nobody can guess the url by chance
+                if (fileName == requestedName)
                 {
-                    if (alternateDirectories != null)
-                    {
-                        alternateDirectories.GetOrAdd(hash, _ => (location as IDebugFileLocalLocation)?.GetFilePath(context));
+                    if (requireResourceVersionHash && GetVersionHash(location, context, name) != hash)
+                    {   // check if the resource matches so that nobody can guess the url by chance
+                        logger.LogInformation("Requested resource {name} with hash '{hash}' does not match the expected hash '{expectedHash}' and the request was rejected.", name, hash, GetVersionHash(location, context, name));
+                        return null;
                     }
 
                     return location;
                 }
+                if (allowDebugFileResources)
+                    return TryLoadAlternativeFile(name, fileName, resource, context);
             }
 
-            return TryLoadAlternativeFile(name, hash, context);
+            logger.LogInformation("Requested resource '{name}' not found.", name);
+            return null;
+
         }
 
         private static bool IsAllowedFileName(string name)
@@ -105,21 +117,28 @@ namespace DotVVM.Framework.ResourceManagement
             return name.EndsWith(".map", StringComparison.OrdinalIgnoreCase);
         }
 
-        private ILocalResourceLocation? TryLoadAlternativeFile(string name, string hash, IDotvvmRequestContext context)
+        private ILocalResourceLocation? TryLoadAlternativeFile(string name, string fileName, IResource resource, IDotvvmRequestContext context)
         {
-            if (!IsAllowedFileName(name))
-                return null;
-
-            if (alternateDirectories != null && alternateDirectories.TryGetValue(hash, out var filePath) && filePath != null)
+            if (!IsAllowedFileName(fileName))
             {
-                var directory = Path.GetDirectoryName(Path.Combine(context.Configuration.ApplicationPhysicalPath, filePath));
-                if (directory != null)
+                logger.LogWarning("Requested additional file '{fileName}' for resource {resourceName} is not allowed.", fileName, name);
+                return null;
+            }
+
+            // Load something.map.js or anything from the same directory
+            var resourceDirectories =
+                (resource as ILinkResource)?.GetLocations()
+                    .OfType<IDebugFileLocalLocation>()
+                    .Select(x => x.GetFilePath(context)).WhereNotNull()
+                    .Select(filePath => Path.GetDirectoryName(Path.Combine(context.Configuration.ApplicationPhysicalPath, filePath))).WhereNotNull()
+                    .Distinct();
+
+            foreach (var directory in resourceDirectories ?? [])
+            {
+                var sourceFile = Path.Combine(directory, fileName);
+                if (File.Exists(sourceFile))
                 {
-                    var sourceFile = Path.Combine(directory, name);
-                    if (File.Exists(sourceFile))
-                    {
-                        return new FileResourceLocation(sourceFile);
-                    }
+                    return new FileResourceLocation(sourceFile);
                 }
             }
             return null;

--- a/src/Framework/Framework/ResourceManagement/LocalResourceUrlManager.cs
+++ b/src/Framework/Framework/ResourceManagement/LocalResourceUrlManager.cs
@@ -82,9 +82,8 @@ namespace DotVVM.Framework.ResourceManagement
             var name = DecodeResourceName(requestedName);
             var fileName = (string)parameters["fileName"]!;
             var hash = (string?)context.Query["v"];
-            var type = context.Query.TryGetValue("type", out var x) ? x : null;
             if (resources.FindResource(name) is IResource resource &&
-                FindLocation(resource, type, out mimeType) is ILocalResourceLocation location)
+                FindLocation(resource, out mimeType) is ILocalResourceLocation location)
             {
                 if (fileName == requestedName)
                 {
@@ -144,7 +143,7 @@ namespace DotVVM.Framework.ResourceManagement
             return null;
         }
 
-        protected ILocalResourceLocation? FindLocation(IResource resource, string? type, out string? mimeType)
+        protected ILocalResourceLocation? FindLocation(IResource resource, out string? mimeType)
         {
             if (!(resource is ILinkResource link))
             {
@@ -154,7 +153,7 @@ namespace DotVVM.Framework.ResourceManagement
 
             mimeType = link.MimeType;
             return link
-                .GetLocations(type)
+                .GetLocations()
                 .OfType<ILocalResourceLocation>()
                 .FirstOrDefault();
         }

--- a/src/Framework/Testing/ControlTestHelper.cs
+++ b/src/Framework/Testing/ControlTestHelper.cs
@@ -48,6 +48,7 @@ namespace DotVVM.Framework.Testing
             this.Configuration.Markup.AddCodeControls("tc", exampleControl: typeof(FakeHeadResourceLink));
             this.Configuration.ApplicationPhysicalPath = Path.GetTempPath();
             this.Configuration.Debug = debug;
+            this.Configuration.Runtime.AllowResourceVersionHash.Disable(); // reduce noise in tests
             config?.Invoke(this.Configuration);
             presenter = (DotvvmPresenter)this.Configuration.ServiceProvider.GetRequiredService<IDotvvmPresenter>();
         }

--- a/src/Framework/Testing/DotvvmTestHelper.cs
+++ b/src/Framework/Testing/DotvvmTestHelper.cs
@@ -110,6 +110,7 @@ namespace DotVVM.Framework.Testing
             config.RouteTable.Add("TestRoute", "TestRoute", "TestView.dothtml");
             config.Debug = true;
             config.Diagnostics.Apply(config);
+            config.Runtime.AllowResourceVersionHash.Disable(); // reduce noise in tests
             config.Freeze();
             return config;
         });

--- a/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.AddResourceWithMasterPage.html
+++ b/src/Tests/ControlTests/testoutputs/ServerSideStyleTests.AddResourceWithMasterPage.html
@@ -5,13 +5,13 @@
     
     
     <!-- Resource knockout of type ScriptResource. Pointing to EmbeddedResourceLocation. -->
-    <script src=/_dotvvm/resource/knockout/knockout defer></script>
+    <script src=/_dotvvm/resource-knockout/knockout defer></script>
     <!-- Resource dotvvm.internal of type ScriptModuleResource. Pointing to EmbeddedResourceLocation. -->
-    <script src="/_dotvvm/resource/dotvvm--internal/dotvvm--internal" type=module></script>
+    <script src="/_dotvvm/resource-dotvvm--internal/dotvvm--internal" type=module></script>
     <!-- Resource dotvvm of type InlineScriptResource. -->
     
     <!-- Resource dotvvm.debug of type ScriptResource. Pointing to EmbeddedResourceLocation. -->
-    <script src=/_dotvvm/resource/dotvvm--debug/dotvvm--debug defer></script>
+    <script src=/_dotvvm/resource-dotvvm--debug/dotvvm--debug defer></script>
 </head>
     <body>
         

--- a/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModule.html
+++ b/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModule.html
@@ -2,17 +2,17 @@
 	<head>
 		
 		<!-- Resource knockout of type ScriptResource. Pointing to EmbeddedResourceLocation. -->
-		<script defer="" src="/_dotvvm/resource/knockout/knockout"></script>
+		<script defer="" src="/_dotvvm/resource-knockout/knockout"></script>
 		
 		<!-- Resource dotvvm.internal of type ScriptModuleResource. Pointing to EmbeddedResourceLocation. -->
-		<script src="/_dotvvm/resource/dotvvm--internal/dotvvm--internal" type="module"></script>
+		<script src="/_dotvvm/resource-dotvvm--internal/dotvvm--internal" type="module"></script>
 		
 		<!-- Resource dotvvm of type InlineScriptResource. -->          
 		<!-- Resource dotvvm.debug of type ScriptResource. Pointing to EmbeddedResourceLocation. -->
-		<script defer="" src="/_dotvvm/resource/dotvvm--debug/dotvvm--debug"></script>
+		<script defer="" src="/_dotvvm/resource-dotvvm--debug/dotvvm--debug"></script>
 		
 		<!-- Resource viewModule.import.6DLlOTYMqGV5yPAJoz5k_moKDBgEmZ3_HLLQ2zKDo74 of type ViewModuleImportResource. -->
-		<script type="module">import * as m0 from "/_dotvvm/resource/myModule/myModule";dotvvm.viewModules.registerMany({"myModule": m0});</script>
+		<script type="module">import * as m0 from "/_dotvvm/resource-myModule/myModule";dotvvm.viewModules.registerMany({"myModule": m0});</script>
 		
 		<!-- Resource viewModule.init.6DLlOTYMqGV5yPAJoz5k_moKDBgEmZ3_HLLQ2zKDo74 of type ViewModuleInitResource. -->
 		<script type="module">dotvvm.events.init.subscribeOnce(() => {

--- a/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModuleInControl.html
+++ b/src/Tests/ControlTests/testoutputs/ViewModulesServerSideTests.IncludeViewModuleInControl.html
@@ -2,20 +2,20 @@
 	<head>
 		
 		<!-- Resource knockout of type ScriptResource. Pointing to EmbeddedResourceLocation. -->
-		<script defer="" src="/_dotvvm/resource/knockout/knockout"></script>
+		<script defer="" src="/_dotvvm/resource-knockout/knockout"></script>
 		
 		<!-- Resource dotvvm.internal of type ScriptModuleResource. Pointing to EmbeddedResourceLocation. -->
-		<script src="/_dotvvm/resource/dotvvm--internal/dotvvm--internal" type="module"></script>
+		<script src="/_dotvvm/resource-dotvvm--internal/dotvvm--internal" type="module"></script>
 		
 		<!-- Resource dotvvm of type InlineScriptResource. -->          
 		<!-- Resource viewModule.import.lIquTPFe3a42GboPePTmYZ4Xc1S4ok-JXmZud9HUybE of type ViewModuleImportResource. -->
-		<script type="module">import * as m0 from "/_dotvvm/resource/controlModule/controlModule";dotvvm.viewModules.registerMany({"controlModule": m0});</script>
+		<script type="module">import * as m0 from "/_dotvvm/resource-controlModule/controlModule";dotvvm.viewModules.registerMany({"controlModule": m0});</script>
 		
 		<!-- Resource dotvvm.debug of type ScriptResource. Pointing to EmbeddedResourceLocation. -->
-		<script defer="" src="/_dotvvm/resource/dotvvm--debug/dotvvm--debug"></script>
+		<script defer="" src="/_dotvvm/resource-dotvvm--debug/dotvvm--debug"></script>
 		
 		<!-- Resource viewModule.import.HIj399FcjVwbyaIvDKFctn7Ghr0UMajY-haUgZypcHs of type ViewModuleImportResource. -->
-		<script type="module">import * as m0 from "/_dotvvm/resource/viewModule/viewModule";dotvvm.viewModules.registerMany({"viewModule": m0});</script>
+		<script type="module">import * as m0 from "/_dotvvm/resource-viewModule/viewModule";dotvvm.viewModules.registerMany({"viewModule": m0});</script>
 		
 		<!-- Resource viewModule.init.HIj399FcjVwbyaIvDKFctn7Ghr0UMajY-haUgZypcHs of type ViewModuleInitResource. -->
 		<script type="module">dotvvm.events.init.subscribeOnce(() => {

--- a/src/Tracing/ApplicationInsights/RequestTelemetryFilter.cs
+++ b/src/Tracing/ApplicationInsights/RequestTelemetryFilter.cs
@@ -27,7 +27,7 @@ namespace DotVVM.Tracing.ApplicationInsights
             {
                 return true;
             }
-            if (request.Url.AbsolutePath.StartsWith("/_dotvvm/resource") || request.ResponseCode.Equals("404"))
+            if (request.Url.AbsolutePath.StartsWith("/_dotvvm/resource-") || request.ResponseCode.Equals("404"))
             {
                 return false;
             }


### PR DESCRIPTION
* this is more backward compatible with v4, as relative references like `../../something`  will keep working
* version hash is moved to query string, which is more conventional (and does not cause compatibility issues for a long time already)