### PR TITLE
Fix resource URL caching with multiple PathBase

### DIFF
--- a/src/Framework/Framework/ResourceManagement/LocalResourceLocation.cs
+++ b/src/Framework/Framework/ResourceManagement/LocalResourceLocation.cs
@@ -1,18 +1,32 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
+using System.Threading;
 using DotVVM.Framework.Hosting;
-using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DotVVM.Framework.ResourceManagement
 {
     public abstract class LocalResourceLocation : ILocalResourceLocation
     {
-        public string GetUrl(IDotvvmRequestContext context, string name) =>
-            context.Services.GetRequiredService<ILocalResourceUrlManager>().GetResourceUrl(this, context, name);
+        private Tuple<string, string>? cache;
+
+        public string GetUrl(IDotvvmRequestContext context, string name)
+        {
+            if (this.cache is var (cachedName, cachedUrl))
+            {
+                // almost all resource locations have a single name
+                if (cachedName == name)
+                    return cachedUrl;
+            }
+            var url = context.Services.GetRequiredService<ILocalResourceUrlManager>().GetResourceUrl(this, context, name);
+
+            var debug = context.Configuration.Debug;
+            if (!debug && this.cache is null)
+            {
+                Interlocked.CompareExchange(ref this.cache, value: Tuple.Create(name, url), comparand: null);
+            }
+            return url;
+        }
 
         public abstract Stream LoadResource(IDotvvmRequestContext context);
     }

--- a/src/Framework/Framework/ResourceManagement/LocalResourceUrlManager.cs
+++ b/src/Framework/Framework/ResourceManagement/LocalResourceUrlManager.cs
@@ -48,11 +48,11 @@ namespace DotVVM.Framework.ResourceManagement
             if (allowResourceVersionHash)
             {
                 var versionHash = GetVersionHash(resource, context, name);
-                return context.TranslateVirtualPath($"~/{HostingConstants.ResourceRouteName}-{encodedName}/{encodedName}?v={versionHash}");
+                return $"~/{HostingConstants.ResourceRouteName}-{encodedName}/{encodedName}?v={versionHash}";
             }
             else
             {
-                return context.TranslateVirtualPath($"~/{HostingConstants.ResourceRouteName}-{encodedName}/{encodedName}");
+                return $"~/{HostingConstants.ResourceRouteName}-{encodedName}/{encodedName}";
             }
         }
 

--- a/src/Framework/Framework/ResourceManagement/ResourcesRenderer.cs
+++ b/src/Framework/Framework/ResourceManagement/ResourcesRenderer.cs
@@ -1,20 +1,18 @@
 ﻿using DotVVM.Framework.Controls;
 using DotVVM.Framework.Hosting;
+using DotVVM.Framework.Utils;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 
 namespace DotVVM.Framework.ResourceManagement
 {
     public static class ResourcesRenderer
     {
-        private static ConditionalWeakTable<IResource, string> renderedCache = new ConditionalWeakTable<IResource, string>();
-
-        public static void RenderResourceCached(this NamedResource resource, IHtmlWriter writer, IDotvvmRequestContext context)
+        public static void RenderResource(this NamedResource resource, IHtmlWriter writer, IDotvvmRequestContext context)
         {
-            writer.WriteUnencodedText(resource.GetRenderedTextCached(context));
+            resource.Resource.Render(writer, context, resource.Name);
         }
 
         static void WriteResourceInfo(NamedResource resource, IHtmlWriter writer, bool preload)
@@ -62,7 +60,7 @@ namespace DotVVM.Framework.ResourceManagement
                     if (writeDebugInfo) WriteResourceInfo(resource, writer, preload: false);
                     // TODO: warning for missing dependencies
                     resourceManager.MarkRendered(resource);
-                    resource.RenderResourceCached(writer, context);
+                    resource.RenderResource(writer, context);
                 }
                 else if (position == ResourceRenderPosition.Head && resourcePosition == ResourceRenderPosition.Body && resource.Resource is IPreloadResource preloadResource)
                 {
@@ -77,19 +75,27 @@ namespace DotVVM.Framework.ResourceManagement
                 writer.WriteUnencodedText("\n");
         }
 
+        [Obsolete("Use .RenderToString (cache is no longer available)")]
         public static string GetRenderedTextCached(this NamedResource resource, IDotvvmRequestContext context) =>
-            // don't use cache when debug, so the resource can be refreshed when file is changed
-            context.Configuration.Debug ?
-            RenderToString(resource, context) :
-            renderedCache.GetValue(resource.Resource, _ => RenderToString(resource, context));
+            RenderToString(resource, context);
 
-        private static string RenderToString(NamedResource resource, IDotvvmRequestContext context)
+        public static string RenderToString(this NamedResource resource, IDotvvmRequestContext context)
         {
             using (var text = new StringWriter())
             {
                 resource.Resource.Render(new HtmlWriter(text, context), context, resource.Name);
                 return text.ToString();
             }
+        }
+
+        public static Memory<byte> RenderToStringUtf8(this NamedResource resource, IDotvvmRequestContext context)
+        {
+            var ms = new MemoryStream();
+            using (var text = new StreamWriter(ms, encoding: StringUtils.Utf8))
+            {
+                resource.Resource.Render(new HtmlWriter(text, context), context, resource.Name);
+            }
+            return ms.ToMemory();
         }
     }
 }

--- a/src/Framework/Framework/ResourceManagement/UrlResourceLocation.cs
+++ b/src/Framework/Framework/ResourceManagement/UrlResourceLocation.cs
@@ -21,7 +21,7 @@ namespace DotVVM.Framework.ResourceManagement
 
         public string GetUrl(IDotvvmRequestContext context, string name)
         {
-            return context.TranslateVirtualPath(context.Configuration.Debug ? DebugUrl : Url);
+            return context.Configuration.Debug ? DebugUrl : Url;
         }
     }
 }

--- a/src/Framework/Framework/Utils/MemoryUtils.cs
+++ b/src/Framework/Framework/Utils/MemoryUtils.cs
@@ -7,9 +7,9 @@ namespace DotVVM.Framework.Utils
     static class MemoryUtils
     {
         public static Span<byte> ToSpan(this MemoryStream stream) =>
-            stream.TryGetBuffer(out var buffer) ? buffer.AsSpan().Slice(0, (int)stream.Length) : stream.ToArray();
+            stream.TryGetBuffer(out ArraySegment<byte> buffer) ? buffer.AsSpan() : stream.ToArray();
         public static Memory<byte> ToMemory(this MemoryStream stream) =>
-            stream.TryGetBuffer(out var buffer) ? buffer.AsMemory().Slice(0, (int)stream.Length) : stream.ToArray();
+            stream.TryGetBuffer(out ArraySegment<byte> buffer) ? buffer.AsMemory() : stream.ToArray();
 
         public static MemoryStream CloneReadOnly(this MemoryStream stream)
         {

--- a/src/Framework/Framework/ViewModel/Serialization/DefaultViewModelSerializer.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/DefaultViewModelSerializer.cs
@@ -265,7 +265,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
             writer.WriteStartObject("resources"u8);
             foreach (var resource in newResources)
             {
-                writer.WriteString(resource.Name, resource.GetRenderedTextCached(context));
+                writer.WriteString(resource.Name, resource.RenderToStringUtf8(context).Span);
             }
             writer.WriteEndObject();
         }

--- a/src/Tests/Runtime/ResourceRenderTests.cs
+++ b/src/Tests/Runtime/ResourceRenderTests.cs
@@ -1,8 +1,10 @@
 using System.IO;
 using CheckTestOutput;
+using DotVVM.Framework.Configuration;
 using DotVVM.Framework.Controls;
 using DotVVM.Framework.ResourceManagement;
 using DotVVM.Framework.Testing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace DotVVM.Framework.Tests.Runtime
@@ -57,6 +59,97 @@ namespace DotVVM.Framework.Tests.Runtime
 
             var output = Render(res);
             check.CheckString(output, fileExtension: "html");
+        }
+
+        [TestMethod]
+        public void ResourceRenderer_ExpandsVirtualScriptAndStylesheetUrls()
+        {
+            var script = new NamedResource("test-script", new ScriptResource(new UrlResourceLocation("~/Scripts/test.js")));
+            var stylesheet = new NamedResource("test-stylesheet", new StylesheetResource(new UrlResourceLocation("~/Styles/test.css")));
+            var firstContext = DotvvmTestHelper.CreateContext();
+            ((TestHttpContext)firstContext.HttpContext).Request.PathBase = "";
+            var secondContext = DotvvmTestHelper.CreateContext();
+            ((TestHttpContext)secondContext.HttpContext).Request.PathBase = "/app";
+
+            var firstScriptOutput = script.RenderToString(firstContext);
+            var secondScriptOutput = script.RenderToString(secondContext);
+            var firstStylesheetOutput = stylesheet.RenderToString(firstContext);
+            var secondStylesheetOutput = stylesheet.RenderToString(secondContext);
+
+            Assert.IsFalse(firstScriptOutput.Contains("~/"));
+            Assert.IsFalse(secondScriptOutput.Contains("~/"));
+            Assert.IsFalse(firstStylesheetOutput.Contains("~/"));
+            Assert.IsFalse(secondStylesheetOutput.Contains("~/"));
+            StringAssert.Contains(firstScriptOutput, "src=/Scripts/test.js");
+            StringAssert.Contains(secondScriptOutput, "src=/app/Scripts/test.js");
+            StringAssert.Contains(firstStylesheetOutput, "href=/Styles/test.css");
+            StringAssert.Contains(secondStylesheetOutput, "href=/app/Styles/test.css");
+        }
+
+        [TestMethod]
+        public void ResourceRenderer_ExpandsVirtualPreloadUrls()
+        {
+            var resourceManager = new ResourceManager(DotvvmTestHelper.DefaultConfig.Resources);
+            var context = DotvvmTestHelper.CreateContext();
+            ((TestHttpContext)context.HttpContext).Request.PathBase = "/app";
+#pragma warning disable CS0618 // Test the preload path for resources rendered in the body.
+            var script = new NamedResource("test-script", new ScriptResource(new UrlResourceLocation("~/Scripts/test.js"), defer: false));
+            var scriptModule = new NamedResource("test-module", new ScriptModuleResource(new UrlResourceLocation("~/Modules/test.js"), defer: false));
+#pragma warning restore CS0618
+
+            using var text = new StringWriter();
+            var writer = new HtmlWriter(text, context);
+            ResourcesRenderer.RenderResources(resourceManager, [ script, scriptModule ], writer, context, ResourceRenderPosition.Head);
+            var output = text.ToString();
+
+            Assert.IsFalse(output.Contains("~/"));
+            StringAssert.Contains(output, "href=/app/Scripts/test.js");
+            StringAssert.Contains(output, "href=/app/Modules/test.js");
+        }
+
+        [TestMethod]
+        public void LocalResourceLocation_CachedFileResourceUrlReturnsVirtualUrl()
+        {
+            var configuration = DotvvmTestHelper.CreateConfiguration();
+            configuration.Runtime.AllowResourceVersionHash.Disable();
+            configuration.Freeze();
+            var resource = new FileResourceLocation("~/Scripts/test.js");
+            var firstContext = DotvvmTestHelper.CreateContext(configuration);
+            ((TestHttpContext)firstContext.HttpContext).Request.PathBase = "";
+            var secondContext = DotvvmTestHelper.CreateContext(configuration);
+            ((TestHttpContext)secondContext.HttpContext).Request.PathBase = "/app";
+
+            var firstUrl = ((IResourceLocation)resource).GetUrl(firstContext, "test");
+            var secondUrl = ((IResourceLocation)resource).GetUrl(secondContext, "test");
+            var virtualUrl = firstContext.Services.GetRequiredService<ILocalResourceUrlManager>().GetResourceUrl(resource, firstContext, "test");
+            var renderedScript = new NamedResource("test", new ScriptResource(resource)).RenderToString(secondContext);
+
+            Assert.AreEqual("~/_dotvvm/resource-test/test", firstUrl);
+            Assert.AreEqual("~/_dotvvm/resource-test/test", secondUrl);
+            Assert.AreEqual("~/_dotvvm/resource-test/test", virtualUrl);
+            StringAssert.Contains(renderedScript, "src=/app/_dotvvm/resource-test/test");
+        }
+
+        [TestMethod]
+        public void LocalResourceLocation_CachedEmbeddedResourceUrlWithHashReturnsVirtualUrl()
+        {
+            var resource = new EmbeddedResourceLocation(
+                typeof(DotvvmConfiguration).Assembly,
+                "DotVVM.Framework.Resources.Scripts.knockout-latest.js");
+            var firstContext = DotvvmTestHelper.CreateContext();
+            ((TestHttpContext)firstContext.HttpContext).Request.PathBase = "";
+            var secondContext = DotvvmTestHelper.CreateContext();
+            ((TestHttpContext)secondContext.HttpContext).Request.PathBase = "/app";
+
+            var firstUrl = ((IResourceLocation)resource).GetUrl(firstContext, "knockout");
+            var secondUrl = ((IResourceLocation)resource).GetUrl(secondContext, "knockout");
+            var virtualUrl = firstContext.Services.GetRequiredService<ILocalResourceUrlManager>().GetResourceUrl(resource, firstContext, "knockout");
+            var renderedScript = new NamedResource("knockout", new ScriptResource(resource)).RenderToString(secondContext);
+
+            StringAssert.StartsWith(firstUrl, "~/_dotvvm/resource-knockout/knockout?v=");
+            StringAssert.StartsWith(secondUrl, "~/_dotvvm/resource-knockout/knockout?v=");
+            StringAssert.StartsWith(virtualUrl, "~/_dotvvm/resource-knockout/knockout?v=");
+            StringAssert.Contains(renderedScript, "src=\"/app/_dotvvm/resource-knockout/knockout?v=");
         }
     }
 }


### PR DESCRIPTION
We remove the rendered resource cache. Instead we try to cache the virtual URL directly in the LocalResourceLocation.

Resolves #1828