### PR TITLE
Allow returning validation errors without aborting postback

### DIFF
--- a/src/Framework/Framework/Hosting/DotvvmRequestContextExtensions.cs
+++ b/src/Framework/Framework/Hosting/DotvvmRequestContextExtensions.cs
@@ -182,7 +182,7 @@ public static class DotvvmRequestContextExtensions
         }
     }
 
-    private static void PreprocessModelState(this IDotvvmRequestContext context)
+    internal static void PreprocessModelState(this IDotvvmRequestContext context)
     {
         if (!context.ModelState.IsValid)
         {

--- a/src/Framework/Framework/Resources/Scripts/postback/postbackCore.ts
+++ b/src/Framework/Framework/Resources/Scripts/postback/postbackCore.ts
@@ -9,7 +9,7 @@ import { handleRedirect } from './redirect';
 import { handleIncludedReturnedFiles } from './includedFiles';
 import * as evaluator from '../utils/evaluator'
 import * as gate from './gate'
-import { showValidationErrorsFromServer } from '../validation/validation';
+import { showValidationErrorsFromServer, ValidationErrorDescriptor } from '../validation/validation';
 import { DotvvmPostbackError } from '../shared-classes';
 import { getKnownTypes, updateTypeInfo } from '../metadata/typeMap';
 import { isPrimitive } from '../utils/objects';
@@ -142,6 +142,9 @@ async function processPostbackResponse(options: PostbackOptions, context: any, p
     if (result.action == "successfulCommand") {
         result.viewModel = updater.patchViewModel(getState(), result.viewModel)
         updater.updateViewModelAndControls(result, updateTypeInfo);
+        if (result.modelState) {
+            showValidationErrorsFromServer(result, options)
+        }
         events.postbackViewModelUpdated.trigger({
             ...options,
             response,
@@ -217,5 +220,6 @@ type PostbackResponse =
         action: string
         resultIdFragment?: string,
         typeMetadata?: TypeMap
+        modelState?: ValidationErrorDescriptor[]
         customProperties?: { [key: string]: any }
     }

--- a/src/Framework/Framework/ViewModel/Serialization/DefaultViewModelSerializer.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/DefaultViewModelSerializer.cs
@@ -209,6 +209,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
                     writer.WritePropertyName("commandResult"u8);
                     WriteCommandData(commandResult, writer, buffer);
                 }
+                WriteModelStateIfInvalid(context, writer);
                 AddCustomPropertiesIfAny(context, writer, buffer);
 
                 if (postbackUpdatedControls is not null)
@@ -290,6 +291,18 @@ namespace DotVVM.Framework.ViewModel.Serialization
             DotvvmMetrics.ViewModelSize.Record(outputBuffer.Length, context.RouteLabel(), context.RequestTypeLabel());
             DotvvmMetrics.ViewModelSerializationTime.Record(timer.ElapsedSeconds, context.RouteLabel(), context.RequestTypeLabel());
             return outputBuffer.ToMemory();
+        }
+
+        private void WriteModelStateIfInvalid(IDotvvmRequestContext context, Utf8JsonWriter writer)
+        {
+            if (context.RequestType != DotvvmRequestType.Command || context.ModelState.IsValid)
+                return;
+
+            context.PreprocessModelState();
+            writer.WritePropertyName("modelState"u8);
+            JsonSerializer.Serialize(writer, context.ModelState.Errors, jsonOptions.PlainJsonOptions);
+
+            DotvvmMetrics.ValidationErrorsReturned.Record(context.ModelState.Errors.Count, context.RouteLabel(), context.RequestTypeLabel());
         }
 
         private void AddCustomPropertiesIfAny(IDotvvmRequestContext context, Utf8JsonWriter writer, MemoryStream outputBuffer)

--- a/src/Samples/Common/ViewModels/FeatureSamples/Validation/ModelStateErrorsViewModel.cs
+++ b/src/Samples/Common/ViewModels/FeatureSamples/Validation/ModelStateErrorsViewModel.cs
@@ -27,23 +27,34 @@ namespace DotVVM.Samples.Common.ViewModels.FeatureSamples.Validation
 
         public string Property456 { get; set; }
 
+        public int Counter { get; set; }
+
         public void Command1()
         {
+            Counter++;
             this.AddModelError(v => v.Property456, "Property456 contains error");
             Context.FailOnInvalidModelState();
         }
 
         public void Command2()
         {
+            Counter++;
             this.AddModelError(v => v.Nested1.MyProperty, "MyProperty contains error");
             Context.FailOnInvalidModelState();
         }
 
         public void Command3()
         {
+            Counter++;
             this.AddModelError(v => v.Nested2[2].Property123, "Property123 contains error");
             this.AddModelError(v => v.Nested2[0].Property123, "Property123 contains error");
             Context.FailOnInvalidModelState();
+        }
+
+        public void Command4()
+        {
+            Counter++;
+            this.AddModelError(v => v.Property456, "Property456 contains error without FailOnInvalidModelState");
         }
 
         public class NestedVM1 : DotvvmViewModelBase

--- a/src/Samples/Common/Views/FeatureSamples/Validation/ModelStateErrors.dothtml
+++ b/src/Samples/Common/Views/FeatureSamples/Validation/ModelStateErrors.dothtml
@@ -12,6 +12,10 @@
         <dot:ValidationSummary class="vmErrors" IncludeErrorsFromChildren="true" />
     </p>
     <p>
+        Root property:
+        <dot:Validator class="property456Error" data-ui="property456-error" ShowErrorMessageText Value="{value: Property456}" />
+    </p>
+    <p>
         Nested VM:
         <dot:Validator class="vm1Error" ShowErrorMessageText Value="{value:  Nested1.MyProperty}" />
     </p>
@@ -28,6 +32,12 @@
     <dot:Button Click="{command: Command1()}">Command 1</dot:Button>
     <dot:Button Click="{command: Command2()}">Command 2</dot:Button>
     <dot:Button Click="{command: Command3()}">Command 3</dot:Button>
+    <dot:Button Click="{command: Command4()}">Command 4</dot:Button>
+
+    <p>
+        Successful command count:
+        <span data-ui="successful-command-count">{{value: Counter}}</span>
+    </p>
 </body>
 </html>
 

--- a/src/Samples/Tests/Tests/Feature/PostBackTests.cs
+++ b/src/Samples/Tests/Tests/Feature/PostBackTests.cs
@@ -267,7 +267,7 @@ namespace DotVVM.Samples.Tests.Feature
                 button.Click();
                 AssertUI.HasClass(button, "pending");
                 browser.WaitFor(() => {
-                    AssertUI.HasClass(button, "success"); // TODO: we should change the behavior so server-side validation will reject the promise
+                    AssertUI.HasClass(button, "success");
                     AssertUI.InnerTextEquals(counter, "1");
                 }, 5000);
 

--- a/src/Samples/Tests/Tests/Feature/ValidationTests.cs
+++ b/src/Samples/Tests/Tests/Feature/ValidationTests.cs
@@ -316,6 +316,26 @@ namespace DotVVM.Samples.Tests.Feature
             });
         }
         [Fact]
+        public void Feature_Validation_ModelStateErrors_ManualErrorsWithoutFailCompletePostback()
+        {
+            RunInAllBrowsers(browser => {
+                browser.NavigateToUrl(SamplesRouteUrls.FeatureSamples_Validation_ModelStateErrors);
+
+                var button = browser.ElementAt("input[type=button]", 3);
+                AssertUI.InnerTextEquals(browser.Single("[data-ui=successful-command-count]"), "0");
+                AssertUI.IsNotDisplayed(browser.Single("[data-ui=property456-error]"));
+
+                button.Click();
+                browser.WaitForPostback();
+
+                AssertUI.InnerTextEquals(browser.Single("[data-ui=successful-command-count]"), "1");
+                browser.FindElements(".vmErrors li").ThrowIfDifferentCountThan(1);
+                AssertUI.IsDisplayed(browser.Single("[data-ui=property456-error]"));
+                AssertUI.InnerTextEquals(browser.Single("[data-ui=property456-error]"), "Property456 contains error without FailOnInvalidModelState");
+            });
+        }
+
+        [Fact]
         public void Feature_Validation_ModelStateErrors()
         {
             RunInAllBrowsers(browser => {

--- a/src/Tests/ControlTests/CommandTests.cs
+++ b/src/Tests/ControlTests/CommandTests.cs
@@ -7,6 +7,7 @@ using DotVVM.Framework.ViewModel;
 using DotVVM.Framework.Tests.Binding;
 using System;
 using DotVVM.Framework.Runtime.Commands;
+using DotVVM.Framework.ViewModel.Validation;
 
 namespace DotVVM.Framework.Tests.ControlTests
 {
@@ -61,6 +62,21 @@ namespace DotVVM.Framework.Tests.ControlTests
                 var exception = await Assert.ThrowsExceptionAsync<InvalidCommandInvocationException>(() => r.RunCommand("IntProp = IntProp + 1"));
                 StringAssert.Contains(exception.Message, "Execution of '{command: IntProp = IntProp + 1}' was disallowed by '<dot:Button Click={command: IntProp = IntProp + 1} Enabled={value: StringProp == \"test\"} Text=Click Visible={value: BoolProp} />");
             }
+        }
+
+        [TestMethod]
+        public async Task Command_ModelStateErrorAddedManually_ReturnsSuccessfulCommandWithValidationErrors()
+        {
+            var r = await cth.RunPage(typeof(ManualModelStateErrorViewModel), """
+                <dot:Button Text=Validate Click={command: AddManualError()} />
+                """);
+
+            var validationResult = await r.RunCommand("AddManualError()", applyChanges: false);
+
+            Assert.AreEqual("successfulCommand", (string)validationResult.ResultJson!["action"]!);
+            var modelState = validationResult.ResultJson["modelState"]!.AsArray();
+            Assert.AreEqual(1, modelState.Count);
+            Assert.AreEqual("Manual command error.", (string)modelState[0]!["errorMessage"]!);
         }
 
         
@@ -134,6 +150,14 @@ namespace DotVVM.Framework.Tests.ControlTests
             public OmgViewModelWhichCannotBeCreatedByConstructorButIsInstantiatedManually(int b)
             {
                 this.b = b;
+            }
+        }
+
+        public class ManualModelStateErrorViewModel : DotvvmViewModelBase
+        {
+            public void AddManualError()
+            {
+                this.AddModelError("Manual command error.");
             }
         }
     }


### PR DESCRIPTION
If you don't call FailOnInvalidModelState, postback will pass as successful (i.e. viewmodel changes are sent to client), but we will still add the validation errors on the client

Resolves #1487