### PR TITLE
serializer: Preserve EqualityComparer of deserialized dictionary

### DIFF
--- a/src/Framework/Framework/ViewModel/Serialization/DotvvmDictionaryConverter.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/DotvvmDictionaryConverter.cs
@@ -3,6 +3,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
+#if NET8_0_OR_GREATER
+using System.Collections.Frozen;
+#endif
 using System.Globalization;
 using System.Linq;
 using System.Text.Json;
@@ -61,7 +64,10 @@ namespace DotVVM.Framework.ViewModel.Serialization
                 }
                 else
                 {
-                    // immutable dict
+                    // preserve comparers, and type
+                    if (value is IImmutableDictionary<K, V> immutableDict)
+                        return (TDictionary)(object)immutableDict.Clear().AddRange(newDict);
+
                     return CreateDictionary(newDict, typeToConvert);
                 }
             }
@@ -69,7 +75,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
             private Dictionary<K, V> ReadDictionaryItems(ref Utf8JsonReader reader, IReadOnlyDictionary<K, V>? existingDict, JsonSerializerOptions options, DotvvmSerializationState state)
             {
                 reader.AssertRead(JsonTokenType.StartArray);
-                var newDict = new Dictionary<K, V>();
+                var newDict = new Dictionary<K, V>(GetKeyComparer(existingDict));
 
                 while (reader.TokenType != JsonTokenType.EndArray)
                 {
@@ -80,6 +86,16 @@ namespace DotVVM.Framework.ViewModel.Serialization
 
                 return newDict;
             }
+
+            private static IEqualityComparer<K>? GetKeyComparer(IReadOnlyDictionary<K, V>? dictionary) =>
+                dictionary switch {
+                    Dictionary<K, V> { Comparer: var c } => c,
+                    ImmutableDictionary<K, V> { KeyComparer: var c } => c,
+#if NET8_0_OR_GREATER
+                    FrozenDictionary<K, V> { Comparer: var c } => c,
+#endif
+                    _ => null
+                };
 
             private TDictionary CreateDictionary(Dictionary<K, V> dict, Type typeToConvert)
             {

--- a/src/Framework/Framework/ViewModel/Serialization/DotvvmDictionaryConverter.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/DotvvmDictionaryConverter.cs
@@ -102,6 +102,8 @@ namespace DotVVM.Framework.ViewModel.Serialization
                 // Create the appropriate dictionary type
                 if (dict is TDictionary result)
                     return result;
+                if (typeof(TDictionary) == typeof(SortedDictionary<K, V>))
+                    return (TDictionary)(object)new SortedDictionary<K, V>(dict);
                 if (ImmutableDictionary<K, V>.Empty is TDictionary)
                     return (TDictionary)(object)dict.ToImmutableDictionary();
                 throw new NotSupportedException($"Cannot create instance of {typeToConvert.ToCode()}.");

--- a/src/Tests/ViewModel/SerializerTests.cs
+++ b/src/Tests/ViewModel/SerializerTests.cs
@@ -19,6 +19,9 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Runtime.Serialization;
 using System.Collections.Immutable;
+#if NET8_0_OR_GREATER
+using System.Collections.Frozen;
+#endif
 
 namespace DotVVM.Framework.Tests.ViewModel
 {
@@ -737,6 +740,32 @@ namespace DotVVM.Framework.Tests.ViewModel
             Assert.AreEqual("Item3", objPopulated.Dictionary["key3"].P1);
         }
 
+
+        [TestMethod]
+        public void SortedDictionaryPopulate_PreservesInstanceAndComparer()
+        {
+            var obj = new TestViewModelWithSortedDictionary {
+                Dictionary = new() {
+                    ["key"] = new() { P1 = "new" }
+                }
+            };
+            var json = Serialize(obj, out var _, isPostback: true);
+            var existingValue = new TestViewModelWithBind { P1 = "old" };
+            var obj2 = new TestViewModelWithSortedDictionary {
+                Dictionary = new(StringComparer.OrdinalIgnoreCase) {
+                    ["KEY"] = existingValue
+                }
+            };
+            var originalDictionary = obj2.Dictionary;
+
+            var result = PopulateViewModel(json, obj2);
+
+            Assert.AreSame(originalDictionary, result.Dictionary);
+            Assert.IsTrue(result.Dictionary.ContainsKey("KEY"));
+            Assert.AreSame(existingValue, result.Dictionary["key"]);
+            Assert.AreEqual("new", existingValue.P1);
+        }
+
         [TestMethod]
         public void SupportImmutableArrayCollection()
         {
@@ -875,6 +904,53 @@ namespace DotVVM.Framework.Tests.ViewModel
             Assert.AreNotSame(originalInstances.FirstValue, objPopulated.ImmutableDictionary["key3"]);
             Assert.AreEqual("Item3", objPopulated.ImmutableDictionary["key3"].P1);
         }
+
+        [TestMethod]
+        public void ImmutableDictionaryPopulate_PreservesComparer()
+        {
+            var obj = new TestViewModelWithAdvancedCollections {
+                ImmutableDictionary = ImmutableDictionary<string, TestViewModelWithBind>.Empty
+                    .Add("key", new() { P1 = "new" })
+            };
+            var json = Serialize(obj, out var _, isPostback: true);
+            var obj2 = new TestViewModelWithAdvancedCollections {
+                ImmutableDictionary = ImmutableDictionary.Create<string, TestViewModelWithBind>(StringComparer.OrdinalIgnoreCase)
+                    .Add("key", new() { P1 = "old" })
+            };
+
+            var result = PopulateViewModel(json, obj2);
+
+            Assert.IsTrue(result.ImmutableDictionary.ContainsKey("KEY"));
+        }
+
+#if NET8_0_OR_GREATER
+        [TestMethod]
+        public void ReadOnlyFrozenDictionaryPopulate_PreservesComparerWhenReplaced()
+        {
+            IReadOnlyDictionary<string, TestViewModelWithBind> dictionary = new Dictionary<string, TestViewModelWithBind> {
+                ["key"] = new() { P1 = "new" }
+            };
+            var json = Serialize(dictionary, out var _, isPostback: true);
+            var existingDictionary = new Dictionary<string, TestViewModelWithBind>(StringComparer.OrdinalIgnoreCase) {
+                ["key"] = new() { P1 = "old" }
+            }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+            var converter = (IDotvvmJsonConverter)JsonOptions.GetConverter(typeof(IReadOnlyDictionary<string, TestViewModelWithBind>));
+            var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
+            reader.Read();
+
+            using var state = CreateState(true, new JsonObject());
+            var result = (IReadOnlyDictionary<string, TestViewModelWithBind>)converter.PopulateUntyped(
+                ref reader,
+                typeof(IReadOnlyDictionary<string, TestViewModelWithBind>),
+                existingDictionary,
+                JsonOptions,
+                state
+            );
+
+            Assert.IsInstanceOfType<Dictionary<string, TestViewModelWithBind>>(result);
+            Assert.IsTrue(result.ContainsKey("KEY"));
+        }
+#endif
 
         [TestMethod]
         public void DoesNotCloneSettableRecord()
@@ -2008,6 +2084,10 @@ namespace DotVVM.Framework.Tests.ViewModel
         public ImmutableDictionary<string, TestViewModelWithBind> ImmutableDictionary { get; set; } = ImmutableDictionary<string, TestViewModelWithBind>.Empty;
     }
 
+    public class TestViewModelWithSortedDictionary
+    {
+        public SortedDictionary<string, TestViewModelWithBind> Dictionary { get; set; } = new();
+    }
     public class DerivedSubclassA : DerivedItemA
     {
         public string SubProperty { get; set; }

--- a/src/Tests/ViewModel/SerializerTests.cs
+++ b/src/Tests/ViewModel/SerializerTests.cs
@@ -740,6 +740,18 @@ namespace DotVVM.Framework.Tests.ViewModel
             Assert.AreEqual("Item3", objPopulated.Dictionary["key3"].P1);
         }
 
+        [TestMethod]
+        public void SortedDictionaryDeserialize()
+        {
+            var obj = new SortedDictionary<string, TestViewModelWithBind> {
+                ["key"] = new() { P1 = "value" }
+            };
+            var json = Serialize(obj, out var encryptedValues, isPostback: true);
+
+            var result = Deserialize<SortedDictionary<string, TestViewModelWithBind>>(json, encryptedValues);
+
+            Assert.AreEqual("value", result["key"].P1);
+        }
 
         [TestMethod]
         public void SortedDictionaryPopulate_PreservesInstanceAndComparer()


### PR DESCRIPTION
If we cannot keep the original instance (i.e. it's readonly), at least keep its EqualityComparer.