### PR TITLE
FileUpload can handle pasted and dropped files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,4 @@ sample.db
 /ci/scripts/npm/dotvvm-types/index.d.ts
 
 signconfig.json
+/src/Samples/Common/Temp/Upload

--- a/src/Framework/Framework/Resources/Scripts/binding-handlers/all-handlers.ts
+++ b/src/Framework/Framework/Resources/Scripts/binding-handlers/all-handlers.ts
@@ -9,6 +9,7 @@ import updateProgress from './update-progress'
 import gridviewdataset from './gridviewdataset'
 import namedCommand from './named-command'
 import fileUpload from './file-upload'
+import fileUploadPasteDrop from './file-upload-paste-drop'
 import jsComponents from './js-component'
 import modalDialog from './modal-dialog'
 import appendableDataPager from './appendable-data-pager'
@@ -29,6 +30,7 @@ const allHandlers: KnockoutHandlerDictionary = {
     ...gridviewdataset,
     ...namedCommand,
     ...fileUpload,
+    ...fileUploadPasteDrop,
     ...jsComponents,
     ...modalDialog,
     ...appendableDataPager,

--- a/src/Framework/Framework/Resources/Scripts/binding-handlers/file-upload-paste-drop.ts
+++ b/src/Framework/Framework/Resources/Scripts/binding-handlers/file-upload-paste-drop.ts
@@ -1,0 +1,51 @@
+import { uploadFiles } from "../controls/fileUpload";
+
+export default {
+    "dotvvm-FileUpload-UploadOnPasteOrDrop": {
+        init: function (element: HTMLElement, valueAccessor: () => any, allBindings?: any, viewModel?: any, bindingContext?: KnockoutBindingContext) {
+            const options = ko.unwrap(valueAccessor());
+            const uploadUrl = ko.unwrap(options.url);
+            const collectionObservable = options.collection;
+
+            function callUploadFiles(files: FileList) {
+                uploadFiles(collectionObservable, options.multiple, uploadUrl, files, () => {
+                    if (element.hasAttribute("data-dotvvm-upload-completed")) {
+                        new Function(element.getAttribute("data-dotvvm-upload-completed")!).call(element);
+                    }
+                });
+            }
+
+            // Handle paste events
+            element.addEventListener("paste", function(e: ClipboardEvent) {
+                e.preventDefault();
+                
+                if (e.clipboardData && e.clipboardData.files && e.clipboardData.files.length > 0) {
+                    callUploadFiles(e.clipboardData.files);
+                }
+            });
+
+            // Handle drop events
+            element.addEventListener("dragover", function(e: DragEvent) {
+                e.preventDefault();
+                e.stopPropagation();
+                element.classList.add("dotvvm-upload-dragover");
+            });
+
+            element.addEventListener("dragleave", function(e: DragEvent) {
+                e.preventDefault();
+                e.stopPropagation();
+                element.classList.remove("dotvvm-upload-dragover");
+            });
+
+            element.addEventListener("drop", function(e: DragEvent) {
+                e.preventDefault();
+                e.stopPropagation();
+                element.classList.remove("dotvvm-upload-dragover");
+                
+                if (e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+                    callUploadFiles(e.dataTransfer.files);
+                }
+            });
+        }
+    }
+}

--- a/src/Framework/Framework/Resources/Scripts/binding-handlers/file-upload.ts
+++ b/src/Framework/Framework/Resources/Scripts/binding-handlers/file-upload.ts
@@ -1,44 +1,20 @@
+import { uploadFiles } from '../controls/fileUpload';
+
 export default {
     "dotvvm-FileUpload": {
         init: function (element: HTMLInputElement, valueAccessor: () => any, allBindings?: any, viewModel?: any, bindingContext?: KnockoutBindingContext) {
-
             var args = ko.unwrap(valueAccessor());
-
-            function reportProgress(isBusy: boolean, percent: number, resultOrError: string | DotvvmStaticCommandResponse<DotvvmFileUploadData[]>) {
-                dotvvm.fileUpload.reportProgress(<HTMLInputElement> element, isBusy, percent, resultOrError);
-            }
 
             element.addEventListener("change", function() {
                 if (!element.files || !element.files.length) return;
 
-                var xhr = XMLHttpRequest ? new XMLHttpRequest() : new ((window as any)["ActiveXObject"])("Microsoft.XMLHTTP");
-                xhr.open("POST", args.url, true);
-                xhr.setRequestHeader("X-DotVVM-AsyncUpload", "true");
-                xhr.upload.onprogress = function (e: ProgressEvent) {
-                    if (e.lengthComputable) {
-                        reportProgress(true, Math.round(e.loaded * 100 / e.total), '');
+                uploadFiles(ko.contextFor(element).$rawData, element.multiple, args.url, element.files, () => {
+                    if (element.parentElement!.hasAttribute("data-dotvvm-upload-completed")) {
+                        new Function(element.parentElement!.getAttribute("data-dotvvm-upload-completed")!).call(element);
                     }
-                };
-                xhr.onload = function () {
-                    if (xhr.status == 200) {
-                        reportProgress(false, 100, JSON.parse(xhr.responseText));
-                        element.value = "";
-                    } else {
-                        reportProgress(false, 0, "Upload failed.");
-                    }
-                };
-
-                var formData = new FormData();
-                if (element.files.length > 1) {
-                    for (var i = 0; i < element.files.length; i++) {
-                        formData.append("upload[]", element.files[i]);
-                    }
-                } else if (element.files.length > 0) {
-                    formData.append("upload", element.files[0]);
-                }
-                xhr.send(formData);
+                    element.value = "";
+                });
             });
-
         }
     }
 }

--- a/src/Framework/Framework/Resources/Scripts/controls/fileUpload.ts
+++ b/src/Framework/Framework/Resources/Scripts/controls/fileUpload.ts
@@ -7,33 +7,52 @@ export function showUploadDialog(sender: HTMLElement) {
     fileUpload!.click();
 }
 
-export function reportProgress(inputControl: HTMLInputElement, isBusy: boolean, progress: number, result: DotvvmStaticCommandResponse<DotvvmFileUploadData[]> | string): void {
-    // find target control viewmodel
-    const targetControl = <HTMLDivElement> inputControl.parentElement!;
-    const viewModel = <DotvvmFileUploadCollection> ko.dataFor(targetControl.firstChild!);
-
-    // determine the status
-    if (typeof result === "string") {
-        // error during upload
-        viewModel.Error(result);
-    } else if ("result" in result) {
-        // files were uploaded successfully
-        viewModel.Error("");
-        updateTypeInfo(result.typeMetadata);
-
-        // if multiple files are allowed, we append to the collection
-        // if it's not, we replace the collection with the one new file
-        const allowMultiple = inputControl.multiple
-        const filesObservable = viewModel.Files as DotvvmObservable<any>;
-        const newFiles = allowMultiple ? [...filesObservable.state, ...result.result] : result.result;
-        filesObservable.setState!(newFiles)
-
-        // call the handler
-        if (((<any> targetControl.attributes)["data-dotvvm-upload-completed"] || { value: null }).value) {
-            new Function((<any> targetControl.attributes)["data-dotvvm-upload-completed"].value).call(targetControl);
+export function uploadFiles(viewModel: DotvvmObservable<DotvvmFileUploadCollection>, allowMultiple: boolean, url: string, files: FileList, onCompleted: () => void) {
+    var xhr = XMLHttpRequest ? new XMLHttpRequest() : new ((window as any)["ActiveXObject"])("Microsoft.XMLHTTP");
+    xhr.open("POST", url, true);
+    xhr.setRequestHeader("X-DotVVM-AsyncUpload", "true");
+    xhr.upload.onprogress = function (e: ProgressEvent) {
+        if (e.lengthComputable) {
+            (viewModel as any).patchState({ Error: null, IsBusy: true, Progress: Math.round(e.loaded * 100 / e.total) });
         }
-    }
-    viewModel.Progress(progress);
-    viewModel.IsBusy(isBusy);
-}
+    };
+    xhr.onerror = function () {
+        (viewModel as any).patchState({ Error: "Upload failed.", IsBusy: false, Progress: 0 });
+    };
+    xhr.onload = function () {
+        if (xhr.status == 200) {
+            (viewModel as any).patchState({ Error: null, IsBusy: true, Progress: 100 });
 
+            const result = JSON.parse(xhr.responseText) as DotvvmStaticCommandResponse<DotvvmFileUploadData[]>;
+            if ("typeMetadata" in result) {
+                updateTypeInfo(result.typeMetadata);
+            }
+            if (!("result" in result)) {
+                throw new Error("FileUpload result is empty!");
+            }
+
+            // if multiple files are allowed, we append to the collection
+            // if it's not, we replace the collection with the one new file
+            const newFiles = allowMultiple ? [...viewModel.state.Files as any, ...result.result] : result.result;
+            (viewModel as any).patchState({ Files: newFiles });
+
+            // call the handler
+            onCompleted();
+
+            (viewModel as any).patchState({ IsBusy: false });
+
+        } else {
+            (viewModel as any).patchState({ Error: "Upload failed.", IsBusy: false, Progress: 0 });
+        }
+    };
+
+    var formData = new FormData();
+    if (files.length > 1) {
+        for (var i = 0; i < files.length; i++) {
+            formData.append("upload[]", files[i]);
+        }
+    } else if (files.length > 0) {
+        formData.append("upload", files[0]);
+    }
+    xhr.send(formData);
+}

--- a/src/Framework/Framework/Resources/Scripts/dotvvm-root.ts
+++ b/src/Framework/Framework/Resources/Scripts/dotvvm-root.ts
@@ -54,7 +54,6 @@ const dotvvmExports = {
         wrapObservable: evaluator.wrapObservable
     },
     fileUpload: {
-        reportProgress: fileUpload.reportProgress,
         showUploadDialog: fileUpload.showUploadDialog
     },
     api: {

--- a/src/Framework/Framework/Resources/Scripts/global-declarations.ts
+++ b/src/Framework/Framework/Resources/Scripts/global-declarations.ts
@@ -297,10 +297,10 @@ type CoerceErrorType = {
 type CoerceResult = CoerceErrorType | { value: any, wasCoerced?: boolean, isError?: false };
 
 type DotvvmFileUploadCollection = {
-    Files: KnockoutObservableArray<KnockoutObservable<DotvvmFileUploadData>>;
-    Progress: KnockoutObservable<number>;
-    Error: KnockoutObservable<string>;
-    IsBusy: KnockoutObservable<boolean>;
+    Files: DotvvmObservable<DotvvmObservable<DotvvmFileUploadData>[]>;
+    Progress: DotvvmObservable<number>;
+    Error: DotvvmObservable<string>;
+    IsBusy: DotvvmObservable<boolean>;
 }
 type DotvvmFileUploadData = {
     FileId: KnockoutObservable<string>;

--- a/src/Samples/Common/ViewModels/ControlSamples/FileUpload/PasteDropViewModel.cs
+++ b/src/Samples/Common/ViewModels/ControlSamples/FileUpload/PasteDropViewModel.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Hosting;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.ControlSamples.FileUpload
+{
+	public class PasteDropViewModel : DotvvmViewModelBase
+	{
+		public string Text { get; set; }
+
+        public int FilesCount { get; set; }
+
+        public UploadedFilesCollection Files { get; set; } = new UploadedFilesCollection();
+
+
+        public void OnUploadCompleted()
+        {
+            FilesCount++;
+        }
+    }
+}
+

--- a/src/Samples/Common/Views/ControlSamples/FileUpload/PasteDrop.dothtml
+++ b/src/Samples/Common/Views/ControlSamples/FileUpload/PasteDrop.dothtml
@@ -1,0 +1,31 @@
+﻿@viewModel DotVVM.Samples.Common.ViewModels.ControlSamples.FileUpload.PasteDropViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+
+    <h1>Past file &amp; Drop file</h1>
+
+    <dot:TextBox Type="MultiLine" Text="{value: Text}"
+                 FileUpload.UploadOnPasteOrDrop="{value: Files}"
+                 FileUpload.UploadCompleted="{command: OnUploadCompleted()}"/>
+
+    <dot:Repeater DataSource="{value: Files.Files}" WrapperTagName="ul">
+        <li>{{value: FileId}}: {{value: FileName}}</li>
+    </dot:Repeater>
+
+    <p>Error: {{value: Files.Error}}</p>
+    <p Visible="{value: Files.IsBusy}">busy</p>
+    <p>Progress: {{value: Files.Progress}}</p>
+
+    <p>Number of uploaded files: {{value: FilesCount}}</p>
+
+</body>
+</html>
+
+

--- a/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
@@ -81,6 +81,7 @@ namespace DotVVM.Testing.Abstractions
         public const string ControlSamples_FileUpload_FileSize = "ControlSamples/FileUpload/FileSize";
         public const string ControlSamples_FileUpload_FileUpload = "ControlSamples/FileUpload/FileUpload";
         public const string ControlSamples_FileUpload_IsAllowedOrNot = "ControlSamples/FileUpload/IsAllowedOrNot";
+        public const string ControlSamples_FileUpload_PasteDrop = "ControlSamples/FileUpload/PasteDrop";
         public const string ControlSamples_GridView_ColumnVisible = "ControlSamples/GridView/ColumnVisible";
         public const string ControlSamples_GridView_GridViewCellDecorators = "ControlSamples/GridView/GridViewCellDecorators";
         public const string ControlSamples_GridView_GridViewInlineEditing = "ControlSamples/GridView/GridViewInlineEditing";

--- a/src/Samples/Tests/Tests/Control/FileUploadTests.cs
+++ b/src/Samples/Tests/Tests/Control/FileUploadTests.cs
@@ -163,9 +163,53 @@ namespace DotVVM.Samples.Tests.Control
             return tempFile;
         }
 
-        //TODO: FileUpload with UploadCompleted command
+        [Fact]
+        public void Control_FileUpload_PasteDrop_InitialState()
+        {
+            RunInAllBrowsers(browser =>
+            {
+                browser.NavigateToUrl(SamplesRouteUrls.ControlSamples_FileUpload_PasteDrop);
 
-        // TODO: RenderSettings.Mode="Server"
+                // Verify initial state
+                var textBox = browser.Single("textarea");
+                AssertUI.IsDisplayed(textBox);
+
+                // Verify files count is 0
+                var filesCountParagraph = browser.FindElements("p").Last();
+                AssertUI.TextEquals(filesCountParagraph, "Number of uploaded files: 0");
+
+                // Verify the repeater is empty initially
+                var items = browser.FindElements("ul li");
+                items.ThrowIfDifferentCountThan(0);
+
+                // Verify error is empty
+                var errorParagraph = browser.ElementAt("p", 0);
+                AssertUI.TextEquals(errorParagraph, "Error:");
+
+                // Verify busy is not visible
+                var busyElements = browser.FindElements("p").Where(p => p.GetText().Contains("busy"));
+                Assert.Empty(busyElements);
+            });
+        }
+
+        [Fact]
+        public void Control_FileUpload_PasteDrop_TextBoxHasBinding()
+        {
+            RunInAllBrowsers(browser =>
+            {
+                browser.NavigateToUrl(SamplesRouteUrls.ControlSamples_FileUpload_PasteDrop);
+
+                var textBox = browser.Single("textarea");
+
+                // Verify the textarea has the dotvvm-FileUpload-UploadOnPasteOrDrop binding
+                var bindingAttribute = textBox.GetAttribute("data-bind");
+                Assert.Contains("dotvvm-FileUpload-UploadOnPasteOrDrop", bindingAttribute);
+
+                // Verify the textarea has upload completed handler
+                var uploadCompletedAttribute = textBox.GetAttribute("data-dotvvm-upload-completed");
+                Assert.NotNull(uploadCompletedAttribute);
+            });
+        }
 
     }
 }


### PR DESCRIPTION
I needed to add support for pasting or dropping files in textarea, so I refactored the `FileUpload` core functionality and exposed some of its properties as attached:

```
    <dot:TextBox Type="MultiLine" Text="{value: Text}"
                 FileUpload.UploadOnPasteOrDrop="{value: Files}"
                 FileUpload.UploadCompleted="{command: OnUploadCompleted()}"/>
```

When a file is pasted or dropped to the textarea, it will be automatically uploaded and placed to the `Files` collection.

We'll need to look at the implementation, I don't like it much - I was fighting with TypeScript definitions of DotVVM observables. 