### PR TITLE
Fix metadata serializer ignoredTypes

### DIFF
--- a/src/Framework/Framework/ViewModel/Serialization/ViewModelTypeMetadataSerializer.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/ViewModelTypeMetadataSerializer.cs
@@ -56,6 +56,9 @@ namespace DotVVM.Framework.ViewModel.Serialization
                 var map = queue.Dequeue();
                 var typeId = map.ClientTypeId;
 
+                if (ignoredTypes is {} && ignoredTypes.Contains(typeId))
+                    continue;
+
                 json.WritePropertyName(typeId);
                 var metadata = GetObjectTypeMetadataCached(map);
                 json.WriteRawValue(metadata.MetadataJson, skipInputValidation: true);
@@ -64,11 +67,9 @@ namespace DotVVM.Framework.ViewModel.Serialization
 
                 foreach (var dependentType in metadata.DependentObjectTypes)
                 {
-                    if (!visitedTypes.Contains(dependentType))
+                    if (visitedTypes.Add(dependentType))
                     {
-                        visitedTypes.Add(dependentType);
-                        if (ignoredTypes?.Contains(map.ClientTypeId) != true)
-                            queue.Enqueue(viewModelSerializationMapper.GetMap(dependentType));
+                        queue.Enqueue(viewModelSerializationMapper.GetMap(dependentType));
                     }
                 }
             }

--- a/src/Tests/ViewModel/ViewModelTypeMetadataSerializerTests.cs
+++ b/src/Tests/ViewModel/ViewModelTypeMetadataSerializerTests.cs
@@ -64,11 +64,11 @@ namespace DotVVM.Framework.Tests.ViewModel
         }
 #endif
 
-        JsonObject SerializeMetadata(ViewModelTypeMetadataSerializer serializer, params Type[] types)
+        JsonObject SerializeMetadata(ViewModelTypeMetadataSerializer serializer, Type[] types, ISet<string>? ignoredTypes = null)
         {
             var json = GetSerializedString(writer => {
                 writer.WriteStartObject();
-                serializer.SerializeTypeMetadata(types.Select(mapper.GetMap), writer, "typeMetadata"u8);
+                serializer.SerializeTypeMetadata(types.Select(mapper.GetMap), writer, "typeMetadata"u8, ignoredTypes);
                 writer.WriteEndObject();
             });
             return JsonNode.Parse(json).AsObject()["typeMetadata"].AsObject();
@@ -81,7 +81,7 @@ namespace DotVVM.Framework.Tests.ViewModel
             {
                 var typeMetadataSerializer = new ViewModelTypeMetadataSerializer(mapper);
 
-                var result = SerializeMetadata(typeMetadataSerializer, typeof(TestViewModel));
+                var result = SerializeMetadata(typeMetadataSerializer, [typeof(TestViewModel)]);
 
                 var checker = new OutputChecker("testoutputs");
                 checker.CheckJsonObject(result);
@@ -93,7 +93,7 @@ namespace DotVVM.Framework.Tests.ViewModel
         {
             CultureUtils.RunWithCulture("en-US", () => {
                 var typeMetadataSerializer = new ViewModelTypeMetadataSerializer(mapper);
-                var result = SerializeMetadata(typeMetadataSerializer, typeof(TestViewModel));
+                var result = SerializeMetadata(typeMetadataSerializer, [typeof(TestViewModel)]);
 
                 var rules = XAssert.IsType<JsonArray>(result[typeof(TestViewModel).GetTypeHash()]["properties"]["ServerToClient"]["validationRules"]);
                 XAssert.Single(rules);
@@ -110,9 +110,24 @@ namespace DotVVM.Framework.Tests.ViewModel
                 config.ClientSideValidation = false;
 
                 var typeMetadataSerializer = new ViewModelTypeMetadataSerializer(mapper, config);
-                var result = SerializeMetadata(typeMetadataSerializer, typeof(TestViewModel));
+                var result = SerializeMetadata(typeMetadataSerializer, [typeof(TestViewModel)]);
 
                 XAssert.Null(result[typeof(TestViewModel).GetTypeHash()]["properties"]["ServerToClient"]["validationRules"]);
+            });
+        }
+
+        [TestMethod]
+        public void ViewModelTypeMetadata_IgnoreNestedTypeMetadata()
+        {
+            CultureUtils.RunWithCulture("en-US", () =>
+            {
+                var typeMetadataSerializer = new ViewModelTypeMetadataSerializer(mapper);
+                var result = SerializeMetadata(typeMetadataSerializer, [typeof(TestViewModel)],
+                    ignoredTypes: new HashSet<string> { typeof(NestedTestViewModel).GetTypeHash() }
+                );
+
+                Assert.IsNotNull(result[typeof(TestViewModel).GetTypeHash()]);
+                Assert.IsNull(result[typeof(NestedTestViewModel).GetTypeHash()]);
             });
         }
 


### PR DESCRIPTION
We'd not respect it for transitively resolved viewmodel types since we checked map.TypeId of the ‘parent’ type