### PR TITLE
Require T: Delegate in ICommandBinding

### DIFF
--- a/src/Framework/Framework/Binding/BindingHelper.cs
+++ b/src/Framework/Framework/Binding/BindingHelper.cs
@@ -243,6 +243,7 @@ namespace DotVVM.Framework.Binding
         /// Finds expected DataContext and gets the delegate from command binding.
         /// </summary>
         public static T GetCommandDelegate<T>(this ICommandBinding<T> binding, DotvvmBindableObject control)
+            where T : Delegate
         {
             return ExecDelegate(
                 binding.BindingDelegate,

--- a/src/Framework/Framework/Binding/DotvvmBindingCacheHelper.cs
+++ b/src/Framework/Framework/Binding/DotvvmBindingCacheHelper.cs
@@ -97,6 +97,7 @@ namespace DotVVM.Framework.Binding
 
         /// <summary> Compiles a new `{command: ...code...}` binding which can be evaluated server-side and also client-side. The result is implicitly converted to <typeparamref name="TResult" />. The result is cached. Note that command bindings might be easier to create using the <see cref="CommandBindingExpression.CommandBindingExpression(BindingCompilationService, Func{object[], System.Threading.Tasks.Task}, string)" /> constructor. </summary>
         public CommandBindingExpression<TResult> CreateCommand<TResult>(string code, DataContextStack dataContext, BindingParserOptions? parserOptions = null)
+            where TResult : Delegate
         {
             return CreateCachedBinding($"Command<{typeof(TResult).ToCode()}>:{code}", new object?[] { dataContext, parserOptions }, () =>
                 new CommandBindingExpression<TResult>(compilationService, new object?[] {
@@ -120,6 +121,7 @@ namespace DotVVM.Framework.Binding
 
         /// <summary> Compiles a new `{staticCommand: ...code...}` binding which can be evaluated server-side and also client-side. The result is implicitly converted to <typeparamref name="TResult" />. The result is cached. </summary>
         public StaticCommandBindingExpression<TResult> CreateStaticCommand<TResult>(string code, DataContextStack dataContext, BindingParserOptions? parserOptions = null)
+            where TResult : Delegate
         {
             return CreateCachedBinding($"StaticCommand<{typeof(TResult).ToCode()}>:{code}", new object?[] { dataContext, parserOptions }, () =>
                 new StaticCommandBindingExpression<TResult>(compilationService, new object?[] {

--- a/src/Framework/Framework/Binding/Expressions/CommandBindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/CommandBindingExpression.cs
@@ -182,6 +182,7 @@ namespace DotVVM.Framework.Binding.Expressions
     }
 
     public class CommandBindingExpression<T> : CommandBindingExpression, ICommandBinding<T>
+        where T : Delegate
     {
         public new BindingDelegate<T> BindingDelegate => base.BindingDelegate.ToGeneric<T>();
         public CommandBindingExpression(BindingCompilationService service, IEnumerable<object?> properties) : base(service, properties) { }

--- a/src/Framework/Framework/Binding/Expressions/ControlCommandBindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/ControlCommandBindingExpression.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using DotVVM.Framework.Compilation;
-using DotVVM.Framework.Controls;
 
 namespace DotVVM.Framework.Binding.Expressions
 {
@@ -21,6 +19,7 @@ namespace DotVVM.Framework.Binding.Expressions
     }
 
     public class ControlCommandBindingExpression<T> : ControlCommandBindingExpression, ICommandBinding<T>
+        where T : Delegate
     {
         public ControlCommandBindingExpression(BindingCompilationService service, IEnumerable<object> properties) : base(service, properties) { }
 

--- a/src/Framework/Framework/Binding/Expressions/ICommandBinding.cs
+++ b/src/Framework/Framework/Binding/Expressions/ICommandBinding.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Immutable;
 using DotVVM.Framework.Compilation.Javascript;
 using DotVVM.Framework.Runtime.Filters;
 
@@ -12,6 +13,7 @@ namespace DotVVM.Framework.Binding.Expressions
     }
 
     public interface ICommandBinding<out T>: ICommandBinding
+        where T : Delegate
     {
         new BindingDelegate<T> BindingDelegate { get; }
     }
@@ -22,6 +24,7 @@ namespace DotVVM.Framework.Binding.Expressions
         ParametrizedCode OptionsLambdaJavascript { get; }
     }
     public interface IStaticCommandBinding<out T> : ICommandBinding<T>, IStaticCommandBinding
+        where T : System.Delegate
     {
     }
 }

--- a/src/Framework/Framework/Binding/Expressions/StaticCommandBindingExpression.cs
+++ b/src/Framework/Framework/Binding/Expressions/StaticCommandBindingExpression.cs
@@ -71,6 +71,7 @@ namespace DotVVM.Framework.Binding.Expressions
     }
 
     public class StaticCommandBindingExpression<T>: StaticCommandBindingExpression, IStaticCommandBinding<T>
+        where T : Delegate
     {
         public StaticCommandBindingExpression(BindingCompilationService service, IEnumerable<object?> properties) : base(service, properties) { }
         public new BindingDelegate<T> BindingDelegate => base.BindingDelegate.ToGeneric<T>();

--- a/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
+++ b/src/Framework/Framework/Controls/DotvvmBindableObjectHelper.cs
@@ -393,6 +393,7 @@ namespace DotVVM.Framework.Controls
         /// </summary>
         public static ICommandBinding<TProperty>? GetCommandBinding<TControl, TProperty>(this TControl control, Expression<Func<TControl, TProperty>> prop)
             where TControl : DotvvmBindableObject
+            where TProperty : Delegate
             => (ICommandBinding<TProperty>?)control.GetCommandBinding(control.GetDotvvmProperty(prop));
 
         /// <summary> Returns the value of the DotvvmProperty referenced in the lambda expression. If the property contains a binding, it is evaluted. </summary>
@@ -426,6 +427,7 @@ namespace DotVVM.Framework.Controls
         /// Gets the command binding set to the dotvvm property of the specified <paramref name="propName" />. Returns null if the property is not a binding, throws if the binding is not command, controlCommand or staticCommand.
         /// </summary>
         public static ICommandBinding<TProperty>? GetCommandBinding<TProperty>(this DotvvmBindableObject control, string propName)
+            where TProperty : Delegate
             => (ICommandBinding<TProperty>?)control.GetCommandBinding(control.GetDotvvmProperty(propName));
 
         /// <summary> Gets the specified control capability - reads all the properties in the capability at once. Throws if this control does not support the capability. </summary>


### PR DESCRIPTION
This prevents common error of using only the command return value, instead of the function which should be returned by the command binding