### PR TITLE
 compiler: Fix duplicated type error on directives 

### DIFF
--- a/src/Framework/Framework/Compilation/ControlTree/ControlTreeResolverBase.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/ControlTreeResolverBase.cs
@@ -529,7 +529,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
                 from controlName in Enumerable.Concat([ c.tagName ?? c.type.PrimaryName ], c.type.AlternativeNames)
                 let nameScore = StringSimilarity.DamerauLevenshteinDistance(elementName.ToLowerInvariant(), controlName.ToLowerInvariant())
                 where prefixScore + nameScore <= threshold
-                orderby (prefixScore + nameScore, controlName, c.tagPrefix) descending
+                orderby (prefixScore + nameScore), controlName, c.tagPrefix
                 select (c.tagPrefix, controlName, c.type)
             ).Take(limit).ToArray();
         }
@@ -636,7 +636,7 @@ namespace DotVVM.Framework.Compilation.ControlTree
                         {
                             if (controlResolver.FindProperty(control.Metadata, element.TagName, MappingMode.InnerElement) is {} property)
                             {
-                                element.TagNameNode.AddWarning($"This element looks like an inner element property {property.FullName}, but it isn't, because it is prefixed by other content ('{content.FirstOrDefault(c => c.IsNotEmpty())}')).");
+                                element.TagNameNode.AddWarning($"This element looks like an inner element property {property.FullName}, but it isn't, because it is prefixed by other content ('{content.FirstOrDefault(c => c.IsNotEmpty())}').");
                             }
                             else
                             {

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/DirectiveCompilationService.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/DirectiveCompilationService.cs
@@ -26,12 +26,12 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
             this.configuration = configuration;
         }
 
-        public ResolvedTypeDescriptor? ResolveType(DothtmlDirectiveNode directive, BindingParserNode nameSyntax, ImmutableList<NamespaceImport> imports)
+        public ResolvedTypeDescriptor? ResolveType(DothtmlDirectiveNode directive, BindingParserNode nameSyntax, ImmutableList<NamespaceImport> imports, string? errorContext = null)
         {
             if (CompileDirectiveExpression(directive, nameSyntax, imports) is not StaticClassIdentifierExpression expression)
             {
                 var help = GetMissingTypeHelp(nameSyntax, imports);
-                directive.AddError($"Could not resolve type '{nameSyntax.ToDisplayString()}'.{(help is null ? "" : " " + help)}");
+                directive.AddError($"Could not resolve type '{nameSyntax.ToDisplayString()}'{errorContext}.{(help is null ? "" : " " + help)}");
                 return null;
             }
             else return new ResolvedTypeDescriptor(expression.Type);

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedPropertyDeclarationDirective.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedPropertyDeclarationDirective.cs
@@ -40,11 +40,6 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
 
             var propertyTypeDescriptor = service.ResolveType(dothtmlDirective, typeSyntax, imports);
 
-            if (propertyTypeDescriptor == null)
-            {
-                dothtmlDirective.AddError($"Could not resolve type {typeSyntax.ToDisplayString()}.");
-            }
-
             PropertyType = propertyTypeDescriptor;
 
             //Chack that I am not asigning incompatible types 

--- a/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedPropertyDirectiveAttributeReference.cs
+++ b/src/Framework/Framework/Compilation/ControlTree/Resolved/ResolvedPropertyDirectiveAttributeReference.cs
@@ -30,12 +30,7 @@ namespace DotVVM.Framework.Compilation.ControlTree.Resolved
             NameSyntax = attributePropertyNameReference;
             Initializer = initializer;
 
-            var typeDescriptor = directiveService.ResolveType(directiveNode, TypeSyntax, imports);
-
-            if (typeDescriptor == null)
-            {
-                directiveNode.AddError($"Could not resolve type {TypeSyntax.ToDisplayString()} when trying to resolve property attribute type.");
-            }
+            var typeDescriptor = directiveService.ResolveType(directiveNode, TypeSyntax, imports, " when trying to resolve property attribute type");
             Type = typeDescriptor;
 
         }

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/CompilationWarningsTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/CompilationWarningsTests.cs
@@ -142,7 +142,7 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
             XAssert.Empty(correctTemplateElement.TagNameNode.NodeWarnings);
             Assert.AreEqual("HTML element name 'SepratrorTemplate' should not contain uppercase letters. Did you mean SeparatorTemplate, or another DotVVM property?", XAssert.Single(mistakeTemplateElement.TagNameNode.NodeWarnings));
             Assert.AreEqual("HTML element name 'TextBox' should not contain uppercase letters. Did you mean dot:CheckBox, dot:ListBox, dot:TextBox, or another DotVVM control?", XAssert.Single(mistakeTextBoxElement.TagNameNode.NodeWarnings));
-            Assert.AreEqual("This element looks like an inner element property Repeater.SeparatorTemplate, but it isn't, because it is prefixed by other content ('<SepratrorTemplate>')).", XAssert.Single(lateTemplate.TagNameNode.NodeWarnings));
+            Assert.AreEqual("This element looks like an inner element property Repeater.SeparatorTemplate, but it isn't, because it is prefixed by other content ('<SepratrorTemplate>').", XAssert.Single(lateTemplate.TagNameNode.NodeWarnings));
         }
 
         [TestMethod]

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/CompilationWarningsTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/CompilationWarningsTests.cs
@@ -141,7 +141,7 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
 
             XAssert.Empty(correctTemplateElement.TagNameNode.NodeWarnings);
             Assert.AreEqual("HTML element name 'SepratrorTemplate' should not contain uppercase letters. Did you mean SeparatorTemplate, or another DotVVM property?", XAssert.Single(mistakeTemplateElement.TagNameNode.NodeWarnings));
-            Assert.AreEqual("HTML element name 'TextBox' should not contain uppercase letters. Did you mean dot:CheckBox, dot:ListBox, dot:TextBox, or another DotVVM control?", XAssert.Single(mistakeTextBoxElement.TagNameNode.NodeWarnings));
+            Assert.AreEqual("HTML element name 'TextBox' should not contain uppercase letters. Did you mean dot:TextBox, dot:ListBox, dot:CheckBox, or another DotVVM control?", XAssert.Single(mistakeTextBoxElement.TagNameNode.NodeWarnings));
             Assert.AreEqual("This element looks like an inner element property Repeater.SeparatorTemplate, but it isn't, because it is prefixed by other content ('<SepratrorTemplate>').", XAssert.Single(lateTemplate.TagNameNode.NodeWarnings));
         }
 

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/DefaultControlTreeResolverTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/DefaultControlTreeResolverTests.cs
@@ -20,6 +20,7 @@ using DotVVM.Framework.Compilation.Styles;
 using DotVVM.Framework.Compilation;
 using Microsoft.Extensions.DependencyInjection;
 using DotVVM.Framework.Tests.Runtime.ControlTree.DefaultControlTreeResolver;
+using DotVVM.Framework.Testing;
 
 namespace DotVVM.Framework.Tests.Runtime.ControlTree
 {
@@ -202,7 +203,7 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
             Assert.AreEqual(1, control.ConstructorParameters.Length);
             Assert.AreEqual("dot:xxxButton", control.ConstructorParameters[0]);
             var node = (control.DothtmlNode as DothtmlElementNode).TagNameNode;
-            Assert.AreEqual("The control <dot:xxxButton> could not be resolved! Did you mean dot:LinkButton, dot:Button, or other DotVVM control?", XAssert.Single(node.NodeErrors));
+            Assert.AreEqual("The control <dot:xxxButton> could not be resolved! Did you mean dot:Button, dot:LinkButton, or other DotVVM control?", XAssert.Single(node.NodeErrors));
 
             Assert.AreEqual(root, control.Parent);
         }

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/PropertyDirectiveTests.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/PropertyDirectiveTests.cs
@@ -108,5 +108,31 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
 
 
         }
+
+        [TestMethod]
+        public void ResolvedTree_PropertyDirective_InvalidType_DoesNotDuplicateError()
+        {
+            var root = ParseSource(@"@viewModel object
+@property invalidType MyProperty
+");
+
+            var property = root.Directives["property"].Single() as IAbstractPropertyDeclarationDirective;
+
+            Assert.AreEqual(1, property.DothtmlNode.NodeErrors.Count());
+            Assert.AreEqual("Could not resolve type 'invalidType'.", property.DothtmlNode.NodeErrors.Single());
+        }
+
+        [TestMethod]
+        public void ResolvedTree_PropertyDirective_InvalidAttributeType_ErrorReported()
+        {
+            var root = ParseSource(@"@viewModel object
+@property string MyProperty, DotVVM.Framework.Controls.NonExistingAttribute.Required = true
+");
+
+            var property = root.Directives["property"].Single() as IAbstractPropertyDeclarationDirective;
+
+            Assert.AreEqual(1, property.DothtmlNode.NodeErrors.Count());
+            Assert.AreEqual("Could not resolve type 'DotVVM.Framework.Controls.NonExistingAttribute' when trying to resolve property attribute type.", property.DothtmlNode.NodeErrors.Single());
+        }
     }
 }

--- a/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/ViewModelDirectiveTest.cs
+++ b/src/Tests/Runtime/ControlTree/DefaultControlTreeResolver/ViewModelDirectiveTest.cs
@@ -32,6 +32,17 @@ namespace DotVVM.Framework.Tests.Runtime.ControlTree
         }
 
         [TestMethod]
+        public void ResolvedTree_InvalidViewModelType_DoesNotDuplicateError()
+        {
+            var root = ParseSource(@"@viewModel invalid
+");
+
+            var directiveNode = ((DothtmlRootNode)root.DothtmlNode).Directives.First();
+            Assert.AreEqual(1, directiveNode.NodeErrors.Count());
+            Assert.AreEqual("Could not resolve type 'invalid'.", directiveNode.NodeErrors.Single());
+        }
+
+        [TestMethod]
         public void ResolvedTree_EmptyViewModelType()
         {
             var root = ParseSource(@"@viewModel


### PR DESCRIPTION
plus flipped order of the "Did you mean X or Y or Z" suggestion