### PR TITLE
Add _page.Resource(...) – server-side evaluated part of value binding

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,7 +22,7 @@
   <PropertyGroup Label="Building">
     <LangVersion>13.0</LangVersion>
     <!-- Disable warning for missing XML doc comments. -->
-    <NoWarn>$(NoWarn);CS1591;CS1573</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;CS1573;NU1900</NoWarn>
     <Deterministic>true</Deterministic>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <OldFrameworkTargetVersion>net472</OldFrameworkTargetVersion>

--- a/src/Framework/Framework/Binding/BindingHelper.cs
+++ b/src/Framework/Framework/Binding/BindingHelper.cs
@@ -52,14 +52,20 @@ namespace DotVVM.Framework.Binding
         /// <summary>
         /// Adjusts the knockout expression to `currentControl`s DataContext like it was translated in `currentBinding`s context
         /// </summary>
-        public static string FormatKnockoutScript(this ParametrizedCode code, DotvvmBindableObject currentControl, IBinding currentBinding) =>
-            JavascriptTranslator.FormatKnockoutScript(code, dataContextLevel: FindDataContextTarget(currentBinding, currentControl).stepsUp);
+        public static string FormatKnockoutScript(this ParametrizedCode code, DotvvmBindableObject currentControl, IBinding currentBinding)
+        {
+            var (stepsUp, targetControl) = FindDataContextTarget(currentBinding, currentControl);
+            return JavascriptTranslator.FormatKnockoutScript(code, dataContextLevel: stepsUp, targetControl: targetControl);
+        }
 
         /// <summary>
         /// Adjusts the knockout expression to `currentControl`s DataContext like it was translated in `currentBinding`s context
         /// </summary>
-        public static string FormatKnockoutScript(this ParametrizedCode code, DotvvmBindableObject currentControl, IBinding currentBinding, int additionalDataContextSteps) =>
-            JavascriptTranslator.FormatKnockoutScript(code, dataContextLevel: FindDataContextTarget(currentBinding, currentControl).stepsUp + additionalDataContextSteps);
+        public static string FormatKnockoutScript(this ParametrizedCode code, DotvvmBindableObject currentControl, IBinding currentBinding, int additionalDataContextSteps)
+        {
+            var (stepsUp, targetControl) = FindDataContextTarget(currentBinding, currentControl);
+            return JavascriptTranslator.FormatKnockoutScript(code, dataContextLevel: stepsUp + additionalDataContextSteps, targetControl: targetControl);
+        }
 
         /// <summary>
         /// Gets Internal.PathFragmentProperty or DataContext.KnockoutExpression. Returns null if none of these is set.

--- a/src/Framework/Framework/Binding/BindingPageInfo.cs
+++ b/src/Framework/Framework/Binding/BindingPageInfo.cs
@@ -18,6 +18,12 @@ namespace DotVVM.Framework.Binding
         /// <summary> Returns false on server and true in JavaScript. </summary>
         public bool EvaluatingOnClient => false;
 
+        /// <summary>
+        /// Evaluates the argument server-side when page is initially rendered.
+        /// Content is not updated reactively and not re-evaluated on static command execution.
+        /// </summary>
+        public T Resource<T>(T value) => value;
+
         internal static void RegisterJavascriptTranslations(JavascriptTranslatableMethodCollection methods)
         {
             methods.AddPropertyTranslator(() => new BindingPageInfo().EvaluatingOnServer,

--- a/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
+++ b/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
@@ -129,10 +129,11 @@ namespace DotVVM.Framework.Compilation.Binding
         }
 
         public KnockoutJsExpressionBindingProperty CompileToJavascript(CastedExpressionBindingProperty expression,
-            DataContextStack dataContext)
+            DataContextStack dataContext,
+            IBinding binding)
         {
             return new KnockoutJsExpressionBindingProperty(
-                   javascriptTranslator.CompileToJavascript(expression.Expression, dataContext).ApplyAction(a => a.Freeze()));
+                   javascriptTranslator.CompileToJavascript(expression.Expression, dataContext, debugBinding: binding).ApplyAction(a => a.Freeze()));
         }
 
         public SimplePathExpressionBindingProperty FormatSimplePath(IBinding binding)

--- a/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
+++ b/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
@@ -133,7 +133,7 @@ namespace DotVVM.Framework.Compilation.Binding
             IBinding binding)
         {
             return new KnockoutJsExpressionBindingProperty(
-                   javascriptTranslator.CompileToJavascript(expression.Expression, dataContext, debugBinding: binding).ApplyAction(a => a.Freeze()));
+                   javascriptTranslator.CompileToJavascript(expression.Expression, dataContext, wrapperBinding: binding).ApplyAction(a => a.Freeze()));
         }
 
         public SimplePathExpressionBindingProperty FormatSimplePath(IBinding binding)
@@ -371,7 +371,7 @@ namespace DotVVM.Framework.Compilation.Binding
                     Expression.ArrayIndex(expr, indexParameter()) :
                 expression.Expression.Type.Implements(typeof(IEnumerable<>), out var ienumerable) ?
                     (Expression)Expression.Call(
-                        typeof(Enumerable), 
+                        typeof(Enumerable),
                         "ElementAt",
                         ienumerable.GetGenericArguments(),
                         expression.Expression,
@@ -389,8 +389,8 @@ namespace DotVVM.Framework.Compilation.Binding
         }
 
 
-        public StaticCommandJsAstProperty CompileStaticCommand(DataContextStack dataContext, CastedExpressionBindingProperty expression) =>
-            new StaticCommandJsAstProperty(this.staticCommandBindingCompiler.CompileToJavascript(dataContext, expression.Expression));
+        public StaticCommandJsAstProperty CompileStaticCommand(DataContextStack dataContext, CastedExpressionBindingProperty expression, IBinding binding) =>
+            new StaticCommandJsAstProperty(this.staticCommandBindingCompiler.CompileToJavascript(dataContext, expression.Expression, binding));
 
         [Obsolete("Deprecated in favor of StaticCommandOptionsLambdaJavascriptProperty.")]
         public StaticCommandJavascriptProperty FormatStaticCommand(StaticCommandJsAstProperty code) =>

--- a/src/Framework/Framework/Compilation/Binding/StaticCommandBindingCompiler.cs
+++ b/src/Framework/Framework/Compilation/Binding/StaticCommandBindingCompiler.cs
@@ -45,10 +45,10 @@ namespace DotVVM.Framework.Compilation.Binding
             return new JavascriptTranslator(configForStaticCommands, serializationMapper);
         }
 
-        public JsExpression CompileToJavascript(DataContextStack dataContext, Expression expression)
+        public JsExpression CompileToJavascript(DataContextStack dataContext, Expression expression, IBinding wrapperBinding)
         {
             var expressionWithVariableResolved = TranslateVariableDeclaration(expression);
-            var jsExpression = CreateCommandExpression(dataContext, expressionWithVariableResolved);
+            var jsExpression = CreateCommandExpression(dataContext, expressionWithVariableResolved, wrapperBinding);
 
             if (jsExpression is JsArrowFunctionExpression wrapperFunction)
             {
@@ -91,7 +91,7 @@ namespace DotVVM.Framework.Compilation.Binding
             }
         }
 
-        private JsExpression CreateCommandExpression(DataContextStack dataContext, Expression expression)
+        private JsExpression CreateCommandExpression(DataContextStack dataContext, Expression expression, IBinding wrapperBinding)
         {
             var knockoutContext =
                 new JsSymbolicParameter(
@@ -111,7 +111,7 @@ namespace DotVVM.Framework.Compilation.Binding
 
             var javascriptTranslator = this.CreateTranslator(dataContext);
 
-            var jsExpression = javascriptTranslator.CompileToJavascript(expression, dataContext, preferUsingState: true, isRootAsync: true);
+            var jsExpression = javascriptTranslator.CompileToJavascript(expression, dataContext, wrapperBinding: wrapperBinding, preferUsingState: true, isRootAsync: true);
             return (JsExpression)jsExpression.AssignParameters(symbol =>
                 symbol == JavascriptTranslator.KnockoutContextParameter ? currentContextVariable.ToExpression() :
                 symbol == JavascriptTranslator.KnockoutViewModelParameter ? currentViewModelVariable.ToExpression() :

--- a/src/Framework/Framework/Compilation/BindingCompiler.cs
+++ b/src/Framework/Framework/Compilation/BindingCompiler.cs
@@ -153,7 +153,7 @@ namespace DotVVM.Framework.Compilation
 
 
             /// <summary> Wraps the expression in a block which declared and initializes all the <see cref="IntroducedVariables" /> </summary>
-            public Expression WrapExpression(Expression expression, IBinding contextObject)
+            public Expression WrapExpression(Expression expression, IBinding? contextObject)
             {
                 var variables = IntroducedVariables.ToArray();
                 if (variables.Length == 0)
@@ -176,7 +176,7 @@ namespace DotVVM.Framework.Compilation
             static readonly PropertyInfo BindableObject_Parent = typeof(DotvvmBindableObject).GetProperty(nameof(DotvvmBindableObject.Parent))!;
 
             /// <summary> Generates block which initializes the needed data context parameters (<see cref="IntroducedVariables" />) </summary>
-            public BlockExpression GenerateInitializer(IBinding contextObject, Expression returnNull)
+            public BlockExpression GenerateInitializer(IBinding? contextObject, Expression returnNull)
             {
                 var result = new List<Expression>();
                 var tempVariables = new List<ParameterExpression>();
@@ -243,7 +243,7 @@ namespace DotVVM.Framework.Compilation
                     if (controlVariable is {})
                     {
                         if (skip > 0)
-                        { // skip N-1 levels + control.Parent to get to the desired control, 
+                        { // skip N-1 levels + control.Parent to get to the desired control,
                             var control = getContextControl(skip - 1, lastContextControl, cx);
                             control = Expression.Property(control, BindableObject_Parent);
                             result.Add(Expression.Assign(controlVariable, control));
@@ -348,22 +348,22 @@ namespace DotVVM.Framework.Compilation
             }
 
             sealed record ErrorInfo(
-                IBinding Binding,
+                IBinding? Binding,
                 DataContextStack DataContext,
                 int? Index
             )
             { }
 
-            sealed record NotEnoughDataContextsException(DataContextStack MissingDataContext, int DataContextIndex, IBinding RelatedBinding, DotvvmBindableObject RelatedControl): DotvvmExceptionBase(RelatedBinding: RelatedBinding, RelatedControl: RelatedControl)
+            sealed record NotEnoughDataContextsException(DataContextStack MissingDataContext, int DataContextIndex, IBinding? RelatedBinding, DotvvmBindableObject RelatedControl): DotvvmExceptionBase(RelatedBinding: RelatedBinding, RelatedControl: RelatedControl)
             {
-                public override string Message => $"Could not evaluate binding {RelatedBinding!.ToString()}, " + 
+                public override string Message => $"Could not evaluate binding {RelatedBinding?.ToString() ?? "?"}, " +
                     $"data context {DataContextIndex switch { 0 => "_this", 1 => "_parent", var n => "_parent"+n }}: {MissingDataContext.DataContextType.ToCode(stripNamespace: true)} does not exist. " +
                     $"Control has the following contexts: {string.Join(", ", RelatedControl!.GetDataContexts().Select(c => c?.GetType().ToCode(stripNamespace: true) ?? "?"))}";
             }
 
-            sealed record WrongDataContextTypeException(DataContextStack ExpectedDataContext, Type? ReceivedType, int? DataContextIndex, IBinding RelatedBinding, DotvvmBindableObject RelatedControl): DotvvmExceptionBase(RelatedBinding: RelatedBinding, RelatedControl: RelatedControl)
+            sealed record WrongDataContextTypeException(DataContextStack ExpectedDataContext, Type? ReceivedType, int? DataContextIndex, IBinding? RelatedBinding, DotvvmBindableObject RelatedControl): DotvvmExceptionBase(RelatedBinding: RelatedBinding, RelatedControl: RelatedControl)
             {
-                public override string Message => $"Could not evaluate binding {RelatedBinding!.ToString()}, " + 
+                public override string Message => $"Could not evaluate binding {RelatedBinding?.ToString() ?? "?"}, " +
                     $"data context {DataContextIndex switch { null => "?", 0 => "_this", 1 => "_parent", var n => "_parent"+n }}: " +
                     $"{ExpectedDataContext.DataContextType.ToCode()} was expected, but got {ReceivedType?.ToCode() ?? "null"}. " +
                     $"Control has the following contexts: {string.Join(", ", RelatedControl!.GetDataContexts().Select(c => c?.GetType().ToCode(stripNamespace: true) ?? "?"))}";

--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslationVisitor.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslationVisitor.cs
@@ -6,7 +6,9 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using DotVVM.Framework.Binding;
+using DotVVM.Framework.Binding.Expressions;
 using DotVVM.Framework.Binding.HelperNamespace;
+using DotVVM.Framework.Compilation.Binding;
 using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Compilation.ControlTree.Resolved;
 using DotVVM.Framework.Compilation.Javascript.Ast;
@@ -21,12 +23,13 @@ namespace DotVVM.Framework.Compilation.Javascript
     public class JavascriptTranslationVisitor
     {
         private readonly IJavascriptMethodTranslator Translator;
+        private readonly IBinding? DebugBinding;
 
         public DataContextStack DataContext { get; }
 
         private readonly Dictionary<DataContextStack, int> ContextMap;
         public bool WriteUnknownParameters { get; set; } = true;
-        public JavascriptTranslationVisitor(DataContextStack dataContext, IJavascriptMethodTranslator translator)
+        public JavascriptTranslationVisitor(DataContextStack dataContext, IJavascriptMethodTranslator translator, IBinding? debugBinding = null)
         {
             this.ContextMap =
                 dataContext
@@ -36,6 +39,7 @@ namespace DotVVM.Framework.Compilation.Javascript
                 .ToDictionary(a => a.a, a => a.i);
             this.DataContext = dataContext;
             this.Translator = translator;
+            this.DebugBinding = debugBinding;
         }
         public JsExpression Translate(Expression expression)
         {
@@ -244,11 +248,19 @@ namespace DotVVM.Framework.Compilation.Javascript
         public static JsLiteral TranslateConstant(ConstantExpression expression) =>
             new JsLiteral(expression.Value).WithAnnotation(new ViewModelInfoAnnotation(expression.Type, containsObservables: false));
 
+
+        static readonly MethodInfo PageResourceMethod =
+            (MethodInfo)MethodFindingHelper.GetMethodFromExpression(() => default(BindingPageInfo)!.Resource(default(MethodFindingHelper.Generic.T)));
+
         public JsExpression TranslateMethodCall(MethodCallExpression expression)
         {
-            var result = TryTranslateMethodCall(expression.Method, expression.Object, expression.Arguments.ToArray());
+            var method = expression.Method;
+            if (method.IsGenericMethod && method.GetGenericMethodDefinition() == PageResourceMethod)
+                return TranslateResourceSubexpression(expression.Arguments.Single());
+
+            var result = TryTranslateMethodCall(method, expression.Object, expression.Arguments.ToArray());
             if (result == null)
-                throw new NotSupportedException($"Method {ReflectionUtils.FormatMethodInfo(expression.Method)} cannot be translated to Javascript");
+                throw new NotSupportedException($"Method {ReflectionUtils.FormatMethodInfo(method)} cannot be translated to Javascript");
             return result;
         }
 
@@ -463,15 +475,42 @@ namespace DotVVM.Framework.Compilation.Javascript
             return operand;
         }
 
+        public JsExpression TranslateResourceSubexpression(Expression expression)
+        {
+            InitOnlyPropertyCheckingVisitor.Instance.Visit(expression);
+
+            var replacementVisitor = new BindingCompiler.ParameterReplacementVisitor(DataContext);
+            var expr = replacementVisitor.Visit(expression);
+            expr = ExpressionNullPropagationVisitor.PropagateNulls(expr, _ => true);
+            expr = ExpressionUtils.ConvertToObject(expr);
+            expr = replacementVisitor.WrapExpression(expr, DebugBinding!);
+
+            var resultLambda = Expression.Lambda<BindingDelegate>(expr, BindingCompiler.CurrentControlParameter);
+            var resultDelegate = resultLambda.Compile();
+
+            return new JsSymbolicParameter(new JavascriptTranslator.ResourceSymbolicParameter(
+                control => new CodeParameterAssignment(
+                    new ParametrizedCode(
+                        JavascriptCompilationHelper.CompileConstant(resultDelegate(control!), htmlSafe: true),
+                        OperatorPrecedence.Max
+                    )
+                ),
+                requiresControl: replacementVisitor.IntroducedVariables.Any()
+            ));
+        }
+
         public JsExpression TranslateMemberAccess(MemberExpression expression)
         {
             var getter = (expression.Member as PropertyInfo)?.GetMethod;
-            if (expression.Expression == null)
+            if (expression.Expression is null)
             {
                 // static
-                return TryTranslateMethodCall(getter, null, new Expression[0]) ??
-                    new JsLiteral((
-                        ((expression.Member as FieldInfo)?.GetValue(null) ?? (expression.Member as PropertyInfo)?.GetValue(null))));
+                if (TryTranslateMethodCall(getter, null, []) is {} translated)
+                    return translated;
+                if (expression.Member is PropertyInfo)
+                    return TranslateResourceSubexpression(expression);
+
+                return new JsLiteral(((FieldInfo)expression.Member).GetValue(null));
             }
             else
             {

--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslationVisitor.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslationVisitor.cs
@@ -488,6 +488,8 @@ namespace DotVVM.Framework.Compilation.Javascript
             var resultLambda = Expression.Lambda<BindingDelegate>(expr, BindingCompiler.CurrentControlParameter);
             var resultDelegate = resultLambda.Compile();
 
+            var annotation = new ViewModelInfoAnnotation(expression.Type, containsObservables: false);
+
             return new JsSymbolicParameter(new JavascriptTranslator.ResourceSymbolicParameter(
                 control => new CodeParameterAssignment(
                     new ParametrizedCode(
@@ -496,7 +498,7 @@ namespace DotVVM.Framework.Compilation.Javascript
                     )
                 ),
                 requiresControl: replacementVisitor.IntroducedVariables.Any()
-            ));
+            )).WithAnnotation(annotation);
         }
 
         public JsExpression TranslateMemberAccess(MemberExpression expression)

--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslationVisitor.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslationVisitor.cs
@@ -23,13 +23,13 @@ namespace DotVVM.Framework.Compilation.Javascript
     public class JavascriptTranslationVisitor
     {
         private readonly IJavascriptMethodTranslator Translator;
-        private readonly IBinding? DebugBinding;
+        private readonly IBinding? WrapperBinding;
 
         public DataContextStack DataContext { get; }
 
         private readonly Dictionary<DataContextStack, int> ContextMap;
         public bool WriteUnknownParameters { get; set; } = true;
-        public JavascriptTranslationVisitor(DataContextStack dataContext, IJavascriptMethodTranslator translator, IBinding? debugBinding = null)
+        public JavascriptTranslationVisitor(DataContextStack dataContext, IJavascriptMethodTranslator translator, IBinding? wrapperBinding = null)
         {
             this.ContextMap =
                 dataContext
@@ -39,7 +39,7 @@ namespace DotVVM.Framework.Compilation.Javascript
                 .ToDictionary(a => a.a, a => a.i);
             this.DataContext = dataContext;
             this.Translator = translator;
-            this.DebugBinding = debugBinding;
+            this.WrapperBinding = wrapperBinding;
         }
         public JsExpression Translate(Expression expression)
         {
@@ -483,7 +483,7 @@ namespace DotVVM.Framework.Compilation.Javascript
             var expr = replacementVisitor.Visit(expression);
             expr = ExpressionNullPropagationVisitor.PropagateNulls(expr, _ => true);
             expr = ExpressionUtils.ConvertToObject(expr);
-            expr = replacementVisitor.WrapExpression(expr, DebugBinding!);
+            expr = replacementVisitor.WrapExpression(expr, WrapperBinding);
 
             var resultLambda = Expression.Lambda<BindingDelegate>(expr, BindingCompiler.CurrentControlParameter);
             var resultDelegate = resultLambda.Compile();

--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslator.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslator.cs
@@ -186,8 +186,8 @@ namespace DotVVM.Framework.Compilation.Javascript
         /// <summary>
         /// Get's Javascript code that can be executed inside knockout data-bind attribute.
         /// </summary>
-        public static string FormatKnockoutScript(JsExpression expression, bool allowDataGlobal = true, int dataContextLevel = 0) =>
-            FormatKnockoutScript(expression.FormatParametrizedScript(), allowDataGlobal, dataContextLevel); // TODO
+        public static string FormatKnockoutScript(JsExpression expression, bool allowDataGlobal = true, int dataContextLevel = 0, DotvvmBindableObject? targetControl = null) =>
+            FormatKnockoutScript(expression.FormatParametrizedScript(), allowDataGlobal, dataContextLevel, targetControl);
         /// <summary>
         /// Get's Javascript code that can be executed inside knockout data-bind attribute.
         /// </summary>

--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslator.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslator.cs
@@ -160,9 +160,9 @@ namespace DotVVM.Framework.Compilation.Javascript
             return new JsViewModelPropertyAdjuster(mapper, preferUsingState);
         }
 
-        public JsExpression CompileToJavascript(Expression binding, DataContextStack dataContext, bool preferUsingState = false, bool isRootAsync = false, IBinding? debugBinding = null)
+        public JsExpression CompileToJavascript(Expression binding, DataContextStack dataContext, bool preferUsingState = false, bool isRootAsync = false, IBinding? wrapperBinding = null)
         {
-            var translator = new JavascriptTranslationVisitor(dataContext, DefaultMethodTranslator, debugBinding);
+            var translator = new JavascriptTranslationVisitor(dataContext, DefaultMethodTranslator, wrapperBinding);
             var script = new JsParenthesizedExpression(translator.Translate(binding));
             script.AcceptVisitor(AdjustingVisitor(preferUsingState));
             script.AcceptVisitor(new PromiseAwaitingVisitor(isRootAsync));
@@ -205,7 +205,7 @@ namespace DotVVM.Framework.Compilation.Javascript
                                     default);
                 }
                 else
-                    return resourceOnlyToString(expression, targetControl);
+                    return resourceOnlyToString(expression, targetControl, allowDataGlobal);
             }
 
             // separate method to avoid closure allocation if dataContextLevel == 0
@@ -237,11 +237,15 @@ namespace DotVVM.Framework.Compilation.Javascript
                         return default;
                     }
                 });
-            static string resourceOnlyToString(ParametrizedCode expression, DotvvmBindableObject? targetControl) =>
+            static string resourceOnlyToString(ParametrizedCode expression, DotvvmBindableObject? targetControl, bool allowDataGlobal) =>
                 expression.ToString(o => {
                     if (o is ResourceSymbolicParameter resource)
                     {
                         return resource.Evaluate(targetControl, expression, null);
+                    }
+                    else if (o == KnockoutViewModelParameter && !allowDataGlobal)
+                    {
+                        return CodeParameterAssignment.FromIdentifier("$data");
                     }
                     else
                     {

--- a/src/Framework/Framework/Compilation/Javascript/JavascriptTranslator.cs
+++ b/src/Framework/Framework/Compilation/Javascript/JavascriptTranslator.cs
@@ -13,6 +13,7 @@ using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Compilation.Javascript.Ast;
 using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Controls;
+using DotVVM.Framework.Runtime;
 using DotVVM.Framework.Utils;
 using DotVVM.Framework.ViewModel;
 using DotVVM.Framework.ViewModel.Serialization;
@@ -110,6 +111,30 @@ namespace DotVVM.Framework.Compilation.Javascript
             }
         }
 
+        public sealed class ResourceSymbolicParameter: CodeSymbolicParameter
+        {
+            public Func<DotvvmBindableObject?, CodeParameterAssignment> Binding { get; }
+            public bool RequiresControl { get; }
+            public ResourceSymbolicParameter(Func<DotvvmBindableObject?, CodeParameterAssignment> binding, bool requiresControl)
+            {
+                this.Binding = binding;
+                this.RequiresControl = requiresControl;
+            }
+
+            public CodeParameterAssignment Evaluate(DotvvmBindableObject? targetControl, ParametrizedCode? debugCode, IBinding? debugBinding)
+            {
+                if (targetControl is {} || !RequiresControl)
+                    return Binding(targetControl);
+                throw new Error(debugCode, debugBinding);
+            }
+
+            sealed record Error(ParametrizedCode? RelatedCode, IBinding? RelatedBinding)
+                : DotvvmExceptionBase(RelatedBinding: RelatedBinding)
+            {
+                public override string Message => $"Cannot evaluate resource symbolic parameter without knowing the target control of '{RelatedBinding?.ToString() ?? RelatedCode?.ToDebugString() ?? "<unknown binding>"}'";
+            }
+        }
+
 
         private readonly IViewModelSerializationMapper mapper;
 
@@ -135,9 +160,9 @@ namespace DotVVM.Framework.Compilation.Javascript
             return new JsViewModelPropertyAdjuster(mapper, preferUsingState);
         }
 
-        public JsExpression CompileToJavascript(Expression binding, DataContextStack dataContext, bool preferUsingState = false, bool isRootAsync = false)
+        public JsExpression CompileToJavascript(Expression binding, DataContextStack dataContext, bool preferUsingState = false, bool isRootAsync = false, IBinding? debugBinding = null)
         {
-            var translator = new JavascriptTranslationVisitor(dataContext, DefaultMethodTranslator);
+            var translator = new JavascriptTranslationVisitor(dataContext, DefaultMethodTranslator, debugBinding);
             var script = new JsParenthesizedExpression(translator.Translate(binding));
             script.AcceptVisitor(AdjustingVisitor(preferUsingState));
             script.AcceptVisitor(new PromiseAwaitingVisitor(isRootAsync));
@@ -162,27 +187,31 @@ namespace DotVVM.Framework.Compilation.Javascript
         /// Get's Javascript code that can be executed inside knockout data-bind attribute.
         /// </summary>
         public static string FormatKnockoutScript(JsExpression expression, bool allowDataGlobal = true, int dataContextLevel = 0) =>
-            FormatKnockoutScript(expression.FormatParametrizedScript(), allowDataGlobal, dataContextLevel);
+            FormatKnockoutScript(expression.FormatParametrizedScript(), allowDataGlobal, dataContextLevel); // TODO
         /// <summary>
         /// Get's Javascript code that can be executed inside knockout data-bind attribute.
         /// </summary>
-        public static string FormatKnockoutScript(ParametrizedCode expression, bool allowDataGlobal = true, int dataContextLevel = 0)
+        public static string FormatKnockoutScript(ParametrizedCode expression, bool allowDataGlobal = true, int dataContextLevel = 0, DotvvmBindableObject? targetControl = null)
         {
             if (dataContextLevel == 0)
             {
-                if (allowDataGlobal)
-                    return expression.ToDefaultString();
+                if (expression.TryToDefaultString() is {} defaultString)
+                {
+                    if (allowDataGlobal)
+                        return defaultString;
+                    else
+                        return expression.ToString(static o =>
+                                    o == KnockoutViewModelParameter ? CodeParameterAssignment.FromIdentifier("$data") :
+                                    default);
+                }
                 else
-                    return expression.ToString(static o =>
-                                o == KnockoutViewModelParameter ? CodeParameterAssignment.FromIdentifier("$data") :
-                                default);
-
+                    return resourceOnlyToString(expression, targetControl);
             }
 
             // separate method to avoid closure allocation if dataContextLevel == 0
-            return shiftToString(expression, dataContextLevel);
+            return shiftToString(expression, dataContextLevel, targetControl);
 
-            static string shiftToString(ParametrizedCode expression, int dataContextLevel) =>
+            static string shiftToString(ParametrizedCode expression, int dataContextLevel, DotvvmBindableObject? targetControl) =>
                 expression.ToString(o => {
                     if (o is ViewModelSymbolicParameter vm)
                     {
@@ -198,6 +227,21 @@ namespace DotVVM.Framework.Compilation.Javascript
                     {
                         var p = GetKnockoutContextParameter(dataContextLevel).DefaultAssignment;
                         return new(p.Code!.ToDefaultString(), p.Code.OperatorPrecedence);
+                    }
+                    else if (o is ResourceSymbolicParameter resource)
+                    {
+                        return resource.Evaluate(targetControl, expression, null);
+                    }
+                    else
+                    {
+                        return default;
+                    }
+                });
+            static string resourceOnlyToString(ParametrizedCode expression, DotvvmBindableObject? targetControl) =>
+                expression.ToString(o => {
+                    if (o is ResourceSymbolicParameter resource)
+                    {
+                        return resource.Evaluate(targetControl, expression, null);
                     }
                     else
                     {

--- a/src/Framework/Framework/Compilation/Javascript/ParametrizedCode.cs
+++ b/src/Framework/Framework/Compilation/Javascript/ParametrizedCode.cs
@@ -112,6 +112,15 @@ namespace DotVVM.Framework.Compilation.Javascript
             return this.evaluatedDefault = ToString(_ => default);
         }
 
+        internal string? TryToDefaultString()
+        {
+            // warning: this has weird semantics
+            // * in some cases, it will return null, even when default value could be initialized
+            // * then, after ToString is called, the ParametrizedCode notices all parameters are constants and sets the cache
+            // * subsequent calls will return the initialized default
+            return this.evaluatedDefault;
+        }
+
         public string ToDebugString()
         {
             if (stringParts is null)

--- a/src/Framework/Framework/Controls/KnockoutHelper.cs
+++ b/src/Framework/Framework/Controls/KnockoutHelper.cs
@@ -204,9 +204,10 @@ namespace DotVVM.Framework.Controls
                     IStaticCommandBinding { OptionsLambdaJavascript: var optionsLambdaExpression } => (true, optionsLambdaExpression),
                     _ => (false, expression.CommandJavascript)
                 };
+            var dataContextTarget = expression.FindDataContextTarget(control);
             var adjustedExpression =
                 JavascriptTranslator.AdjustKnockoutScriptContext(jsExpression,
-                    dataContextLevel: expression.FindDataContextTarget(control).stepsUp);
+                    dataContextLevel: dataContextTarget.stepsUp);
             if (options.ParameterAssignment is {})
             {
                 adjustedExpression = adjustedExpression.AssignParameters(options.ParameterAssignment);
@@ -280,6 +281,7 @@ namespace DotVVM.Framework.Controls
                     p == CommandBindingExpression.CommandArgumentsParameter ? options.CommandArgs ?? default :
                     p == CommandBindingExpression.PostbackHandlersParameter ? CodeParameterAssignment.FromIdentifier(getHandlerScript()) :
                     p == CommandBindingExpression.AbortSignalParameter ? abortSignal :
+                    p is JavascriptTranslator.ResourceSymbolicParameter resource ? resource.Evaluate(dataContextTarget.target, parametrizedCode, expression) :
                     default
                 );
             }
@@ -432,7 +434,7 @@ namespace DotVVM.Framework.Controls
                 return $"[{handlerNameJson},{{q:{MakeStringLiteral(queueName!)}}}]";
             }
         }
-        
+
         /// <summary> Returns a lambda function taking the knockout context as its single argument, returning the result of the IValueBinding. </summary>
         public static string GetValueBindingContextLambda(this IValueBinding binding, DotvvmBindableObject contextControl, bool unwrapped = false)
         {

--- a/src/Framework/Testing/BindingTestHelper.cs
+++ b/src/Framework/Testing/BindingTestHelper.cs
@@ -258,11 +258,16 @@ namespace DotVVM.Framework.Testing
         /// <summary> Returns the "body" of the JavaScript code produced by the staticCommand.
         /// The method is intended for asserting that the generated code is equal to the correct thing, if you intend to execute the code, please use <see cref="KnockoutHelper.GenerateClientPostBackExpression" /> directly. </summary>
         public static string GetStaticCommandJavascriptBody(StaticCommandBindingExpression binding, bool stripBoilerplate = true)
+            => GetStaticCommandJavascriptBody(binding, new Literal(), stripBoilerplate);
+
+        /// <summary> Returns the "body" of the JavaScript code produced by the staticCommand.
+        /// The method is intended for asserting that the generated code is equal to the correct thing, if you intend to execute the code, please use <see cref="KnockoutHelper.GenerateClientPostBackExpression" /> directly. </summary>
+        public static string GetStaticCommandJavascriptBody(StaticCommandBindingExpression binding, DotvvmBindableObject control, bool stripBoilerplate = true)
         {
             var expr = KnockoutHelper.GenerateClientPostBackExpression(
                 "NonExistentProperty",
                 binding,
-                new Literal(),
+                control,
                 new PostbackScriptOptions(
                     allowPostbackHandlers: false,
                     returnValue: null,

--- a/src/Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/Tests/Binding/JavascriptCompilationTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text.Json.Serialization;
@@ -21,6 +22,9 @@ using DotVVM.Framework.ViewModel;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static DotVVM.Framework.Configuration.FreezableUtils;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DotVVM.Framework.Tests.Resources;
 
 namespace DotVVM.Framework.Tests.Binding
 {
@@ -37,6 +41,7 @@ namespace DotVVM.Framework.Tests.Binding
             var methods = configuration.Markup.JavascriptTranslator.MethodCollection;
             methods.AddMethodTranslator(() => TestJsTransations.GetTestPlainObject(), new GenericMethodCompiler(args => new JsIdentifierExpression("testPlainObject").WithAnnotation(new ViewModelInfoAnnotation(typeof(TestArraysViewModel), containsObservables: false))));
             methods.AddMethodTranslator(() => TestJsTransations.GetTestObjectWithObservables(), new GenericMethodCompiler(args => new JsIdentifierExpression("testPlainObject").WithAnnotation(new ViewModelInfoAnnotation(typeof(TestArraysViewModel), containsObservables: true))));
+            methods.AddPropertyTranslator(() => StaticPropertyResourceTest.TranslatedProperty, new GenericMethodCompiler(args => new JsLiteral("translated")));
             configuration.Freeze();
             bindingHelper = new BindingTestHelper(configuration);
         }
@@ -238,6 +243,243 @@ namespace DotVVM.Framework.Tests.Binding
         {
             var js = CompileBinding("_page.EvaluatingOnServer");
             Assert.AreEqual("false", js);
+        }
+
+        [TestMethod]
+        public void JavascriptCompilation_BindingPageInfo_Resource()
+        {
+            Assert.AreEqual("server value", new BindingPageInfo().Resource("server value"));
+
+            var js = CompileBinding("_page.Resource(\"client \" + \"value\")");
+            Assert.AreEqual("\"client value\"", js);
+        }
+
+        [TestMethod]
+        public void JavascriptCompilation_BindingPageInfo_Resource_AccessesViewModel()
+        {
+            var viewModel = new TestViewModel { StringProp = "root", IntProp = 7 };
+            var control = CreateControlWithDataContext(viewModel, out _);
+            var binding = bindingHelper.ValueBinding<object>("_page.Resource(StringProp + ':' + IntProp)", new [] { typeof(TestViewModel) });
+
+            var js = binding.GetKnockoutBindingExpression(control);
+
+            Assert.AreEqual("\"root:7\"", js);
+        }
+
+        [TestMethod]
+        public void JavascriptCompilation_BindingPageInfo_Resource_EvaluatesAtBindingDataContextWhenUsedInNestedDataContext()
+        {
+            var viewModel = new TestViewModel { StringProp = "root" };
+            var rootControl = CreateControlWithDataContext(viewModel, out var rootDataContext);
+            var childDataContext = DataContextStack.Create(typeof(string), rootDataContext);
+            var childControl = CreateChildControl(rootControl, childDataContext, "child");
+            var binding = bindingHelper.ValueBinding<object>("_page.Resource(StringProp)", rootDataContext);
+
+            var js = binding.GetKnockoutBindingExpression(childControl);
+
+            Assert.AreEqual("\"root\"", js);
+        }
+
+        [TestMethod]
+        public void JavascriptCompilation_BindingPageInfo_Resource_PreservesClientDataContextShift()
+        {
+            var viewModel = new TestViewModel { StringProp = "root" };
+            var rootControl = CreateControlWithDataContext(viewModel, out var rootDataContext);
+            var childDataContext = DataContextStack.Create(typeof(string), rootDataContext);
+            var childControl = CreateChildControl(rootControl, childDataContext, "child");
+            var binding = bindingHelper.ValueBinding<object>("_page.Resource(StringProp) + StringProp", rootDataContext);
+
+            var js = binding.GetKnockoutBindingExpression(childControl);
+
+            Assert.AreEqual("(\"root\"??\"\")+($parent.StringProp()??\"\")", js);
+        }
+
+        [TestMethod]
+        public void JavascriptCompilation_BindingPageInfo_Resource_SerializesComplexJson()
+        {
+            var viewModel = new TestViewModel {
+                TestViewModel2 = new TestViewModel2 {
+                    MyProperty = 7,
+                    SomeString = "nested",
+                    Collection = new List<Something> { new Something { Value = true } }
+                }
+            };
+            var control = CreateControlWithDataContext(viewModel, out var dataContext);
+            var binding = bindingHelper.ValueBinding<object>("_page.Resource(TestViewModel2)", dataContext);
+
+            var js = binding.GetKnockoutBindingExpression(control);
+
+            using var json = JsonDocument.Parse(js);
+            Assert.AreEqual(7, json.RootElement.GetProperty(nameof(TestViewModel2.MyProperty)).GetInt32());
+            Assert.AreEqual("nested", json.RootElement.GetProperty(nameof(TestViewModel2.SomeString)).GetString());
+            Assert.IsTrue(json.RootElement.GetProperty(nameof(TestViewModel2.Collection))[0].GetProperty(nameof(Something.Value)).GetBoolean());
+        }
+
+        [TestMethod]
+        public void JavascriptCompilation_BindingPageInfo_Resource_WithParentAndCurrentDataContext()
+        {
+            var viewModel = new TestViewModel { StringProp = "root" };
+            var rootControl = CreateControlWithDataContext(viewModel, out var rootDataContext);
+            var childDataContext = DataContextStack.Create(typeof(string), rootDataContext);
+            var childControl = CreateChildControl(rootControl, childDataContext, "child");
+            var binding = bindingHelper.ValueBinding<object>("_page.Resource(_parent.StringProp + ':' + _this)", childDataContext);
+
+            var js = binding.GetKnockoutBindingExpression(childControl);
+
+            Assert.AreEqual("\"root:child\"", js);
+        }
+
+        [TestMethod]
+        public void JavascriptCompilation_BindingPageInfo_Resource_SerializesPrimitiveAndNullValues()
+        {
+            var viewModel = new TestViewModel { BoolProp = true, IntProp = 7, StringProp = null };
+            var control = CreateControlWithDataContext(viewModel, out var dataContext);
+
+            Assert.AreEqual("true", bindingHelper.ValueBinding<object>("_page.Resource(BoolProp)", dataContext).GetKnockoutBindingExpression(control));
+            Assert.AreEqual("7", bindingHelper.ValueBinding<object>("_page.Resource(IntProp)", dataContext).GetKnockoutBindingExpression(control));
+            Assert.AreEqual("null", bindingHelper.ValueBinding<object>("_page.Resource(StringProp)", dataContext).GetKnockoutBindingExpression(control));
+        }
+
+        [TestMethod]
+        public void JavascriptCompilation_BindingPageInfo_Resource_RequiresTargetControlForViewModelAccess()
+        {
+            var binding = bindingHelper.ValueBinding<object>("_page.Resource(StringProp)", new [] { typeof(TestViewModel) });
+
+            try
+            {
+                JavascriptTranslator.FormatKnockoutScript(binding.KnockoutExpression);
+                Assert.Fail("Formatting a resource expression that needs a view model should require a target control.");
+            }
+            catch (DotvvmExceptionBase ex)
+            {
+                StringAssert.Contains(ex.Message, "Cannot evaluate resource symbolic parameter without knowing the target control");
+            }
+        }
+
+        [TestMethod]
+        public void JavascriptCompilation_BindingPageInfo_Resource_WorksWithAdditionalDataContextShift()
+        {
+            var viewModel = new TestViewModel { StringProp = "root" };
+            var rootControl = CreateControlWithDataContext(viewModel, out var rootDataContext);
+            var childDataContext = DataContextStack.Create(typeof(string), rootDataContext);
+            var childControl = CreateChildControl(rootControl, childDataContext, "child");
+            var binding = bindingHelper.ValueBinding<object>("_page.Resource(StringProp) + StringProp", rootDataContext);
+
+            var js = binding.KnockoutExpression.FormatKnockoutScript(childControl, binding, additionalDataContextSteps: 1);
+
+            Assert.AreEqual("(\"root\"??\"\")+($parents[1].StringProp()??\"\")", js);
+        }
+
+        [TestMethod]
+        public void JavascriptCompilation_BindingPageInfo_Resource_UsesParentBindingInRuntimeDataContextErrors()
+        {
+            var rootDataContext = bindingHelper.CreateDataContext(new [] { typeof(TestViewModel) });
+            var childDataContext = DataContextStack.Create(typeof(string), rootDataContext);
+            var rootControl = new PlaceHolder();
+            rootControl.SetDataContextType(rootDataContext);
+            rootControl.DataContext = new object();
+            var childControl = CreateChildControl(rootControl, childDataContext, "child");
+            var binding = bindingHelper.ValueBinding<object>("_page.Resource(_parent.StringProp)", childDataContext);
+
+            try
+            {
+                binding.GetKnockoutBindingExpression(childControl);
+                Assert.Fail("Expected resource evaluation to fail on the wrong runtime data context type.");
+            }
+            catch (Exception ex)
+            {
+                StringAssert.Contains(ex.ToString(), "_page.Resource(_parent.StringProp)");
+            }
+        }
+
+        [TestMethod]
+        public void JavascriptCompilation_ResxResourceProperty_IsEvaluatedWhenKnockoutScriptIsFormatted()
+        {
+            try
+            {
+                AutoUIPropertyNames.Culture = CultureInfo.InvariantCulture;
+                var binding = bindingHelper.ValueBinding<object>("DotVVM.Framework.Tests.Resources.AutoUIPropertyNames.FirstName", Type.EmptyTypes);
+                var expression = binding.KnockoutExpression;
+
+                AutoUIPropertyNames.Culture = CultureInfo.GetCultureInfo("cs");
+                var js = JavascriptTranslator.FormatKnockoutScript(expression);
+
+                Assert.AreEqual(AutoUIPropertyNames.FirstName, JsonSerializer.Deserialize<string>(js));
+            }
+            finally
+            {
+                AutoUIPropertyNames.Culture = null;
+            }
+        }
+
+        [TestMethod]
+        public void JavascriptCompilation_ResxResourceProperty_PreservesClientDataContextShift()
+        {
+            try
+            {
+                AutoUIPropertyNames.Culture = CultureInfo.InvariantCulture;
+                var viewModel = new TestViewModel { StringProp = "root" };
+                var rootControl = CreateControlWithDataContext(viewModel, out var rootDataContext);
+                var childDataContext = DataContextStack.Create(typeof(string), rootDataContext);
+                var childControl = CreateChildControl(rootControl, childDataContext, "child");
+                var binding = bindingHelper.ValueBinding<object>("DotVVM.Framework.Tests.Resources.AutoUIPropertyNames.FirstName + StringProp", rootDataContext);
+                var expression = binding.KnockoutExpression;
+
+                AutoUIPropertyNames.Culture = CultureInfo.GetCultureInfo("cs");
+                var js = expression.FormatKnockoutScript(childControl, binding);
+
+                Assert.AreEqual("(\"Křestní jméno osoby\"??\"\")+($parent.StringProp()??\"\")", js);
+            }
+            finally
+            {
+                AutoUIPropertyNames.Culture = null;
+            }
+        }
+
+        [TestMethod]
+        public void JavascriptCompilation_StaticPropertyWithoutTranslator_IsEvaluatedWhenKnockoutScriptIsFormatted()
+        {
+            try
+            {
+                StaticPropertyResourceTest.UntranslatedProperty = "compiled";
+                var binding = bindingHelper.ValueBinding<object>("DotVVM.Framework.Tests.Binding.StaticPropertyResourceTest.UntranslatedProperty", Type.EmptyTypes);
+                var expression = binding.KnockoutExpression;
+
+                StaticPropertyResourceTest.UntranslatedProperty = "formatted";
+                var js = JavascriptTranslator.FormatKnockoutScript(expression);
+
+                Assert.AreEqual("\"formatted\"", js);
+            }
+            finally
+            {
+                StaticPropertyResourceTest.UntranslatedProperty = "";
+            }
+        }
+
+        [TestMethod]
+        public void JavascriptCompilation_StaticPropertyWithTranslator_UsesTranslator()
+        {
+            var js = CompileBinding("DotVVM.Framework.Tests.Binding.StaticPropertyResourceTest.TranslatedProperty");
+
+            Assert.AreEqual("\"translated\"", js);
+        }
+
+        static DotvvmControl CreateControlWithDataContext(object viewModel, out DataContextStack dataContext)
+        {
+            dataContext = bindingHelper.CreateDataContext(new [] { viewModel.GetType() });
+            var control = new PlaceHolder();
+            control.SetDataContextType(dataContext);
+            control.DataContext = viewModel;
+            return control;
+        }
+
+        static DotvvmControl CreateChildControl(DotvvmControl parent, DataContextStack dataContext, object viewModel)
+        {
+            var child = new PlaceHolder();
+            child.SetDataContextType(dataContext);
+            child.DataContext = viewModel;
+            parent.Children.Add(child);
+            return child;
         }
 
         [TestMethod]
@@ -1654,6 +1896,12 @@ namespace DotVVM.Framework.Tests.Binding
         public string GetString() => "";
         public string PostDateToString(DateTime date) => date.ToShortDateString();
         public DateTime GetCurrentTime(string name) => DateTime.UtcNow;
+    }
+
+    public static class StaticPropertyResourceTest
+    {
+        public static string UntranslatedProperty { get; set; } = "";
+        public static string TranslatedProperty => "server";
     }
 
     public class TestArraysViewModel

--- a/src/Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/Tests/Binding/JavascriptCompilationTests.cs
@@ -316,6 +316,46 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        public void JavascriptCompilation_BindingPageInfo_Resource_MemberAccessUsesPlainObjectInClientExpression()
+        {
+            var viewModel = new TestViewModel {
+                TestViewModel2 = new TestViewModel2 {
+                    MyProperty = 7,
+                    SomeString = "nested",
+                    Collection = new List<Something>()
+                }
+            };
+            var control = CreateControlWithDataContext(viewModel, out var dataContext);
+            var binding = bindingHelper.ValueBinding<object>("_page.Resource(TestViewModel2).MyProperty + 1", dataContext);
+
+            var js = binding.GetKnockoutBindingExpression(control);
+
+            StringAssert.Contains(js, $".{nameof(TestViewModel2.MyProperty)}");
+            Assert.IsFalse(js.Contains($".{nameof(TestViewModel2.MyProperty)}()"), js);
+            StringAssert.EndsWith(js, $".{nameof(TestViewModel2.MyProperty)}+1");
+        }
+
+        [TestMethod]
+        public void JavascriptCompilation_BindingPageInfo_Resource_UnwrappedBindingUsesPlainObject()
+        {
+            var viewModel = new TestViewModel {
+                TestViewModel2 = new TestViewModel2 {
+                    MyProperty = 7,
+                    SomeString = "nested",
+                    Collection = new List<Something>()
+                }
+            };
+            var control = CreateControlWithDataContext(viewModel, out var dataContext);
+            var binding = bindingHelper.ValueBinding<object>("_page.Resource(TestViewModel2)", dataContext);
+
+            var js = binding.GetKnockoutBindingExpression(control, unwrapped: true);
+
+            using var json = JsonDocument.Parse(js);
+            Assert.AreEqual(7, json.RootElement.GetProperty(nameof(TestViewModel2.MyProperty)).GetInt32());
+            Assert.AreEqual("nested", json.RootElement.GetProperty(nameof(TestViewModel2.SomeString)).GetString());
+        }
+
+        [TestMethod]
         public void JavascriptCompilation_BindingPageInfo_Resource_WithParentAndCurrentDataContext()
         {
             var viewModel = new TestViewModel { StringProp = "root" };
@@ -388,6 +428,8 @@ namespace DotVVM.Framework.Tests.Binding
             }
             catch (Exception ex)
             {
+                StringAssert.Contains(ex.ToString(), "Could not evaluate binding {value: _page.Resource(_parent.StringProp)}");
+                StringAssert.Contains(ex.ToString(), "data context _parent: DotVVM.Framework.Tests.Binding.TestViewModel was expected, but got object");
                 StringAssert.Contains(ex.ToString(), "_page.Resource(_parent.StringProp)");
             }
         }

--- a/src/Tests/Binding/StaticCommandCompilationTests.cs
+++ b/src/Tests/Binding/StaticCommandCompilationTests.cs
@@ -97,6 +97,22 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        public void StaticCommandCompilation_BindingPageInfo_Resource()
+        {
+            var viewModel = new TestViewModel { StringProp = "root" };
+            var context = releaseHelper.CreateDataContext(new [] { typeof(TestViewModel) });
+            var control = new PlaceHolder {
+                DataContext = viewModel
+            };
+            control.SetDataContextType(context);
+            var binding = releaseHelper.StaticCommand("StringProp = _page.Resource(StringProp + ' server')", context);
+
+            var result = BindingTestHelper.GetStaticCommandJavascriptBody(binding, control);
+
+            Assert.AreEqual("{options.viewModel.StringProp(\"root server\");}", result);
+        }
+
+        [TestMethod]
         public void StaticCommandCompilation_JsOnlyCommand()
         {
             var result = CompileBinding("StringProp = StringProp.Length.ToString()", niceMode: false, typeof(TestViewModel));


### PR DESCRIPTION
It is evaluated during initial request.

Accesses to static properties now translate to this construct, so using resources should 'just work'