### PR TITLE
Fix staticCommand plan for unserializable parameter default values

### DIFF
--- a/src/Framework/Framework/Compilation/Binding/MemberExpressionFactory.cs
+++ b/src/Framework/Framework/Compilation/Binding/MemberExpressionFactory.cs
@@ -420,10 +420,10 @@ namespace DotVVM.Framework.Compilation.Binding
             if (parameter.HasDefaultValue)
             {
                 var value = parameter.DefaultValue;
-                if (value is null && parameter.ParameterType.IsValueType)
+                if (value is null)
                 {
-                    // null with struct type means `default(T)`
-                    value = ReflectionUtils.GetDefaultValue(parameter.ParameterType);
+                    // null with struct type also means `default(T)`
+                    return Expression.Default(parameter.ParameterType);
                 }
                 return Expression.Constant(value, parameter.ParameterType);
             }

--- a/src/Framework/Framework/Compilation/Binding/StaticCommandBindingCompiler.cs
+++ b/src/Framework/Framework/Compilation/Binding/StaticCommandBindingCompiler.cs
@@ -173,6 +173,7 @@ namespace DotVVM.Framework.Compilation.Binding
         Argument,
         Inject,
         Constant,
+        /// Parameter default value (not necessarily default(T))
         DefaultValue,
         Invocation
     }

--- a/src/Framework/Framework/Compilation/Binding/StaticCommandMethodTranslator.cs
+++ b/src/Framework/Framework/Compilation/Binding/StaticCommandMethodTranslator.cs
@@ -75,6 +75,13 @@ namespace DotVVM.Framework.Compilation.Binding
             var argPlans = allArguments.Select((arg, index) => {
                 if (arg.OriginalExpression.GetParameterAnnotation() is BindingParameterAnnotation { ExtensionParameter:  InjectedServiceExtensionParameter service })
                     return new StaticCommandParameterPlan(StaticCommandParameterType.Inject, ResolvedTypeDescriptor.ToSystemType(service.ParameterType));
+                else if (arg.OriginalExpression is DefaultExpression)
+                {
+                    if (method.GetParameters()[index - (method.IsStatic ? 0 : 1)].DefaultValue is null)
+                        return new StaticCommandParameterPlan(StaticCommandParameterType.DefaultValue, null);
+                    else
+                        return new StaticCommandParameterPlan(StaticCommandParameterType.Constant, ReflectionUtils.GetDefaultValue(arg.OriginalExpression.Type));
+                }
                 else if (arg.OriginalExpression is ConstantExpression constant)
                 {
                     if (constant.Value == method.GetParameters()[index - (method.IsStatic ? 0 : 1)].DefaultValue)

--- a/src/Tests/Binding/StaticCommandCompilationTests.cs
+++ b/src/Tests/Binding/StaticCommandCompilationTests.cs
@@ -13,6 +13,8 @@ using DotVVM.Framework.ViewModel;
 using Microsoft.Extensions.DependencyInjection;
 using DotVVM.Framework.Compilation.ControlTree.Resolved;
 using System.Collections.Immutable;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using DotVVM.Framework.Compilation.Javascript.Ast;
 using DotVVM.Framework.Binding;
 using DotVVM.Framework.Testing;
@@ -152,6 +154,23 @@ namespace DotVVM.Framework.Tests.Binding
         {
             var result = CompileBinding("DateFrom = DateTo", niceMode: false, typeof(TestViewModel));
             Assert.AreEqual("{let vm=options.viewModel;vm.DateFrom(dotvvm.serialization.serializeDate(vm.DateTo.state,false));}", result);
+        }
+
+        [TestMethod]
+        public void StaticCommandCompilation_DefaultStructParameterIsNotSerialized()
+        {
+            var binding = releaseHelper.StaticCommand("StaticCommands.GetValueWithUnserializableDefault()", [ typeof(TestViewModel) ]);
+            var result = BindingTestHelper.GetStaticCommandJavascriptBody(binding);
+            var plan = binding.GetProperty<StaticCommandJsAstProperty>().Expression
+                .DescendantNodesAndSelf()
+                .Select(n => n.Annotation<StaticCommandMethodTranslator.StaticCommandInvocationJsAnnotation>())
+                .OfType<StaticCommandMethodTranslator.StaticCommandInvocationJsAnnotation>()
+                .Single()
+                .Plan;
+
+            Assert.AreEqual("{await dotvvm.staticCommandPostback(\"XXXX\",[],options);}", result);
+            Assert.AreEqual(StaticCommandParameterType.DefaultValue, plan.Arguments.Single().Type);
+            Assert.AreEqual(0, plan.Method.Invoke(null, plan.Arguments.Select(a => a.Arg).ToArray()));
         }
 
         [TestMethod]
@@ -461,6 +480,21 @@ namespace DotVVM.Framework.Tests.Binding
 
         [AllowStaticCommand]
         public static DateTime GetDate() => DateTime.UtcNow;
+
+        [AllowStaticCommand]
+        public static int GetValueWithUnserializableDefault(UnserializableStruct value = default) => value.Value;
+    }
+
+    [JsonConverter(typeof(UnserializableStructJsonConverter))]
+    public struct UnserializableStruct
+    {
+        public int Value { get; set; }
+    }
+
+    public class UnserializableStructJsonConverter : JsonConverter<UnserializableStruct>
+    {
+        public override UnserializableStruct Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => throw new NotSupportedException();
+        public override void Write(Utf8JsonWriter writer, UnserializableStruct value, JsonSerializerOptions options) => throw new NotSupportedException();
     }
 
     public abstract class TestInnerService<TOutput>


### PR DESCRIPTION
This mainly affected CancellationToken, which is fixed in a better way by #2100. However, same problem affects all unserializable value types.

This is regression in v5.0, probably introduced in 54676ae10