### PR TITLE
Fix crash in ValueOrBinding.AsString

### DIFF
--- a/src/Framework/Framework/Binding/ValueOrBindingExtensions.cs
+++ b/src/Framework/Framework/Binding/ValueOrBindingExtensions.cs
@@ -72,9 +72,9 @@ public static class ValueOrBindingExtensions
     /// <summary> Returns ValueOrBinding with the value of `a?.ToString() ?? ""`. The resulting binding is cached, so it's safe to use this method at runtime. </summary>
     public static ValueOrBinding<string> AsString<T>(this ValueOrBinding<T> v)
     {
-        if (v.BindingOrDefault is IBinding binding)
+        if (v.BindingOrDefault is IStaticValueBinding binding)
             return new(
-                binding.GetProperty<ExpectedAsStringBindingExpression>().Binding
+                (IStaticValueBinding<string>)binding.GetProperty<ExpectedAsStringBindingExpression>().Binding
             );
         else if (v.ValueOrDefault is null)
         {

--- a/src/Tests/Binding/JavascriptCompilationTests.cs
+++ b/src/Tests/Binding/JavascriptCompilationTests.cs
@@ -617,6 +617,21 @@ namespace DotVVM.Framework.Tests.Binding
         }
 
         [TestMethod]
+        public void JavascriptCompilation_ValueOrBindingAsString_ValueBinding()
+        {
+            var viewModel = new TestViewModel { DoubleProp = 123d };
+            var control = CreateControlWithDataContext(viewModel, out var dataContext);
+            var valueBinding = bindingHelper.ValueBinding<double>("DoubleProp", dataContext);
+            var value = new ValueOrBinding<double>(valueBinding);
+
+            var stringValue = value.AsString();
+            var stringBinding = (IValueBinding<string>)stringValue.BindingOrDefault!;
+
+            Assert.AreEqual("dotvvm.globalize.bindingNumberToString(DoubleProp)", stringBinding.GetKnockoutBindingExpression(control));
+            Assert.AreEqual("123", stringValue.Evaluate(control));
+        }
+
+        [TestMethod]
         public void JavascriptCompilation_ParentReference()
         {
             var result = bindingHelper.ValueBinding<object>("_parent", new [] {typeof(TestViewModel), typeof(string) });


### PR DESCRIPTION
ValueOrBinding<string> validates that the binding returns type string, but the ExpectedAsString binding only changes the converted type, not the parsed ReturnType.

This is basically just a workaround for the underlying problem, but it's non-trivial to fix. We don't want to look at the converted type, since most bindings would return System.Object