### PR TITLE
Fix JsonPolymorphic attribute with DisableDotvvmConverter=true

### DIFF
--- a/src/Framework/Framework/ViewModel/Serialization/ViewModelTypeMetadataSerializer.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/ViewModelTypeMetadataSerializer.cs
@@ -162,7 +162,15 @@ namespace DotVVM.Framework.ViewModel.Serialization
 
         internal void WriteTypeIdentifier(Utf8JsonWriter json, Type type, HashSet<Type> dependentObjectTypes, HashSet<Type> dependentEnumTypes)
         {
-            if (type.IsEnum)
+            var attribute = type.GetCustomAttribute<DotvvmSerializationAttribute>();
+
+            if (type == typeof(object) || ReflectionUtils.IsJsonDom(type) || attribute?.DisableDotvvmConverter == true)
+            {
+                json.WriteStartObject();
+                json.WriteString("type"u8, "dynamic"u8);
+                json.WriteEndObject();
+            }
+            else if (type.IsEnum)
             {
                 dependentEnumTypes.Add(type);
                 json.WriteStringValue(GetEnumTypeName(type));
@@ -182,12 +190,6 @@ namespace DotVVM.Framework.ViewModel.Serialization
                     json.WriteStringValue(GetPrimitiveTypeName(typeof(string)));
                 else
                     json.WriteStringValue(GetPrimitiveTypeName(type));
-            }
-            else if (type == typeof(object) || ReflectionUtils.IsJsonDom(type))
-            {
-                json.WriteStartObject();
-                json.WriteString("type"u8, "dynamic"u8);
-                json.WriteEndObject();
             }
             else if (type.IsGenericType && ReflectionUtils.ImplementsGenericDefinition(type, typeof(IDictionary<,>)))
             {

--- a/src/Samples/Common/ViewModels/FeatureSamples/Serialization/STJPolymorphismWithOptoutViewModel.cs
+++ b/src/Samples/Common/ViewModels/FeatureSamples/Serialization/STJPolymorphismWithOptoutViewModel.cs
@@ -1,0 +1,63 @@
+using System.Text.Json.Serialization;
+using DotVVM.Framework.ViewModel;
+
+namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.Serialization
+{
+    public class STJPolymorphismWithOptoutViewModel : DotvvmViewModelBase
+    {
+        public BaseClass BaseObject { get; set; } = new Derived1 { Property1 = "abc", BaseProperty = "base1" };
+
+        public string Result { get; set; }
+
+        public void TestCommand()
+        {
+            Result = $"Command: Type={BaseObject.GetType().Name}, DerivedProperty={BaseObject switch {
+                Derived1 d => d.Property1,
+                Derived2 d => d.Property2.ToString(),
+                _ => "unknown"
+            }}";
+        }
+
+        public void ChangeToDerived1()
+        {
+            BaseObject = new Derived1 { Property1 = "derived1_value", BaseProperty = "base1" };
+        }
+
+        public void ChangeToDerived2()
+        {
+            BaseObject = new Derived2 { Property2 = 42, BaseProperty = "base2" };
+        }
+
+        [AllowStaticCommand]
+        public static string TestStaticCommand(BaseClass obj) =>
+            $"StaticCommand: Type={obj.GetType().Name}, DerivedProperty={obj switch {
+                Derived1 d => d.Property1,
+                Derived2 d => d.Property2.ToString(),
+                _ => "unknown"
+            }}";
+    }
+
+    [JsonPolymorphic(TypeDiscriminatorPropertyName = "$t", UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor)]
+    [JsonDerivedType(typeof(Derived1), typeDiscriminator: 1)]
+    [JsonDerivedType(typeof(Derived2), typeDiscriminator: 2)]
+    [DotvvmSerialization(DisableDotvvmConverter = true)]
+    public class BaseClass
+    {
+        public string BaseProperty { get; set; }
+    }
+
+    public class Derived1 : BaseClass
+    {
+        public string Property1 { get; set; }
+    }
+
+    public class Derived2 : BaseClass
+    {
+        public int Property2 { get; set; }
+    }
+
+    public class Derived2B : Derived2
+    {
+        public int Property2B { get; set; }
+    }
+}

--- a/src/Samples/Common/Views/FeatureSamples/Serialization/STJPolymorphismWithOptout.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/Serialization/STJPolymorphismWithOptout.dothtml
@@ -1,0 +1,37 @@
+@viewModel DotVVM.Samples.Common.ViewModels.FeatureSamples.Serialization.STJPolymorphismWithOptoutViewModel, DotVVM.Samples.Common
+
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+
+    <div>
+        <p>Base Property: {{value: BaseObject.BaseProperty}}</p>
+    </div>
+
+    <div data-ui="change-derived1">
+        <dot:Button Text="Set to Derived1" Click="{command: ChangeToDerived1()}" />
+    </div>
+
+    <div data-ui="change-derived2">
+        <dot:Button Text="Set to Derived2" Click="{command: ChangeToDerived2()}" />
+    </div>
+
+    <div data-ui="test-command">
+        <dot:Button Text="Test Command" Click="{command: TestCommand()}" />
+    </div>
+
+    <div data-ui="test-staticcommand">
+        <dot:Button Text="Test StaticCommand" Click="{staticCommand: Result = ViewModel.TestStaticCommand(BaseObject)}" />
+    </div>
+
+    <p class="result" data-ui="result">{{value: Result}}</p>
+
+    <code><pre data-ui="viewmodel-json" data-bind="text: JSON.stringify(dotvvm.serialization.serialize($data), null, '   ')"></pre></code>
+
+</body>
+</html>

--- a/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
+++ b/src/Samples/Tests/Abstractions/SamplesRouteUrls.designer.cs
@@ -361,6 +361,7 @@ namespace DotVVM.Testing.Abstractions
         public const string FeatureSamples_Serialization_Serialization = "FeatureSamples/Serialization/Serialization";
         public const string FeatureSamples_Serialization_SerializationDateTimeOffset = "FeatureSamples/Serialization/SerializationDateTimeOffset";
         public const string FeatureSamples_Serialization_SpecialFloatSerialization = "FeatureSamples/Serialization/SpecialFloatSerialization";
+        public const string FeatureSamples_Serialization_STJPolymorphismWithOptout = "FeatureSamples/Serialization/STJPolymorphismWithOptout";
         public const string FeatureSamples_Serialization_TimeSpan = "FeatureSamples/Serialization/TimeSpan";
         public const string FeatureSamples_Serialization_TransferredOnlyInPath = "FeatureSamples/Serialization/TransferredOnlyInPath";
         public const string FeatureSamples_ServerComments_ServerComments = "FeatureSamples/ServerComments/ServerComments";

--- a/src/Samples/Tests/Tests/Feature/SerializationTests.cs
+++ b/src/Samples/Tests/Tests/Feature/SerializationTests.cs
@@ -347,6 +347,48 @@ namespace DotVVM.Samples.Tests.Feature
             });
         }
 
+        [Fact]
+        public void Feature_Serialization_STJPolymorphismWithOptout()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_Serialization_STJPolymorphismWithOptout);
+
+                void changeDerived1() => browser.Single("change-derived1", SelectByDataUi).Single("input[type=button]").Click();
+                void changeDerived2() => browser.Single("change-derived2", SelectByDataUi).Single("input[type=button]").Click();
+                void testCommand() => browser.Single("test-command", SelectByDataUi).Single("input[type=button]").Click();
+                void testStaticCommand() => browser.Single("test-staticcommand", SelectByDataUi).Single("input[type=button]").Click();
+
+                var result = () => browser.Single("result", SelectByDataUi);
+                var json = () => browser.Single("viewmodel-json", SelectByDataUi);
+
+                AssertUI.InnerText(json(), s => s.Contains(" \"$t\": 1") && s.Contains(" \"Property1\": \"abc\""));
+
+                testCommand();
+                AssertUI.TextEquals(result(), "Command: Type=Derived1, DerivedProperty=abc");
+
+                testStaticCommand();
+                AssertUI.TextEquals(result(), "StaticCommand: Type=Derived1, DerivedProperty=abc");
+
+                changeDerived2();
+                AssertUI.InnerText(json(), s => s.Contains(" \"$t\": 2") && s.Contains(" \"Property2\": 42"));
+
+                testCommand();
+                AssertUI.TextEquals(result(), "Command: Type=Derived2, DerivedProperty=42");
+
+                testStaticCommand();
+                AssertUI.TextEquals(result(), "StaticCommand: Type=Derived2, DerivedProperty=42");
+
+                changeDerived1();
+                AssertUI.InnerText(json(), s => s.Contains(" \"$t\": 1") && s.Contains(" \"Property1\": \"derived1_value\""));
+
+                testCommand();
+                AssertUI.TextEquals(result(), "Command: Type=Derived1, DerivedProperty=derived1_value");
+
+                testStaticCommand();
+                AssertUI.TextEquals(result(), "StaticCommand: Type=Derived1, DerivedProperty=derived1_value");
+            });
+        }
+
         public SerializationTests(ITestOutputHelper output) : base(output)
         {
         }

--- a/src/Tests/ViewModel/SerializerTests.cs
+++ b/src/Tests/ViewModel/SerializerTests.cs
@@ -1610,6 +1610,16 @@ namespace DotVVM.Framework.Tests.ViewModel
             public string Property { get; set; }
         }
 
+        [TestMethod]
+        public void Error_UsageOfJsonPolymorphic()
+        {
+            var obj = new TestViewModelWithJsonPolymorphic { MyProperty = new JsonPolymorphicType.Case2 { CommonProperty = "A", Prop2 = 123 } };
+            var ex = XAssert.ThrowsAny<Exception>(() => SerializeAndDeserialize(obj));
+
+            Assert.AreEqual(
+                "Can not serialize DotVVM.Framework.Tests.ViewModel.JsonPolymorphicType as [JsonPolymorphic] attribute is currently not supported by DotVVM. You can use [DotvvmSerialization(DisableDotvvmConverter = true)] to fall back to System.Text.Json default behavior, please note the client-side bindings to such models may not work properly.",
+                ex.GetBaseException().Message);
+        }
     }
 
     public class DataNode
@@ -1987,5 +1997,28 @@ namespace DotVVM.Framework.Tests.ViewModel
     public class TestViewModelWithAbstractPolymorphicCollection
     {
         public List<AbstractBaseItem> Items { get; set; } = new List<AbstractBaseItem>();
+    }
+
+    [JsonPolymorphic(TypeDiscriminatorPropertyName = "$type")]
+    [JsonDerivedType(typeof(JsonPolymorphicType), 0)]
+    [JsonDerivedType(typeof(Case1), 1)]
+    [JsonDerivedType(typeof(Case2), 2)]
+    public class JsonPolymorphicType
+    {
+        public string CommonProperty { get; set; }
+        public sealed class Case1: JsonPolymorphicType
+        {
+            public string Prop1 { get; set; }
+        }
+
+        public sealed class Case2: JsonPolymorphicType
+        {
+            public int Prop2 { get; set; }
+        }
+    }
+
+    public class TestViewModelWithJsonPolymorphic
+    {
+        public JsonPolymorphicType MyProperty { get; set; }
     }
 }


### PR DESCRIPTION
Main fix is that we need to use `type: dynamic` in metadata, because System.Text.Json does not tolerate any properties starting with `$` during deserialization.

Apart from that I added error during initialization if you use JsonPolymorphic and did not set DisableDotvvmConverter, since it's most likely unintended.
We also want to add support for this later, and if make it a hard error now, it won't be a breaking change to add some support.