### PR TITLE
Fix validation of deserialized numeric enum values

### DIFF
--- a/src/Framework/Framework/ViewModel/Serialization/DotvvmEnumConverter.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/DotvvmEnumConverter.cs
@@ -66,7 +66,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
             }
 
             ulong allowedBitMap = 0;
-            if (isFlags)
+            if (!isFlags)
             {
                 foreach (var field in fieldsDedup)
                 {

--- a/src/Framework/Framework/ViewModel/Serialization/DotvvmEnumConverter.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/DotvvmEnumConverter.cs
@@ -54,7 +54,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
                                         .ToArray();
 
 
-            var maxNameLen = fieldList.Max(x => x.Name.Length);
+            var maxNameLen = fieldList.Count == 0 ? 0 : fieldList.Max(x => x.Name.Length);
             var nameToEnum = new (TEnum Value, byte[] Name)[maxNameLen + 1][];
             // index enum names by length, then sort them by name
             // the names in enumToName are already deduplicated, each value is represented by the shortest name
@@ -195,7 +195,16 @@ namespace DotVVM.Framework.ViewModel.Serialization
                     if (typeof(IsFlags) == typeof(False))
                     {
                         Span<byte> name = maxNameLen < 512 ? stackalloc byte[maxNameLen + 1] : new byte[maxNameLen + 1];
-                        var length = reader.CopyString(name);
+                        int length;
+                        try
+                        {
+                            length = reader.CopyString(name);
+                        }
+                        catch (ArgumentException ex)
+                        {
+                            // CopyString doesn't have a TryCopyString overload
+                            throw new JsonException($"Cannot parse {reader.GetString()} as {typeof(TEnum).Name}", ex);
+                        }
                         name = name.Slice(0, length);
                         return FindEnumName(name);
                     }
@@ -208,15 +217,18 @@ namespace DotVVM.Framework.ViewModel.Serialization
                             Span<byte> buffer = valueLength < 512 ? stackalloc byte[valueLength] : (rentedBuffer = ArrayPool<byte>.Shared.Rent(valueLength));
                             var bufferLength = reader.CopyString(buffer);
                             buffer = buffer.Slice(0, bufferLength);
+                            var fullBuffer = buffer;
 
                             ulong result = 0;
                             while (true)
                             {
+                                if (buffer.Length == 0)
+                                    return ThrowInvalidEnumName(fullBuffer);
                                 buffer = buffer.Slice(buffer[0] == ' ' ? 1 : 0);
 
                                 var nextIndex = MemoryExtensions.IndexOf(buffer, (byte)',');
                                 if (nextIndex == 0)
-                                    return ThrowInvalidEnumName(buffer);
+                                    return ThrowInvalidEnumName(fullBuffer);
 
                                 var token = nextIndex < 0 ? buffer : buffer.Slice(0, nextIndex);
 
@@ -243,7 +255,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
 
             TEnum FindEnumName(ReadOnlySpan<byte> name)
             {
-                if (name.Length > maxNameLen)
+                if (name.Length > maxNameLen || name.Length == 0)
                     return ThrowInvalidEnumName(name);
                 var fields = nameToEnum[name.Length];
                 if (fields is null)

--- a/src/Framework/Framework/ViewModel/Serialization/DotvvmEnumConverter.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/DotvvmEnumConverter.cs
@@ -36,8 +36,8 @@ namespace DotVVM.Framework.ViewModel.Serialization
                 var name = field.GetCustomAttribute<EnumMemberAttribute>()?.Value ?? field.Name;
                 var nameUtf8 = StringUtils.Utf8.GetBytes(name);
 
-                if (isFlags && name.IndexOfAny([',', ' ']) >= 0)
-                    throw new NotSupportedException("Flags enum cannot have EnumMemberAttribute with comma or a space.");
+                if (isFlags && (name.IndexOf(',') >= 0 || name[0] == ' ' || name[name.Length - 1] == ' '))
+                    throw new NotSupportedException("Flags enum cannot have EnumMemberAttribute with comma or space at the edges.");
 
                 var value = (TEnum)field.GetValue(null)!;
                 fieldList.Add((value, nameUtf8));
@@ -375,8 +375,7 @@ namespace DotVVM.Framework.ViewModel.Serialization
                         if (bufferPosition > 0)
                         {   // insert ', '
                             buffer[bufferPosition++] = (byte)',';
-                            if (writer.Options.Indented)
-                                buffer[bufferPosition++] = (byte)' ';
+                            buffer[bufferPosition++] = (byte)' ';
                         }
 
                         flag.Name.CopyTo(buffer.Slice(bufferPosition));

--- a/src/Framework/Framework/ViewModel/Serialization/DotvvmEnumConverter.cs
+++ b/src/Framework/Framework/ViewModel/Serialization/DotvvmEnumConverter.cs
@@ -58,10 +58,10 @@ namespace DotVVM.Framework.ViewModel.Serialization
             var nameToEnum = new (TEnum Value, byte[] Name)[maxNameLen + 1][];
             // index enum names by length, then sort them by name
             // the names in enumToName are already deduplicated, each value is represented by the shortest name
-            foreach (var field in enumToName.GroupBy(x => x.Value.Length))
+            foreach (var field in fieldList.GroupBy(x => x.Name.Length))
             {
-                var array = field.Select(f => (f.Key, f.Value)).ToArray();
-                Array.Sort(array, (a, b) => a.Value.AsSpan().SequenceCompareTo(b.Value.AsSpan()));
+                var array = field.Select(f => (f.Value, f.Name)).ToArray();
+                Array.Sort(array, (a, b) => a.Name.AsSpan().SequenceCompareTo(b.Name.AsSpan()));
                 nameToEnum[field.Key] = array;
             }
 

--- a/src/Tests/ViewModel/SerializerTests.cs
+++ b/src/Tests/ViewModel/SerializerTests.cs
@@ -1266,12 +1266,12 @@ namespace DotVVM.Framework.Tests.ViewModel
         [DataRow(TestViewModelWithEnums.DuplicateNameEnum.DAndAlsoLonger, "'D'", true)]
         [DataRow((TestViewModelWithEnums.DuplicateNameEnum)3, "3", false)]
         [DataRow(TestViewModelWithEnums.Int32FlagsEnum.ABC, "'a+b+c'", true)]
-        [DataRow(TestViewModelWithEnums.Int32FlagsEnum.A | TestViewModelWithEnums.Int32FlagsEnum.BCD, "'b+c+d,a'", true)]
+        [DataRow(TestViewModelWithEnums.Int32FlagsEnum.A | TestViewModelWithEnums.Int32FlagsEnum.BCD, "'b+c+d, a'", true)]
         [DataRow(TestViewModelWithEnums.Int32FlagsEnum.Everything, "'everything'", true)]
         [DataRow((TestViewModelWithEnums.Int32FlagsEnum)2356543, "2356543", true)] // allowed because Everything = -1 covers its bits (can be changed in future though)
         [DataRow((TestViewModelWithEnums.Int32FlagsEnum)0, "0", true)]
         [DataRow((TestViewModelWithEnums.UInt64FlagsEnum)0, "0", true)]
-        [DataRow(TestViewModelWithEnums.UInt64FlagsEnum.F1 | TestViewModelWithEnums.UInt64FlagsEnum.F2 | TestViewModelWithEnums.UInt64FlagsEnum.F64, "'F64,F2,F1'", true)]
+        [DataRow(TestViewModelWithEnums.UInt64FlagsEnum.F1 | TestViewModelWithEnums.UInt64FlagsEnum.F2 | TestViewModelWithEnums.UInt64FlagsEnum.F64, "'F64, F2, F1'", true)]
         [DataRow(TestViewModelWithEnums.UInt64FlagsEnum.F64, "'F64'", true)]
         [DataRow((TestViewModelWithEnums.UInt64FlagsEnum)12 | TestViewModelWithEnums.UInt64FlagsEnum.F64, "9223372036854775820", false)]
         [DataRow((TestViewModelWithEnums.UInt64FlagsEnum)ulong.MaxValue, "18446744073709551615", false)]
@@ -1363,6 +1363,25 @@ namespace DotVVM.Framework.Tests.ViewModel
             Assert.ThrowsException<JsonException>(() => JsonSerializer.Deserialize<EmptyEnum>("null", options));
             Assert.ThrowsException<JsonException>(() => JsonSerializer.Deserialize<EmptyFlagsEnum>("null", options));
         }
+
+        [TestMethod]
+        public void TestFlagsEnumSerialization_AllowsSpacesInEnumMember()
+        {
+            var json = JsonSerializer.Serialize(FlagsEnumWithSpace.ReadOnly, DefaultSerializerSettingsProvider.Instance.SettingsHtmlUnsafe);
+
+            Assert.AreEqual("\"read only\"", json);
+        }
+
+        [TestMethod]
+        public void TestFlagsEnumSerialization_IsIndependentOfFormatting()
+        {
+            var compactOptions = new JsonSerializerOptions(DefaultSerializerSettingsProvider.Instance.SettingsHtmlUnsafe) { WriteIndented = false };
+            var indentedOptions = new JsonSerializerOptions(DefaultSerializerSettingsProvider.Instance.SettingsHtmlUnsafe) { WriteIndented = true };
+            var value = NumericFlagsEnum.One | NumericFlagsEnum.Two;
+
+            Assert.AreEqual(JsonSerializer.Serialize(value, compactOptions), JsonSerializer.Serialize(value, indentedOptions));
+        }
+
         enum NumericEnum
         {
             One = 1,
@@ -1380,6 +1399,14 @@ namespace DotVVM.Framework.Tests.ViewModel
 
         [Flags]
         enum EmptyFlagsEnum { }
+
+        [Flags]
+        enum FlagsEnumWithSpace
+        {
+            [EnumMember(Value = "read only")]
+            ReadOnly = 1
+        }
+
         [TestMethod]
         public void DoesNotTouchIrrelevantGetters()
         {

--- a/src/Tests/ViewModel/SerializerTests.cs
+++ b/src/Tests/ViewModel/SerializerTests.cs
@@ -1268,13 +1268,14 @@ namespace DotVVM.Framework.Tests.ViewModel
         [DataRow(TestViewModelWithEnums.Int32FlagsEnum.ABC, "'a+b+c'", true)]
         [DataRow(TestViewModelWithEnums.Int32FlagsEnum.A | TestViewModelWithEnums.Int32FlagsEnum.BCD, "'b+c+d,a'", true)]
         [DataRow(TestViewModelWithEnums.Int32FlagsEnum.Everything, "'everything'", true)]
-        [DataRow((TestViewModelWithEnums.Int32FlagsEnum)2356543, "2356543", false)]
+        [DataRow((TestViewModelWithEnums.Int32FlagsEnum)2356543, "2356543", true)] // allowed because Everything = -1 covers its bits (can be changed in future though)
         [DataRow((TestViewModelWithEnums.Int32FlagsEnum)0, "0", true)]
         [DataRow((TestViewModelWithEnums.UInt64FlagsEnum)0, "0", true)]
         [DataRow(TestViewModelWithEnums.UInt64FlagsEnum.F1 | TestViewModelWithEnums.UInt64FlagsEnum.F2 | TestViewModelWithEnums.UInt64FlagsEnum.F64, "'F64,F2,F1'", true)]
         [DataRow(TestViewModelWithEnums.UInt64FlagsEnum.F64, "'F64'", true)]
         [DataRow((TestViewModelWithEnums.UInt64FlagsEnum)12 | TestViewModelWithEnums.UInt64FlagsEnum.F64, "9223372036854775820", false)]
         [DataRow((TestViewModelWithEnums.UInt64FlagsEnum)ulong.MaxValue, "18446744073709551615", false)]
+        [DataRow((TestViewModelWithEnums.UInt64FlagsEnum)2356543, "2356543", false)]
         [DataRow((TestViewModelWithEnums.UInt64FlagsEnum)0, "0", true)]
         public void TestEnumSerialization(object enumValue, string serializedValue, bool canDeserialize)
         {
@@ -1305,6 +1306,33 @@ namespace DotVVM.Framework.Tests.ViewModel
             }
         }
 
+        [TestMethod]
+        public void TestEnumDeserialization_AcceptsDefinedNumericValue()
+        {
+            var value = JsonSerializer.Deserialize<NumericEnum>("2", DefaultSerializerSettingsProvider.Instance.SettingsHtmlUnsafe);
+
+            Assert.AreEqual(NumericEnum.Two, value);
+        }
+
+        [TestMethod]
+        public void TestFlagsEnumDeserialization_AcceptsCombinationOfDefinedBits()
+        {
+            var value = JsonSerializer.Deserialize<NumericFlagsEnum>("3", DefaultSerializerSettingsProvider.Instance.SettingsHtmlUnsafe);
+
+            Assert.AreEqual(NumericFlagsEnum.One | NumericFlagsEnum.Two, value);
+        }
+        enum NumericEnum
+        {
+            One = 1,
+            Two = 2
+        }
+
+        [Flags]
+        enum NumericFlagsEnum
+        {
+            One = 1,
+            Two = 2
+        }
         [TestMethod]
         public void DoesNotTouchIrrelevantGetters()
         {

--- a/src/Tests/ViewModel/SerializerTests.cs
+++ b/src/Tests/ViewModel/SerializerTests.cs
@@ -1321,6 +1321,14 @@ namespace DotVVM.Framework.Tests.ViewModel
 
             Assert.AreEqual(NumericFlagsEnum.One | NumericFlagsEnum.Two, value);
         }
+
+        [TestMethod]
+        public void TestEnumDeserialization_AcceptsAlias()
+        {
+            var value = JsonSerializer.Deserialize<TestViewModelWithEnums.DuplicateNameEnum>("\"B\"", DefaultSerializerSettingsProvider.Instance.SettingsHtmlUnsafe);
+
+            Assert.AreEqual(TestViewModelWithEnums.DuplicateNameEnum.B, value);
+        }
         enum NumericEnum
         {
             One = 1,

--- a/src/Tests/ViewModel/SerializerTests.cs
+++ b/src/Tests/ViewModel/SerializerTests.cs
@@ -1329,6 +1329,40 @@ namespace DotVVM.Framework.Tests.ViewModel
 
             Assert.AreEqual(TestViewModelWithEnums.DuplicateNameEnum.B, value);
         }
+
+        [TestMethod]
+        public void TestEmptyEnumSerialization()
+        {
+            var json = JsonSerializer.Serialize((EmptyEnum)0, DefaultSerializerSettingsProvider.Instance.SettingsHtmlUnsafe);
+
+            Assert.AreEqual("0", json);
+            Assert.AreEqual("0", JsonSerializer.Serialize((EmptyFlagsEnum)0, DefaultSerializerSettingsProvider.Instance.SettingsHtmlUnsafe));
+        }
+
+        [DataTestMethod]
+        [DataRow("1")]
+        [DataRow("\"\"")]
+        [DataRow("\"Unknown\"")]
+        public void TestEmptyEnumDeserialization_RejectsValues(string json)
+        {
+            var options = DefaultSerializerSettingsProvider.Instance.SettingsHtmlUnsafe;
+
+            Assert.ThrowsException<JsonException>(() => JsonSerializer.Deserialize<EmptyEnum>(json, options));
+            Assert.ThrowsException<JsonException>(() => JsonSerializer.Deserialize<EmptyFlagsEnum>(json, options));
+            Assert.ThrowsException<JsonException>(() => JsonSerializer.Deserialize<EmptyEnum?>(json, options));
+            Assert.ThrowsException<JsonException>(() => JsonSerializer.Deserialize<EmptyFlagsEnum?>(json, options));
+        }
+
+        [TestMethod]
+        public void TestEmptyEnumDeserialization_Null()
+        {
+            var options = DefaultSerializerSettingsProvider.Instance.SettingsHtmlUnsafe;
+
+            Assert.IsNull(JsonSerializer.Deserialize<EmptyEnum?>("null", options));
+            Assert.IsNull(JsonSerializer.Deserialize<EmptyFlagsEnum?>("null", options));
+            Assert.ThrowsException<JsonException>(() => JsonSerializer.Deserialize<EmptyEnum>("null", options));
+            Assert.ThrowsException<JsonException>(() => JsonSerializer.Deserialize<EmptyFlagsEnum>("null", options));
+        }
         enum NumericEnum
         {
             One = 1,
@@ -1341,6 +1375,11 @@ namespace DotVVM.Framework.Tests.ViewModel
             One = 1,
             Two = 2
         }
+
+        enum EmptyEnum { }
+
+        [Flags]
+        enum EmptyFlagsEnum { }
         [TestMethod]
         public void DoesNotTouchIrrelevantGetters()
         {


### PR DESCRIPTION
multiple fixes in multiple commits:

* numeric values were incorrectly validated during deserialization (isFlags inverted)
* multiple names with the same values were ignored for deserialization
* empty enums caused crashes
* space in EnumMember is now allowed
* we always format flags as "a, b" instead of formatting them as "a,b" in release mode