### PR TITLE
Allow Sec-Fetch-Dest: empty by default

### DIFF
--- a/src/Framework/Framework/Configuration/DotvvmSecurityConfiguration.cs
+++ b/src/Framework/Framework/Configuration/DotvvmSecurityConfiguration.cs
@@ -48,10 +48,18 @@ namespace DotVVM.Framework.Configuration
         public DotvvmFeatureFlag ContentTypeOptionsHeader { get; } = new("ContentTypeOptionsHeader", true);
 
         /// <summary>
-        /// Verifies Sec-Fetch headers on the GET request coming to dothtml pages. The request must have `Sec-Fetch-Dest: document` or `Sec-Fetch-Site: same-origin` if the request is for SPA. If the FrameOptionsSameOrigin is enabled, DotVVM will also allow `Sec-Fetch-Dest: document` and if FrameOptionsSameOrigin is enabled, DotVVM will also allow iframe from an cross-site request. This protects agains cross-site page scraping. Also prevents potential XSS bug to scrape the non-SPA pages.
+        /// Verifies Sec-Fetch headers on the GET request coming to dothtml pages. The request must have `Sec-Fetch-Dest: document` or `Sec-Fetch-Site: same-origin` if the request is for SPA. If the FrameOptionsSameOrigin is enabled, DotVVM will also allow `Sec-Fetch-Dest: frame` and if FrameOptionsCrossOrigin is enabled, DotVVM will also allow iframe from a cross-site request. This protects against cross-site page scraping.
         /// </summary>
         [JsonPropertyName("verifySecFetchForPages")]
         public DotvvmFeatureFlag VerifySecFetchForPages { get; } = new("VerifySecFetchForPages", true);
+
+        /// <summary>
+        /// Prevents requests with Sec-Fetch-Dest: empty from going through.
+        /// Together with enabled <see cref="FrameOptionsSameOrigin" />, this provides defense-in-depth protection against one compromised page requesting data from other pages.
+        /// Note that this option never applies to SPA pages.
+        /// </summary>
+        [JsonPropertyName("preventPageLoadByJavascript")]
+        public DotvvmFeatureFlag PreventPageLoadByJavascript { get; } = new("PreventPageLoadByJavascript", false);
 
         /// <summary>
         /// Verifies Sec-Fetch headers on the POST request executing staticCommands and commands. The request must have `Sec-Fetch-Site: same-origin`. This protects again cross-site malicious requests even if SameSite cookies and CSRF tokens would fail. It also prevents websites on a subdomain to perform postbacks.
@@ -94,6 +102,7 @@ namespace DotVVM.Framework.Configuration
             this.XssProtectionHeader.Freeze();
             this.ContentTypeOptionsHeader.Freeze();
             this.VerifySecFetchForPages.Freeze();
+            this.PreventPageLoadByJavascript.Freeze();
             this.VerifySecFetchForCommands.Freeze();
             this.RequireSecFetchHeaders.Freeze();
         }

--- a/src/Framework/Framework/Hosting/DotvvmPresenter.cs
+++ b/src/Framework/Framework/Hosting/DotvvmPresenter.cs
@@ -241,7 +241,7 @@ namespace DotVVM.Framework.Hosting
                         .Concat(ActionFilterHelper.GetActionFilters<ICommandActionFilter>(context.ViewModel.GetType()));
                     if (actionInfo.Binding?.GetProperty<ActionFiltersBindingProperty>(ErrorHandlingMode.ReturnNull) is ActionFiltersBindingProperty filters)
                         methodFilters = methodFilters.Concat(filters.Filters.OfType<ICommandActionFilter>());
-                    
+
                     var commandTimer = ValueStopwatch.StartNew();
                     try
                     {
@@ -446,7 +446,7 @@ namespace DotVVM.Framework.Hosting
                     throw new Exception("Unhandled exception occurred in the command!", context.CommandException);
                 }
             }
-            
+
             return null;
         }
 
@@ -482,8 +482,9 @@ namespace DotVVM.Framework.Hosting
             var requestType = DotvvmRequestContext.DetermineRequestType(context.HttpContext);
             var isPost = requestType is DotvvmRequestType.Command or DotvvmRequestType.StaticCommand;
             var checksAllowed = (isPost ? SecurityConfiguration.VerifySecFetchForCommands : SecurityConfiguration.VerifySecFetchForPages).IsEnabledForRoute(route);
-            var dest = context.HttpContext.Request.Headers["Sec-Fetch-Dest"];
-            var site = context.HttpContext.Request.Headers["Sec-Fetch-Site"];
+            var headers = context.HttpContext.Request.Headers;
+            var dest = headers["Sec-Fetch-Dest"];
+            var site = headers["Sec-Fetch-Site"];
 
             if (SecurityConfiguration.RequireSecFetchHeaders.IsEnabledForRoute(route))
                 if (string.IsNullOrEmpty(dest) || string.IsNullOrEmpty(site))
@@ -529,6 +530,13 @@ namespace DotVVM.Framework.Hosting
                 if (dest is "document" or "frame" or "iframe")
                 { // fine, this is allowed even cross-site
                 }
+                else if (dest is "empty" && !SecurityConfiguration.PreventPageLoadByJavascript.IsEnabledForRoute(route))
+                { // ok, but only allow cross-site with Sec-Purpose: prefetch
+                    if (site != "same-origin" && headers["Sec-Purpose"] != "prefetch")
+                        await context.RejectRequest("""
+                            Pages cannot be loaded using JavaScript cross-site.
+                            """);
+                }
                 // if SPA is used, dest will be empty, since it's initiated from JS
                 // we only allow this with the X-DotVVM-SpaContentPlaceHolder header
                 // we "trust" the client - as if he lies about it being a SPA request,
@@ -537,15 +545,15 @@ namespace DotVVM.Framework.Hosting
                 {
                     if (context.RequestType is not DotvvmRequestType.SpaNavigate)
                         await context.RejectRequest($"""
-                            Pages can not be loaded using Javascript for security reasons.
+                            Pages cannot be loaded using JavaScript for security reasons.
 
                             Try refreshing the page to get rid of the error.
 
-                            If you are the developer, you can disable this check by setting DotvvmConfiguration.Security.VerifySecFetchForPages.ExcludeRoute("{route}").
-                            Note that this security check is not compatible with page preloading, such as TurboLinks, Cloudflare Speed Brain, or similar. You'll need to disable one of these. The check is "only" a deference-in-depth measure against XSS and disabling it is perfectly safe in the absence of other vulnerabilities.
+                            If you are the developer, you can disable this check by setting DotvvmConfiguration.Security.PreventPageLoadByJavascript.ExcludeRoute("{route}").
+                            Note that this security check is not compatible with page preloading, such as TurboLinks, Cloudflare Speed Brain, or similar. You'll need to disable one of these. The check is "only" a defense-in-depth measure against XSS and disabling it is perfectly safe in the absence of other vulnerabilities.
                             """);
                     if (site != "same-origin")
-                        await context.RejectRequest($"Cross site SPA requests are disabled.");
+                        await context.RejectRequest($"Cross site SPA or JavaScript requests are disabled.");
                 }
                 else
                     await context.RejectRequest($"Cannot load a DotVVM page with Sec-Fetch-Dest: {dest}.");

--- a/src/Framework/Framework/Routing/RouteHelper.cs
+++ b/src/Framework/Framework/Routing/RouteHelper.cs
@@ -36,9 +36,9 @@ namespace DotVVM.Framework.Routing
             }
         }
         /// <summary>
-        /// Verify whether all provided virtual paths exist and required properties are set. 
+        /// Verify whether all provided virtual paths exist and required properties are set.
         /// </summary>
-        /// <exception cref="DotvvmConfigurationException">Throws exception when configuration has invalid registrations.</exception> 
+        /// <exception cref="DotvvmConfigurationException">Throws exception when configuration has invalid registrations.</exception>
         public static void AssertConfigurationIsValid(this DotvvmConfiguration config)
         {
             var invalidRoutes = new List<DotvvmConfigurationAssertResult<RouteBase>>();
@@ -116,6 +116,7 @@ namespace DotVVM.Framework.Routing
                 config.Security.ContentTypeOptionsHeader,
                 config.Security.VerifySecFetchForCommands,
                 config.Security.VerifySecFetchForPages,
+                config.Security.PreventPageLoadByJavascript,
                 config.Security.RequireSecFetchHeaders,
                 config.Security.ReferrerPolicy,
                 config.ExperimentalFeatures.LazyCsrfToken,


### PR DESCRIPTION
It is probably too annoying to have enabled by-default and lead to people disabling other Sec-Fetch-Dest checks, since we lacked more granular option.

The check is also bit situational, since it doesn't offer any protection if SPA is used or if iframes are allowed.

This patch adds PreventPageLoadByJavascript, which is disabled by default and offers the "old" strict behavior.