### PR TITLE
Fix some ValueOrBinding glitches

### DIFF
--- a/src/Framework/Framework/Binding/BindingCombinator.cs
+++ b/src/Framework/Framework/Binding/BindingCombinator.cs
@@ -43,7 +43,8 @@ namespace DotVVM.Framework.Binding
         public static readonly BindingCombinatorDescriptor AndAlsoCombination = new BindingCombinatorDescriptor(CreateAndAlsoCombination);
         public static void AndAssignProperty(this DotvvmBindableObject obj, DotvvmProperty property, object value)
         {
-            if (property.PropertyType != typeof(bool)) throw new NotSupportedException($"Can only AND boolean properties, {property} is of type {property.PropertyType}");
+            if (property.PropertyType != typeof(bool) && property.PropertyType != typeof(bool?))
+                throw new NotSupportedException($"Can only AND boolean properties, {property} is of type {property.PropertyType}");
             if (!obj.IsPropertySet(property))
             {
                 obj.SetValue(property, value);
@@ -62,9 +63,9 @@ namespace DotVVM.Framework.Binding
                 else
                 {
                     var currentBinding = currentValue as IBinding ??
-                        throw new NotSupportedException($"A IBinding instance or bool was expected in property {property}, got {obj.GetValue(property)?.GetType().ToCode() ?? "null"}");
+                        throw new NotSupportedException($"An IBinding instance or bool was expected in property {property}, got {obj.GetValue(property)?.GetType().ToCode() ?? "null"}.");
                     var binding = value as IBinding ??
-                        throw new NotSupportedException($"A IBinding instance or bool was expected to AndAssign to property {property}, got {obj.GetValue(property)?.GetType().ToCode() ?? "null"}");
+                        throw new NotSupportedException($"An IBinding instance or bool was expected to AndAssign to property {property}, got {value?.GetType().ToCode() ?? "null"}.");
                     // resource + value binding can't be combined - evaluate the resource binding
                     if (currentBinding is IValueBinding != binding is IValueBinding)
                     {

--- a/src/Framework/Framework/Binding/ValueOrBinding.cs
+++ b/src/Framework/Framework/Binding/ValueOrBinding.cs
@@ -60,7 +60,10 @@ namespace DotVVM.Framework.Binding
         public static ValueOrBinding<T> FromBoxedValue(object? value) =>
             value is IStaticValueBinding<T> bindingS ? new ValueOrBinding<T>(bindingS) :
             value is IBinding binding ? new ValueOrBinding<T>(binding) :
-            value is ValueOrBinding vob ? new ValueOrBinding<T>(vob.BindingOrDefault, (T)vob.BoxedValue!) :
+            value is ValueOrBinding vob ? vob.BindingOrDefault switch {
+                null => new ValueOrBinding<T>(null, (T)vob.BoxedValue!),
+                {} b => new ValueOrBinding<T>(b, default)
+            } :
             new ValueOrBinding<T>((T)value!);
 
         /// <summary> If the binding <see cref="HasValue" />, returns it. If it <see cref="HasBinding" />, evaluates it on the <paramref name="control"/> and returns the result. </summary>

--- a/src/Framework/Framework/Binding/ValueOrBindingExtensions.cs
+++ b/src/Framework/Framework/Binding/ValueOrBindingExtensions.cs
@@ -16,7 +16,8 @@ using DotVVM.Framework.Utils;
 public static class ValueOrBindingExtensions
 {
     /// <summary> Returns the value or the binding from the ValueOrBinding container. Equivalent to calling <code>vob.BindingOrDefault ?? vob.BoxedValue</code> </summary>
-    public static object? UnwrapToObject(this ValueOrBinding vob) =>
+    public static object? UnwrapToObject(this ValueOrBinding? vob) =>
+        vob is null ? null :
         vob.BindingOrDefault ?? vob.BoxedValue;
 
     /// <summary> If the obj is ValueOrBinding, returns the binding or the value from the container. Equivalent to <code>obj is ValueOrBinding vob ? vob.UnwrapToObject() : obj</code> </summary>

--- a/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
+++ b/src/Framework/Framework/Compilation/Binding/GeneralBindingPropertyResolvers.cs
@@ -330,13 +330,20 @@ namespace DotVVM.Framework.Compilation.Binding
 
         public DataSourceAccessBinding GetDataSourceAccess(ParsedExpressionBindingProperty expression, IBinding binding)
         {
-            if (typeof(IGridViewDataSet).IsAssignableFrom(expression.Expression.Type) && !expression.Expression.Type.IsInterface)
-                return new DataSourceAccessBinding(binding.DeriveBinding(new ParsedExpressionBindingProperty(
-                    Expression.Property(expression.Expression, nameof(IGridViewDataSet.Items))
-                )));
-            else if (typeof(IEnumerable).IsAssignableFrom(expression.Expression.Type))
+            var type = expression.Expression.Type;
+            if (type.Implements(typeof(IGridViewDataSet<>), out var dataSetInterface))
+            {
+                var itemsProperty = dataSetInterface.GetProperty(nameof(IGridViewDataSet.Items))!;
+                var property = Expression.Property(expression.Expression, itemsProperty);
+                return new DataSourceAccessBinding(binding.DeriveBinding(new ParsedExpressionBindingProperty(property)));
+            }
+            else if (typeof(IEnumerable).IsAssignableFrom(type))
                 return new DataSourceAccessBinding(binding);
-            else throw new NotSupportedException($"Cannot make datasource from binding '{expression.Expression}' of type '{expression.Expression.Type}'.");
+            else
+            {
+                var help = typeof(IGridViewDataSet).IsAssignableFrom(type) ? " It only implements the untyped IGridViewDataSet, make sure to supply typed IGridViewDataSet<T>" : "";
+                throw new NotSupportedException($"Cannot make datasource from binding '{expression.Expression}' of type '{type.ToCode()}'." + help);
+            }
         }
 
         public DataSourceLengthBinding GetDataSourceLength(ParsedExpressionBindingProperty expression, IBinding binding)

--- a/src/Framework/Framework/Compilation/BindingParserOptions.cs
+++ b/src/Framework/Framework/Compilation/BindingParserOptions.cs
@@ -9,10 +9,11 @@ using DotVVM.Framework.Compilation.ControlTree;
 using DotVVM.Framework.Binding.Expressions;
 using FastExpressionCompiler;
 using System.Net;
+using System.Collections;
 
 namespace DotVVM.Framework.Compilation
 {
-    public class BindingParserOptions : IDebugHtmlFormattableObject
+    public class BindingParserOptions : IDebugHtmlFormattableObject, IEquatable<BindingParserOptions>
     {
         public Type BindingType { get; }
         public string ScopeParameter { get; }
@@ -77,6 +78,24 @@ namespace DotVVM.Framework.Compilation
 
         public BindingParserOptions WithScopeParameter(string scopeParameter)
             => new BindingParserOptions(BindingType, scopeParameter, ImportNamespaces, ExtensionParameters);
+
+        public override int GetHashCode() =>
+            (
+                this.ScopeParameter.GetHashCode(),
+                this.BindingType.GetHashCode(),
+                StructuralComparisons.StructuralEqualityComparer.GetHashCode(this.ExtensionParameters),
+                StructuralComparisons.StructuralEqualityComparer.GetHashCode(this.ImportNamespaces)
+            ).GetHashCode();
+
+        public override bool Equals(object? other) =>
+            other is BindingParserOptions otherT && this.Equals(otherT);
+
+        public bool Equals(BindingParserOptions? other) =>
+            other is {} &&
+            other.BindingType == this.BindingType &&
+            other.ScopeParameter == this.ScopeParameter &&
+            other.ImportNamespaces.SequenceEqual(this.ImportNamespaces) &&
+            other.ExtensionParameters.SequenceEqual(this.ExtensionParameters);
 
         public override string ToString()
         {

--- a/src/Framework/Framework/Compilation/NamespaceImport.cs
+++ b/src/Framework/Framework/Compilation/NamespaceImport.cs
@@ -34,7 +34,7 @@ namespace DotVVM.Framework.Compilation
             string.Equals(Namespace, other.Namespace) && string.Equals(Alias, other.Alias);
 
         public override int GetHashCode() =>
-            unchecked(((Namespace?.GetHashCode() ?? 0) * 397) ^ (Alias?.GetHashCode() ?? 0));
+            unchecked((Namespace.GetHashCode() * 397) ^ (Alias?.GetHashCode() ?? 0));
 
 		public override string ToString() => "import(" + (Alias == null ? Namespace : Alias + "=" + Namespace) + ")";
     }

--- a/src/Tests/Binding/BindingCombinatorTests.cs
+++ b/src/Tests/Binding/BindingCombinatorTests.cs
@@ -138,6 +138,17 @@ namespace DotVVM.Framework.Binding
             Assert.AreEqual(false, control.GetValueRaw(HtmlGenericControl.VisibleProperty));
         }
 
+        [TestMethod]
+        public void AndAssignProperty_UnexpectedNewOperandReportsItsType()
+        {
+            var control = CreateControl(new BooleanViewModel { Left = true });
+            control.SetValue(HtmlGenericControl.VisibleProperty, BoolBinding(nameof(BooleanViewModel.Left)));
+            var exception = Assert.ThrowsException<NotSupportedException>(() =>
+                control.AndAssignProperty(HtmlGenericControl.VisibleProperty, "not a bool or binding"));
+
+            StringAssert.Contains(exception.Message, "got string.");
+            StringAssert.Contains(exception.Message, "IBinding instance or bool was expected");
+        }
 
         private ValueBindingExpression<bool> BoolBinding(string property) => bindings.ValueBinding<bool>(property, context);
 

--- a/src/Tests/Binding/BindingCombinatorTests.cs
+++ b/src/Tests/Binding/BindingCombinatorTests.cs
@@ -1,0 +1,176 @@
+#nullable enable
+
+using System;
+using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Compilation;
+using DotVVM.Framework.Compilation.ControlTree;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Testing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotVVM.Framework.Binding
+{
+    [TestClass]
+    public class BindingCombinatorTests
+    {
+        private BindingTestHelper bindings = new BindingTestHelper();
+        private DataContextStack context;
+
+        public BindingCombinatorTests()
+        {
+            context = bindings.CreateDataContext([typeof(BooleanViewModel)]);
+        }
+
+        [TestMethod]
+        public void GetCombination_ComputesOnceAndCachesByDescriptorAndOrderedBindings()
+        {
+            var a = new TestBinding();
+            var b = new TestBinding();
+            var calls = 0;
+            var descriptor = new BindingCombinator.BindingCombinatorDescriptor((left, right) => {
+                calls++;
+                return left;
+            });
+
+            var first = descriptor.GetCombination(a, b);
+            var same = descriptor.GetCombination(a, b);
+            var reversed = descriptor.GetCombination(b, a);
+            var otherDescriptor = new BindingCombinator.BindingCombinatorDescriptor((left, right) => right);
+
+            Assert.AreSame(a, first);
+            Assert.AreSame(first, same);
+            Assert.AreSame(b, reversed);
+            Assert.AreEqual(2, calls);
+            Assert.AreSame(b, otherDescriptor.GetCombination(a, b));
+        }
+
+        [TestMethod]
+        public void GetCombination_CachesFactoryException()
+        {
+            var a = new TestBinding();
+            var b = new TestBinding();
+            var calls = 0;
+            var descriptor = new BindingCombinator.BindingCombinatorDescriptor((_, _) => {
+                calls++;
+                throw new InvalidOperationException("Expected failure");
+            });
+
+            Assert.ThrowsException<InvalidOperationException>(() => descriptor.GetCombination(a, b));
+            Assert.ThrowsException<InvalidOperationException>(() => descriptor.GetCombination(a, b));
+            Assert.AreEqual(1, calls);
+        }
+
+        [TestMethod]
+        [DataRow(false, false, false, false)]
+        [DataRow(false, true, false, true)]
+        [DataRow(true, false, false, true)]
+        [DataRow(true, true, true, true)]
+        public void BooleanDescriptors_CreateEvaluatableShortCircuitExpressions(bool leftValue, bool rightValue, bool expectedAnd, bool expectedOr)
+        {
+            var left = BoolBinding(nameof(BooleanViewModel.Left));
+            var right = BoolBinding(nameof(BooleanViewModel.Right));
+            var and = (IStaticValueBinding<bool>)BindingCombinator.AndAlsoCombination.GetCombination(left, right);
+            var or = (IStaticValueBinding<bool>)BindingCombinator.OrElseCombination.GetCombination(left, right);
+            var control = CreateControl(new BooleanViewModel { Left = leftValue, Right = rightValue });
+
+            Assert.AreEqual(expectedAnd, and.Evaluate(control));
+            Assert.AreEqual(expectedOr, or.Evaluate(control));
+            Assert.AreSame(and, BindingCombinator.AndAlsoCombination.GetCombination(left, right));
+            Assert.AreSame(or, BindingCombinator.OrElseCombination.GetCombination(left, right));
+        }
+
+        [TestMethod]
+        public void AndAssignProperty_RejectsUnsupportedPropertyAndOperands()
+        {
+            var control = new HtmlGenericControl("div");
+
+            var exception = Assert.ThrowsException<NotSupportedException>(() =>
+                control.AndAssignProperty(HtmlGenericControl.InnerTextProperty, "text"));
+
+            StringAssert.Contains(exception.Message, "Can only AND boolean properties");
+        }
+
+        [TestMethod]
+        public void AndAssignProperty_AppliesBooleanIdentitiesWithoutCreatingBindings()
+        {
+            var binding = BoolBinding(nameof(BooleanViewModel.Left));
+
+            var unset = new HtmlGenericControl("div");
+            unset.AndAssignProperty(HtmlGenericControl.VisibleProperty, false);
+            Assert.AreEqual(false, unset.GetValueRaw(HtmlGenericControl.VisibleProperty));
+            AssertAssignment(false, binding, false);
+            AssertAssignment(binding, true, binding);
+            AssertAssignment(true, binding, binding);
+            AssertAssignment(binding, false, false);
+        }
+
+        [TestMethod]
+        public void AndAssignProperty_CombinesTwoValueBindingsAndReusesCombination()
+        {
+            var left = BoolBinding(nameof(BooleanViewModel.Left));
+            var right = BoolBinding(nameof(BooleanViewModel.Right));
+            var control = CreateControl(new BooleanViewModel { Left = true, Right = false });
+
+            control.SetValue(HtmlGenericControl.VisibleProperty, left);
+            control.AndAssignProperty(HtmlGenericControl.VisibleProperty, right);
+            var combined = (IStaticValueBinding<bool>)control.GetValueRaw(HtmlGenericControl.VisibleProperty)!;
+
+            Assert.IsFalse(combined.Evaluate(control));
+            Assert.AreSame(
+                BindingCombinator.AndAlsoCombination.GetCombination(left, right),
+                combined);
+        }
+
+        [TestMethod]
+        public void AndAssignProperty_EvaluatesResourceBindingWhenMixedWithValueBinding()
+        {
+            var valueBinding = BoolBinding(nameof(BooleanViewModel.Left));
+            var resourceBinding = bindings.ResourceBinding<bool>(nameof(BooleanViewModel.Right), context);
+            var control = CreateControl(new BooleanViewModel { Left = true, Right = true });
+
+            control.SetValue(HtmlGenericControl.VisibleProperty, resourceBinding);
+            control.AndAssignProperty(HtmlGenericControl.VisibleProperty, valueBinding);
+            Assert.AreSame(valueBinding, control.GetValueRaw(HtmlGenericControl.VisibleProperty));
+
+            control.DataContext = new BooleanViewModel { Left = true, Right = false };
+            control.SetValue(HtmlGenericControl.VisibleProperty, valueBinding);
+            control.AndAssignProperty(HtmlGenericControl.VisibleProperty, resourceBinding);
+            Assert.AreEqual(false, control.GetValueRaw(HtmlGenericControl.VisibleProperty));
+        }
+
+
+        private ValueBindingExpression<bool> BoolBinding(string property) => bindings.ValueBinding<bool>(property, context);
+
+        private void AssertAssignment(object current, object assigned, object expected)
+        {
+            var control = CreateControl(new BooleanViewModel { Left = true });
+            control.SetValue(HtmlGenericControl.VisibleProperty, current);
+            control.AndAssignProperty(HtmlGenericControl.VisibleProperty, assigned);
+            var actual = control.GetValueRaw(HtmlGenericControl.VisibleProperty);
+            if (expected is IBinding)
+                Assert.AreSame(expected, actual);
+            else
+                Assert.AreEqual(expected, actual);
+        }
+
+        private HtmlGenericControl CreateControl(BooleanViewModel viewModel)
+        {
+            var control = new HtmlGenericControl("div") { DataContext = viewModel };
+            control.SetDataContextType(context);
+            return control;
+        }
+
+        private sealed class BooleanViewModel
+        {
+            public bool Left { get; set; }
+            public bool Right { get; set; }
+        }
+
+        private sealed class TestBinding : IBinding
+        {
+            public DataContextStack? DataContext => null;
+            public BindingResolverCollection? GetAdditionalResolvers() => null;
+            public object? GetProperty(Type type, ErrorHandlingMode errorMode = ErrorHandlingMode.ThrowException) => null;
+        }
+    }
+}

--- a/src/Tests/Binding/DotvvmBindingCacheHelperTests.cs
+++ b/src/Tests/Binding/DotvvmBindingCacheHelperTests.cs
@@ -1,0 +1,146 @@
+#nullable enable
+
+using System;
+using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Compilation;
+using DotVVM.Framework.Compilation.ControlTree;
+using DotVVM.Framework.Runtime.Caching;
+using DotVVM.Framework.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotVVM.Framework.Binding
+{
+    [TestClass]
+    public class DotvvmBindingCacheHelperTests
+    {
+        private BindingCompilationService service = null!;
+        private DotvvmBindingCacheHelper helper = null!;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            service = DotvvmTestHelper.DefaultConfig.ServiceProvider.GetRequiredService<BindingCompilationService>();
+            helper = new DotvvmBindingCacheHelper(new SimpleDictionaryCacheAdapter(), service);
+        }
+
+        [TestMethod]
+        public void Constructor_RejectsNullCache()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => new DotvvmBindingCacheHelper(null!, service));
+        }
+
+        [TestMethod]
+        public void CreateCachedBinding_CachesByBindingTypeIdentifierAndStructuralKeys()
+        {
+            var factoryCalls = 0;
+
+            var first = helper.CreateCachedBinding("binding", new object?[] { "key", 42 }, () => {
+                factoryCalls++;
+                return new TestBinding();
+            });
+            var same = helper.CreateCachedBinding("binding", new object?[] { new string("key".ToCharArray()), 42 }, () => {
+                factoryCalls++;
+                return new TestBinding();
+            });
+            var differentIdentifier = helper.CreateCachedBinding("other", new object?[] { "key", 42 }, () => new TestBinding());
+            var differentKeyOrder = helper.CreateCachedBinding("binding", new object?[] { 42, "key" }, () => new TestBinding());
+            var differentBindingType = helper.CreateCachedBinding<OtherTestBinding>("binding", new object?[] { "key", 42 }, () => new OtherTestBinding());
+
+            Assert.AreSame(first, same);
+            Assert.AreEqual(1, factoryCalls);
+            Assert.AreNotSame(first, differentIdentifier);
+            Assert.AreNotSame(first, differentKeyOrder);
+            Assert.AreNotSame<object>(first, differentBindingType);
+        }
+
+        [TestMethod]
+        public void CreateCachedBinding_AllowsNullOverriddenEqualsAndExplicitReferenceEqualityKeys()
+        {
+            var referenceKey = new object();
+
+            var binding = helper.CreateCachedBinding(
+                "binding",
+                new object?[] { null, new EquatableKey(1), new Tuple<object>(referenceKey) },
+                () => new TestBinding());
+
+            Assert.IsNotNull(binding);
+        }
+
+        [TestMethod]
+        public void CreateCachedBinding_RejectsKeyWithoutObjectEqualsOverride()
+        {
+            var exception = Assert.ThrowsException<Exception>(() =>
+                helper.CreateCachedBinding("binding", new object?[] { new ReferenceKey() }, () => new TestBinding()));
+
+            StringAssert.Contains(exception.Message, typeof(ReferenceKey).FullName!);
+            StringAssert.Contains(exception.Message, "Object.Equals");
+        }
+
+        [TestMethod]
+        public void CreateCachedBinding_StoresHighPriorityItem()
+        {
+            var cache = new RecordingCacheAdapter();
+            var helper = new DotvvmBindingCacheHelper(cache, service);
+
+            helper.CreateCachedBinding("binding", Array.Empty<object?>(), () => new TestBinding());
+
+            Assert.AreEqual(DotvvmCacheItemPriority.High, cache.LastPriority);
+        }
+
+        [TestMethod]
+        public void BindingFactoryMethods_CacheEquivalentRequestsAndSeparateBindingKinds()
+        {
+            var context = DataContextStack.Create(typeof(CacheViewModel));
+
+            var value = helper.CreateValueBinding<bool>("Flag", context);
+            var sameValue = helper.CreateValueBinding<bool>("Flag", context);
+            var untypedValue = helper.CreateValueBinding("Flag", context);
+            var resource = helper.CreateResourceBinding<bool>("Flag", context);
+            var sameResource = helper.CreateResourceBinding<bool>("Flag", context);
+            var command = helper.CreateCommand<Action>("() => Flag = !Flag", context);
+            var sameCommand = helper.CreateCommand<Action>("() => Flag = !Flag", context);
+            var staticCommand = helper.CreateStaticCommand<Action>("() => Flag = !Flag", context);
+            var sameStaticCommand = helper.CreateStaticCommand<Action>("() => Flag = !Flag", context);
+
+            Assert.AreSame(value, sameValue);
+            Assert.AreNotSame(value, untypedValue);
+            Assert.AreSame(resource, sameResource);
+            Assert.AreSame(command, sameCommand);
+            Assert.AreSame(staticCommand, sameStaticCommand);
+            Assert.AreNotSame<object>(command, staticCommand);
+        }
+
+        private class TestBinding : IBinding
+        {
+            public DataContextStack? DataContext => null;
+            public BindingResolverCollection? GetAdditionalResolvers() => null;
+            public object? GetProperty(Type type, ErrorHandlingMode errorMode = ErrorHandlingMode.ThrowException) => null;
+        }
+
+        private sealed class OtherTestBinding : TestBinding { }
+
+        private sealed record EquatableKey(int Value);
+        private sealed class ReferenceKey { }
+
+        private sealed class CacheViewModel
+        {
+            public bool Flag { get; set; }
+        }
+
+        private sealed class RecordingCacheAdapter : IDotvvmCacheAdapter
+        {
+            public DotvvmCacheItemPriority? LastPriority { get; private set; }
+
+            public T GetOrAdd<TKey, T>(TKey key, Func<TKey, DotvvmCachedItem<T>> factoryFunc) where TKey : notnull
+            {
+                var item = factoryFunc(key);
+                LastPriority = item.Priority;
+                return item.Value;
+            }
+
+            public T? Get<T>(object key) => default;
+            public object? Remove(object key) => null;
+        }
+    }
+}

--- a/src/Tests/Binding/ValueOrBindingTests.cs
+++ b/src/Tests/Binding/ValueOrBindingTests.cs
@@ -263,6 +263,26 @@ namespace DotVVM.Framework.Binding
         }
 
         [TestMethod]
+        public void GetItems_InterfaceTypedBindingReturnsItems()
+        {
+            var expected = new List<int> { 1, 2 };
+            var control = CreateControl(new TestViewModel { InterfaceDataSet = new GridViewDataSet<int> { Items = expected } });
+            var binding = Binding<IGridViewDataSet<int>>(nameof(TestViewModel.InterfaceDataSet));
+            var dataSet = new ValueOrBinding<IGridViewDataSet<int>>(binding);
+
+            Assert.AreSame(expected, dataSet.GetItems().Evaluate(control));
+        }
+
+        [TestMethod]
+        public void GetItems_InterfaceTypedBindingFails()
+        {
+            var binding = Binding<IPageableGridViewDataSet<PagingOptions>>(nameof(TestViewModel.InterfacePageableDataSet));
+            // binding.GetProperty<DataSourceAccessBinding>();
+            var exception = XAssert.ThrowsAny<Exception>(() => binding.GetProperty<DataSourceAccessBinding>());
+            StringAssert.Contains(exception.Message, "untyped IGridViewDataSet");
+        }
+
+        [TestMethod]
         public void AndOr_ApplyBooleanIdentitiesAndCombineBindings()
         {
             var leftBinding = Binding<bool>(nameof(TestViewModel.Flag));

--- a/src/Tests/Binding/ValueOrBindingTests.cs
+++ b/src/Tests/Binding/ValueOrBindingTests.cs
@@ -1,0 +1,335 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DotVVM.Framework.Binding.Expressions;
+using DotVVM.Framework.Binding.Properties;
+using DotVVM.Framework.Compilation.ControlTree;
+using DotVVM.Framework.Controls;
+using DotVVM.Framework.Testing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotVVM.Framework.Binding
+{
+    [TestClass]
+    public class ValueOrBindingTests
+    {
+        private BindingTestHelper bindings = null!;
+        private DataContextStack context = null!;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            bindings = new BindingTestHelper();
+            context = bindings.CreateDataContext(new[] { typeof(TestViewModel) });
+        }
+
+        [TestMethod]
+        public void Constructors_PreserveStateAndValidateBindings()
+        {
+            ValueOrBinding<int> defaultNumber = default;
+            var nullString = new ValueOrBinding<string?>((string?)null);
+            var numberBinding = Binding<int>(nameof(TestViewModel.Number));
+            var boundNumber = new ValueOrBinding<int>(numberBinding);
+            var exception = Assert.ThrowsException<BindingHelper.InvalidBindingTypeException>(() =>
+                new ValueOrBinding<string>((IBinding)numberBinding));
+
+            AssertValue(0, defaultNumber);
+            AssertValue<string?>(null, nullString);
+            AssertBinding(numberBinding, boundNumber);
+            Assert.AreEqual("null", nullString.ToString());
+            Assert.AreSame(numberBinding, exception.Binding);
+            Assert.ThrowsException<ArgumentNullException>(() => new ValueOrBinding<int>((IBinding)null!));
+            Assert.ThrowsException<ArgumentNullException>(() => new ValueOrBinding<int>((IStaticValueBinding<int>)null!));
+        }
+
+        [TestMethod]
+        public void FromBoxedValue_HandlesRawValuesBindingsAndValueContainers()
+        {
+            var binding = Binding<int>(nameof(TestViewModel.Number));
+
+            var raw = ValueOrBinding<int>.FromBoxedValue(12);
+            var directBinding = ValueOrBinding<int>.FromBoxedValue(binding);
+            var nestedValue = ValueOrBinding<int>.FromBoxedValue(new ValueOrBinding<int>(13));
+
+            AssertValue(12, raw);
+            AssertBinding(binding, directBinding);
+            AssertValue(13, nestedValue);
+        }
+
+        [TestMethod]
+        public void Evaluate_ReturnsValueOrEvaluatesBinding()
+        {
+            var control = CreateControl(new TestViewModel { Number = 42 });
+            var binding = Binding<int>(nameof(TestViewModel.Number));
+
+            Assert.AreEqual(7, new ValueOrBinding<int>(7).Evaluate(control));
+            Assert.AreEqual(42, new ValueOrBinding<int>(binding).Evaluate(control));
+            Assert.AreEqual("12", new ValueOrBinding<int>(12).ToString());
+            Assert.AreEqual(binding.ToString(), new ValueOrBinding<int>(binding).ToString());
+        }
+
+        [TestMethod]
+        public void GetValueAndGetBinding_RejectWrongState()
+        {
+            var binding = Binding<int>(nameof(TestViewModel.Number));
+            var withValue = new ValueOrBinding<int>(7);
+            var withBinding = new ValueOrBinding<int>(binding);
+
+            var bindingExpected = Assert.ThrowsException<DotvvmControlException>(() => withValue.GetBinding());
+            var valueExpected = Assert.ThrowsException<DotvvmControlException>(() => withBinding.GetValue());
+
+            StringAssert.Contains(bindingExpected.Message, "contains a value: 7");
+            StringAssert.Contains(valueExpected.Message, "contains a binding");
+            Assert.AreSame(binding, valueExpected.RelatedBinding);
+        }
+
+        [TestMethod]
+        public void CastHelpers_PreserveValuesAndBindings()
+        {
+            var stringBinding = Binding<string>(nameof(TestViewModel.Text));
+            var downcastValue = ValueOrBinding<object>.DownCast(new ValueOrBinding<string>("text"));
+            var downcastBinding = ValueOrBinding<object>.DownCast(new ValueOrBinding<string>(stringBinding));
+            var upcastValue = new ValueOrBinding<object>("text").UpCast<string>();
+            var upcastBinding = new ValueOrBinding<object>((IBinding)stringBinding).UpCast<string>();
+            ValueOrBinding nonGenericValue = new ValueOrBinding<string>("text");
+            ValueOrBinding nonGenericBinding = new ValueOrBinding<string>(stringBinding);
+
+            AssertValue<object>("text", downcastValue);
+            AssertBinding(stringBinding, downcastBinding);
+            AssertValue("text", upcastValue);
+            AssertBinding(stringBinding, upcastBinding);
+            AssertValue("text", ValueOrBinding<string>.UpCast(nonGenericValue));
+            AssertBinding(stringBinding, ValueOrBinding<string>.UpCast(nonGenericBinding));
+            Assert.ThrowsException<InvalidCastException>(() => new ValueOrBinding<object>(1).UpCast<string>());
+        }
+
+        [TestMethod]
+        public void Process_InvokesOnlyBranchMatchingState()
+        {
+            var binding = Binding<int>(nameof(TestViewModel.Number));
+            var valueCalls = 0;
+            var bindingCalls = 0;
+
+            new ValueOrBinding<int>(5).Process(_ => valueCalls++, _ => bindingCalls++);
+            new ValueOrBinding<int>(binding).Process(_ => valueCalls++, _ => bindingCalls++);
+            var valueResult = new ValueOrBinding<int>(5).Process(v => v * 2, _ => -1);
+            var bindingResult = new ValueOrBinding<int>(binding).Process(_ => -1, b => ReferenceEquals(b, binding) ? 1 : 0);
+
+            Assert.AreEqual(1, valueCalls);
+            Assert.AreEqual(1, bindingCalls);
+            Assert.AreEqual(10, valueResult);
+            Assert.AreEqual(1, bindingResult);
+        }
+
+        [TestMethod]
+        public void ProcessValueBinding_TreatsValuesAndResourceBindingsAsValues()
+        {
+            var control = CreateControl(new TestViewModel { Number = 42 });
+            var resource = ResourceBinding<int>(nameof(TestViewModel.Number));
+            var valueBinding = Binding<int>(nameof(TestViewModel.Number));
+
+            var rawResult = new ValueOrBinding<int>(5).ProcessValueBinding(control, v => $"value:{v}", _ => "binding");
+            var resourceResult = new ValueOrBinding<int>(resource).ProcessValueBinding(control, v => $"value:{v}", _ => "binding");
+            var bindingResult = new ValueOrBinding<int>(valueBinding).ProcessValueBinding(control, _ => "value", b => ReferenceEquals(b, valueBinding) ? "binding" : "other");
+            string? actionResult = null;
+            new ValueOrBinding<int>(resource).ProcessValueBinding(control, v => actionResult = $"value:{v}", _ => actionResult = "binding");
+
+            Assert.AreEqual("value:5", rawResult);
+            Assert.AreEqual("value:42", resourceResult);
+            Assert.AreEqual("binding", bindingResult);
+            Assert.AreEqual("value:42", actionResult);
+        }
+
+        [TestMethod]
+        public void EvaluateResourceBinding_OnlyUnwrapsStaticNonValueBinding()
+        {
+            var control = CreateControl(new TestViewModel { Number = 42 });
+            var resource = new ValueOrBinding<int>(ResourceBinding<int>(nameof(TestViewModel.Number)));
+            var valueBinding = Bound<int>(nameof(TestViewModel.Number));
+            var value = new ValueOrBinding<int>(5);
+
+            var evaluatedResource = resource.EvaluateResourceBinding(control);
+            var untouchedValueBinding = valueBinding.EvaluateResourceBinding(control);
+            var untouchedValue = value.EvaluateResourceBinding(control);
+
+            AssertValue(42, evaluatedResource);
+            AssertBinding(valueBinding.BindingOrDefault!, untouchedValueBinding);
+            AssertValue(5, untouchedValue);
+        }
+
+        [TestMethod]
+        public void JavascriptExpressions_SerializeValuesAndUseValueBindings()
+        {
+            var control = CreateControl(new TestViewModel { Text = "hello" });
+            var value = new ValueOrBinding<string>("hello");
+            var binding = Bound<string>(nameof(TestViewModel.Text));
+            var ordinary = new object();
+
+            Assert.AreEqual("\"hello\"", value.GetJsExpression(control));
+            Assert.AreEqual("\"hello\"", value.GetParametrizedJsExpression(control).ToDefaultString());
+            StringAssert.Contains(binding.GetJsExpression(control), nameof(TestViewModel.Text));
+            StringAssert.Contains(binding.GetJsExpression(control, unwrapped: true), nameof(TestViewModel.Text));
+            Assert.AreEqual("hello", value.UnwrapToObject());
+            Assert.AreSame(binding.BindingOrDefault, binding.UnwrapToObject());
+            Assert.AreSame(ordinary, ValueOrBindingExtensions.UnwrapToObject(ordinary));
+            Assert.IsNull(ValueOrBindingExtensions.UnwrapToObject((object?)null));
+        }
+
+        [TestMethod]
+        public void ValueAndNullPredicates_DistinguishValuesFromBindings()
+        {
+            var binding = Bound<string?>(nameof(TestViewModel.NullableText));
+
+            Assert.IsTrue(new ValueOrBinding<int>(5).ValueEquals(5));
+            Assert.IsFalse(new ValueOrBinding<int>(5).ValueEquals(6));
+            Assert.IsTrue(new ValueOrBinding<string>("TEST").ValueEquals("test", StringComparer.OrdinalIgnoreCase));
+            Assert.IsFalse(binding.ValueEquals(null));
+            Assert.IsTrue(new ValueOrBinding<string?>((string?)null).ValueIsNull());
+            Assert.IsFalse(binding.ValueIsNull());
+            Assert.IsTrue(new ValueOrBinding<string?>((string?)null).ValueIsNullOrEmpty());
+            Assert.IsTrue(new ValueOrBinding<string?>("").ValueIsNullOrEmpty());
+            Assert.IsFalse(binding.ValueIsNullOrEmpty());
+            Assert.IsTrue(new ValueOrBinding<string?>((string?)null).IsNull().GetValue());
+            Assert.IsFalse(new ValueOrBinding<string>("text").IsNull().GetValue());
+            Assert.IsTrue(new ValueOrBinding<string>("text").NotNull().GetValue());
+            Assert.IsTrue(new ValueOrBinding<string>((string)null!).IsNullOrEmpty().GetValue());
+            Assert.IsTrue(new ValueOrBinding<string>("").IsNullOrEmpty().GetValue());
+            Assert.IsTrue(new ValueOrBinding<string>(" ").IsNullOrWhitespace().GetValue());
+            Assert.IsTrue(new ValueOrBinding<string>("text").NotNullOrEmpty().GetValue());
+            Assert.IsTrue(new ValueOrBinding<string>("text").NotNullOrWhitespace().GetValue());
+        }
+
+        [TestMethod]
+        public void SimpleTransformations_ComputeConstantValues()
+        {
+            var items = new List<int> { 1, 2 };
+            var dataSet = new GridViewDataSet<int> { Items = items };
+
+            Assert.IsFalse(new ValueOrBinding<bool>(true).Negate().GetValue());
+            Assert.IsNull(new ValueOrBinding<bool?>((bool?)null).Negate().GetValue());
+            Assert.IsTrue(new ValueOrBinding<int>(1).IsMoreThanZero().GetValue());
+            Assert.IsFalse(new ValueOrBinding<int>(0).IsMoreThanZero().GetValue());
+            Assert.AreSame(items, new ValueOrBinding<IGridViewDataSet<int>>(dataSet).GetItems().GetValue());
+            Assert.AreEqual("", new ValueOrBinding<object?>((object?)null).AsString().GetValue());
+            Assert.AreEqual("12", new ValueOrBinding<int>(12).AsString().GetValue());
+            Assert.AreEqual("FirstValue", new ValueOrBinding<TestEnum>(TestEnum.FirstValue).AsString().GetValue());
+        }
+
+        [TestMethod]
+        public void BindingTransformations_ReturnCachedEvaluatableBindings()
+        {
+            var control = CreateControl(new TestViewModel());
+            var flagBinding = Binding<bool>(nameof(TestViewModel.Flag));
+            var flag = new ValueOrBinding<bool>(flagBinding);
+            var nullableFlag = Bound<bool?>(nameof(TestViewModel.NullableFlag));
+            var number = Bound<int>(nameof(TestViewModel.Number));
+            var text = Bound<string>(nameof(TestViewModel.Text));
+            var nullableText = Bound<string?>(nameof(TestViewModel.NullableText));
+            var dataSet = new ValueOrBinding<IGridViewDataSet<int>>(Binding<GridViewDataSet<int>>(nameof(TestViewModel.DataSet)));
+
+            Assert.IsFalse(flag.Negate().Evaluate(control));
+            Assert.IsFalse(flagBinding.Negate().Evaluate(control));
+            Assert.IsNull(nullableFlag.Negate().Evaluate(control));
+            Assert.IsTrue(number.IsMoreThanZero().Evaluate(control));
+            Assert.AreEqual("2", number.AsString().Evaluate(control));
+            Assert.IsFalse(text.IsNullOrEmpty().Evaluate(control));
+            Assert.IsFalse(text.IsNullOrWhitespace().Evaluate(control));
+            Assert.IsTrue(text.NotNullOrEmpty().Evaluate(control));
+            Assert.IsTrue(text.NotNullOrWhitespace().Evaluate(control));
+            Assert.IsTrue(nullableText.IsNull().Evaluate(control));
+            CollectionAssert.AreEqual(new[] { 1, 2 }, dataSet.GetItems().Evaluate(control)!.ToArray());
+            Assert.AreSame(flag.Negate().BindingOrDefault, flag.Negate().BindingOrDefault);
+            Assert.AreSame(text.IsNullOrEmpty().BindingOrDefault, text.IsNullOrEmpty().BindingOrDefault);
+        }
+
+        [TestMethod]
+        public void AndOr_ApplyBooleanIdentitiesAndCombineBindings()
+        {
+            var leftBinding = Binding<bool>(nameof(TestViewModel.Flag));
+            var rightBinding = Binding<bool>(nameof(TestViewModel.OtherFlag));
+            var left = new ValueOrBinding<bool>(leftBinding);
+            var right = new ValueOrBinding<bool>(rightBinding);
+            var control = CreateControl(new TestViewModel());
+
+            AssertValue(false, new ValueOrBinding<bool>(false).And(left));
+            AssertBinding(leftBinding, new ValueOrBinding<bool>(true).And(left));
+            AssertValue(false, left.And(new ValueOrBinding<bool>(false)));
+            AssertBinding(leftBinding, left.And(new ValueOrBinding<bool>(true)));
+            AssertValue(true, new ValueOrBinding<bool>(true).Or(left));
+            AssertBinding(leftBinding, new ValueOrBinding<bool>(false).Or(left));
+            AssertValue(true, left.Or(new ValueOrBinding<bool>(true)));
+            AssertBinding(leftBinding, left.Or(new ValueOrBinding<bool>(false)));
+
+            var and = left.And(right);
+            var or = left.Or(right);
+            Assert.IsFalse(and.Evaluate(control));
+            Assert.IsTrue(or.Evaluate(control));
+            Assert.AreSame(and.BindingOrDefault, left.And(right).BindingOrDefault);
+            Assert.AreSame(or.BindingOrDefault, left.Or(right).BindingOrDefault);
+        }
+
+        [TestMethod]
+        public void Select_MapsValuesAndCachesEquivalentBindingMappings()
+        {
+            var value = new ValueOrBinding<int>(4).Select(i => i * 2);
+            var sourceBinding = Binding<int>(nameof(TestViewModel.Number));
+            var first = sourceBinding.Select(i => i * 2);
+            var same = sourceBinding.Select(i => i * 2);
+            var control = CreateControl(new TestViewModel { Number = 4 });
+
+            Assert.AreEqual(8, value.GetValue());
+            Assert.AreSame(first, same);
+            Assert.AreEqual(8, first.Evaluate(control));
+        }
+
+        private ValueBindingExpression<T> Binding<T>(string property) => bindings.ValueBinding<T>(property, context);
+        private ResourceBindingExpression<T> ResourceBinding<T>(string property) => bindings.ResourceBinding<T>(property, context);
+        private ValueOrBinding<T> Bound<T>(string property) => new(Binding<T>(property));
+
+        private static void AssertValue<T>(T expected, ValueOrBinding<T> actual)
+        {
+            Assert.IsTrue(actual.HasValue);
+            Assert.IsFalse(actual.HasBinding);
+            Assert.AreEqual(expected, actual.ValueOrDefault);
+            Assert.AreEqual(expected, actual.GetValue());
+            Assert.AreEqual(expected, actual.BoxedValue);
+            Assert.IsNull(actual.BindingOrDefault);
+        }
+
+        private static void AssertBinding<T>(IBinding expected, ValueOrBinding<T> actual)
+        {
+            Assert.IsTrue(actual.HasBinding);
+            Assert.IsFalse(actual.HasValue);
+            Assert.AreSame(expected, actual.BindingOrDefault);
+            Assert.AreSame(expected, actual.GetBinding());
+            Assert.IsNull(actual.BoxedValue);
+        }
+
+        private HtmlGenericControl CreateControl(TestViewModel viewModel)
+        {
+            var control = new HtmlGenericControl("div") { DataContext = viewModel };
+            control.SetDataContextType(context);
+            return control;
+        }
+
+        private sealed class TestViewModel
+        {
+            public bool Flag { get; set; } = true;
+            public bool OtherFlag { get; set; }
+            public bool? NullableFlag { get; set; }
+            public int Number { get; set; } = 2;
+            public string Text { get; set; } = "text";
+            public string? NullableText { get; set; }
+            public GridViewDataSet<int> DataSet { get; set; } = new() { Items = new List<int> { 1, 2 } };
+            public IGridViewDataSet<int> InterfaceDataSet { get; set; } = new GridViewDataSet<int>();
+            public IPageableGridViewDataSet<PagingOptions> InterfacePageableDataSet { get; set; } = new GridViewDataSet<int>();
+        }
+
+        private enum TestEnum
+        {
+            FirstValue
+        }
+    }
+}

--- a/src/Tests/Binding/ValueOrBindingTests.cs
+++ b/src/Tests/Binding/ValueOrBindingTests.cs
@@ -178,6 +178,12 @@ namespace DotVVM.Framework.Binding
         }
 
         [TestMethod]
+        public void UnwrapToObject_UntypedNullReturnsNull()
+        {
+            Assert.IsNull(ValueOrBindingExtensions.UnwrapToObject(null));
+        }
+
+        [TestMethod]
         public void ValueAndNullPredicates_DistinguishValuesFromBindings()
         {
             var binding = Bound<string?>(nameof(TestViewModel.NullableText));

--- a/src/Tests/Binding/ValueOrBindingTests.cs
+++ b/src/Tests/Binding/ValueOrBindingTests.cs
@@ -322,6 +322,16 @@ namespace DotVVM.Framework.Binding
             Assert.AreEqual(8, first.Evaluate(control));
         }
 
+        [TestMethod]
+        public void Select_ConstantMappingCreatesEvaluatableBinding()
+        {
+            var sourceBinding = Binding<int>(nameof(TestViewModel.Number));
+            var constant = sourceBinding.Select(_ => "constant");
+            var control = CreateControl(new TestViewModel { Number = 4 });
+
+            Assert.AreEqual("constant", constant.Evaluate(control));
+        }
+
         private ValueBindingExpression<T> Binding<T>(string property) => bindings.ValueBinding<T>(property, context);
         private ResourceBindingExpression<T> ResourceBinding<T>(string property) => bindings.ResourceBinding<T>(property, context);
         private ValueOrBinding<T> Bound<T>(string property) => new(Binding<T>(property));

--- a/src/Tests/Binding/ValueOrBindingTests.cs
+++ b/src/Tests/Binding/ValueOrBindingTests.cs
@@ -184,6 +184,18 @@ namespace DotVVM.Framework.Binding
         }
 
         [TestMethod]
+        public void FromBoxedValue_ValueContainerWithBindingPreservesBinding()
+        {
+            var binding = Binding<int>(nameof(TestViewModel.Number));
+            ValueOrBinding boxed = new ValueOrBinding<int>(binding);
+
+            var result = ValueOrBinding<int>.FromBoxedValue(boxed);
+
+            Assert.AreSame(binding, result.GetBinding());
+        }
+
+
+        [TestMethod]
         public void ValueAndNullPredicates_DistinguishValuesFromBindings()
         {
             var binding = Bound<string?>(nameof(TestViewModel.NullableText));

--- a/src/Tests/ControlTests/ResourceDataContextTests.cs
+++ b/src/Tests/ControlTests/ResourceDataContextTests.cs
@@ -123,6 +123,20 @@ namespace DotVVM.Framework.Tests.ControlTests
         }
 
         [TestMethod]
+        public async Task RepeaterWithPageResourceInValueBinding()
+        {
+            var r = await cth.RunPage(typeof(TestViewModel), @"
+                    <dot:Repeater DataSource={resource: Customers.Items}>
+                        {{value: _parent.StringPrefix + _page.Resource(Name)}}
+                    </dot:Repeater>
+               "
+            );
+
+            StringAssert.Contains(r.FormattedHtml, "(StringPrefix() ?? \"\") + (\"One\" ?? \"\")");
+            StringAssert.Contains(r.FormattedHtml, "(StringPrefix() ?? \"\") + (\"Two\" ?? \"\")");
+        }
+
+        [TestMethod]
         public async Task DataContextRevert()
         {
             // revert client-side data context by DataContext={value: _root...}


### PR DESCRIPTION
I vibecoded some test coverage for ValueOrBinding, and then fixed some identified issues (separated into commits):

* `ValueOrBinding.UnwrapToObject(null)` unnecessarily crashed
* `ValueOrBinding<TStruct>.FromBoxedValue(x)` crashed when x was ValueOrBinding with a binding
* DataSourceAccess binding property now accepts interfaces like `IGridViewDataSet<T> ` (but still rejectes non-generic dataset interfaces)
* Adds Equals/GetHashCode to BindingParserOptions, so it can be used as a binding cache key (which ValueOrBidning.Select tries to do)