### PR TITLE
Integration tests upgraded to .NET 10 because of Marten 9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,7 +151,7 @@ jobs:
         title: WebForms Adapter Tests
         github-token: ${{ secrets.GITHUB_TOKEN }}
         target-framework: net472
-    - name: Integration Tests (net8.0)
+    - name: Integration Tests (net10.0)
       uses: ./.github/unittest
       if: ${{ matrix.os == 'ubuntu-latest' && (success() || failure()) }}
       with:
@@ -159,7 +159,7 @@ jobs:
         name: integration-tests
         title: Integration Tests
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        target-framework: net8.0
+        target-framework: net10.0
 
   js-tests:
     runs-on: ubuntu-latest

--- a/src/IntegrationTests/DotVVM.Framework.IntegrationTests.csproj
+++ b/src/IntegrationTests/DotVVM.Framework.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>$(DotnetCoreTargetVersion)</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>


### PR DESCRIPTION
We intentionally target the latest Marten version in our integration tests to ensure we get notified about breaking changes in Queryable handling.

Marten 9 no longer supports .NET 8, so I upgraded this project to .NET 10 and kept the wildcard.