### PR TITLE
Fix null handling when calling custom JsonConverters

### DIFF
--- a/src/Framework/Framework/ViewModel/Serialization/CustomPrimitiveTypeJsonConverter.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/CustomPrimitiveTypeJsonConverter.cs
@@ -21,6 +21,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
         class InnerConverter<T>: JsonConverter<T> where T: IDotvvmPrimitiveType
         {
             private CustomPrimitiveTypeRegistration registration = ReflectionUtils.TryGetCustomPrimitiveTypeRegistration(typeof(T)) ?? throw new InvalidOperationException($"The type {typeof(T)} is not a custom primitive type!");
+            public override bool HandleNull => true;
             public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
                 if (reader.TokenType is JsonTokenType.String
@@ -51,7 +52,10 @@ namespace DotVVM.Framework.ViewModel.Serialization
 
             public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
             {
-                writer.WriteStringValue(registration.ToStringMethod(value));
+                if (value is null)
+                    writer.WriteNullValue();
+                else
+                    writer.WriteStringValue(registration.ToStringMethod(value));
             }
         }
     }

--- a/src/Framework/Framework/ViewModel/Serialization/DotvvmByteArrayConverter.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/DotvvmByteArrayConverter.cs
@@ -10,6 +10,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
 {
     public class DotvvmByteArrayConverter : JsonConverter<byte[]>
     {
+        public override bool HandleNull => true;
         public override byte[]? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             if (reader.TokenType == JsonTokenType.Null)

--- a/src/Framework/Framework/ViewModel/Serialization/DotvvmObjectConverter.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/DotvvmObjectConverter.cs
@@ -9,6 +9,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
     /// <summary> Mimicks Newtonsoft.Json behavior for System.Object - number -> double, string -> string, true/false -> bool, otherwise JsonElement </summary>
     public class DotvvmObjectConverter : JsonConverter<object?>
     {
+        public override bool HandleNull => true;
         public override void Write(Utf8JsonWriter writer, object? value, JsonSerializerOptions options)
         {
             if (value is null)

--- a/src/Framework/Framework/ViewModel/Serialization/ViewModelSerializationMap.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/ViewModelSerializationMap.cs
@@ -543,6 +543,13 @@ namespace DotVVM.Framework.ViewModel.Serialization
             return property.JsonConverter;
         }
 
+        private static bool ConverterHandlesNull(JsonConverter converter) =>
+            // converter.HandleNull is defined only on JsonConverter<T> :/
+            (bool)typeof(JsonConverter<>)
+                .MakeGenericType(converter.Type.NotNull())
+                .GetProperty(nameof(JsonConverter<object>.HandleNull))!
+                .GetValue(converter)!;
+
         private Expression CallPropertyConverterRead(JsonConverter converter, Type type, Expression reader, Expression jsonOptions, Expression dotvvmState, Expression? existingValue)
         {
             Debug.Assert(reader.Type == typeof(Utf8JsonReader).MakeByRefType() || reader.Type == typeof(Utf8JsonReader), $"{reader.Type} != {typeof(Utf8JsonReader).MakeByRefType()}");
@@ -562,7 +569,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
             else
             {
                 var read = Call(Constant(converter), "Read", Type.EmptyTypes, reader, Constant(type), jsonOptions);
-                if (read.Type.IsValueType)
+                if (!type.IsAssignableFromNull() || ConverterHandlesNull(converter))
                     return read;
                 else
                     return Condition(
@@ -586,7 +593,16 @@ namespace DotVVM.Framework.ViewModel.Serialization
             }
             else
             {
-                return Call(Constant(converter), nameof(IDotvvmJsonConverter<object>.Write), Type.EmptyTypes, writer, value, jsonOptions);
+                var write = Call(Constant(converter), nameof(IDotvvmJsonConverter<object>.Write), Type.EmptyTypes, writer, value, jsonOptions);
+
+                if (!value.Type.IsAssignableFromNull() || ConverterHandlesNull(converter))
+                    return write;
+                else
+                    return IfThenElse(
+                        Equal(value, Default(value.Type)),
+                        Call(writer, nameof(Utf8JsonWriter.WriteNullValue), Type.EmptyTypes),
+                        write
+                    );
             }
         }
 
@@ -674,6 +690,10 @@ namespace DotVVM.Framework.ViewModel.Serialization
             var type = existingValue.Type;
             Debug.Assert(type.UnwrapNullableType() == property.Type.UnwrapNullableType(), $"{type} != {property.Type}, property: {property.PropertyInfo.DeclaringType}.{property.Name}");
 
+            if (GetPropertyConverter(property, type) is {} customConverter)
+            {
+                return CallPropertyConverterRead(customConverter, type, reader, jsonOptions, dotvvmState, property.Populate ? existingValue : null);
+            }
             if (ReflectionUtils.IsNullable(existingValue.Type))
             {
                 return Condition(
@@ -681,10 +701,6 @@ namespace DotVVM.Framework.ViewModel.Serialization
                     ifTrue: Default(type),
                     ifFalse: Convert(DeserializePropertyValue(property, reader, existingValue.UnwrapNullable(throwOnNull: false), jsonOptions, dotvvmState), type)
                 );
-            }
-            if (GetPropertyConverter(property, type) is {} customConverter)
-            {
-                return CallPropertyConverterRead(customConverter, type, reader, jsonOptions, dotvvmState, property.Populate ? existingValue : null);
             }
 
             if (TryDeserializePrimitive(reader, type) is {} primitive)
@@ -730,6 +746,10 @@ namespace DotVVM.Framework.ViewModel.Serialization
             Debug.Assert(dotvvmState.Type == typeof(DotvvmSerializationState));
             Debug.Assert(value.Type.UnwrapNullableType() == property.Type.UnwrapNullableType(), $"{value.Type} != {property.Type}");
 
+            if (GetPropertyConverter(property, value.Type) is {} converter)
+            {
+                return CallPropertyConverterWrite(converter, writer, value, jsonOptions, dotvvmState);
+            }
             if (ReflectionUtils.IsNullableType(value.Type))
             {
                 return IfThenElse(
@@ -737,11 +757,6 @@ namespace DotVVM.Framework.ViewModel.Serialization
                     GetSerializeExpression(property, writer, Property(value, "Value"), jsonOptions, dotvvmState),
                     Call(writer, "WriteNullValue", Type.EmptyTypes)
                 );
-            }
-
-            if (GetPropertyConverter(property, value.Type) is {} converter)
-            {
-                return CallPropertyConverterWrite(converter, writer, value, jsonOptions, dotvvmState);
             }
             if (TrySerializePrimitive(writer, value) is {} primitive)
             {

--- a/src/Tests/ViewModel/SerializerTests.cs
+++ b/src/Tests/ViewModel/SerializerTests.cs
@@ -1547,6 +1547,38 @@ namespace DotVVM.Framework.Tests.ViewModel
         }
 
         [TestMethod]
+        public void PropertyJsonConverter_DoesNotReceiveNull()
+        {
+            var (viewModel, json) = SerializeAndDeserialize(new TestViewModelWithNullPropertyJsonConverter());
+
+            Assert.IsNull(viewModel.Value);
+            Assert.IsNull(json["Value"]);
+        }
+
+        [TestMethod]
+        public void PropertyJsonConverter_ReceivesNullWhenSupported()
+        {
+            var json = Serialize(new TestViewModelWithNullHandlingPropertyJsonConverter(), out _);
+            Assert.AreEqual("written null", JsonNode.Parse(json)["Value"].GetValue<string>());
+
+            var viewModel = Deserialize<TestViewModelWithNullHandlingPropertyJsonConverter>("""{"Value":null}""");
+            Assert.AreEqual("read null", viewModel.Value);
+        }
+
+        [TestMethod]
+        public void PropertyJsonConverter_SupportsNullableValueType()
+        {
+            var (viewModel, json) = SerializeAndDeserialize(new TestViewModelWithNullablePropertyJsonConverter { Value = 42 });
+
+            Assert.AreEqual(42, viewModel.Value);
+            Assert.AreEqual("42", json["Value"].GetValue<string>());
+
+            (viewModel, json) = SerializeAndDeserialize(new TestViewModelWithNullablePropertyJsonConverter());
+            Assert.IsNull(viewModel.Value);
+            Assert.IsNull(json["Value"]);
+        }
+
+        [TestMethod]
         public void SupportCustomConverters_DynamicDispatch()
         {
             var obj = new TestViewModelWithCustomConverter() { Property1 = "A", Property2 = "B" };
@@ -2032,6 +2064,54 @@ namespace DotVVM.Framework.Tests.ViewModel
                 writer.WriteEndObject();
             }
         }
+    }
+
+    public class TestViewModelWithNullPropertyJsonConverter
+    {
+        [JsonConverter(typeof(NullRejectingStringJsonConverter))]
+        public string Value { get; set; }
+    }
+
+    public class NullRejectingStringJsonConverter : JsonConverter<string>
+    {
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+            reader.TokenType == JsonTokenType.Null ? throw new InvalidOperationException("Converter received null.") : reader.GetString();
+
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options) =>
+            writer.WriteStringValue(value ?? throw new InvalidOperationException("Converter received null."));
+    }
+
+    public class TestViewModelWithNullHandlingPropertyJsonConverter
+    {
+        [JsonConverter(typeof(NullHandlingStringJsonConverter))]
+        public string Value { get; set; }
+    }
+
+    public class NullHandlingStringJsonConverter : JsonConverter<string>
+    {
+        public override bool HandleNull => true;
+
+        public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+            reader.TokenType == JsonTokenType.Null ? "read null" : reader.GetString();
+
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options) =>
+            writer.WriteStringValue(value ?? "written null");
+    }
+
+    public class TestViewModelWithNullablePropertyJsonConverter
+    {
+        [JsonConverter(typeof(NullableIntJsonConverter))]
+        public int? Value { get; set; }
+    }
+
+    public class NullableIntJsonConverter : JsonConverter<int?>
+    {
+        // HandleNull defaults to false, so we shoudln't get null value in either direction
+        public override int? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+            int.Parse(reader.GetString());
+
+        public override void Write(Utf8JsonWriter writer, int? value, JsonSerializerOptions options) =>
+            writer.WriteStringValue(value.Value.ToString());
     }
 
     [JsonConverter(typeof(TestEnumCustomConverter))]


### PR DESCRIPTION
System.Text.Json converters have HandleNull property, which we should respect:
* when false (default), both serialization and deserialization should handle null values before the converter is called. Conterintuitively this is the case even if converter is explicitely defined for Nullable<...> type
* when true: we don't check for null and let converter handle it

We always allow null in DotvvmConverters, because they all already handle it, and it keeps the generated code smaller.