### PR TITLE
fix JS operations with nullable booleans

### DIFF
--- a/src/Tests/Binding/BindingCompilationTests.cs
+++ b/src/Tests/Binding/BindingCompilationTests.cs
@@ -1455,6 +1455,7 @@ namespace DotVVM.Framework.Tests.Binding
     public class TestViewModel
     {
         public bool BoolProp { get; set; }
+        public bool? NullableBoolProp { get; set; }
         public string StringProp { get; set; }
         public int IntProp { get; set; }
         public int? NullableIntProp { get; set; }

--- a/src/Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/Tests/Binding/JavascriptCompilationTests.cs
@@ -206,7 +206,7 @@ namespace DotVVM.Framework.Tests.Binding
         public void JavascriptCompilation_ExclusiveOr_ReturnsBooleanIfOperandsAreBooleans()
         {
             var js = CompileBinding("BoolProp = BoolProp ^ true", new[] { typeof(TestViewModel) });
-            Assert.AreEqual("BoolProp(BoolProp()!=true).BoolProp", js);
+            Assert.AreEqual("BoolProp(!BoolProp()!=!true).BoolProp", js);
         }
 
         [TestMethod]
@@ -1577,6 +1577,21 @@ namespace DotVVM.Framework.Tests.Binding
             Assert.AreEqual(JavascriptTranslator.KnockoutViewModelParameter, symbolicParameters[5].Parameter);
 
             Assert.AreEqual("context.$parents[1].IntProp() + context.$parentContext.$index() + context.$parentContext.$index() + context.$parent.MyProperty() + context.$index() + vm.SomeString().length", formatted2);
+        }
+
+        [DataTestMethod]
+        [DataRow("!BoolProp", "!BoolProp()")]
+        [DataRow("!NullableBoolProp", "!NullableBoolProp()")]
+        [DataRow("BoolProp && NullableBoolProp", "BoolProp()&&NullableBoolProp")]
+        [DataRow("!(BoolProp && NullableBoolProp)", "!(BoolProp()&&NullableBoolProp())")]
+        [DataRow("BoolProp & NullableBoolProp", "!(!BoolProp()|!NullableBoolProp())")]
+        [DataRow("BoolProp ^ NullableBoolProp", "!BoolProp()!=!NullableBoolProp()")]
+        [DataRow("BoolProp || NullableBoolProp", "BoolProp()||NullableBoolProp")]
+        [DataRow("BoolProp | NullableBoolProp", "!(!BoolProp()&!NullableBoolProp())")]
+        public void JavascriptCompilation_BooleanOperators(string csharp, string js)
+        {
+            var result = CompileBinding(csharp, typeof(TestViewModel));
+            Assert.AreEqual(js, result);
         }
 
         public class TestMarkupControl: DotvvmMarkupControl


### PR DESCRIPTION
Resolves #1991

We generally do not follow C# null semantics and treat null as false for simplicity.
This patch fixes ! & | ^ operators on bool? to actually follow this relaxed semantic