### PR TITLE
Fix defense-in-depth against terminating knockout comments

### DIFF
--- a/src/Framework/Framework/Controls/HtmlWriter.cs
+++ b/src/Framework/Framework/Controls/HtmlWriter.cs
@@ -172,7 +172,7 @@ namespace DotVVM.Framework.Controls
 
         public void WriteKnockoutDataBindComment(string name, string expression)
         {
-            if (name.Contains("-->") || expression.Contains("-->"))
+            if (name.Contains("-->") || name.Contains("--!>") || expression.Contains("-->") || expression.Contains("--!>"))
                 throw new Exception("Knockout data bind comment can't contain substring '-->'. If you have discovered this exception in your log, you probably have a XSS vulnerability in you website.");
 
             EnsureTagFullyOpen();


### PR DESCRIPTION
HTML comments can be also terminated with --!>, oops

It's not a security bug, since it only converts
confidentiality/integrity problem into availablity. Good deal for most of our apps, but not a fix by itself.