### PR TITLE
Publish DotVVM.Compiler in main "DotVVM" nuget package

### DIFF
--- a/ci/scripts/Publish-NuGetPackages.ps1
+++ b/ci/scripts/Publish-NuGetPackages.ps1
@@ -41,6 +41,52 @@ function Get-TemplateProjects {
     return . "$PSScriptRoot/Get-PublicProjects.ps1" | Where-Object { $_.Type -eq "template" }
 }
 
+function Prepare-DotVVMCompilerPackage {
+    $compilerProject = Join-Path $root "src/Tools/Compiler/DotVVM.Compiler.csproj"
+    $compilerOutput = Join-Path $root "artifacts/bin/DotVVM.Compiler/Release"
+    $stagingDirectory = Join-Path $root "artifacts/package-assets/DotVVM.Compiler"
+
+    if (Test-Path $compilerOutput) {
+        Remove-Item -Recurse -Force $compilerOutput
+    }
+    if (Test-Path $stagingDirectory) {
+        Remove-Item -Recurse -Force $stagingDirectory
+    }
+
+    dotnet build $compilerProject `
+        --configuration Release `
+        --no-restore `
+        -p:DOTVVM_ROOT="$root" `
+        -p:DOTVVM_VERSION="$version"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Building DotVVM.Compiler failed with exit code $LASTEXITCODE."
+    }
+
+    function Copy-CompilerFiles([string]$source, [string]$packageDirectory, [string[]]$files) {
+        $destination = Join-Path $stagingDirectory $packageDirectory
+        New-Item -ItemType Directory -Path $destination -Force | Out-Null
+        foreach ($file in $files) {
+            Copy-Item (Join-Path $source $file) $destination -ErrorAction Stop
+        }
+    }
+
+    foreach ($output in Get-ChildItem $compilerOutput -Directory) {
+        if (Test-Path (Join-Path $output.FullName "DotVVM.Compiler.runtimeconfig.json")) {
+            Copy-CompilerFiles $output.FullName "net" @(
+                "DotVVM.Compiler.dll",
+                "DotVVM.Compiler.deps.json",
+                "DotVVM.Compiler.runtimeconfig.json"
+            )
+        }
+        elseif (Test-Path (Join-Path $output.FullName "DotVVM.Compiler.exe")) {
+            Copy-CompilerFiles $output.FullName "netfw" @(
+                "DotVVM.Compiler.exe",
+                "DotVVM.Compiler.exe.config"
+            )
+        }
+    }
+}
+
 function Build-PublicProjectPackages {
     $packages = . "$PSScriptRoot/Get-PublicProjects.ps1" | Where-Object { $_.Type -ne "template" }
     foreach ($package in $packages) {
@@ -48,6 +94,9 @@ function Build-PublicProjectPackages {
         $dir = Join-Path "$root" "$($package.Path)"
         try {
             dotnet build --nologo -c Release --no-restore --no-incremental -p:DOTVVM_ROOT="$root" -p:DOTVVM_VERSION="$version" "$dir"
+            if ($package.Name -eq "DotVVM") {
+                Prepare-DotVVMCompilerPackage
+            }
             dotnet pack -c Release --no-build -p:DOTVVM_ROOT="$root" -p:DOTVVM_VERSION="$version" "$dir"
         }
         finally {

--- a/src/Framework/Framework/DotVVM.Framework.csproj
+++ b/src/Framework/Framework/DotVVM.Framework.csproj
@@ -114,6 +114,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(DOTVVM_ROOT)' != ''">
+    <None Include="$(DOTVVM_ROOT)/artifacts/package-assets/DotVVM.Compiler/net/*" Pack="true" PackagePath="tools/net" />
+    <None Include="$(DOTVVM_ROOT)/artifacts/package-assets/DotVVM.Compiler/netfw/*" Pack="true" PackagePath="tools/netfw" />
     <None Include="$(DOTVVM_ROOT)/artifacts/bin/DotVVM.Analyzers.Package/$(Configuration)/netstandard2.0/DotVVM.Analyzers.dll" PackagePath="analyzers/dotnet/cs" Pack="true" Visible="false" />
     <None Include="$(DOTVVM_ROOT)/artifacts/bin/DotVVM.Analyzers.Package/$(Configuration)/netstandard2.0/DotVVM.Analyzers.CodeFixes.dll" PackagePath="analyzers/dotnet/cs" Pack="true" Visible="false" />
     <None Include="../../Analyzers/Analyzers.Package/tools/*.ps1" PackagePath="tools" Pack="true" />


### PR DESCRIPTION
This will make sure DotVVM.Compiler of the right version always exists, making commandline more stable and simpler

It will allow us to change the API used by compiler however we want to