### PR TITLE
Fixed viewmodel protection issue when SPA and Protect attribute are used together [4.3]

### DIFF
--- a/src/Framework/Framework/Security/ProtectionHelpers.cs
+++ b/src/Framework/Framework/Security/ProtectionHelpers.cs
@@ -9,7 +9,7 @@ namespace DotVVM.Framework.Security
     {
         public static string GetRequestIdentity(IDotvvmRequestContext context)
         {
-            return context.HttpContext.Request.Url.ToString();
+            return context.HttpContext.Request.Url.ToString().Replace("/" + HostingConstants.SpaUrlIdentifier, "");
         }
 
         public static string GetUserIdentity(IDotvvmRequestContext context)

--- a/src/Samples/Common/ViewModels/ComplexSamples/SPA/SiteViewModel.cs
+++ b/src/Samples/Common/ViewModels/ComplexSamples/SPA/SiteViewModel.cs
@@ -7,11 +7,15 @@ using DotVVM.Framework.ViewModel;
 namespace DotVVM.Samples.BasicSamples.ViewModels.ComplexSamples.SPA
 {
 	public class SiteViewModel : DotvvmViewModelBase
-	{
+    {
+        [Protect(ProtectMode.SignData)]
+        public string ProtectedValue { get; set; }
+
         public string SampleText { get; set; }
         public void AddSampleText()
         {
             SampleText = "Sample Text";
+            ProtectedValue = "protected value";
         }
 
         [AllowStaticCommand]


### PR DESCRIPTION
Hotfix for the SPA/Protect issue for the 4.3 branch.

Properly fixed in 5.0 in #2039 