### PR TITLE
workaround for FastExpressionCompiler 5.2 ToCode bug when enum is used

### DIFF
--- a/src/Framework/Framework/Utils/ReflectionUtils.cs
+++ b/src/Framework/Framework/Utils/ReflectionUtils.cs
@@ -549,7 +549,7 @@ namespace DotVVM.Framework.Utils
                         assemblyName = "System.Private.CoreLib";
                     }
 #endif
-                    var fullName = t.IsEnum ? t.FullName.Replace('+', '.') : t.ToCode();
+                    var fullName = t.IsEnum ? t.FullName!.Replace('+', '.') : t.ToCode();
                     var hashBytes = sha1.ComputeHash(Encoding.UTF8.GetBytes(fullName + ", " + assemblyName));
 
                     return Convert.ToBase64String(hashBytes, 0, 12);

--- a/src/Framework/Framework/Utils/ReflectionUtils.cs
+++ b/src/Framework/Framework/Utils/ReflectionUtils.cs
@@ -549,8 +549,8 @@ namespace DotVVM.Framework.Utils
                         assemblyName = "System.Private.CoreLib";
                     }
 #endif
-                    var typeName = t.ToCode() + ", " + assemblyName;
-                    var hashBytes = sha1.ComputeHash(Encoding.UTF8.GetBytes(typeName));
+                    var fullName = t.IsEnum ? t.FullName.Replace('+', '.') : t.ToCode();
+                    var hashBytes = sha1.ComputeHash(Encoding.UTF8.GetBytes(fullName + ", " + assemblyName));
 
                     return Convert.ToBase64String(hashBytes, 0, 12);
                 }


### PR DESCRIPTION
This should be safely backportable to v4.3