### PR TITLE
EmbeddedResourceLocation: add source maps

### DIFF
--- a/src/Framework/Framework/Configuration/DotvvmConfiguration.cs
+++ b/src/Framework/Framework/Configuration/DotvvmConfiguration.cs
@@ -353,15 +353,17 @@ namespace DotVVM.Framework.Configuration
                 new EmbeddedResourceLocation(
                     typeof(DotvvmConfiguration).Assembly,
                     "DotVVM.Framework.obj.javascript.root_only.dotvvm-root.js",
-                    debugName: "DotVVM.Framework.obj.javascript.root_only_debug.dotvvm-root.js"),
-                dependencies: new[] { ResourceConstants.KnockoutJSResourceName },
+                    debugName: "DotVVM.Framework.obj.javascript.root_only_debug.dotvvm-root.js",
+                    sourceMaps: [ ("dotvvm-root.js.map", "DotVVM.Framework.obj.javascript.root_only_debug.dotvvm-root.js.map") ]),
+                dependencies: [ ResourceConstants.KnockoutJSResourceName],
                 module: true);
             configuration.Resources.RegisterScript(ResourceConstants.DotvvmResourceName + ".internal-spa",
                 new EmbeddedResourceLocation(
                     typeof(DotvvmConfiguration).Assembly,
                     "DotVVM.Framework.obj.javascript.root_spa.dotvvm-root.js",
-                    debugName: "DotVVM.Framework.obj.javascript.root_spa_debug.dotvvm-root.js"),
-                dependencies: new[] { ResourceConstants.KnockoutJSResourceName },
+                    debugName: "DotVVM.Framework.obj.javascript.root_spa_debug.dotvvm-root.js",
+                    sourceMaps: [ ("dotvvm-root.js.map", "DotVVM.Framework.obj.javascript.root_spa_debug.dotvvm-root.js.map") ]),
+                dependencies: [ ResourceConstants.KnockoutJSResourceName ],
                 module: true);
             configuration.Resources.Register(ResourceConstants.DotvvmResourceName,
                 new InlineScriptResource(@"", ResourceRenderPosition.Anywhere, defer: true) {

--- a/src/Framework/Framework/DotVVM.Framework.csproj
+++ b/src/Framework/Framework/DotVVM.Framework.csproj
@@ -26,8 +26,10 @@
     <EmbeddedResource Include="Resources\Scripts\DotVVM.ErrorPage.js" />
     <EmbeddedResource Include="obj/javascript/root-only/dotvvm-root.js" />
     <EmbeddedResource Include="obj/javascript/root-only-debug/dotvvm-root.js" />
+    <EmbeddedResource Include="obj/javascript/root-only-debug/dotvvm-root.js.map" />
     <EmbeddedResource Include="obj/javascript/root-spa/dotvvm-root.js" />
     <EmbeddedResource Include="obj/javascript/root-spa-debug/dotvvm-root.js" />
+    <EmbeddedResource Include="obj/javascript/root-spa-debug/dotvvm-root.js.map" />
     <EmbeddedResource Include="Resources\Scripts\Globalize\globalize.min.js" />
     <EmbeddedResource Include="Resources\Scripts\knockout-latest.js" />
     <EmbeddedResource Include="Resources\Scripts\knockout-latest.debug.js" />

--- a/src/Framework/Framework/ResourceManagement/FileResourceLocation.cs
+++ b/src/Framework/Framework/ResourceManagement/FileResourceLocation.cs
@@ -30,5 +30,6 @@ namespace DotVVM.Framework.ResourceManagement
             File.OpenRead(Path.Combine(context.Configuration.ApplicationPhysicalPath, context.Configuration.Debug ? DebugFilePath : FilePath));
 
         public string GetFilePath(IDotvvmRequestContext context) => FilePath;
+        ILocalResourceLocation? IDebugFileLocalLocation.TryGetSourceMap(string fileName) => null;
     }
 }

--- a/src/Framework/Framework/ResourceManagement/IDebugFileLocalLocation.cs
+++ b/src/Framework/Framework/ResourceManagement/IDebugFileLocalLocation.cs
@@ -9,5 +9,6 @@ namespace DotVVM.Framework.ResourceManagement
     public interface IDebugFileLocalLocation: ILocalResourceLocation
     {
         string? GetFilePath(IDotvvmRequestContext context);
+        ILocalResourceLocation? TryGetSourceMap(string fileName);
     }
 }

--- a/src/Framework/Framework/ResourceManagement/LocalResourceUrlManager.cs
+++ b/src/Framework/Framework/ResourceManagement/LocalResourceUrlManager.cs
@@ -124,10 +124,17 @@ namespace DotVVM.Framework.ResourceManagement
                 return null;
             }
 
+            var locations = (resource as ILinkResource)?.GetLocations().OfType<IDebugFileLocalLocation>().ToArray() ?? [];
+
+            foreach (var location in locations)
+            {
+                if (location.TryGetSourceMap(fileName) is {} sourceMap)
+                    return sourceMap;
+            }
+
             // Load something.map.js or anything from the same directory
             var resourceDirectories =
-                (resource as ILinkResource)?.GetLocations()
-                    .OfType<IDebugFileLocalLocation>()
+                locations
                     .Select(x => x.GetFilePath(context)).WhereNotNull()
                     .Select(filePath => Path.GetDirectoryName(Path.Combine(context.Configuration.ApplicationPhysicalPath, filePath))).WhereNotNull()
                     .Distinct();


### PR DESCRIPTION
This allows us to ship source maps with our pre-compiled scripts in DotVVM.Framework and the component libraries