### PR TITLE
Export the fetchCsrfToken function as dotvvm.getCsrfToken 

### DIFF
--- a/src/Framework/Framework/Resources/Scripts/binding-handlers/file-upload.ts
+++ b/src/Framework/Framework/Resources/Scripts/binding-handlers/file-upload.ts
@@ -1,4 +1,4 @@
-import { fetchCsrfToken } from "../postback/http";
+import { getCsrfToken } from "../postback/http";
 
 export default {
     "dotvvm-FileUpload": {
@@ -18,7 +18,7 @@ export default {
                     xhr.open("POST", args.url, true);
                     xhr.setRequestHeader("X-DotVVM-AsyncUpload", "true");
                     xhr.setRequestHeader("X-DotVVM-UploadToken", args.token);
-                    xhr.setRequestHeader("X-DotVVM-CsrfToken", await fetchCsrfToken(undefined));
+                    xhr.setRequestHeader("X-DotVVM-CsrfToken", await getCsrfToken(undefined));
                     xhr.upload.onprogress = function (e: ProgressEvent) {
                         if (e.lengthComputable) {
                             reportProgress(true, Math.round(e.loaded * 100 / e.total), '');

--- a/src/Framework/Framework/Resources/Scripts/dotvvm-root.ts
+++ b/src/Framework/Framework/Resources/Scripts/dotvvm-root.ts
@@ -29,7 +29,7 @@ import { DotvvmEvent } from "./events"
 import translations from './translations/translations'
 import { loadDataSet, postProcessors as loaderPostProcessors } from './dataset/loader'
 import * as dataSetTranslations from './dataset/translations'
-import { fetchCsrfToken } from "./postback/http"
+import { getCsrfToken } from "./postback/http"
 
 if (window["dotvvm"]) {
     throw new Error('DotVVM is already loaded!')
@@ -76,7 +76,7 @@ const dotvvmExports = {
     applyPostbackHandlers,
     validation: validation.globalValidationObject,
     postBack,
-    getCsrfToken: fetchCsrfToken,
+    getCsrfToken: getCsrfToken,
     init,
     registerGlobalComponent: viewModuleManager.registerGlobalComponent,
     isPostbackRunning,

--- a/src/Framework/Framework/Resources/Scripts/dotvvm-root.ts
+++ b/src/Framework/Framework/Resources/Scripts/dotvvm-root.ts
@@ -29,6 +29,7 @@ import { DotvvmEvent } from "./events"
 import translations from './translations/translations'
 import { loadDataSet, postProcessors as loaderPostProcessors } from './dataset/loader'
 import * as dataSetTranslations from './dataset/translations'
+import { fetchCsrfToken } from "./postback/http"
 
 if (window["dotvvm"]) {
     throw new Error('DotVVM is already loaded!')
@@ -75,6 +76,7 @@ const dotvvmExports = {
     applyPostbackHandlers,
     validation: validation.globalValidationObject,
     postBack,
+    getCsrfToken: fetchCsrfToken,
     init,
     registerGlobalComponent: viewModuleManager.registerGlobalComponent,
     isPostbackRunning,

--- a/src/Framework/Framework/Resources/Scripts/postback/http.ts
+++ b/src/Framework/Framework/Resources/Scripts/postback/http.ts
@@ -53,7 +53,9 @@ export async function fetchJson<T>(url: string, init: RequestInit): Promise<Wrap
 
 let csrfTokenFactory: Promise<string> | undefined;
 
-export async function fetchCsrfToken(signal: AbortSignal | undefined): Promise<string> {
+/** Returns the DotVVM CSRF token.
+  * If LazyCsrfToken is enabled, this function will fetch it from the server, otherwise returns immediately */
+export async function getCsrfToken(signal: AbortSignal | undefined): Promise<string> {
     let token = getState().$csrfToken
     if (token == null) {
         csrfTokenFactory ??= (async () => {

--- a/src/Framework/Framework/Resources/Scripts/postback/postbackCore.ts
+++ b/src/Framework/Framework/Resources/Scripts/postback/postbackCore.ts
@@ -50,7 +50,7 @@ export async function postbackCore(
     }
 
     return await http.retryOnInvalidCsrfToken(async () => {
-        await http.fetchCsrfToken(options.abortSignal);
+        await http.getCsrfToken(options.abortSignal);
 
         updateDynamicPathFragments(context, path);
 

--- a/src/Framework/Framework/Resources/Scripts/postback/staticCommand.ts
+++ b/src/Framework/Framework/Resources/Scripts/postback/staticCommand.ts
@@ -37,7 +37,7 @@ export async function staticCommandPostback(command: string, args: any[], option
         const absolutePaths = resolveRelativeValidationPaths(paths, options.knockoutContext)
 
         await http.retryOnInvalidCsrfToken(async () => {
-            const csrfToken = await http.fetchCsrfToken(options.abortSignal);
+            const csrfToken = await http.getCsrfToken(options.abortSignal);
             data = { 
                 args: args.map(a => serialize(a)), 
                 command, 

--- a/src/Framework/Framework/Resources/Scripts/tests/eventArgs.test.ts
+++ b/src/Framework/Framework/Resources/Scripts/tests/eventArgs.test.ts
@@ -31,7 +31,7 @@ function appendAdditionalHeaders(headers: Headers, additionalHeaders?: { [key: s
 
 
 jest.mock("../postback/http", () => ({
-    async fetchCsrfToken() {
+    async getCsrfToken() {
         getStateManager().update(vm => ({ ...vm, $csrfToken: "test token" }))
     },
 

--- a/src/Framework/Framework/Resources/Scripts/tests/postback.test.ts
+++ b/src/Framework/Framework/Resources/Scripts/tests/postback.test.ts
@@ -38,7 +38,7 @@ function appendAdditionalHeaders(headers: Headers, additionalHeaders?: { [key: s
 }
 
 jest.mock("../postback/http", () => ({
-    async fetchCsrfToken() {
+    async getCsrfToken() {
         getStateManager().update(vm => ({ ...vm, $csrfToken: "test token" }))
     },
 

--- a/src/Samples/Tests/Tests/Complex/SPAErrorReportingTests.cs
+++ b/src/Samples/Tests/Tests/Complex/SPAErrorReportingTests.cs
@@ -50,7 +50,7 @@ namespace DotVVM.Samples.Tests.Complex
 
                     SetOfflineMode(true);
 
-                    // try to submit command in offline mode (we don't have CSRF token in Lazy CSRF mode yet, so we should fail in fetchCsrfToken)
+                    // try to submit command in offline mode (we don't have CSRF token in Lazy CSRF mode yet, so we should fail in getCsrfToken)
                     browser.Single("input[type=text]").SendKeys("aaa");
                     browser.ElementAt("input[type=button]", 0).Click().Wait(250);
                     browser.Single("#debugWindow button").Click();


### PR DESCRIPTION
It's necessary in BP for sending requests