### PR TITLE
Avoid registering DotvvmPresenter as IDotvvmPresenter

### DIFF
--- a/src/Framework/Framework/DependencyInjection/DotVVMServiceCollectionExtensions.cs
+++ b/src/Framework/Framework/DependencyInjection/DotVVMServiceCollectionExtensions.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton<IViewModelParameterBinder, AttributeViewModelParameterBinder>();
             services.TryAddSingleton<IOutputRenderer, DefaultOutputRenderer>();
             services.TryAddSingleton<StaticCommandExecutor>();
-            services.TryAddSingleton<IDotvvmPresenter, DotvvmPresenter>();
+            services.TryAddSingleton<DotvvmPresenter>();
             services.TryAddSingleton<IMarkupFileLoader, AggregateMarkupFileLoader>();
             services.TryAddSingleton<IControlBuilderFactory, DefaultControlBuilderFactory>();
             services.TryAddSingleton<IControlResolver, DefaultControlResolver>();

--- a/src/Framework/Framework/Hosting/LocalizablePresenter.cs
+++ b/src/Framework/Framework/Hosting/LocalizablePresenter.cs
@@ -59,7 +59,7 @@ namespace DotVVM.Framework.Hosting
                 context.Parameters!.TryGetValue(name, out var value) && !string.IsNullOrEmpty(value as string) ? CultureInfo.GetCultureInfo((string)value!) : null;
             var presenter = new LocalizablePresenter(
                 redirectWhenNotFound ? WithRedirectOnFailure(redirect, getCulture) : getCulture,
-                context => context.Services.GetRequiredService<IDotvvmPresenter>().ProcessRequest(context)
+                context => context.Services.GetRequiredService<DotvvmPresenter>().ProcessRequest(context)
             );
             return _ => presenter;
         }
@@ -87,7 +87,7 @@ namespace DotVVM.Framework.Hosting
                 context.Query.TryGetValue(name, out var value) && !string.IsNullOrEmpty(value) ? CultureInfo.GetCultureInfo(value) : null;
             var presenter = new LocalizablePresenter(
                 redirectWhenNotFound ? WithRedirectOnFailure(redirect, getCulture) : getCulture,
-                context => context.Services.GetRequiredService<IDotvvmPresenter>().ProcessRequest(context)
+                context => context.Services.GetRequiredService<DotvvmPresenter>().ProcessRequest(context)
             );
             return _ => presenter;
         }

--- a/src/Framework/Framework/Routing/DotvvmRouteTable.cs
+++ b/src/Framework/Framework/Routing/DotvvmRouteTable.cs
@@ -120,7 +120,7 @@ namespace DotVVM.Framework.Routing
                 }
                 return presenter;
             }
-            return provider.GetRequiredService<IDotvvmPresenter>();
+            return provider.GetRequiredService<DotvvmPresenter>();
         }
 
         /// <summary>

--- a/src/Framework/Testing/ControlTestHelper.cs
+++ b/src/Framework/Testing/ControlTestHelper.cs
@@ -50,7 +50,7 @@ namespace DotVVM.Framework.Testing
             this.Configuration.Debug = debug;
             this.Configuration.Runtime.AllowResourceVersionHash.Disable(); // reduce noise in tests
             config?.Invoke(this.Configuration);
-            presenter = (DotvvmPresenter)this.Configuration.ServiceProvider.GetRequiredService<IDotvvmPresenter>();
+            presenter = this.Configuration.ServiceProvider.GetRequiredService<DotvvmPresenter>();
         }
 
         public T GetService<T>() where T: notnull => Configuration.ServiceProvider.GetRequiredService<T>();

--- a/src/Tests/Runtime/PresenterTests.cs
+++ b/src/Tests/Runtime/PresenterTests.cs
@@ -48,7 +48,7 @@ namespace DotVVM.Framework.Tests.Runtime
             configuration.Runtime.MaxPostbackSizeBytes = 1024 * 512;
 
             configuration.Freeze();
-            presenter = (DotvvmPresenter)configuration.ServiceProvider.GetRequiredService<IDotvvmPresenter>();
+            presenter = configuration.ServiceProvider.GetRequiredService<DotvvmPresenter>();
 
 
             var controlBuilderFactory = configuration.ServiceProvider.GetRequiredService<IControlBuilderFactory>();
@@ -56,6 +56,16 @@ namespace DotVVM.Framework.Tests.Runtime
 
             var command = view.GetAllDescendants().OfType<Button>().Select(b => b.GetValueRaw(Button.ClickProperty) as CommandBindingExpression).First(x => x is not null);
             commandId = command.BindingId;
+        }
+
+        [TestMethod]
+        public void DotvvmPresenter_IsNotRegisteredAsIDotvvmPresenter()
+        {
+            var services = new ServiceCollection();
+            DotvvmServiceCollectionExtensions.RegisterDotVVMServices(services);
+
+            Assert.IsFalse(services.Any(s => s.ServiceType == typeof(IDotvvmPresenter)));
+            Assert.IsTrue(services.Any(s => s.ServiceType == typeof(DotvvmPresenter)));
         }
 
         [TestMethod]


### PR DESCRIPTION
Resolves #1688

IDotvvmPresenter is implemented by many classes, most of which should not accidentally replace the default IDotvvmPresenter