### PR TITLE
publish: add --tag next to preview NPM packages

### DIFF
--- a/.github/workflows/publish-internal.yml
+++ b/.github/workflows/publish-internal.yml
@@ -152,13 +152,13 @@ jobs:
           -email "${{ secrets.INTERNAL_NPM_EMAIL }}"
 
     - name: Publish dotvvm-types
-      run: npm publish
+      run: npm publish ${{ inputs.release-type != 'Stable' && '--tag next' || '' }}
       working-directory: ci/scripts/npm/dotvvm-types
 
     - name: Publish JsComponent.React
-      run: npm publish
+      run: npm publish ${{ inputs.release-type != 'Stable' && '--tag next' || '' }}
       working-directory: src/Framework/JsComponent.React
 
     - name: Publish JsComponent.Svelte
-      run: npm publish
+      run: npm publish ${{ inputs.release-type != 'Stable' && '--tag next' || '' }}
       working-directory: src/Framework/JsComponent.Svelte


### PR DESCRIPTION
NPM 11+ fails when --tag is not present and version seems like a pre-release. Older NPM versions just published it as latest, which is also not great.