### PR TITLE
Fixed viewmodel protection issue when SPA and Protect attribute are used together

### DIFF
--- a/src/Framework/Framework/Hosting/HostingConstants.cs
+++ b/src/Framework/Framework/Hosting/HostingConstants.cs
@@ -18,7 +18,6 @@ namespace DotVVM.Framework.Hosting
         [Obsolete("Use PostBackHeaderName instead")]
         public const string SpaPostBackHeaderName = PostBackHeaderName;
         public const string SpaContentPlaceHolderID = "__dot_SpaContentPlaceHolder";
-        public const string SpaUrlIdentifier = "_dotvvm/spa";
 
         public const string SpaContentPlaceHolderDataAttributeName = "data-dotvvm-spacontentplaceholder";
 

--- a/src/Framework/Framework/Hosting/Middlewares/DotvvmRoutingMiddleware.cs
+++ b/src/Framework/Framework/Hosting/Middlewares/DotvvmRoutingMiddleware.cs
@@ -51,14 +51,7 @@ namespace DotVVM.Framework.Hosting.Middlewares
             {
                 url = requestPath;
             }
-            url = url?.Trim('/') ?? "";
-
-            // remove SPA identifier from the URL
-            if (url.StartsWith(HostingConstants.SpaUrlIdentifier, StringComparison.Ordinal))
-            {
-                url = url.Substring(HostingConstants.SpaUrlIdentifier.Length).Trim('/');
-            }
-            return url;
+            return url?.Trim('/') ?? "";
         }
 
         internal static RouteBase? FindExactMatchRoute(IEnumerable<RouteBase> routes, string matchUrl, out IDictionary<string, object?>? parameters)

--- a/src/Framework/Framework/Resources/Scripts/spa/navigation.ts
+++ b/src/Framework/Framework/Resources/Scripts/spa/navigation.ts
@@ -34,12 +34,10 @@ export async function navigateCore(url: string, options: PostbackOptions, handle
         gate.disablePostbacks()
 
         // compose URLs
-        // TODO: get rid of _dotvvm/spa
-        const spaFullUrl = uri.addVirtualDirectoryToUrl("/_dotvvm/spa" + uri.addLeadingSlash(url));
         const displayUrl = uri.addVirtualDirectoryToUrl(url);
 
         // send the request
-        response = await http.getJSON<any>(spaFullUrl, getSpaPlaceHoldersUniqueId(), options.abortSignal);
+        response = await http.getJSON<any>(displayUrl, getSpaPlaceHoldersUniqueId(), options.abortSignal);
 
         // if another postback has already been passed, don't do anything
         if (options.postbackId < lastStartedNavigation) {

--- a/src/Framework/Framework/Resources/Scripts/tests/eventArgs.test.ts
+++ b/src/Framework/Framework/Resources/Scripts/tests/eventArgs.test.ts
@@ -208,7 +208,7 @@ const fetchDefinitions = {
         } as any;
     },
     spaNavigateRedirect: async <T>(url: string, init: RequestInit) => {
-        if (url == "/_dotvvm/spa/newUrl") {
+        if (url == "/newUrl") {
             return await fetchDefinitions.spaNavigateSuccess(url, init);
         }
         return {

--- a/src/Framework/Framework/Runtime/DefaultDotvvmViewBuilder.cs
+++ b/src/Framework/Framework/Runtime/DefaultDotvvmViewBuilder.cs
@@ -77,7 +77,7 @@ namespace DotVVM.Framework.Runtime
                 if (spaContentPlaceHolders.Count == 0 || !spaContentPlaceHolderIds.Contains(spaContentPlaceHolders[0].GetSpaContentPlaceHolderUniqueId()))
                 {
                     // the client has loaded different page which does not contain current SpaContentPlaceHolder - he needs to be redirected
-                    context.RedirectToUrl(context.HttpContext.Request.Url.AbsoluteUri.Replace("/" + HostingConstants.SpaUrlIdentifier, ""));
+                    context.RedirectToUrl(context.HttpContext.Request.Url.AbsoluteUri);
                 }
             }
         }

--- a/src/Samples/Common/ViewModels/ComplexSamples/SPA/SiteViewModel.cs
+++ b/src/Samples/Common/ViewModels/ComplexSamples/SPA/SiteViewModel.cs
@@ -7,11 +7,15 @@ using DotVVM.Framework.ViewModel;
 namespace DotVVM.Samples.BasicSamples.ViewModels.ComplexSamples.SPA
 {
 	public class SiteViewModel : DotvvmViewModelBase
-	{
+    {
+        [Protect(ProtectMode.SignData)]
+        public string ProtectedValue { get; set; }
+
         public string SampleText { get; set; }
         public void AddSampleText()
         {
             SampleText = "Sample Text";
+            ProtectedValue = "protected value";
         }
 
         [AllowStaticCommand]


### PR DESCRIPTION
We introduced a regression in version `4.3.9`.

When SPA is used and there is any property with `Protect` attribute which triggers `$encryptedValues` entry in the viewmodel, the application crashes on postbacks following SPA navigation because of viewmodel protection. 

The issue is this:
1. Clean GET to a SPA page (e.g. `/`). CSRF token is based on the `/` URL.
2. SPA navigation to another page (e.g. `/test`). CSRF token is incorrectly based on the `/_dotvvm/spa/test` URL, as we were adding this prefix. The prefix itself is different in the `4.*` branch, but the problem is the same.
3. Postback is made; however, the CSRF validation assumes the `/test` URL, and thus, the token is considered tampered with.

For 5.0, this PR removes the entire `_dotvvm/spa` ceremony, as we no longer need it. We can (and already do) distinguish SPA requests based on the presence of the `X-DotVVM-SpaContentPlaceHolder` header.

For 4.3, I didn't want to use the same solution, because even the `Context.HttpContext.Request.Url` reported `/___dotvvm-spa___/...` URLs on SPA navigation - this would change and it might theoretically break someone (although I think that if someone ran into this, they would probably just remove this URL fragment instead of relying on it). Therefore, I just remove this identifier when generating request identity when CSRF token is generated. Fixed in a separate PR.

I didn't add any new tests - I just added a protected property to the existing sample, and existing tests started crashing. They work again after this fix.